### PR TITLE
fix: locking + atomic writes + timeout threading

### DIFF
--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -69,6 +69,7 @@ class LoopAgentBridge:
         announce_callback: object = None,
         tools: list[dict] | None = None,
         system_prompt: str = "",
+        tool_timeouts: dict[str, int] | None = None,
     ) -> list[str]:
         """Spawn agents for a loop iteration.
 
@@ -120,6 +121,7 @@ class LoopAgentBridge:
                 announce_callback=announce_callback,
                 tools=tools,
                 system_prompt=system_prompt,
+                tool_timeouts=tool_timeouts,
             )
 
             if not agent_id.startswith("Error"):

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -621,6 +621,7 @@ class AgentManager:
         announce_callback: AnnounceCallback | None = None,
         tools: list[dict] | None = None,
         system_prompt: str = "",
+        tool_timeouts: dict[str, int] | None = None,
     ) -> list[str]:
         """Spawn multiple agents at once. Returns list of agent_ids (or error strings).
 
@@ -641,6 +642,7 @@ class AgentManager:
                 announce_callback=announce_callback,
                 tools=tools,
                 system_prompt=system_prompt,
+                tool_timeouts=tool_timeouts,
             )
             ids.append(aid)
         return ids

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -655,6 +655,7 @@ class OdinBot(commands.Bot):
             skills_dir="./data/skills",
             tool_executor=self.tool_executor,
             memory_path=self._memory_path,
+            tool_timeouts=config.tools.tool_timeouts,
         )
 
         # Apply skill URL allowlist from config
@@ -2832,7 +2833,7 @@ class OdinBot(commands.Bot):
                     elif tool_name == "delete_knowledge":
                         result = self._handle_delete_knowledge(tool_input)
                     elif tool_name == "set_permission":
-                        result = self._handle_set_permission(
+                        result = await self._handle_set_permission(
                             str(message.author.id), tool_input,
                         )
                     elif tool_name == "search_audit":
@@ -3407,14 +3408,14 @@ class OdinBot(commands.Bot):
             return f"No document found with source '{source}'."
         return f"Deleted '{source}' from knowledge base ({count} chunks removed)."
 
-    def _handle_set_permission(self, caller_id: str, inp: dict) -> str:
+    async def _handle_set_permission(self, caller_id: str, inp: dict) -> str:
         """Set a user's permission tier. Only admins can call this."""
         if not self.permissions.is_admin(caller_id):
             return "Permission denied. Only admins can change permission tiers."
         target_user_id = inp["user_id"]
         tier = inp["tier"]
         try:
-            self.permissions.set_tier(target_user_id, tier)
+            await self.permissions.set_tier(target_user_id, tier)
         except ValueError as e:
             return str(e)
         return f"Permission tier for user {target_user_id} set to **{tier}**."
@@ -3863,6 +3864,7 @@ class OdinBot(commands.Bot):
             system_prompt=system_prompt,
             parent_id=parent_id_arg,
             max_depth=max_depth,
+            tool_timeouts=self.config.tools.tool_timeouts,
         )
 
         if agent_id.startswith("Error"):
@@ -4300,7 +4302,7 @@ class OdinBot(commands.Bot):
         if tool_name == "delete_knowledge":
             return self._handle_delete_knowledge(tool_input)
         if tool_name == "set_permission":
-            return self._handle_set_permission(user_id, tool_input)
+            return await self._handle_set_permission(user_id, tool_input)
         if tool_name == "search_audit":
             return await self._handle_search_audit(tool_input)
 

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -3415,7 +3415,7 @@ class OdinBot(commands.Bot):
         target_user_id = inp["user_id"]
         tier = inp["tier"]
         try:
-            await self.permissions.set_tier(target_user_id, tier)
+            await self.permissions.async_set_tier(target_user_id, tier)
         except ValueError as e:
             return str(e)
         return f"Permission tier for user {target_user_id} set to **{tier}**."
@@ -4029,6 +4029,7 @@ class OdinBot(commands.Bot):
             tool_executor_callback=_tool_cb,
             tools=tools,
             system_prompt=system_prompt,
+            tool_timeouts=self.config.tools.tool_timeouts,
         )
 
         # Format response

--- a/src/permissions/manager.py
+++ b/src/permissions/manager.py
@@ -66,17 +66,21 @@ class PermissionManager:
             return self._overrides[user_id]
         return self._config_tiers.get(user_id, self._default_tier)
 
-    async def set_tier(self, user_id: str, tier: str) -> None:
+    def set_tier(self, user_id: str, tier: str) -> None:
         """Set a user's permission tier (persisted as runtime override)."""
         if tier not in VALID_TIERS:
             raise ValueError(f"Invalid tier '{tier}'. Must be one of: {', '.join(VALID_TIERS)}")
-        async with self._lock:
-            self._overrides[user_id] = tier
-            self._save_overrides()
+        self._overrides[user_id] = tier
+        self._save_overrides()
         log.info("Permission tier for user %s set to %s", user_id, tier)
 
-    async def delete_tier(self, user_id: str) -> bool:
-        """Remove a user's permission override. Returns True if it existed."""
+    async def async_set_tier(self, user_id: str, tier: str) -> None:
+        """Async-safe version of set_tier with locking."""
+        async with self._lock:
+            self.set_tier(user_id, tier)
+
+    async def async_delete_tier(self, user_id: str) -> bool:
+        """Remove a user's permission override with locking. Returns True if it existed."""
         async with self._lock:
             if user_id in self._overrides:
                 del self._overrides[user_id]

--- a/src/permissions/manager.py
+++ b/src/permissions/manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -39,6 +40,7 @@ class PermissionManager:
         self._default_tier = default_tier if default_tier in VALID_TIERS else "user"
         self._overrides_path = Path(overrides_path)
         self._overrides: dict[str, str] = {}
+        self._lock = asyncio.Lock()
         self._load_overrides()
 
     def _load_overrides(self) -> None:
@@ -54,7 +56,9 @@ class PermissionManager:
 
     def _save_overrides(self) -> None:
         self._overrides_path.parent.mkdir(parents=True, exist_ok=True)
-        self._overrides_path.write_text(json.dumps(self._overrides, indent=2))
+        tmp = self._overrides_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._overrides, indent=2))
+        tmp.replace(self._overrides_path)
 
     def get_tier(self, user_id: str) -> str:
         """Get the permission tier for a user. Runtime overrides take precedence."""
@@ -62,13 +66,23 @@ class PermissionManager:
             return self._overrides[user_id]
         return self._config_tiers.get(user_id, self._default_tier)
 
-    def set_tier(self, user_id: str, tier: str) -> None:
+    async def set_tier(self, user_id: str, tier: str) -> None:
         """Set a user's permission tier (persisted as runtime override)."""
         if tier not in VALID_TIERS:
             raise ValueError(f"Invalid tier '{tier}'. Must be one of: {', '.join(VALID_TIERS)}")
-        self._overrides[user_id] = tier
-        self._save_overrides()
+        async with self._lock:
+            self._overrides[user_id] = tier
+            self._save_overrides()
         log.info("Permission tier for user %s set to %s", user_id, tier)
+
+    async def delete_tier(self, user_id: str) -> bool:
+        """Remove a user's permission override. Returns True if it existed."""
+        async with self._lock:
+            if user_id in self._overrides:
+                del self._overrides[user_id]
+                self._save_overrides()
+                return True
+        return False
 
     def filter_tools(self, user_id: str, tools: list[dict]) -> list[dict] | None:
         """Filter tool list based on user's tier.

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -85,6 +85,7 @@ class ToolExecutor:
         self.output_streamer = output_streamer
         self._metrics: dict[str, dict[str, int]] = {}
         self._memory_lock = asyncio.Lock()
+        self._lists_lock = asyncio.Lock()
         self.risk_stats = RiskStats()
         self.recovery_stats = RecoveryStats()
         self.validation_stats = ResultValidationStats()
@@ -860,7 +861,9 @@ class ToolExecutor:
         if not self._memory_path:
             return
         self._memory_path.parent.mkdir(parents=True, exist_ok=True)
-        self._memory_path.write_text(json.dumps(data, indent=2))
+        tmp = self._memory_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._memory_path)
 
     def _load_memory(self) -> dict[str, str]:
         """Load merged global memory (backward-compatible for system prompt)."""
@@ -1003,7 +1006,10 @@ class ToolExecutor:
     def _save_lists(self, data: dict) -> None:
         path = self._lists_path()
         if path:
-            path.write_text(json.dumps(data, indent=2))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data, indent=2))
+            tmp.replace(path)
 
     async def _handle_manage_list(self, inp: dict, *, user_id: str | None = None) -> str:
         from datetime import datetime
@@ -1013,166 +1019,172 @@ class ToolExecutor:
         raw_items = inp.get("items", [])
         owner_pref = inp.get("owner", "shared")
 
-        lists = await asyncio.to_thread(self._load_lists)
+        return await self._manage_list_locked(action, list_name, raw_items, owner_pref, user_id)
 
-        if action == "list_all":
-            if not lists:
-                return "No lists exist yet. Add items to create one."
-            lines = ["**Your Lists**\n"]
-            for name, lst in sorted(lists.items()):
-                lst_owner = lst.get("owner", "shared")
-                if lst_owner != "shared" and lst_owner != user_id:
-                    continue
-                count = len(lst.get("items", []))
-                done = sum(1 for i in lst.get("items", []) if i.get("done"))
-                owner_label = "shared" if lst_owner == "shared" else "personal"
-                if done:
-                    lines.append(f"- **{name}** ({count} items, {done} done) [{owner_label}]")
-                else:
-                    lines.append(f"- **{name}** ({count} items) [{owner_label}]")
-            if len(lines) == 1:
-                return "No lists visible to you."
-            return "\n".join(lines)
+    async def _manage_list_locked(self, action, list_name, raw_items, owner_pref, user_id):
+        from datetime import datetime
 
-        if not list_name:
-            return "list_name is required for this action."
+        async with self._lists_lock:
+            lists = await asyncio.to_thread(self._load_lists)
 
-        # Resolve the list — check for personal or shared
-        lst = lists.get(list_name)
-        if lst and lst.get("owner") not in ("shared", user_id, None):
-            return f"You don't have access to the '{list_name}' list."
-
-        if action == "show":
-            if not lst or not lst.get("items"):
-                return f"The '{list_name}' list is empty."
-            return self._format_list(list_name, lst)
-
-        if action == "clear":
-            if not lst or not lst.get("items"):
-                return f"The '{list_name}' list is already empty."
-            count = len(lst["items"])
-            lst["items"] = []
-            await asyncio.to_thread(self._save_lists, lists)
-            return f"Cleared {count} item(s) from the '{list_name}' list."
-
-        if action == "add":
-            if not raw_items:
-                return "No items specified to add."
-            # Create list on the fly if it doesn't exist
-            if not lst:
-                owner = user_id if owner_pref == "personal" and user_id else "shared"
-                lst = {"owner": owner, "items": []}
-                lists[list_name] = lst
-            added, already = [], []
-            for name in raw_items:
-                name = name.strip()
-                if not name:
-                    continue
-                if any(i["name"].lower() == name.lower() for i in lst["items"]):
-                    already.append(name)
-                    continue
-                lst["items"].append({
-                    "name": name,
-                    "added_by": user_id or "",
-                    "added_at": datetime.now().isoformat(),
-                    "done": False,
-                })
-                added.append(name)
-            await asyncio.to_thread(self._save_lists, lists)
-            parts = []
-            if added:
-                parts.append(f"Added to '{list_name}': {', '.join(added)}")
-            if already:
-                parts.append(f"Already on the list: {', '.join(already)}")
-            parts.append(f"\n{self._format_list(list_name, lst)}")
-            return "\n".join(parts)
-
-        if action == "remove":
-            if not lst:
-                return f"The '{list_name}' list doesn't exist."
-            if not raw_items:
-                return "No items specified to remove."
-            removed, not_found = [], []
-            for name in raw_items:
-                name = name.strip()
-                if not name:
-                    continue
-                q = name.lower()
-                matches = [i for i, item in enumerate(lst["items"]) if q in item["name"].lower()]
-                if matches:
-                    for idx in sorted(matches, reverse=True):
-                        removed.append(lst["items"].pop(idx)["name"])
-                else:
-                    not_found.append(name)
-            await asyncio.to_thread(self._save_lists, lists)
-            parts = []
-            if removed:
-                parts.append(f"Removed from '{list_name}': {', '.join(removed)}")
-            if not_found:
-                parts.append(f"Not found: {', '.join(not_found)}")
-            if lst["items"]:
+            if action == "list_all":
+                if not lists:
+                    return "No lists exist yet. Add items to create one."
+                lines = ["**Your Lists**\n"]
+                for name, lst in sorted(lists.items()):
+                    lst_owner = lst.get("owner", "shared")
+                    if lst_owner != "shared" and lst_owner != user_id:
+                        continue
+                    count = len(lst.get("items", []))
+                    done = sum(1 for i in lst.get("items", []) if i.get("done"))
+                    owner_label = "shared" if lst_owner == "shared" else "personal"
+                    if done:
+                        lines.append(f"- **{name}** ({count} items, {done} done) [{owner_label}]")
+                    else:
+                        lines.append(f"- **{name}** ({count} items) [{owner_label}]")
+                if len(lines) == 1:
+                    return "No lists visible to you."
+                return "\n".join(lines)
+    
+            if not list_name:
+                return "list_name is required for this action."
+    
+            # Resolve the list — check for personal or shared
+            lst = lists.get(list_name)
+            if lst and lst.get("owner") not in ("shared", user_id, None):
+                return f"You don't have access to the '{list_name}' list."
+    
+            if action == "show":
+                if not lst or not lst.get("items"):
+                    return f"The '{list_name}' list is empty."
+                return self._format_list(list_name, lst)
+    
+            if action == "clear":
+                if not lst or not lst.get("items"):
+                    return f"The '{list_name}' list is already empty."
+                count = len(lst["items"])
+                lst["items"] = []
+                await asyncio.to_thread(self._save_lists, lists)
+                return f"Cleared {count} item(s) from the '{list_name}' list."
+    
+            if action == "add":
+                if not raw_items:
+                    return "No items specified to add."
+                # Create list on the fly if it doesn't exist
+                if not lst:
+                    owner = user_id if owner_pref == "personal" and user_id else "shared"
+                    lst = {"owner": owner, "items": []}
+                    lists[list_name] = lst
+                added, already = [], []
+                for name in raw_items:
+                    name = name.strip()
+                    if not name:
+                        continue
+                    if any(i["name"].lower() == name.lower() for i in lst["items"]):
+                        already.append(name)
+                        continue
+                    lst["items"].append({
+                        "name": name,
+                        "added_by": user_id or "",
+                        "added_at": datetime.now().isoformat(),
+                        "done": False,
+                    })
+                    added.append(name)
+                await asyncio.to_thread(self._save_lists, lists)
+                parts = []
+                if added:
+                    parts.append(f"Added to '{list_name}': {', '.join(added)}")
+                if already:
+                    parts.append(f"Already on the list: {', '.join(already)}")
                 parts.append(f"\n{self._format_list(list_name, lst)}")
-            else:
-                parts.append(f"\nThe '{list_name}' list is now empty.")
-            return "\n".join(parts)
-
-        if action == "mark_done":
-            if not lst:
-                return f"The '{list_name}' list doesn't exist."
-            if not raw_items:
-                return "No items specified to mark as done."
-            marked, not_found = [], []
-            for name in raw_items:
-                q = name.strip().lower()
-                if not q:
-                    continue
-                found = False
-                for item in lst["items"]:
-                    if q in item["name"].lower() and not item.get("done"):
-                        item["done"] = True
-                        marked.append(item["name"])
-                        found = True
-                        break
-                if not found:
-                    not_found.append(name.strip())
-            await asyncio.to_thread(self._save_lists, lists)
-            parts = []
-            if marked:
-                parts.append(f"Marked done: {', '.join(marked)}")
-            if not_found:
-                parts.append(f"Not found or already done: {', '.join(not_found)}")
-            parts.append(f"\n{self._format_list(list_name, lst)}")
-            return "\n".join(parts)
-
-        if action == "mark_undone":
-            if not lst:
-                return f"The '{list_name}' list doesn't exist."
-            if not raw_items:
-                return "No items specified to mark as undone."
-            marked, not_found = [], []
-            for name in raw_items:
-                q = name.strip().lower()
-                if not q:
-                    continue
-                found = False
-                for item in lst["items"]:
-                    if q in item["name"].lower() and item.get("done"):
-                        item["done"] = False
-                        marked.append(item["name"])
-                        found = True
-                        break
-                if not found:
-                    not_found.append(name.strip())
-            await asyncio.to_thread(self._save_lists, lists)
-            parts = []
-            if marked:
-                parts.append(f"Marked undone: {', '.join(marked)}")
-            if not_found:
-                parts.append(f"Not found or not done: {', '.join(not_found)}")
-            parts.append(f"\n{self._format_list(list_name, lst)}")
-            return "\n".join(parts)
-
-        return f"Unknown action: {action}"
+                return "\n".join(parts)
+    
+            if action == "remove":
+                if not lst:
+                    return f"The '{list_name}' list doesn't exist."
+                if not raw_items:
+                    return "No items specified to remove."
+                removed, not_found = [], []
+                for name in raw_items:
+                    name = name.strip()
+                    if not name:
+                        continue
+                    q = name.lower()
+                    matches = [i for i, item in enumerate(lst["items"]) if q in item["name"].lower()]
+                    if matches:
+                        for idx in sorted(matches, reverse=True):
+                            removed.append(lst["items"].pop(idx)["name"])
+                    else:
+                        not_found.append(name)
+                await asyncio.to_thread(self._save_lists, lists)
+                parts = []
+                if removed:
+                    parts.append(f"Removed from '{list_name}': {', '.join(removed)}")
+                if not_found:
+                    parts.append(f"Not found: {', '.join(not_found)}")
+                if lst["items"]:
+                    parts.append(f"\n{self._format_list(list_name, lst)}")
+                else:
+                    parts.append(f"\nThe '{list_name}' list is now empty.")
+                return "\n".join(parts)
+    
+            if action == "mark_done":
+                if not lst:
+                    return f"The '{list_name}' list doesn't exist."
+                if not raw_items:
+                    return "No items specified to mark as done."
+                marked, not_found = [], []
+                for name in raw_items:
+                    q = name.strip().lower()
+                    if not q:
+                        continue
+                    found = False
+                    for item in lst["items"]:
+                        if q in item["name"].lower() and not item.get("done"):
+                            item["done"] = True
+                            marked.append(item["name"])
+                            found = True
+                            break
+                    if not found:
+                        not_found.append(name.strip())
+                await asyncio.to_thread(self._save_lists, lists)
+                parts = []
+                if marked:
+                    parts.append(f"Marked done: {', '.join(marked)}")
+                if not_found:
+                    parts.append(f"Not found or already done: {', '.join(not_found)}")
+                parts.append(f"\n{self._format_list(list_name, lst)}")
+                return "\n".join(parts)
+    
+            if action == "mark_undone":
+                if not lst:
+                    return f"The '{list_name}' list doesn't exist."
+                if not raw_items:
+                    return "No items specified to mark as undone."
+                marked, not_found = [], []
+                for name in raw_items:
+                    q = name.strip().lower()
+                    if not q:
+                        continue
+                    found = False
+                    for item in lst["items"]:
+                        if q in item["name"].lower() and item.get("done"):
+                            item["done"] = False
+                            marked.append(item["name"])
+                            found = True
+                            break
+                    if not found:
+                        not_found.append(name.strip())
+                await asyncio.to_thread(self._save_lists, lists)
+                parts = []
+                if marked:
+                    parts.append(f"Marked undone: {', '.join(marked)}")
+                if not_found:
+                    parts.append(f"Not found or not done: {', '.join(not_found)}")
+                parts.append(f"\n{self._format_list(list_name, lst)}")
+                return "\n".join(parts)
+    
+            return f"Unknown action: {action}"
 
     @staticmethod
     def _format_list(list_name: str, lst: dict) -> str:

--- a/src/tools/skill_context.py
+++ b/src/tools/skill_context.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import ipaddress
 import json
 import re
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from collections.abc import Awaitable, Callable
@@ -172,7 +172,7 @@ class SkillContext:
         self._executor = tool_executor
         self._log = get_logger(f"skills.{skill_name}")
         self._memory_path = Path(memory_path) if memory_path else None
-        self._skill_memory_lock = asyncio.Lock()
+        self._skill_memory_lock = threading.Lock()
         self._message_callback = message_callback
         self._file_callback = file_callback
         self._knowledge_store = knowledge_store
@@ -234,11 +234,11 @@ class SkillContext:
         else:
             self._log.warning("post_file called but no channel callback available")
 
-    async def remember(self, key: str, value: str) -> None:
+    def remember(self, key: str, value: str) -> None:
         """Save a key/value pair to persistent memory."""
         if not self._memory_path:
             return
-        async with self._skill_memory_lock:
+        with self._skill_memory_lock:
             memory = self._load_memory()
             memory[key] = value
             self._save_memory(memory)

--- a/src/tools/skill_context.py
+++ b/src/tools/skill_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import json
 import re
@@ -171,6 +172,7 @@ class SkillContext:
         self._executor = tool_executor
         self._log = get_logger(f"skills.{skill_name}")
         self._memory_path = Path(memory_path) if memory_path else None
+        self._skill_memory_lock = asyncio.Lock()
         self._message_callback = message_callback
         self._file_callback = file_callback
         self._knowledge_store = knowledge_store
@@ -232,13 +234,14 @@ class SkillContext:
         else:
             self._log.warning("post_file called but no channel callback available")
 
-    def remember(self, key: str, value: str) -> None:
+    async def remember(self, key: str, value: str) -> None:
         """Save a key/value pair to persistent memory."""
         if not self._memory_path:
             return
-        memory = self._load_memory()
-        memory[key] = value
-        self._save_memory(memory)
+        async with self._skill_memory_lock:
+            memory = self._load_memory()
+            memory[key] = value
+            self._save_memory(memory)
 
     def recall(self, key: str) -> str | None:
         """Retrieve a value from persistent memory. Returns None if not found."""
@@ -433,4 +436,6 @@ class SkillContext:
         if not self._memory_path:
             return
         self._memory_path.parent.mkdir(parents=True, exist_ok=True)
-        self._memory_path.write_text(json.dumps(data, indent=2))
+        tmp = self._memory_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._memory_path)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2143,7 +2143,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not tier or not isinstance(tier, str):
             return web.json_response({"error": "tier is required"}, status=400)
         try:
-            await pm.set_tier(uid, tier)
+            await pm.async_set_tier(uid, tier)
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
         return web.json_response({"user_id": uid, "tier": tier, "status": "updated"})
@@ -2154,7 +2154,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not pm:
             return web.json_response({"error": "permission manager not available"}, status=503)
         uid = request.match_info["user_id"]
-        if await pm.delete_tier(uid):
+        if await pm.async_delete_tier(uid):
             return web.json_response({"user_id": uid, "status": "override_removed"})
         return web.json_response({"error": "no override found for user"}, status=404)
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2143,7 +2143,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not tier or not isinstance(tier, str):
             return web.json_response({"error": "tier is required"}, status=400)
         try:
-            pm.set_tier(uid, tier)
+            await pm.set_tier(uid, tier)
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
         return web.json_response({"user_id": uid, "tier": tier, "status": "updated"})
@@ -2154,9 +2154,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not pm:
             return web.json_response({"error": "permission manager not available"}, status=503)
         uid = request.match_info["user_id"]
-        if uid in pm._overrides:
-            del pm._overrides[uid]
-            pm._save_overrides()
+        if await pm.delete_tier(uid):
             return web.json_response({"user_id": uid, "status": "override_removed"})
         return web.json_response({"error": "no override found for user"}, status=404)
 


### PR DESCRIPTION
## Summary
- Add asyncio.Lock to lists.json, permissions.json, and skill_context.py memory to prevent parallel write races (same family as the memory.json race fixed earlier)
- Convert all shared JSON state writes to atomic (tmp file + replace) to prevent corruption on crash
- Thread `tool_timeouts` config into SkillManager init, agent_manager.spawn(), and LoopAgentBridge so per-tool timeout overrides actually reach skills and agents

## Changes
- `src/tools/executor.py` — lists lock + atomic write for lists.json and memory.json
- `src/permissions/manager.py` — async lock on set_tier/delete_tier + atomic write
- `src/tools/skill_context.py` — async lock on remember() + atomic write
- `src/discord/client.py` — pass tool_timeouts to SkillManager and agent spawn, await async set_tier
- `src/web/api.py` — await async set_tier/delete_tier
- `src/agents/loop_bridge.py` — accept and forward tool_timeouts parameter

## Test plan
- [x] 2241 tests pass (1 pre-existing failure in test_knowledge_import unrelated)
- [ ] Odin code review
- [ ] Deploy and verify memory/list operations work
- [ ] Verify agent spawn respects tool_timeouts