### PR TITLE
fix: codex auth races, session thread safety, agent lifecycle

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -576,7 +576,9 @@ class AgentManager:
             all_done = True
             for aid in agent_ids:
                 agent = self._agents.get(aid)
-                if agent and agent._sm.is_active:
+                if agent is None:
+                    continue
+                if agent._sm.is_active:
                     all_done = False
                     break
             if all_done:
@@ -754,11 +756,10 @@ async def _run_agent(
                 return True
             try:
                 agent.transition(AgentState.KILLED, "cancel signal")
+                agent.ended_at = time.time()
+                log.info("Agent %s (%s) killed after %ds", agent.id, agent.label, int(time.time() - agent.created_at))
             except InvalidStateTransition:
-                log.warning("Agent %s: kill during state %s, forcing terminal", agent.id, agent._sm.state.value)
-                agent._sm._state = AgentState.KILLED
-            agent.ended_at = time.time()
-            log.info("Agent %s (%s) killed after %ds", agent.id, agent.label, int(time.time() - agent.created_at))
+                log.info("Agent %s already in terminal state %s when kill arrived", agent.id, agent._sm.state.value)
             return True
         return False
 

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -252,6 +252,7 @@ class CodexAuthPool:
         self._path = Path(credentials_path)
         self._accounts: list[CodexAuth] = []
         self._current_index = 0
+        self._pool_lock = asyncio.Lock()
         self._init_accounts()
 
     def _init_accounts(self) -> None:
@@ -296,38 +297,38 @@ class CodexAuthPool:
         """Get a token from the current account, rotating if rate-limited."""
         if not self._accounts:
             raise RuntimeError("No Codex credentials configured.")
-        # Try current first, then rotate through others
-        for _ in range(len(self._accounts)):
-            auth = self._accounts[self._current_index]
-            if not auth.is_rate_limited():
-                return await auth.get_access_token()
-            self._rotate()
-        # All limited — use current anyway
-        log.warning("All %d Codex accounts rate-limited, using current", len(self._accounts))
-        return await self._accounts[self._current_index].get_access_token()
+        async with self._pool_lock:
+            for _ in range(len(self._accounts)):
+                auth = self._accounts[self._current_index]
+                if not auth.is_rate_limited():
+                    return await auth.get_access_token()
+                self._rotate()
+            log.warning("All %d Codex accounts rate-limited, using current", len(self._accounts))
+            return await self._accounts[self._current_index].get_access_token()
 
     def get_account_id(self) -> str | None:
         if not self._accounts:
             return None
         return self.current.get_account_id()
 
-    def mark_current_limited(self) -> None:
+    async def mark_current_limited(self) -> None:
         """Mark the current account as rate-limited and rotate to the next."""
         if not self._accounts:
             return
-        current = self._accounts[self._current_index]
-        current.mark_rate_limited()
-        try:
-            email = current._load().get("email", f"account {self._current_index}")
-        except Exception:
-            email = f"account {self._current_index}"
+        async with self._pool_lock:
+            current = self._accounts[self._current_index]
+            current.mark_rate_limited()
+            try:
+                email = current._load().get("email", f"account {self._current_index}")
+            except Exception:
+                email = f"account {self._current_index}"
 
-        if len(self._accounts) > 1:
-            self._rotate()
-            log.warning("Codex %s hit rate limit, rotated to account %d/%d",
-                        email, self._current_index + 1, len(self._accounts))
-        else:
-            log.warning("Codex %s hit rate limit (only account, no rotation)", email)
+            if len(self._accounts) > 1:
+                self._rotate()
+                log.warning("Codex %s hit rate limit, rotated to account %d/%d",
+                            email, self._current_index + 1, len(self._accounts))
+            else:
+                log.warning("Codex %s hit rate limit (only account, no rotation)", email)
 
     def _rotate(self) -> None:
         self._current_index = (self._current_index + 1) % len(self._accounts)

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -424,8 +424,9 @@ class CodexChatClient:
                     error_body = (await resp.read()).decode("utf-8", errors="replace")
 
                     if resp.status == 401 and attempt == 0:
-                        log.warning("Codex auth expired, refreshing token...")
-                        await self.auth._refresh(self.auth._load())
+                        log.warning("Codex auth expired, forcing token refresh...")
+                        if hasattr(self.auth, '_credentials'):
+                            self.auth._credentials = None
                         new_token = await self.auth.get_access_token()
                         headers["Authorization"] = f"Bearer {new_token}"
                         account_id = self.auth.get_account_id()
@@ -435,7 +436,7 @@ class CodexChatClient:
 
                     if resp.status == 429:
                         if hasattr(self.auth, "mark_current_limited"):
-                            self.auth.mark_current_limited()
+                            await self.auth.mark_current_limited()
                         self.breaker.record_failure()
                         last_error = f"HTTP 429: {error_body[:200]}"
                         if attempt < self.max_retries - 1:
@@ -655,8 +656,9 @@ class CodexChatClient:
                     error_body = (await resp.read()).decode("utf-8", errors="replace")
 
                     if resp.status == 401 and attempt == 0:
-                        log.warning("Codex auth expired, refreshing token...")
-                        await self.auth._refresh(self.auth._load())
+                        log.warning("Codex auth expired, forcing token refresh...")
+                        if hasattr(self.auth, '_credentials'):
+                            self.auth._credentials = None
                         new_token = await self.auth.get_access_token()
                         headers["Authorization"] = f"Bearer {new_token}"
                         account_id = self.auth.get_account_id()
@@ -666,7 +668,7 @@ class CodexChatClient:
 
                     if resp.status == 429:
                         if hasattr(self.auth, "mark_current_limited"):
-                            self.auth.mark_current_limited()
+                            await self.auth.mark_current_limited()
                         self.breaker.record_failure()
                         last_error = f"HTTP 429: {error_body[:200]}"
                         if attempt < self.max_retries - 1:

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -1123,16 +1123,19 @@ class SessionManager:
         return results
 
     def scrub_secrets(self, channel_id: str, content: str) -> bool:
-        """Remove a message containing secrets from history."""
+        """Remove a message containing secrets from history.
+
+        Safe to call outside the per-channel lock — builds a new list
+        and atomically replaces session.messages.
+        """
         session = self._sessions.get(channel_id)
         if not session:
             return False
-        before = len(session.messages)
-        session.messages = [
-            m for m in session.messages if content not in m.content
-        ]
-        removed = before - len(session.messages)
+        original = session.messages
+        filtered = [m for m in original if content not in m.content]
+        removed = len(original) - len(filtered)
         if removed:
+            session.messages = filtered
             self._dirty.add(channel_id)
             log.warning(
                 "Scrubbed %d message(s) containing secrets from channel %s",
@@ -1167,21 +1170,26 @@ class SessionManager:
 
     def save(self) -> None:
         """Persist only sessions that changed since the last save."""
-        for cid in self._dirty:
+        to_save = set(self._dirty)
+        self._dirty -= to_save
+        for cid in to_save:
             session = self._sessions.get(cid)
             if session is None:
                 continue
             path = self.persist_dir / f"{cid}.json"
             data = asdict(session)
-            path.write_text(json.dumps(data, indent=2))
-        self._dirty.clear()
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data, indent=2))
+            tmp.replace(path)
 
     def save_all(self) -> None:
         """Persist every session (used during shutdown)."""
-        for cid, session in self._sessions.items():
+        for cid, session in list(self._sessions.items()):
             path = self.persist_dir / f"{cid}.json"
             data = asdict(session)
-            path.write_text(json.dumps(data, indent=2))
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data, indent=2))
+            tmp.replace(path)
         self._dirty.clear()
 
     def load(self) -> None:


### PR DESCRIPTION
## Summary
- Codex 401 refresh no longer bypasses the refresh lock — prevents concurrent token clobbering
- CodexAuthPool rotation wrapped in asyncio.Lock — prevents double-rotation under concurrent requests
- Session save() snapshots _dirty set before iterating — prevents RuntimeError from thread/event-loop race
- Session writes now atomic (tmp+replace)
- scrub_secrets uses copy-on-write for safe concurrent access
- wait_for_agents() treats removed agents as done instead of hanging forever
- Agent kill vs natural completion no longer force-sets internal state machine

## Test plan
- [x] 2241 tests pass (1 pre-existing failure unrelated)
- [ ] Odin code review
- [ ] Deploy and verify auth rotation works under load