### PR TITLE
fix: SSRF URL validation + trajectory path traversal hardening

### DIFF
--- a/src/knowledge/importer.py
+++ b/src/knowledge/importer.py
@@ -119,6 +119,10 @@ class BulkImporter:
         if not url.startswith(("http://", "https://")):
             return ImportResult(source=url, status="error", error="only http/https URLs supported")
 
+        from ..tools.url_safety import is_url_blocked
+        if is_url_blocked(url):
+            return ImportResult(source=url, status="error", error="URL targets a blocked address (private IP, localhost, or metadata endpoint)")
+
         try:
             import fitz
         except ImportError:
@@ -167,6 +171,10 @@ class BulkImporter:
     ) -> ImportResult:
         if not url.startswith(("http://", "https://")):
             return ImportResult(source=url, status="error", error="only http/https URLs supported")
+
+        from ..tools.url_safety import is_url_blocked
+        if is_url_blocked(url):
+            return ImportResult(source=url, status="error", error="URL targets a blocked address (private IP, localhost, or metadata endpoint)")
 
         from ..tools.web import _html_to_text
 

--- a/src/notifications/outbound_webhooks.py
+++ b/src/notifications/outbound_webhooks.py
@@ -241,6 +241,9 @@ class OutboundWebhookDispatcher:
             raise ValueError(f"URL must be under {_MAX_URL_LEN} characters")
         if not url.startswith(("http://", "https://")):
             raise ValueError("URL must start with http:// or https://")
+        from ..tools.url_safety import is_url_blocked
+        if is_url_blocked(url):
+            raise ValueError("Webhook URL targets a blocked address (localhost, private IP, or metadata endpoint)")
         if len(name) > _MAX_NAME_LEN:
             raise ValueError(f"Name must be under {_MAX_NAME_LEN} characters")
         if len(secret) > _MAX_SECRET_LEN:

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -14,7 +14,7 @@ from ..odin_log import get_logger
 
 log = get_logger("browser")
 
-ALLOWED_SCHEMES = ("http://", "https://")
+ALLOWED_SCHEMES = ("http://", "https://")  # re-exported for tests
 _CONNECTION_ERROR_PATTERNS = (
     "connection closed",
     "target closed",

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -32,11 +32,9 @@ DEFAULT_USER_AGENT = (
 
 
 def _validate_url(url: str) -> None:
-    """Reject dangerous URL schemes."""
-    if not any(url.lower().startswith(s) for s in ALLOWED_SCHEMES):
-        raise ValueError(
-            f"URL must start with http:// or https:// (got: {url[:50]})"
-        )
+    """Reject dangerous URL schemes and SSRF targets."""
+    from .url_safety import validate_url_safe
+    validate_url_safe(url)
 
 
 class BrowserManager:

--- a/src/tools/skill_context.py
+++ b/src/tools/skill_context.py
@@ -91,38 +91,8 @@ def set_skill_allowed_urls(urls: list[str]) -> None:
 
 def is_url_blocked(url: str) -> bool:
     """Return True if a URL targets localhost, private IPs, or metadata endpoints."""
-    try:
-        parsed = urlparse(url)
-        host = parsed.hostname or ""
-    except Exception:
-        return True  # malformed → block
-
-    # Block empty/missing hostname
-    if not host:
-        return True
-
-    # Check operator allowlist — matches if the URL starts with any allowed prefix
-    url_base = f"{parsed.scheme}://{host}:{parsed.port}" if parsed.port else f"{parsed.scheme}://{host}"
-    if any(url_base.rstrip("/") == allowed or url.startswith(allowed) for allowed in _SKILL_ALLOWED_URLS):
-        return False
-
-    # Block common localhost names
-    if host in ("localhost", "127.0.0.1", "::1", "0.0.0.0"):
-        return True
-
-    # Block cloud metadata endpoints
-    if host in ("169.254.169.254", "metadata.google.internal"):
-        return True
-
-    # Block private IP ranges
-    try:
-        addr = ipaddress.ip_address(host)
-        if addr.is_private or addr.is_loopback or addr.is_link_local:
-            return True
-    except ValueError:
-        pass  # hostname, not IP — allow
-
-    return False
+    from .url_safety import is_url_blocked as _shared_check
+    return _shared_check(url, allowed_urls=list(_SKILL_ALLOWED_URLS) if _SKILL_ALLOWED_URLS else None)
 
 
 # Tools that skills are allowed to call via execute_tool().

--- a/src/tools/url_safety.py
+++ b/src/tools/url_safety.py
@@ -1,0 +1,56 @@
+"""Shared URL safety validation — blocks SSRF attempts.
+
+Rejects URLs targeting localhost, private IP ranges, cloud metadata
+endpoints, and link-local addresses. Used by browser automation,
+outbound webhooks, and knowledge import.
+"""
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+
+ALLOWED_SCHEMES = ("http://", "https://")
+
+
+def is_url_blocked(url: str, allowed_urls: list[str] | None = None) -> bool:
+    """Return True if a URL targets localhost, private IPs, or metadata endpoints."""
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+    except Exception:
+        return True
+
+    if not host:
+        return True
+
+    if allowed_urls:
+        url_base = f"{parsed.scheme}://{host}:{parsed.port}" if parsed.port else f"{parsed.scheme}://{host}"
+        if any(url_base.rstrip("/") == a or url.startswith(a) for a in allowed_urls):
+            return False
+
+    if host in ("localhost", "127.0.0.1", "::1", "0.0.0.0"):
+        return True
+
+    if host in ("169.254.169.254", "metadata.google.internal"):
+        return True
+
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_private or addr.is_loopback or addr.is_link_local:
+            return True
+    except ValueError:
+        pass
+
+    return False
+
+
+def validate_url_safe(url: str, allowed_urls: list[str] | None = None) -> None:
+    """Validate URL scheme and block SSRF. Raises ValueError on failure."""
+    if not url or not url.strip():
+        raise ValueError("URL is required")
+    url = url.strip()
+    if not any(url.lower().startswith(s) for s in ALLOWED_SCHEMES):
+        raise ValueError(f"URL must start with http:// or https:// (got: {url[:50]})")
+    if is_url_blocked(url, allowed_urls=allowed_urls):
+        raise ValueError(f"URL targets a blocked address (localhost, private IP, or metadata endpoint): {url[:80]}")

--- a/src/tools/url_safety.py
+++ b/src/tools/url_safety.py
@@ -1,20 +1,42 @@
 """Shared URL safety validation — blocks SSRF attempts.
 
 Rejects URLs targeting localhost, private IP ranges, cloud metadata
-endpoints, and link-local addresses. Used by browser automation,
-outbound webhooks, and knowledge import.
+endpoints, and link-local addresses. Validates both literal hostnames
+and DNS-resolved IPs to prevent rebinding attacks.
 """
 from __future__ import annotations
 
 import ipaddress
+import socket
 from urllib.parse import urlparse
 
+from ..odin_log import get_logger
+
+log = get_logger("url_safety")
 
 ALLOWED_SCHEMES = ("http://", "https://")
 
 
-def is_url_blocked(url: str, allowed_urls: list[str] | None = None) -> bool:
-    """Return True if a URL targets localhost, private IPs, or metadata endpoints."""
+def _is_ip_blocked(addr_str: str) -> bool:
+    """Check if an IP address string is private/loopback/link-local/metadata."""
+    try:
+        addr = ipaddress.ip_address(addr_str)
+    except ValueError:
+        return False
+    if addr.is_private or addr.is_loopback or addr.is_link_local:
+        return True
+    if addr_str in ("169.254.169.254", "fd00::"):
+        return True
+    return False
+
+
+def is_url_blocked(url: str, allowed_urls: list[str] | None = None, resolve_dns: bool = True) -> bool:
+    """Return True if a URL targets localhost, private IPs, or metadata endpoints.
+
+    When resolve_dns is True (default), also resolves the hostname and
+    checks resolved IPs — prevents DNS rebinding attacks where a public
+    domain resolves to a private IP.
+    """
     try:
         parsed = urlparse(url)
         host = parsed.hostname or ""
@@ -35,12 +57,19 @@ def is_url_blocked(url: str, allowed_urls: list[str] | None = None) -> bool:
     if host in ("169.254.169.254", "metadata.google.internal"):
         return True
 
-    try:
-        addr = ipaddress.ip_address(host)
-        if addr.is_private or addr.is_loopback or addr.is_link_local:
-            return True
-    except ValueError:
-        pass
+    if _is_ip_blocked(host):
+        return True
+
+    if resolve_dns:
+        try:
+            resolved = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+            for _family, _type, _proto, _canonname, sockaddr in resolved:
+                ip = sockaddr[0]
+                if _is_ip_blocked(ip):
+                    log.warning("DNS rebinding blocked: %s resolves to private IP %s", host, ip)
+                    return True
+        except socket.gaierror:
+            pass
 
     return False
 
@@ -51,6 +80,6 @@ def validate_url_safe(url: str, allowed_urls: list[str] | None = None) -> None:
         raise ValueError("URL is required")
     url = url.strip()
     if not any(url.lower().startswith(s) for s in ALLOWED_SCHEMES):
-        raise ValueError(f"URL must start with http:// or https:// (got: {url[:50]})")
+        raise ValueError(f"URL must start with http:// or https://")
     if is_url_blocked(url, allowed_urls=allowed_urls):
-        raise ValueError(f"URL targets a blocked address (localhost, private IP, or metadata endpoint): {url[:80]}")
+        raise ValueError("URL targets a blocked address (localhost, private IP, or metadata endpoint)")

--- a/src/tools/web.py
+++ b/src/tools/web.py
@@ -65,13 +65,16 @@ async def fetch_url(url: str, max_chars: int = MAX_CONTENT_CHARS) -> str:
     Handles HTML (converts to markdown-like text), JSON (returns raw),
     and plain text. Truncates to max_chars.
     """
+    from .url_safety import is_url_blocked
+    if is_url_blocked(url):
+        return "Error: URL targets a blocked address (localhost, private IP, or metadata endpoint)"
     try:
         async with aiohttp.ClientSession(timeout=FETCH_TIMEOUT) as session:
             async with session.get(
                 url,
                 headers={"User-Agent": USER_AGENT},
                 allow_redirects=True,
-                ssl=False,  # Disable SSL verification — internal infra may use self-signed certs
+                ssl=False,
             ) as resp:
                 if resp.status != 200:
                     return f"HTTP {resp.status}: {resp.reason}"

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -818,7 +818,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if saver is None:
             return web.json_response({"error": "trajectory saving not available"}, status=503)
         filename = request.match_info["filename"]
-        if not filename.endswith(".jsonl") or "/" in filename or "\\" in filename:
+        if not filename.endswith(".jsonl") or "/" in filename or "\\" in filename or ".." in filename:
+            return web.json_response({"error": "invalid filename"}, status=400)
+        safe_path = (saver.directory / filename).resolve()
+        if not safe_path.is_relative_to(saver.directory.resolve()):
             return web.json_response({"error": "invalid filename"}, status=400)
         limit = _safe_int_param(request, "limit", 100, hi=500)
         entries = await saver.read_file(filename, limit=limit)
@@ -2299,7 +2302,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if saver is None:
             return web.json_response({"error": "agent trajectory saving not available"}, status=503)
         filename = request.match_info["filename"]
-        if not filename.endswith(".jsonl") or "/" in filename or "\\" in filename:
+        if not filename.endswith(".jsonl") or "/" in filename or "\\" in filename or ".." in filename:
+            return web.json_response({"error": "invalid filename"}, status=400)
+        safe_path = (saver.directory / filename).resolve()
+        if not safe_path.is_relative_to(saver.directory.resolve()):
             return web.json_response({"error": "invalid filename"}, status=400)
         limit = _safe_int_param(request, "limit", 100, hi=500)
         entries = await saver.read_file(filename, limit=limit)


### PR DESCRIPTION
## Summary
- New shared `src/tools/url_safety.py` — blocks localhost, private IPs, link-local, cloud metadata
- Wired into browser, knowledge importer, outbound webhooks, skill context
- Trajectory API endpoints hardened with .resolve() containment

## Addresses audit items
- C1, O1, O16: SSRF in browser, webhooks, knowledge import
- C6: Trajectory path traversal

## Test plan
- [x] 2241 tests pass
- [ ] Odin review