### PR TITLE
fix: restrict knowledge import paths + enable TLS + pre-check PDF size

### DIFF
--- a/src/knowledge/importer.py
+++ b/src/knowledge/importer.py
@@ -22,6 +22,14 @@ log = get_logger("knowledge.importer")
 
 MAX_BATCH_SIZE = 50
 MAX_FILE_BYTES = 512_000  # 500 KB per file
+
+SAFE_IMPORT_ROOTS = (
+    "/opt/odin",
+    "/opt/heimdall",
+    "/tmp",
+    "/home",
+    "/root",
+)
 MAX_PDF_BYTES = 50_000_000  # 50 MB
 FETCH_TIMEOUT = aiohttp.ClientTimeout(total=30)
 FETCH_MAX_CHARS = 100_000  # larger than tool output — we want full content for ingestion
@@ -59,9 +67,14 @@ class BulkImporter:
         pattern: str = "**/*.md",
         uploader: str = "bulk-import",
     ) -> list[ImportResult]:
-        base = Path(directory)
+        base = Path(directory).resolve()
         if not base.is_dir():
             return [ImportResult(source=directory, status="error", error="directory not found")]
+        if not any(str(base).startswith(root) for root in SAFE_IMPORT_ROOTS):
+            return [ImportResult(
+                source=directory, status="error",
+                error=f"directory not in allowed import roots: {', '.join(SAFE_IMPORT_ROOTS)}",
+            )]
 
         results: list[ImportResult] = []
         resolved_base = base.resolve()
@@ -134,6 +147,9 @@ class BulkImporter:
                 async with session.get(url) as resp:
                     if resp.status != 200:
                         return ImportResult(source=src, status="error", error=f"HTTP {resp.status}")
+                    cl = resp.headers.get("Content-Length")
+                    if cl is not None and int(cl) > MAX_PDF_BYTES:
+                        return ImportResult(source=src, status="error", error=f"PDF too large ({cl} bytes, max {MAX_PDF_BYTES})")
                     pdf_bytes = await resp.read()
                     if len(pdf_bytes) > MAX_PDF_BYTES:
                         return ImportResult(source=src, status="error", error="PDF too large")
@@ -185,7 +201,7 @@ class BulkImporter:
                     url,
                     headers={"User-Agent": "Mozilla/5.0 (compatible; OdinBot/1.0)"},
                     allow_redirects=True,
-                    ssl=False,
+                    ssl=True,
                 ) as resp:
                     if resp.status != 200:
                         return ImportResult(source=src, status="error", error=f"HTTP {resp.status}")

--- a/src/knowledge/importer.py
+++ b/src/knowledge/importer.py
@@ -70,7 +70,7 @@ class BulkImporter:
         base = Path(directory).resolve()
         if not base.is_dir():
             return [ImportResult(source=directory, status="error", error="directory not found")]
-        if not any(str(base).startswith(root) for root in SAFE_IMPORT_ROOTS):
+        if not any(base.is_relative_to(root) for root in SAFE_IMPORT_ROOTS):
             return [ImportResult(
                 source=directory, status="error",
                 error=f"directory not in allowed import roots: {', '.join(SAFE_IMPORT_ROOTS)}",
@@ -147,8 +147,11 @@ class BulkImporter:
                 async with session.get(url) as resp:
                     if resp.status != 200:
                         return ImportResult(source=src, status="error", error=f"HTTP {resp.status}")
-                    cl = resp.headers.get("Content-Length")
-                    if cl is not None and int(cl) > MAX_PDF_BYTES:
+                    try:
+                        cl = int(resp.headers.get("Content-Length", 0)) or None
+                    except (ValueError, TypeError):
+                        cl = None
+                    if cl is not None and cl > MAX_PDF_BYTES:
                         return ImportResult(source=src, status="error", error=f"PDF too large ({cl} bytes, max {MAX_PDF_BYTES})")
                     pdf_bytes = await resp.read()
                     if len(pdf_bytes) > MAX_PDF_BYTES:


### PR DESCRIPTION
## Summary
- import_directory restricted to safe roots — prevents arbitrary filesystem reads
- import_web_url enables TLS verification (was ssl=False)
- PDF import checks Content-Length before reading body to prevent OOM

## Addresses audit items
- O18: Arbitrary directory read via import_directory
- O17: Web import disables TLS verification
- O19: Full PDF body read before size check

## Test plan
- [x] 2241 tests pass
- [ ] Odin review