### PR TITLE
fix: validate scheduler regex at creation + limit runtime input

### DIFF
--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -222,6 +222,14 @@ class Scheduler:
                 f"Invalid trigger source '{source}'. "
                 f"Valid: {', '.join(sorted(valid_sources))}"
             )
+        regex = trigger.get("content_regex")
+        if regex:
+            if len(regex) > 200:
+                raise ValueError("content_regex must be under 200 characters")
+            try:
+                re.compile(regex)
+            except re.error as e:
+                raise ValueError(f"Invalid content_regex: {e}") from e
         if not trigger:
             raise ValueError("Trigger must have at least one condition")
 
@@ -373,9 +381,10 @@ class Scheduler:
                 return False
         if trigger.get("content_regex"):
             try:
-                if not re.search(trigger["content_regex"], content):
+                if not re.search(trigger["content_regex"], content[:10_000]):
                     return False
             except re.error:
+                log.warning("Regex trigger evaluation failed: %s", trigger["content_regex"][:50])
                 return False
         if trigger.get("starts_with"):
             if not content.startswith(trigger["starts_with"]):


### PR DESCRIPTION
## Summary
- Compile-check content_regex at schedule creation — catches bad syntax before persistence
- Reject patterns over 200 chars to limit complexity
- Truncate match input to 10K chars at runtime to bound evaluation time

## Addresses audit items
- O11: Regex trigger catastrophic backtracking
- O12: Regex not validated at creation

## Test plan
- [x] 170 scheduler tests pass
- [ ] Odin review