### PR TITLE
fix: remove channel topic injection + expand audit logging

### DIFF
--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -76,6 +76,43 @@ class AuditLogger:
             except Exception:
                 pass
 
+    async def log_event(
+        self,
+        *,
+        event_type: str,
+        action: str,
+        actor: str = "",
+        detail: str = "",
+        channel_id: str = "",
+        metadata: dict | None = None,
+    ) -> None:
+        """Log a generic state-changing event (agents, schedules, permissions, etc.)."""
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "type": event_type,
+            "action": action,
+            "actor": actor,
+            "detail": detail[:500],
+        }
+        if channel_id:
+            entry["channel_id"] = channel_id
+        if metadata:
+            entry["metadata"] = metadata
+        if self._signer:
+            self._signer.sign(entry)
+        line = json.dumps(entry, default=str) + "\n"
+        try:
+            async with aiofiles.open(self.path, "a") as f:
+                await f.write(line)
+        except Exception as e:
+            log.error("Failed to write audit event: %s", e)
+
+        if self._event_callback:
+            try:
+                await self._event_callback(entry)
+            except Exception:
+                pass
+
     async def log_web_action(
         self,
         *,

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -1345,7 +1345,8 @@ class OdinBot(commands.Bot):
         if task_end:
             self._active_tasks = max(0, self._active_tasks - 1)
         now = time.monotonic()
-        if now - self._last_status_update < self._STATUS_DEBOUNCE:
+        is_finish = task_end and self._active_tasks == 0
+        if not is_finish and now - self._last_status_update < self._STATUS_DEBOUNCE:
             return
         try:
             if self._active_tasks > 0 and text:

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -816,17 +816,6 @@ class OdinBot(commands.Bot):
         # Tool use pattern hints injected separately via _inject_tool_hints()
         # because format_hints is async (needs embedder).
 
-        # Channel-based personality: if the channel has a topic/description set,
-        # inject it as a personality directive. All other rules still apply.
-        if channel is not None:
-            topic = getattr(channel, "topic", None)
-            if topic and topic.strip():
-                prompt += (
-                    f"\n\n## Channel Personality\n"
-                    f"For this channel, adopt the following personality while keeping all other rules intact:\n"
-                    f"{topic.strip()}"
-                )
-
         return prompt
 
     async def _inject_tool_hints(self, system_prompt: str, query: str, user_id: str | None = None) -> str:
@@ -883,16 +872,6 @@ class OdinBot(commands.Bot):
         learned = self._get_cached_reflector(user_id)
         if learned:
             prompt += f"\n\n{learned}"
-
-        # Channel personality
-        if channel is not None:
-            topic = getattr(channel, "topic", None)
-            if topic and topic.strip():
-                prompt += (
-                    f"\n\n## Channel Personality\n"
-                    f"For this channel, adopt the following personality while keeping all other rules intact:\n"
-                    f"{topic.strip()}"
-                )
 
         return prompt
 
@@ -4077,6 +4056,29 @@ class OdinBot(commands.Bot):
         Mirrors the Discord-native tool dispatch in _process_with_tools, using
         a lightweight message proxy instead of a real Discord message.
         """
+        t0 = time.monotonic()
+        result = await self._dispatch_loop_tool_inner(tool_name, tool_input, msg_proxy, user_id)
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        try:
+            await self.audit.log_event(
+                event_type="loop_tool",
+                action=tool_name,
+                actor=user_id,
+                detail=str(result)[:200] if isinstance(result, str) else "",
+                channel_id=str(getattr(msg_proxy.channel, "id", "")),
+                metadata={"tool_input_keys": list((tool_input or {}).keys()), "elapsed_ms": elapsed_ms},
+            )
+        except Exception:
+            pass
+        return result
+
+    async def _dispatch_loop_tool_inner(
+        self,
+        tool_name: str,
+        tool_input: dict,
+        msg_proxy: _LoopMessageProxy,
+        user_id: str,
+    ) -> str | dict:
         # --- Discord-native tools (message + input) ---
         if tool_name == "purge_messages":
             return await self._handle_purge(msg_proxy, tool_input)
@@ -4550,6 +4552,17 @@ class OdinBot(commands.Bot):
 
     async def _on_scheduled_task(self, schedule: dict) -> None:
         """Callback fired by the scheduler when a task is due."""
+        try:
+            await self.audit.log_event(
+                event_type="schedule_execution",
+                action=schedule.get("action", "unknown"),
+                actor="scheduler",
+                detail=f"Schedule {schedule.get('id', '?')}: {schedule.get('description', '')[:100]}",
+                channel_id=schedule.get("channel_id", ""),
+                metadata={"schedule_id": schedule.get("id"), "action": schedule.get("action")},
+            )
+        except Exception:
+            pass
         channel_id = schedule.get("channel_id")
         if not channel_id:
             log.warning("Scheduled task has no channel_id: %s", schedule["id"])

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2149,6 +2149,15 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             await pm.async_set_tier(uid, tier)
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
+        audit = getattr(bot, "audit", None)
+        if audit:
+            session_id = getattr(request, "_session_id", "web-api")
+            await audit.log_event(
+                event_type="permission_change",
+                action="set_tier",
+                actor=f"web:{session_id}",
+                detail=f"Set user {uid} to tier {tier}",
+            )
         return web.json_response({"user_id": uid, "tier": tier, "status": "updated"})
 
     @routes.delete("/api/permissions/user/{user_id}")

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2149,15 +2149,18 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             await pm.async_set_tier(uid, tier)
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
-        audit = getattr(bot, "audit", None)
-        if audit:
-            session_id = getattr(request, "_session_id", "web-api")
-            await audit.log_event(
-                event_type="permission_change",
-                action="set_tier",
-                actor=f"web:{session_id}",
-                detail=f"Set user {uid} to tier {tier}",
-            )
+        try:
+            audit = getattr(bot, "audit", None)
+            if audit:
+                session_id = getattr(request, "_session_id", "web-api")
+                await audit.log_event(
+                    event_type="permission_change",
+                    action="set_tier",
+                    actor=f"web:{session_id}",
+                    detail=f"Set user {uid} to tier {tier}",
+                )
+        except Exception:
+            pass
         return web.json_response({"user_id": uid, "tier": tier, "status": "updated"})
 
     @routes.delete("/api/permissions/user/{user_id}")
@@ -2167,6 +2170,18 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response({"error": "permission manager not available"}, status=503)
         uid = request.match_info["user_id"]
         if await pm.async_delete_tier(uid):
+            try:
+                audit = getattr(bot, "audit", None)
+                if audit:
+                    session_id = getattr(request, "_session_id", "web-api")
+                    await audit.log_event(
+                        event_type="permission_change",
+                        action="delete_tier",
+                        actor=f"web:{session_id}",
+                        detail=f"Removed tier override for user {uid}",
+                    )
+            except Exception:
+                pass
             return web.json_response({"user_id": uid, "status": "override_removed"})
         return web.json_response({"error": "no override found for user"}, status=404)
 


### PR DESCRIPTION
## Summary
**Prompt injection hardening:**
- Removed channel topic injection from both system prompt builders (was legacy channel personality feature, identified as prompt injection vector in audit item O22)

**Audit logging expansion:**
- New `AuditLogger.log_event()` for generic state-change events
- Loop/agent tool execution now audited (wrapped _dispatch_loop_tool)
- Scheduler task execution audited at callback entry
- Web API permission changes audited with session identity

## Addresses audit items
- O22: Channel topic injected into system prompt unsanitized
- O32, O33, O34, O35: Audit log gaps for agents, scheduler, permissions, state changes

## Test plan
- [x] 2241 tests pass
- [ ] Odin review