### PR TITLE
feat: restructure web UI — 19 pages to 6 groups with tabs

### DIFF
--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -24,6 +24,25 @@ const routes = [
   { path: '/history',       component: HistoryPage,       meta: { label: 'History',       icon: '\u{1F4DD}' } },
   { path: '/capabilities',  component: CapabilitiesPage,  meta: { label: 'Capabilities',  icon: '\u{1F527}' } },
   { path: '/system',        component: SystemPage,        meta: { label: 'System',        icon: '\u{2699}\u{FE0F}' } },
+  // Redirects from old routes to new grouped locations
+  { path: '/execution',  redirect: { path: '/operations', query: { tab: 'live' } } },
+  { path: '/agents',     redirect: { path: '/operations', query: { tab: 'agents' } } },
+  { path: '/loops',      redirect: { path: '/operations', query: { tab: 'loops' } } },
+  { path: '/processes',  redirect: { path: '/operations', query: { tab: 'processes' } } },
+  { path: '/schedules',  redirect: { path: '/operations', query: { tab: 'schedules' } } },
+  { path: '/audit',      redirect: { path: '/history', query: { tab: 'audit' } } },
+  { path: '/sessions',   redirect: { path: '/history', query: { tab: 'sessions' } } },
+  { path: '/traces',     redirect: { path: '/history', query: { tab: 'traces' } } },
+  { path: '/usage',      redirect: { path: '/history', query: { tab: 'usage' } } },
+  { path: '/tools',      redirect: { path: '/capabilities', query: { tab: 'tools' } } },
+  { path: '/skills',     redirect: { path: '/capabilities', query: { tab: 'skills' } } },
+  { path: '/knowledge',  redirect: { path: '/capabilities', query: { tab: 'knowledge' } } },
+  { path: '/memory',     redirect: { path: '/capabilities', query: { tab: 'memory' } } },
+  { path: '/health',     redirect: { path: '/system', query: { tab: 'health' } } },
+  { path: '/resources',  redirect: { path: '/system', query: { tab: 'resources' } } },
+  { path: '/logs',       redirect: { path: '/system', query: { tab: 'logs' } } },
+  { path: '/config',     redirect: { path: '/system', query: { tab: 'config' } } },
+  { path: '/internals',  redirect: { path: '/system', query: { tab: 'internals' } } },
 ];
 
 const router = createRouter({

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -4,56 +4,26 @@
  */
 import { api, ws } from './api.js';
 import DashboardPage from './pages/dashboard.js';
-import SessionsPage from './pages/sessions.js';
-import ToolsPage from './pages/tools.js';
-import SkillsPage from './pages/skills.js';
-import KnowledgePage from './pages/knowledge.js';
-import SchedulesPage from './pages/schedules.js';
-import LoopsPage from './pages/loops.js';
-import ProcessesPage from './pages/processes.js';
-import ConfigPage from './pages/config.js';
-import LogsPage from './pages/logs.js';
-import AuditPage from './pages/audit.js';
-import MemoryPage from './pages/memory.js';
-import AgentsPage from './pages/agents.js';
 import ChatPage from './pages/chat.js';
-import UsagePage from './pages/usage.js';
-import TracesPage from './pages/traces.js';
-import HealthPage from './pages/health.js';
-import ResourcesPage from './pages/resources.js';
-import InternalsPage from './pages/internals.js';
-import ExecutionPage from './pages/execution.js';
+import OperationsPage from './pages/operations.js';
+import HistoryPage from './pages/history.js';
+import CapabilitiesPage from './pages/capabilities.js';
+import SystemPage from './pages/system.js';
 
 const { createApp, ref, computed, onMounted, onUnmounted, watch, nextTick } = Vue;
 const { createRouter, createWebHashHistory } = VueRouter;
 
-// All page components imported above
-
 // ---------------------------------------------------------------------------
-// Router
+// Router — 6 top-level items, sub-pages rendered as tabs within each
 // ---------------------------------------------------------------------------
 const routes = [
-  { path: '/',           redirect: '/dashboard' },
-  { path: '/dashboard',  component: DashboardPage,  meta: { label: 'Dashboard',  icon: '\u{1F4CA}' } },
-  { path: '/execution', component: ExecutionPage,  meta: { label: 'Execution',  icon: '\u{1F3AF}' } },
-  { path: '/chat',       component: ChatPage,       meta: { label: 'Chat',       icon: '\u{1F4AD}' } },
-  { path: '/sessions',   component: SessionsPage,   meta: { label: 'Sessions',   icon: '\u{1F4AC}' } },
-  { path: '/tools',      component: ToolsPage,      meta: { label: 'Tools',      icon: '\u{1F527}' } },
-  { path: '/skills',     component: SkillsPage,     meta: { label: 'Skills',     icon: '\u{1F9E9}' } },
-  { path: '/knowledge',  component: KnowledgePage,  meta: { label: 'Knowledge',  icon: '\u{1F4DA}' } },
-  { path: '/schedules',  component: SchedulesPage,  meta: { label: 'Schedules',  icon: '\u{23F0}' } },
-  { path: '/loops',      component: LoopsPage,      meta: { label: 'Loops',      icon: '\u{1F504}' } },
-  { path: '/processes',  component: ProcessesPage,  meta: { label: 'Processes',  icon: '\u{2699}\u{FE0F}' } },
-  { path: '/audit',      component: AuditPage,      meta: { label: 'Audit',      icon: '\u{1F4DD}' } },
-  { path: '/config',     component: ConfigPage,     meta: { label: 'Config',     icon: '\u{2699}\u{FE0F}' } },
-  { path: '/logs',       component: LogsPage,       meta: { label: 'Logs',       icon: '\u{1F4C4}' } },
-  { path: '/memory',     component: MemoryPage,     meta: { label: 'Memory',     icon: '\u{1F9E0}' } },
-  { path: '/agents',     component: AgentsPage,     meta: { label: 'Agents',     icon: '\u{1F916}' } },
-  { path: '/usage',      component: UsagePage,      meta: { label: 'Usage',      icon: '\u{1F4B0}' } },
-  { path: '/traces',     component: TracesPage,     meta: { label: 'Traces',     icon: '\u{1F50D}' } },
-  { path: '/health',     component: HealthPage,     meta: { label: 'Health',     icon: '\u{1FA7A}' } },
-  { path: '/resources',  component: ResourcesPage,  meta: { label: 'Resources',  icon: '\u{1F4E6}' } },
-  { path: '/internals',  component: InternalsPage,  meta: { label: 'Internals',  icon: '\u{1F50C}' } },
+  { path: '/',              redirect: '/dashboard' },
+  { path: '/dashboard',     component: DashboardPage,    meta: { label: 'Dashboard',     icon: '\u{1F4CA}' } },
+  { path: '/chat',          component: ChatPage,          meta: { label: 'Chat',          icon: '\u{1F4AD}' } },
+  { path: '/operations',    component: OperationsPage,    meta: { label: 'Operations',    icon: '\u{1F3AF}' } },
+  { path: '/history',       component: HistoryPage,       meta: { label: 'History',       icon: '\u{1F4DD}' } },
+  { path: '/capabilities',  component: CapabilitiesPage,  meta: { label: 'Capabilities',  icon: '\u{1F527}' } },
+  { path: '/system',        component: SystemPage,        meta: { label: 'System',        icon: '\u{2699}\u{FE0F}' } },
 ];
 
 const router = createRouter({

--- a/ui/js/pages/capabilities.js
+++ b/ui/js/pages/capabilities.js
@@ -1,0 +1,19 @@
+import TabbedPage from './tabbed-page.js';
+import ToolsPage from './tools.js';
+import SkillsPage from './skills.js';
+import KnowledgePage from './knowledge.js';
+import MemoryPage from './memory.js';
+
+export default {
+  components: { TabbedPage },
+  setup() {
+    const tabs = [
+      { id: 'tools', label: 'Tools', component: ToolsPage },
+      { id: 'skills', label: 'Skills', component: SkillsPage },
+      { id: 'knowledge', label: 'Knowledge', component: KnowledgePage },
+      { id: 'memory', label: 'Memory', component: MemoryPage },
+    ];
+    return { tabs };
+  },
+  template: `<tabbed-page :tabs="tabs" default-tab="tools" />`,
+};

--- a/ui/js/pages/capabilities.js
+++ b/ui/js/pages/capabilities.js
@@ -15,5 +15,5 @@ export default {
     ];
     return { tabs };
   },
-  template: `<tabbed-page :tabs="tabs" default-tab="tools" />`,
+  template: `<tabbed-page :tabs="tabs" default-tab="tools" group-label="Capabilities" />`,
 };

--- a/ui/js/pages/history.js
+++ b/ui/js/pages/history.js
@@ -15,5 +15,5 @@ export default {
     ];
     return { tabs };
   },
-  template: `<tabbed-page :tabs="tabs" default-tab="audit" />`,
+  template: `<tabbed-page :tabs="tabs" default-tab="audit" group-label="History" />`,
 };

--- a/ui/js/pages/history.js
+++ b/ui/js/pages/history.js
@@ -1,0 +1,19 @@
+import TabbedPage from './tabbed-page.js';
+import AuditPage from './audit.js';
+import SessionsPage from './sessions.js';
+import TracesPage from './traces.js';
+import UsagePage from './usage.js';
+
+export default {
+  components: { TabbedPage },
+  setup() {
+    const tabs = [
+      { id: 'audit', label: 'Audit', component: AuditPage },
+      { id: 'sessions', label: 'Sessions', component: SessionsPage },
+      { id: 'traces', label: 'Traces', component: TracesPage },
+      { id: 'usage', label: 'Usage', component: UsagePage },
+    ];
+    return { tabs };
+  },
+  template: `<tabbed-page :tabs="tabs" default-tab="audit" />`,
+};

--- a/ui/js/pages/operations.js
+++ b/ui/js/pages/operations.js
@@ -17,5 +17,5 @@ export default {
     ];
     return { tabs };
   },
-  template: `<tabbed-page :tabs="tabs" default-tab="live" />`,
+  template: `<tabbed-page :tabs="tabs" default-tab="live" group-label="Operations" />`,
 };

--- a/ui/js/pages/operations.js
+++ b/ui/js/pages/operations.js
@@ -1,0 +1,21 @@
+import TabbedPage from './tabbed-page.js';
+import ExecutionPage from './execution.js';
+import AgentsPage from './agents.js';
+import LoopsPage from './loops.js';
+import ProcessesPage from './processes.js';
+import SchedulesPage from './schedules.js';
+
+export default {
+  components: { TabbedPage },
+  setup() {
+    const tabs = [
+      { id: 'live', label: 'Live', component: ExecutionPage },
+      { id: 'agents', label: 'Agents', component: AgentsPage },
+      { id: 'loops', label: 'Loops', component: LoopsPage },
+      { id: 'processes', label: 'Processes', component: ProcessesPage },
+      { id: 'schedules', label: 'Schedules', component: SchedulesPage },
+    ];
+    return { tabs };
+  },
+  template: `<tabbed-page :tabs="tabs" default-tab="live" />`,
+};

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -17,5 +17,5 @@ export default {
     ];
     return { tabs };
   },
-  template: `<tabbed-page :tabs="tabs" default-tab="health" />`,
+  template: `<tabbed-page :tabs="tabs" default-tab="health" group-label="System" />`,
 };

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -1,0 +1,21 @@
+import TabbedPage from './tabbed-page.js';
+import HealthPage from './health.js';
+import ResourcesPage from './resources.js';
+import LogsPage from './logs.js';
+import ConfigPage from './config.js';
+import InternalsPage from './internals.js';
+
+export default {
+  components: { TabbedPage },
+  setup() {
+    const tabs = [
+      { id: 'health', label: 'Health', component: HealthPage },
+      { id: 'resources', label: 'Resources', component: ResourcesPage },
+      { id: 'logs', label: 'Logs', component: LogsPage },
+      { id: 'config', label: 'Config', component: ConfigPage },
+      { id: 'internals', label: 'Internals', component: InternalsPage },
+    ];
+    return { tabs };
+  },
+  template: `<tabbed-page :tabs="tabs" default-tab="health" />`,
+};

--- a/ui/js/pages/tabbed-page.js
+++ b/ui/js/pages/tabbed-page.js
@@ -1,0 +1,38 @@
+/**
+ * TabbedPage — Reusable wrapper that renders sub-pages as tabs
+ */
+const { ref, computed, watch } = Vue;
+
+export default {
+  props: {
+    tabs: { type: Array, required: true },
+    // Each tab: { id: 'live', label: 'Live', component: ComponentRef }
+    defaultTab: { type: String, default: '' },
+  },
+  setup(props) {
+    const activeTab = ref(props.defaultTab || props.tabs[0]?.id || '');
+
+    const activeComponent = computed(() => {
+      const tab = props.tabs.find(t => t.id === activeTab.value);
+      return tab?.component || null;
+    });
+
+    return { activeTab, activeComponent };
+  },
+  template: `
+    <div>
+      <div class="flex border-b border-gray-700 mb-4 overflow-x-auto">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          @click="activeTab = tab.id"
+          class="px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors"
+          :class="activeTab === tab.id
+            ? 'text-blue-400 border-b-2 border-blue-400'
+            : 'text-gray-400 hover:text-gray-200'"
+        >{{ tab.label }}</button>
+      </div>
+      <component :is="activeComponent" />
+    </div>
+  `,
+};

--- a/ui/js/pages/tabbed-page.js
+++ b/ui/js/pages/tabbed-page.js
@@ -1,38 +1,72 @@
 /**
- * TabbedPage — Reusable wrapper that renders sub-pages as tabs
+ * TabbedPage — Reusable wrapper with URL-driven tabs
+ * Tab state persisted in query param (?tab=agents) for deep-linking,
+ * back/forward support, and refresh survival.
  */
-const { ref, computed, watch } = Vue;
+const { computed, watch, onMounted } = Vue;
+const { useRoute, useRouter } = VueRouter;
 
 export default {
   props: {
     tabs: { type: Array, required: true },
-    // Each tab: { id: 'live', label: 'Live', component: ComponentRef }
     defaultTab: { type: String, default: '' },
+    groupLabel: { type: String, default: '' },
   },
   setup(props) {
-    const activeTab = ref(props.defaultTab || props.tabs[0]?.id || '');
+    const route = useRoute();
+    const router = useRouter();
+
+    const activeTab = computed({
+      get() {
+        const q = route.query.tab;
+        if (q && props.tabs.some(t => t.id === q)) return q;
+        return props.defaultTab || props.tabs[0]?.id || '';
+      },
+      set(val) {
+        router.replace({ query: { ...route.query, tab: val } });
+      },
+    });
 
     const activeComponent = computed(() => {
       const tab = props.tabs.find(t => t.id === activeTab.value);
       return tab?.component || null;
     });
 
-    return { activeTab, activeComponent };
+    const activeLabel = computed(() => {
+      const tab = props.tabs.find(t => t.id === activeTab.value);
+      return tab?.label || '';
+    });
+
+    watch(activeLabel, (label) => {
+      if (props.groupLabel && label) {
+        document.title = `Odin \u2014 ${props.groupLabel} \u203A ${label}`;
+      }
+    }, { immediate: true });
+
+    return { activeTab, activeComponent, activeLabel };
   },
   template: `
     <div>
-      <div class="flex border-b border-gray-700 mb-4 overflow-x-auto">
+      <div class="flex border-b border-gray-700 mb-4 overflow-x-auto" role="tablist" :aria-label="groupLabel + ' navigation'">
         <button
           v-for="tab in tabs"
           :key="tab.id"
           @click="activeTab = tab.id"
+          role="tab"
+          :id="'tab-' + tab.id"
+          :aria-selected="activeTab === tab.id"
+          :aria-controls="'panel-' + tab.id"
           class="px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors"
           :class="activeTab === tab.id
             ? 'text-blue-400 border-b-2 border-blue-400'
             : 'text-gray-400 hover:text-gray-200'"
         >{{ tab.label }}</button>
       </div>
-      <component :is="activeComponent" />
+      <div role="tabpanel" :id="'panel-' + activeTab" :aria-labelledby="'tab-' + activeTab">
+        <keep-alive>
+          <component :is="activeComponent" :key="activeTab" />
+        </keep-alive>
+      </div>
     </div>
   `,
 };


### PR DESCRIPTION
## Summary
Consolidates 19 separate nav items into 6 operator-intent groups:

| Nav Item | Sub-tabs |
|----------|----------|
| Dashboard | (unchanged) |
| Chat | (unchanged) |
| Operations | Live, Agents, Loops, Processes, Schedules |
| History | Audit, Sessions, Traces, Usage |
| Capabilities | Tools, Skills, Knowledge, Memory |
| System | Health, Resources, Logs, Config, Internals |

All existing pages preserved as tab content. New `TabbedPage` component for sub-navigation.

## Test plan
- [ ] Odin review (approve/reject, do NOT merge)
- [ ] Visual verification in browser