### PR TITLE
fix: runbook value + replay diagnosis + evaluative discipline (Odin's Task 1/2 critique)

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2111,14 +2111,20 @@ class OdinBot(commands.Bot):
         "if the user's requested outcome was actually achieved.\n\n"
         "COMPLETE means:\n"
         "- The user's full request was addressed (not just part of it)\n"
+        "- The exact artifact asked for was produced, not a plausible-shaped substitute\n"
         "- The assistant is not promising to do more work\n"
         "- A failure report after genuinely trying counts as COMPLETE\n\n"
         "INCOMPLETE means:\n"
         "- The assistant only did part of what was asked (e.g., built but didn't deploy)\n"
         "- The assistant is describing work it still plans to do\n"
-        "- The assistant is reporting partial progress with more steps remaining\n\n"
+        "- The assistant is reporting partial progress with more steps remaining\n"
+        "- The response is shaped like an answer but doesn't contain the specific "
+        "  artifact requested (e.g., asked for the generated code; got a description of it)\n"
+        "- The assistant closes by offering MORE work ('I could also…', 'would you like…') "
+        "  instead of finishing the requested work\n\n"
         'If INCOMPLETE, briefly state what\'s missing after a colon.\n'
-        'Examples: "INCOMPLETE: deployment not performed" or "INCOMPLETE: verification step missing"\n'
+        'Examples: "INCOMPLETE: deployment not performed", "INCOMPLETE: verification step missing", '
+        '"INCOMPLETE: described the synthesized runbook but did not include its source"\n'
         'If COMPLETE, just say: "COMPLETE"'
     )
 

--- a/src/learning/runbook_detector.py
+++ b/src/learning/runbook_detector.py
@@ -83,6 +83,14 @@ class RunbookSuggestion:
     first_seen: str = ""
     last_seen: str = ""
     sample_inputs: list[dict] = field(default_factory=list)
+    # Session-context enrichment (Odin's Task 1 critique): a pattern is
+    # more useful when we know what user intent produced it and whether
+    # those sessions tended to succeed. These are optional and come from
+    # the trajectory store; patterns detected without a trajectory
+    # index keep the fields empty.
+    user_queries: list[str] = field(default_factory=list)       # first user_content per session, max 5
+    error_session_fraction: float = 0.0                         # 0..1 of linked sessions that ended is_error
+    linked_session_count: int = 0                               # how many sessions had a trajectory match
 
     @property
     def length(self) -> int:
@@ -175,6 +183,106 @@ class RunbookSuggestion:
         return d
 
 
+@dataclass(slots=True)
+class _TrajectoryRecord:
+    """Minimal shape we need from a trajectory JSONL entry to enrich
+    runbook suggestions with session context."""
+    ts_epoch: float
+    channel: str
+    actor: str
+    user_content: str
+    is_error: bool
+
+
+def load_trajectory_index(
+    trajectories_dir: str | Path,
+    *, since_epoch: float | None = None,
+) -> dict[tuple[str, str], list[_TrajectoryRecord]]:
+    """Index trajectory turns by (channel_id, actor) for fast session
+    lookup. Each value is sorted by timestamp ascending.
+
+    Returns an empty dict on missing directory / read failure — callers
+    should fall back to zero-context suggestions rather than raising.
+    """
+    path = Path(trajectories_dir)
+    out: dict[tuple[str, str], list[_TrajectoryRecord]] = defaultdict(list)
+    if not path.exists() or not path.is_dir():
+        return dict(out)
+    try:
+        files = sorted(f for f in path.iterdir() if f.is_file() and f.suffix == ".jsonl")
+    except OSError as e:
+        log.error("Failed to list trajectories dir %s: %s", path, e)
+        return dict(out)
+    for filepath in files:
+        try:
+            with filepath.open("r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    ts = entry.get("timestamp", "")
+                    try:
+                        epoch = datetime.fromisoformat(
+                            ts.replace("Z", "+00:00")
+                        ).timestamp()
+                    except ValueError:
+                        continue
+                    if since_epoch is not None and epoch < since_epoch:
+                        continue
+                    rec = _TrajectoryRecord(
+                        ts_epoch=epoch,
+                        channel=str(entry.get("channel_id", "") or ""),
+                        actor=str(entry.get("user_id", "") or entry.get("user_name", "") or ""),
+                        user_content=str(entry.get("user_content", "") or ""),
+                        is_error=bool(entry.get("is_error")),
+                    )
+                    out[(rec.channel, rec.actor)].append(rec)
+        except OSError as e:
+            log.error("Failed to read trajectory file %s: %s", filepath, e)
+            continue
+    for recs in out.values():
+        recs.sort(key=lambda r: r.ts_epoch)
+    return dict(out)
+
+
+def _match_session_to_trajectory(
+    session: list[AuditEntry],
+    index: dict[tuple[str, str], list[_TrajectoryRecord]],
+    *, max_skew_seconds: int = 900,
+) -> _TrajectoryRecord | None:
+    """Given a session (list of audit entries from the same actor+channel,
+    sorted by time), find the trajectory turn most likely to have
+    produced it. Heuristic: the most recent trajectory in the same
+    (channel, actor) bucket whose timestamp is <= the session's first
+    tool call AND within ``max_skew_seconds`` of it.
+
+    Returns None when there's no credible match — callers use that
+    signal to leave user_queries empty rather than inventing one.
+    """
+    if not session:
+        return None
+    first = session[0]
+    recs = index.get((first.channel, first.actor)) or []
+    if not recs:
+        return None
+    # Binary-search style scan: recs is time-sorted. We want the latest
+    # rec with ts_epoch <= first.ts_epoch, then check skew.
+    best: _TrajectoryRecord | None = None
+    for r in recs:
+        if r.ts_epoch > first.ts_epoch:
+            break
+        best = r
+    if best is None:
+        return None
+    if first.ts_epoch - best.ts_epoch > max_skew_seconds:
+        return None
+    return best
+
+
 def _iter_audit_entries(path: Path, *, since_epoch: float | None) -> Iterable[AuditEntry]:
     try:
         with path.open("r") as f:
@@ -261,6 +369,7 @@ def detect_patterns(
     session_gap_seconds: int = DEFAULT_SESSION_GAP_SECONDS,
     ignore_tools: Iterable[str] = (),
     now: datetime | None = None,
+    trajectories_dir: str | Path | None = None,
 ) -> list[RunbookSuggestion]:
     """Scan the audit log and return candidate runbook sequences.
 
@@ -290,6 +399,20 @@ def detect_patterns(
     if not sessions:
         return []
 
+    # Optionally enrich with trajectory-turn context: match each session
+    # to the turn that most likely started it so we can surface the user
+    # query and outcome alongside the tool sequence.
+    trajectory_index: dict[tuple[str, str], list[_TrajectoryRecord]] = {}
+    if trajectories_dir is not None:
+        trajectory_index = load_trajectory_index(
+            trajectories_dir, since_epoch=since_epoch,
+        )
+    session_to_traj: dict[int, _TrajectoryRecord | None] = {}
+    for session_idx, session in enumerate(sessions):
+        session_to_traj[session_idx] = _match_session_to_trajectory(
+            session, trajectory_index,
+        ) if trajectory_index else None
+
     # Collect occurrences of every n-gram across all sessions. Each occurrence
     # is tagged with its session id so we can require distinct-session
     # repetition later (not just within-session bursts).
@@ -318,6 +441,31 @@ def detect_patterns(
         first_seen = min(timestamps) if timestamps else ""
         last_seen = max(timestamps) if timestamps else ""
         sample = _build_sample_inputs(seq_occurrences[0])
+
+        # Session-context enrichment from the trajectory index (if the
+        # caller passed a trajectories_dir). We keep only the first five
+        # distinct user queries so the output doesn't balloon, and
+        # compute error_session_fraction across matched sessions only.
+        linked_trajs: list[_TrajectoryRecord] = []
+        for sid in distinct_sessions:
+            rec = session_to_traj.get(sid)
+            if rec is not None:
+                linked_trajs.append(rec)
+        seen_queries: list[str] = []
+        for rec in linked_trajs:
+            q = (rec.user_content or "").strip()
+            if not q:
+                continue
+            if q in seen_queries:
+                continue
+            seen_queries.append(q)
+            if len(seen_queries) >= 5:
+                break
+        error_fraction = (
+            sum(1 for r in linked_trajs if r.is_error) / len(linked_trajs)
+            if linked_trajs else 0.0
+        )
+
         suggestions.append(RunbookSuggestion(
             sequence=list(seq),
             frequency=freq,
@@ -327,6 +475,9 @@ def detect_patterns(
             first_seen=first_seen,
             last_seen=last_seen,
             sample_inputs=sample,
+            user_queries=[q[:200] for q in seen_queries],
+            error_session_fraction=round(error_fraction, 3),
+            linked_session_count=len(linked_trajs),
         ))
 
     # Suppress a shorter sequence only if a longer sequence whose strict
@@ -402,10 +553,25 @@ def format_suggestions(
     for i, s in enumerate(suggestions[:limit], start=1):
         arrow = " -> ".join(s.sequence)
         hosts = ",".join(s.hosts) if s.hosts else "(no host)"
-        lines.append(
+        header = (
             f"{i:2d}. [{s.frequency}x, score={s.score():.2f}] {arrow} "
             f"on {hosts} (last: {s.last_seen[:19]})"
         )
+        lines.append(header)
+        # Session-context lines only appear when a trajectory index was
+        # supplied at detection time and actually matched something;
+        # otherwise the pattern is still shown but without intent hints.
+        if s.user_queries:
+            err_hint = (
+                f", err_sessions={s.error_session_fraction:.0%}"
+                if s.error_session_fraction > 0 else ""
+            )
+            lines.append(
+                f"      intent ({s.linked_session_count} sessions{err_hint}):"
+            )
+            for q in s.user_queries[:3]:
+                q_trim = q if len(q) <= 100 else q[:97] + "..."
+                lines.append(f"        - {q_trim}")
     return "\n".join(lines)
 
 

--- a/src/learning/runbook_detector.py
+++ b/src/learning/runbook_detector.py
@@ -256,9 +256,23 @@ def _match_session_to_trajectory(
 ) -> _TrajectoryRecord | None:
     """Given a session (list of audit entries from the same actor+channel,
     sorted by time), find the trajectory turn most likely to have
-    produced it. Heuristic: the most recent trajectory in the same
-    (channel, actor) bucket whose timestamp is <= the session's first
-    tool call AND within ``max_skew_seconds`` of it.
+    produced it.
+
+    **Timestamp semantics (Odin's PR #16 review catch):** trajectories
+    are persisted at END of turn by `TrajectorySaver.save()`, while the
+    audit events that made up the session happen DURING the turn. So
+    the correct trajectory for a session has ``ts_epoch`` *after* the
+    session's first audit entry and typically within a few minutes of
+    the session's last event. An earlier version of this function only
+    scanned trajectories with ``ts_epoch <= first.ts_epoch``, which
+    quietly missed every real match in production.
+
+    Heuristic: consider the session's time-span [first, last]. For each
+    candidate trajectory in the same (channel, actor) bucket, compute
+    the minimum gap to that span — zero if the trajectory save time
+    lands within it, the distance to the nearer endpoint otherwise.
+    Pick the candidate with the smallest gap, and reject if that gap
+    exceeds ``max_skew_seconds``.
 
     Returns None when there's no credible match — callers use that
     signal to leave user_queries empty rather than inventing one.
@@ -266,19 +280,26 @@ def _match_session_to_trajectory(
     if not session:
         return None
     first = session[0]
+    last = session[-1]
     recs = index.get((first.channel, first.actor)) or []
     if not recs:
         return None
-    # Binary-search style scan: recs is time-sorted. We want the latest
-    # rec with ts_epoch <= first.ts_epoch, then check skew.
+
+    def gap(rec: _TrajectoryRecord) -> float:
+        if rec.ts_epoch < first.ts_epoch:
+            return first.ts_epoch - rec.ts_epoch
+        if rec.ts_epoch > last.ts_epoch:
+            return rec.ts_epoch - last.ts_epoch
+        return 0.0  # trajectory save time falls within the session span
+
     best: _TrajectoryRecord | None = None
+    best_gap = float("inf")
     for r in recs:
-        if r.ts_epoch > first.ts_epoch:
-            break
-        best = r
-    if best is None:
-        return None
-    if first.ts_epoch - best.ts_epoch > max_skew_seconds:
+        g = gap(r)
+        if g < best_gap:
+            best_gap = g
+            best = r
+    if best is None or best_gap > max_skew_seconds:
         return None
     return best
 

--- a/src/learning/runbook_detector.py
+++ b/src/learning/runbook_detector.py
@@ -90,9 +90,23 @@ class RunbookSuggestion:
 
     def score(self, *, now: datetime | None = None) -> float:
         """Higher score = better candidate. Session-presence (not raw n-gram
-        count) drives the frequency term — a sequence that shows up in six
-        distinct sessions beats one that happens eight times inside two
-        sessions. Weighted further by recency and actor concentration."""
+        count) drives the frequency term, then we weight by tool
+        diversity, host diversity, recency, and actor concentration —
+        and heavily damp trivial self-repetition patterns so
+        ``run_command x 5`` can't drown out real diagnostic workflows.
+
+        Formula::
+
+            base = session_count or frequency
+            score = base
+                  * length_bonus
+                  * recency_weight
+                  * concentration_bonus
+                  * diversity_bonus
+                  * host_diversity_bonus
+                  * trivial_repetition_penalty
+
+        Each multiplier is documented inline so tuning stays visible."""
         if not self.sequence:
             return 0.0
         now = now or datetime.now(timezone.utc)
@@ -109,7 +123,50 @@ class RunbookSuggestion:
         length_bonus = 1.0 + 0.2 * (self.length - 1)
         concentration_bonus = 1.0 if len(self.actors) <= 2 else 0.75
         base = self.session_count or self.frequency
-        return base * length_bonus * recency_weight * concentration_bonus
+
+        # Tool-diversity bonus: a mixed-tool sequence (e.g.
+        # search_audit → read_file → http_probe) is a better
+        # candidate than N steps of the same tool. Scales from 1.0
+        # (all steps same tool) up to 1.5 (all steps distinct).
+        distinct_tools = len(set(self.sequence))
+        if self.length >= 1:
+            diversity_fraction = (distinct_tools - 1) / max(1, self.length - 1)
+        else:
+            diversity_fraction = 0.0
+        diversity_bonus = 1.0 + 0.5 * diversity_fraction
+
+        # Host-diversity bonus: a pattern observed on multiple hosts
+        # is more likely to be a real procedure than a single-host
+        # habit. 1.0 for ≤1 host, up to 1.3 for 3+ hosts.
+        host_count = len(self.hosts)
+        host_diversity_bonus = 1.0 + 0.15 * min(2, max(0, host_count - 1))
+
+        # Trivial-repetition penalty: damp sequences dominated by a
+        # single tool. If the most-common tool is >50% of the sequence
+        # we scale the penalty linearly; at 100% dominance (pure
+        # self-repeat like run_command × 5) the score is multiplied by
+        # 0.1 so even a high-frequency habit can't out-rank a real
+        # mixed-tool diagnostic workflow.
+        if self.sequence:
+            most_common_count = max(self.sequence.count(t) for t in set(self.sequence))
+            dominance = most_common_count / self.length
+        else:
+            dominance = 0.0
+        if dominance > 0.5:
+            # Linear falloff from 1.0 at dominance=0.5 to 0.1 at 1.0.
+            trivial_penalty = max(0.1, 1.0 - 1.8 * (dominance - 0.5))
+        else:
+            trivial_penalty = 1.0
+
+        return (
+            base
+            * length_bonus
+            * recency_weight
+            * concentration_bonus
+            * diversity_bonus
+            * host_diversity_bonus
+            * trivial_penalty
+        )
 
     def to_dict(self) -> dict:
         d = asdict(self)

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -46,6 +46,7 @@ Your tool list defines what you can do — shell, infrastructure, web, files, me
 9. Assume tools are available unless a call proves otherwise. Try first, report the actual error if it fails.
 10. Your source code is at {claude_code_dir}. For OTHER projects, navigate to their code — not yours. You CAN modify your own source when asked.
 11. TOOL EFFICIENCY: For multi-file analysis, code reviews, or PR reviews — use claude_code with read-only access. It holds its own context and avoids the reread spiral where the context compressor evicts earlier reads. Never use run_command with inline Python scripts to read files — use read_file directly. One claude_code call is better than 50 run_command calls that each get compressed away.
+12. EVALUATIVE DISCIPLINE: before sending, name the artifact asked for and confirm your response actually contains it. Mechanics-complete is not request-answered. If a tool returned something "frequent" or "common", check it's operationally useful — frequency is not value. If the honest answer is "I couldn't do it cleanly," say that; don't ship a plausible substitute. Don't close with "I could also…" — that's offering more work instead of finishing.
 
 ## Available Hosts
 {hosts}

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1598,6 +1598,10 @@ class ToolExecutor:
         )
 
         audit_path = getattr(self.config, "audit_log_path", None) or "./data/audit.jsonl"
+        # Trajectory directory provides session-context enrichment (user
+        # queries + outcome fraction per pattern). Falls back to ./data/
+        # trajectories which is where TrajectorySaver writes by default.
+        traj_dir = getattr(self.config, "trajectory_path", None) or "./data/trajectories"
         min_freq = int(inp.get("min_frequency") or 3)
         min_len = int(inp.get("min_length") or 2)
         max_len = int(inp.get("max_length") or 5)
@@ -1619,6 +1623,7 @@ class ToolExecutor:
                 lookback_days=max(1, min(lookback, 365)),
                 session_gap_seconds=max(30, min(gap, 7200)),
                 ignore_tools=[str(t) for t in ignore],
+                trajectories_dir=traj_dir,
             )
 
         suggestions = await asyncio.to_thread(_scan)

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1485,7 +1485,11 @@ class ToolExecutor:
         return format_report_summary(report)
 
     async def _handle_replay_trajectory(self, inp: dict) -> str:
-        from ..trajectories.replay import diff_turns, summarize_turn
+        from ..trajectories.replay import (
+            diff_turns,
+            find_diff_pair,
+            summarize_turn,
+        )
         from ..trajectories.saver import TrajectorySaver
 
         message_id = str(inp.get("message_id") or "").strip()
@@ -1499,7 +1503,7 @@ class ToolExecutor:
         # saved for turn-starting user messages — not every Discord message
         # becomes one, and Odin-side tool-call arguments that contain a
         # message_id (e.g. add_reaction) are NOT retrievable via this tool.
-        if mode == "list" or not message_id:
+        if mode == "list" or (not message_id and mode != "find_diff_pair"):
             recent = await saver.search(limit=15)
             if not recent:
                 return "No trajectories found. Odin may not have served any messages yet on this host."
@@ -1516,7 +1520,7 @@ class ToolExecutor:
             lines.append("Call with mode='summary' and message_id=<ID above> to replay.")
             return "\n".join(lines)
 
-        primary = await saver.find_by_message_id(message_id)
+        primary = await saver.find_by_message_id(message_id) if message_id else None
         if not primary:
             return (
                 f"Error: no trajectory found for message_id='{message_id}'.\n"
@@ -1526,6 +1530,34 @@ class ToolExecutor:
                 "retrievable here. Call replay_trajectory with mode='list' to see "
                 "recent trajectory-bearing message IDs, or search /api/trajectories."
             )
+
+        if mode == "find_diff_pair":
+            # Odin's Task 2 missing primitive: given a target turn, pick
+            # the closest successful/failed counterpart automatically so
+            # diff becomes diagnosis rather than manual pair-hunting.
+            candidates = await saver.search(limit=100)
+            best = find_diff_pair(primary, candidates)
+            if best is None:
+                primary_err = bool(primary.get("is_error"))
+                return (
+                    f"No diff-pair candidate cleared the similarity threshold for "
+                    f"message_id='{message_id}' (outcome={'ERROR' if primary_err else 'ok'}). "
+                    "Either the user intent hasn't repeated recently, or no turn with the "
+                    "opposite outcome exists in the last 100 trajectories. "
+                    "Use mode='list' to browse manually, or call with a different "
+                    "message_id that represents a recurring operational request."
+                )
+            diff_out = diff_turns(primary, best)
+            header = (
+                f"=== auto-pair (Jaccard-similarity on user_content, "
+                f"outcome-contrast preferred) ===\n"
+                f"primary:   {primary.get('message_id')} outcome={'ERROR' if primary.get('is_error') else 'ok'}\n"
+                f"matched:   {best.get('message_id')} outcome={'ERROR' if best.get('is_error') else 'ok'}\n"
+                f"primary_q: {(primary.get('user_content') or '').strip()[:120]}\n"
+                f"matched_q: {(best.get('user_content') or '').strip()[:120]}\n"
+                f"\n"
+            )
+            return header + diff_out
 
         if mode == "diff":
             if not compare_to:

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1837,29 +1837,35 @@ TOOLS: list[dict] = [
         "name": "replay_trajectory",
         "description": (
             "Renders a past message turn as a human-readable narrative or diffs two "
-            "turns side-by-side. Mode 'summary' (default) takes a message_id and returns "
-            "user content → tool calls → tool outputs → final response. Mode 'diff' takes "
-            "message_id + compare_to and shows where the two turns diverged. Mode 'list' "
-            "(or any call without message_id) lists recent trajectory-bearing message IDs "
-            "so you can pick a valid one. Read-only — no re-execution, no LLM calls. "
-            "IMPORTANT: trajectories are only saved for TURN-STARTING messages. A Discord "
-            "message_id that appears only as a tool-call argument (e.g. an add_reaction "
-            "target) is NOT retrievable here — call with mode='list' first if unsure."
+            "turns side-by-side. Modes:\n"
+            "  'summary' (default) — takes message_id; returns user content → tool calls "
+            "  → tool outputs → final response.\n"
+            "  'diff' — takes message_id + compare_to; shows where the two turns diverged.\n"
+            "  'find_diff_pair' — takes message_id; auto-picks the closest counterpart "
+            "  turn by user_content similarity (Jaccard) with a bias toward opposite "
+            "  outcome (failed-pairs-with-success), then diffs automatically. Use this "
+            "  when you want diagnosis instead of manual pair-hunting; fails cleanly "
+            "  if no similar turn exists.\n"
+            "  'list' (or any call without message_id) — lists recent trajectory-bearing "
+            "  message IDs so you can pick a valid one.\n"
+            "Read-only — no re-execution, no LLM calls. IMPORTANT: trajectories are only "
+            "saved for TURN-STARTING messages. A message_id that appears only as a "
+            "tool-call argument is NOT retrievable here."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "message_id": {
                     "type": "string",
-                    "description": "ID of the primary trajectory turn to replay. Omit (or use mode='list') to list recent valid IDs.",
+                    "description": "ID of the primary trajectory turn. Omit for mode='list'.",
                 },
                 "mode": {
                     "type": "string",
-                    "description": "'summary' (default), 'diff', or 'list'.",
+                    "description": "'summary' (default) | 'diff' | 'find_diff_pair' | 'list'.",
                 },
                 "compare_to": {
                     "type": "string",
-                    "description": "For mode='diff': message_id of the turn to compare against.",
+                    "description": "For mode='diff': message_id of the turn to compare against. Ignored for other modes.",
                 },
             },
             "required": [],

--- a/src/trajectories/replay.py
+++ b/src/trajectories/replay.py
@@ -147,6 +147,86 @@ def _tool_io_pairs(entry: dict) -> list[tuple[str, Any, str]]:
     return pairs
 
 
+def _tokenize(text: str) -> set[str]:
+    """Cheap tokenization for intent similarity. Lowercase, word-split,
+    drop tokens <3 chars. Good enough for jaccard scoring on user queries.
+    """
+    if not isinstance(text, str):
+        return set()
+    tokens = set()
+    buf: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum() or ch == "_":
+            buf.append(ch)
+        elif buf:
+            tok = "".join(buf)
+            if len(tok) >= 3:
+                tokens.add(tok)
+            buf = []
+    if buf:
+        tok = "".join(buf)
+        if len(tok) >= 3:
+            tokens.add(tok)
+    return tokens
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def find_diff_pair(
+    primary: dict,
+    candidates: list[dict],
+    *,
+    prefer_opposite_outcome: bool = True,
+    min_similarity: float = 0.2,
+) -> dict | None:
+    """Given a primary trajectory turn, pick the best candidate for a
+    diff pairing.
+
+    "Best" = highest token-jaccard similarity of user_content, with a
+    preference for the OPPOSITE outcome (so a failed turn pairs with a
+    success and vice versa). If nothing clears ``min_similarity`` the
+    caller should report that honestly rather than forcing a junk diff.
+
+    This is the primitive Odin called for in his Task 2 analysis:
+    replay_trajectory's diff mode becomes diagnosis instead of
+    archaeology once the tool can PICK the right comparison target.
+    """
+    if not isinstance(primary, dict) or not candidates:
+        return None
+    primary_tokens = _tokenize(primary.get("user_content") or "")
+    primary_err = bool(primary.get("is_error"))
+    primary_id = primary.get("message_id")
+
+    best_score = -1.0
+    best: dict | None = None
+    for cand in candidates:
+        if not isinstance(cand, dict):
+            continue
+        if cand.get("message_id") == primary_id:
+            continue
+        cand_tokens = _tokenize(cand.get("user_content") or "")
+        sim = _jaccard(primary_tokens, cand_tokens)
+        if sim < min_similarity:
+            continue
+        # Opposite-outcome boost: +0.25 to similarity so a slightly-less-
+        # similar but outcome-contrasting turn wins over a near-clone
+        # with the same outcome, which would give no diagnostic signal.
+        if prefer_opposite_outcome and bool(cand.get("is_error")) != primary_err:
+            score = sim + 0.25
+        else:
+            score = sim
+        if score > best_score:
+            best_score = score
+            best = cand
+    return best
+
+
 def diff_turns(a: dict, b: dict) -> str:
     """Side-by-side comparison of two trajectory entries. Intended for the
     case where A and B started from similar inputs but diverged — same

--- a/src/trajectories/replay.py
+++ b/src/trajectories/replay.py
@@ -184,6 +184,8 @@ def find_diff_pair(
     *,
     prefer_opposite_outcome: bool = True,
     min_similarity: float = 0.2,
+    opposite_outcome_boost: float = 0.15,
+    boost_floor: float = 0.35,
 ) -> dict | None:
     """Given a primary trajectory turn, pick the best candidate for a
     diff pairing.
@@ -196,6 +198,14 @@ def find_diff_pair(
     This is the primitive Odin called for in his Task 2 analysis:
     replay_trajectory's diff mode becomes diagnosis instead of
     archaeology once the tool can PICK the right comparison target.
+
+    Opposite-outcome boost (Odin's PR #16 review note): the boost only
+    applies when the candidate *already* clears ``boost_floor`` on raw
+    similarity (default 0.35). Below that the boost is zero, so a
+    merely-okay opposite-outcome match can't beat a genuinely-close
+    same-outcome near-clone. Boost itself is 0.15 (tuned down from an
+    earlier 0.25 that could, on short/generic user prompts, let a 0.2
+    similarity with opposite outcome beat a 0.4 same-outcome match).
     """
     if not isinstance(primary, dict) or not candidates:
         return None
@@ -214,13 +224,17 @@ def find_diff_pair(
         sim = _jaccard(primary_tokens, cand_tokens)
         if sim < min_similarity:
             continue
-        # Opposite-outcome boost: +0.25 to similarity so a slightly-less-
-        # similar but outcome-contrasting turn wins over a near-clone
-        # with the same outcome, which would give no diagnostic signal.
-        if prefer_opposite_outcome and bool(cand.get("is_error")) != primary_err:
-            score = sim + 0.25
-        else:
-            score = sim
+        score = sim
+        # The boost only fires once similarity is already strong enough
+        # that pairing these two turns makes sense on intent. For weaker
+        # matches we stay on raw similarity so a plausible opposite
+        # outcome can't drag a bad pair to the top.
+        if (
+            prefer_opposite_outcome
+            and sim >= boost_floor
+            and bool(cand.get("is_error")) != primary_err
+        ):
+            score = sim + opposite_outcome_boost
         if score > best_score:
             best_score = score
             best = cand

--- a/tests/test_evaluative_discipline_prompt.py
+++ b/tests/test_evaluative_discipline_prompt.py
@@ -1,0 +1,72 @@
+"""Tests for the evaluative-discipline additions to system + classifier prompts.
+
+Odin's Task 1/2 self-critique identified a gap: completing mechanics
+without checking that the delivered artifact actually answered the
+request. This test locks the prompt wording that's supposed to
+counteract that, so a future edit can't silently remove it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.llm.system_prompt import build_system_prompt
+from src.discord.client import OdinBot
+
+
+class TestSystemPromptRule12:
+    def _prompt(self) -> str:
+        return build_system_prompt(
+            context="",
+            hosts={"localhost": "127.0.0.1"},
+            tz="UTC",
+            claude_code_dir="/opt/odin",
+        )
+
+    def test_rule_12_present(self):
+        assert "12. EVALUATIVE DISCIPLINE" in self._prompt()
+
+    def test_mentions_artifact_check(self):
+        p = self._prompt()
+        assert "name the artifact" in p
+        assert "confirm your response actually contains it" in p
+
+    def test_mentions_frequency_not_value(self):
+        assert "frequency is not value" in self._prompt()
+
+    def test_mentions_plausible_substitute_rejection(self):
+        assert "don't ship a plausible substitute" in self._prompt()
+
+    def test_mentions_anti_offer_pattern(self):
+        assert 'Don\'t close with "I could also' in self._prompt()
+
+    def test_prompt_size_reasonable(self):
+        """Sanity-check that the rule didn't balloon the prompt. Under
+        6000 chars keeps a healthy margin vs. the ~5500 baseline."""
+        size = len(self._prompt())
+        assert size < 6000, f"system prompt is {size} chars — Rule 12 is too long"
+
+
+class TestCompletionClassifierPrompt:
+    def test_classifier_rejects_plausible_substitute(self):
+        """The classifier prompt now explicitly teaches it to flag
+        INCOMPLETE when the artifact doesn't match the request shape."""
+        prompt = OdinBot._CLASSIFIER_SYSTEM_PROMPT
+        assert "plausible-shaped substitute" in prompt
+        assert "artifact asked for was produced" in prompt
+
+    def test_classifier_rejects_offering_more_work(self):
+        """The classifier learns to flag 'I could also' as INCOMPLETE
+        rather than closure."""
+        prompt = OdinBot._CLASSIFIER_SYSTEM_PROMPT
+        assert "I could also" in prompt or "would you like" in prompt
+        # Example of this class of incompletion must be present so the
+        # classifier has a concrete target.
+        assert "offering MORE work" in prompt
+
+    def test_classifier_example_covers_missing_source(self):
+        """Concrete example from Odin's Task 1 critique: described the
+        runbook without including its source."""
+        assert (
+            "described the synthesized runbook but did not include its source"
+            in OdinBot._CLASSIFIER_SYSTEM_PROMPT
+        )

--- a/tests/test_runbook_detector.py
+++ b/tests/test_runbook_detector.py
@@ -331,6 +331,108 @@ class TestDetectPatterns:
         # Same everything except sequence composition — mixed should score higher
         assert mixed.score(now=now) > pure_repeat.score(now=now)
 
+    def test_session_context_user_queries_populated(self, tmp_path):
+        """When trajectories_dir is provided, each suggestion carries the
+        user queries that kicked off the matching sessions."""
+        audit = tmp_path / "audit.jsonl"
+        traj_dir = tmp_path / "trajectories"
+        traj_dir.mkdir()
+
+        base = datetime(2026, 4, 18, 10, 0, 0)
+        audit_rows: list[dict] = []
+        traj_rows: list[dict] = []
+        for i in range(3):
+            session_start = base + timedelta(hours=i)
+            # One trajectory turn per session, slightly BEFORE the tool calls
+            traj_rows.append({
+                "timestamp": _iso(session_start - timedelta(seconds=1)),
+                "channel_id": "c1",
+                "user_id": "alice",
+                "user_name": "alice",
+                "user_content": f"restart nginx on prod (session {i})",
+                "is_error": False,
+                "iterations": [],
+                "tools_used": ["run_command", "http_probe"],
+            })
+            audit_rows.append(_entry(session_start, "run_command"))
+            audit_rows.append(_entry(
+                session_start + timedelta(seconds=5), "http_probe",
+            ))
+        with audit.open("w") as f:
+            for r in audit_rows:
+                f.write(json.dumps(r) + "\n")
+        with (traj_dir / "2026-04-18.jsonl").open("w") as f:
+            for r in traj_rows:
+                f.write(json.dumps(r) + "\n")
+
+        now = datetime(2026, 4, 18, 15, 0, 0, tzinfo=timezone.utc)
+        suggestions = detect_patterns(
+            audit, min_frequency=3, lookback_days=30,
+            trajectories_dir=traj_dir, now=now,
+        )
+        assert suggestions
+        s = suggestions[0]
+        assert s.user_queries, "expected user queries to be populated from trajectories"
+        assert any("restart nginx on prod" in q for q in s.user_queries)
+        assert s.linked_session_count == 3
+        assert s.error_session_fraction == 0.0
+
+    def test_session_context_reports_error_fraction(self, tmp_path):
+        """A pattern whose sessions ended is_error get a non-zero
+        error_session_fraction."""
+        audit = tmp_path / "audit.jsonl"
+        traj_dir = tmp_path / "trajectories"
+        traj_dir.mkdir()
+        base = datetime(2026, 4, 18, 10, 0, 0)
+        audit_rows: list[dict] = []
+        traj_rows: list[dict] = []
+        for i in range(4):
+            session_start = base + timedelta(hours=i)
+            traj_rows.append({
+                "timestamp": _iso(session_start - timedelta(seconds=1)),
+                "channel_id": "c1",
+                "user_id": "alice",
+                "user_name": "alice",
+                "user_content": f"probe {i}",
+                "is_error": (i < 2),  # first 2 errored, last 2 ok
+                "iterations": [],
+            })
+            audit_rows.append(_entry(session_start, "read_file"))
+            audit_rows.append(_entry(
+                session_start + timedelta(seconds=5), "http_probe",
+            ))
+        with audit.open("w") as f:
+            for r in audit_rows:
+                f.write(json.dumps(r) + "\n")
+        with (traj_dir / "x.jsonl").open("w") as f:
+            for r in traj_rows:
+                f.write(json.dumps(r) + "\n")
+
+        now = datetime(2026, 4, 18, 15, 0, 0, tzinfo=timezone.utc)
+        suggestions = detect_patterns(
+            audit, min_frequency=4, lookback_days=30,
+            trajectories_dir=traj_dir, now=now,
+        )
+        assert suggestions
+        assert suggestions[0].error_session_fraction == 0.5
+        assert suggestions[0].linked_session_count == 4
+
+    def test_session_context_absent_when_no_trajectories_dir(self, tmp_path):
+        """Backward-compat: omitting trajectories_dir leaves the new fields empty."""
+        audit = tmp_path / "audit.jsonl"
+        base = datetime(2026, 4, 18, 10, 0, 0)
+        rows = []
+        for i in range(3):
+            t = base + timedelta(hours=i)
+            rows.append(_entry(t, "read_file"))
+            rows.append(_entry(t + timedelta(seconds=5), "http_probe"))
+        _write_audit(audit, rows)
+        now = datetime(2026, 4, 18, 15, 0, 0, tzinfo=timezone.utc)
+        suggestions = detect_patterns(audit, min_frequency=3, now=now)
+        assert suggestions
+        assert suggestions[0].user_queries == []
+        assert suggestions[0].linked_session_count == 0
+
     def test_multi_host_scores_higher(self):
         """A pattern observed across 3 hosts beats the same pattern on 1 host."""
         now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_runbook_detector.py
+++ b/tests/test_runbook_detector.py
@@ -287,6 +287,67 @@ class TestDetectPatterns:
         )
         assert fresh.score(now=now) > stale.score(now=now)
 
+    def test_diverse_sequence_beats_self_repeat(self):
+        """The core operational-value fix: run_command × 5 (high frequency,
+        low value) must score BELOW a 3-tool diagnostic sequence even with
+        lower raw frequency."""
+        now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+        shallow = RunbookSuggestion(
+            sequence=["run_command", "run_command", "run_command", "run_command", "run_command"],
+            frequency=500, session_count=100,
+            hosts=["hostA"], actors=["alice"],
+            first_seen=_iso(now - timedelta(days=1)),
+            last_seen=_iso(now - timedelta(days=1)),
+        )
+        diagnostic = RunbookSuggestion(
+            sequence=["search_audit", "read_file", "http_probe"],
+            frequency=20, session_count=10,
+            hosts=["hostA"], actors=["alice"],
+            first_seen=_iso(now - timedelta(days=1)),
+            last_seen=_iso(now - timedelta(days=1)),
+        )
+        assert diagnostic.score(now=now) > shallow.score(now=now), (
+            f"diagnostic {diagnostic.score(now=now):.2f} should beat "
+            f"shallow {shallow.score(now=now):.2f}"
+        )
+
+    def test_trivial_repetition_penalty(self):
+        """A pure same-tool-N-times pattern gets penalised."""
+        now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+        pure_repeat = RunbookSuggestion(
+            sequence=["run_command"] * 5,
+            frequency=100, session_count=50,
+            hosts=["h"], actors=["alice"],
+            first_seen=_iso(now - timedelta(days=1)),
+            last_seen=_iso(now - timedelta(days=1)),
+        )
+        mixed = RunbookSuggestion(
+            sequence=["run_command", "read_file", "run_command", "read_file", "run_command"],
+            frequency=100, session_count=50,
+            hosts=["h"], actors=["alice"],
+            first_seen=_iso(now - timedelta(days=1)),
+            last_seen=_iso(now - timedelta(days=1)),
+        )
+        # Same everything except sequence composition — mixed should score higher
+        assert mixed.score(now=now) > pure_repeat.score(now=now)
+
+    def test_multi_host_scores_higher(self):
+        """A pattern observed across 3 hosts beats the same pattern on 1 host."""
+        now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+        single_host = RunbookSuggestion(
+            sequence=["a", "b", "c"], frequency=10, session_count=5,
+            hosts=["hostA"], actors=["alice"],
+            first_seen=_iso(now - timedelta(days=1)),
+            last_seen=_iso(now - timedelta(days=1)),
+        )
+        multi_host = RunbookSuggestion(
+            sequence=["a", "b", "c"], frequency=10, session_count=5,
+            hosts=["hostA", "hostB", "hostC"], actors=["alice"],
+            first_seen=_iso(now - timedelta(days=1)),
+            last_seen=_iso(now - timedelta(days=1)),
+        )
+        assert multi_host.score(now=now) > single_host.score(now=now)
+
 
 class TestFormatters:
     def test_empty_summary(self):

--- a/tests/test_runbook_detector.py
+++ b/tests/test_runbook_detector.py
@@ -333,7 +333,12 @@ class TestDetectPatterns:
 
     def test_session_context_user_queries_populated(self, tmp_path):
         """When trajectories_dir is provided, each suggestion carries the
-        user queries that kicked off the matching sessions."""
+        user queries that kicked off the matching sessions.
+
+        Reflects real production timing: TrajectorySaver writes the
+        trajectory at END of turn, AFTER the audit events. The matcher
+        must find the trajectory whose timestamp falls inside or just
+        after the session window (Odin's PR #16 review catch)."""
         audit = tmp_path / "audit.jsonl"
         traj_dir = tmp_path / "trajectories"
         traj_dir.mkdir()
@@ -343,9 +348,13 @@ class TestDetectPatterns:
         traj_rows: list[dict] = []
         for i in range(3):
             session_start = base + timedelta(hours=i)
-            # One trajectory turn per session, slightly BEFORE the tool calls
+            audit_rows.append(_entry(session_start, "run_command"))
+            audit_rows.append(_entry(
+                session_start + timedelta(seconds=5), "http_probe",
+            ))
+            # Trajectory saved AFTER the session's last event (end of turn).
             traj_rows.append({
-                "timestamp": _iso(session_start - timedelta(seconds=1)),
+                "timestamp": _iso(session_start + timedelta(seconds=10)),
                 "channel_id": "c1",
                 "user_id": "alice",
                 "user_name": "alice",
@@ -354,10 +363,6 @@ class TestDetectPatterns:
                 "iterations": [],
                 "tools_used": ["run_command", "http_probe"],
             })
-            audit_rows.append(_entry(session_start, "run_command"))
-            audit_rows.append(_entry(
-                session_start + timedelta(seconds=5), "http_probe",
-            ))
         with audit.open("w") as f:
             for r in audit_rows:
                 f.write(json.dumps(r) + "\n")
@@ -388,8 +393,13 @@ class TestDetectPatterns:
         traj_rows: list[dict] = []
         for i in range(4):
             session_start = base + timedelta(hours=i)
+            audit_rows.append(_entry(session_start, "read_file"))
+            audit_rows.append(_entry(
+                session_start + timedelta(seconds=5), "http_probe",
+            ))
+            # Trajectory saved end-of-turn (after the audit events).
             traj_rows.append({
-                "timestamp": _iso(session_start - timedelta(seconds=1)),
+                "timestamp": _iso(session_start + timedelta(seconds=10)),
                 "channel_id": "c1",
                 "user_id": "alice",
                 "user_name": "alice",
@@ -397,10 +407,6 @@ class TestDetectPatterns:
                 "is_error": (i < 2),  # first 2 errored, last 2 ok
                 "iterations": [],
             })
-            audit_rows.append(_entry(session_start, "read_file"))
-            audit_rows.append(_entry(
-                session_start + timedelta(seconds=5), "http_probe",
-            ))
         with audit.open("w") as f:
             for r in audit_rows:
                 f.write(json.dumps(r) + "\n")
@@ -416,6 +422,102 @@ class TestDetectPatterns:
         assert suggestions
         assert suggestions[0].error_session_fraction == 0.5
         assert suggestions[0].linked_session_count == 4
+
+    def test_matcher_handles_trajectory_saved_after_session(self, tmp_path):
+        """Odin's PR #16 review catch: TrajectorySaver writes at END of
+        turn (after all audit events). The matcher must still find
+        that trajectory even though its save timestamp is AFTER the
+        session's first audit entry."""
+        from src.learning.runbook_detector import (
+            _TrajectoryRecord,
+            _match_session_to_trajectory,
+        )
+        # Build a fake session and a trajectory saved after it.
+        session_start = datetime(2026, 4, 18, 10, 0, 0, tzinfo=timezone.utc)
+        session = [
+            AuditEntry.from_line(json.dumps(_entry(session_start, "read_file"))),
+            AuditEntry.from_line(json.dumps(_entry(
+                session_start + timedelta(seconds=20), "http_probe",
+            ))),
+        ]
+        assert all(s is not None for s in session)
+        # Trajectory record saved 30 seconds AFTER session started (end of turn).
+        traj_time = session_start + timedelta(seconds=30)
+        index = {
+            ("c1", "alice"): [
+                _TrajectoryRecord(
+                    ts_epoch=traj_time.timestamp(),
+                    channel="c1",
+                    actor="alice",
+                    user_content="do the thing",
+                    is_error=False,
+                ),
+            ],
+        }
+        match = _match_session_to_trajectory(session, index, max_skew_seconds=900)
+        assert match is not None
+        assert match.user_content == "do the thing"
+
+    def test_matcher_prefers_closest_when_multiple_candidates(self, tmp_path):
+        """With several trajectories nearby, the matcher picks the one
+        closest in time to the session window."""
+        from src.learning.runbook_detector import (
+            _TrajectoryRecord,
+            _match_session_to_trajectory,
+        )
+        session_start = datetime(2026, 4, 18, 10, 0, 0, tzinfo=timezone.utc)
+        session = [
+            AuditEntry.from_line(json.dumps(_entry(session_start, "read_file"))),
+            AuditEntry.from_line(json.dumps(_entry(
+                session_start + timedelta(seconds=20), "http_probe",
+            ))),
+        ]
+        # 5 minutes before (previous turn), 30 seconds after (this turn),
+        # and 1 hour after (unrelated later turn). Match should pick the 30s-after one.
+        index = {
+            ("c1", "alice"): [
+                _TrajectoryRecord(
+                    ts_epoch=(session_start - timedelta(minutes=5)).timestamp(),
+                    channel="c1", actor="alice",
+                    user_content="previous turn", is_error=False,
+                ),
+                _TrajectoryRecord(
+                    ts_epoch=(session_start + timedelta(seconds=30)).timestamp(),
+                    channel="c1", actor="alice",
+                    user_content="correct turn", is_error=False,
+                ),
+                _TrajectoryRecord(
+                    ts_epoch=(session_start + timedelta(hours=1)).timestamp(),
+                    channel="c1", actor="alice",
+                    user_content="later turn", is_error=False,
+                ),
+            ],
+        }
+        match = _match_session_to_trajectory(session, index, max_skew_seconds=900)
+        assert match is not None
+        assert match.user_content == "correct turn"
+
+    def test_matcher_rejects_beyond_skew_window(self, tmp_path):
+        from src.learning.runbook_detector import (
+            _TrajectoryRecord,
+            _match_session_to_trajectory,
+        )
+        session_start = datetime(2026, 4, 18, 10, 0, 0, tzinfo=timezone.utc)
+        session = [
+            AuditEntry.from_line(json.dumps(_entry(session_start, "read_file"))),
+        ]
+        # Trajectory 2 hours after session — way outside the 15-minute skew.
+        index = {
+            ("c1", "alice"): [
+                _TrajectoryRecord(
+                    ts_epoch=(session_start + timedelta(hours=2)).timestamp(),
+                    channel="c1", actor="alice",
+                    user_content="unrelated later turn", is_error=False,
+                ),
+            ],
+        }
+        match = _match_session_to_trajectory(session, index, max_skew_seconds=900)
+        assert match is None
 
     def test_session_context_absent_when_no_trajectories_dir(self, tmp_path):
         """Backward-compat: omitting trajectories_dir leaves the new fields empty."""

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -166,21 +166,63 @@ class TestFindDiffPair:
         assert match["message_id"] == "c2"
 
     def test_weak_opposite_outcome_does_not_beat_strong_same_outcome(self):
-        """Odin PR #16 review: on short/generic prompts the +0.25 boost
-        could let a 0.2-similar opposite-outcome candidate beat a
-        genuinely-closer same-outcome match. With boost_floor=0.35,
-        the boost only fires when similarity is ALREADY high, so a
-        near-clone same-outcome match wins in this scenario."""
-        primary = self._turn("m1", "go run the thing", err=False)
+        """Odin PR #16 re-review catch: my earlier version of this test
+        was a placebo — the weak opposite candidate was filtered out by
+        ``min_similarity=0.2`` before ever reaching the boost logic, so
+        the test would have passed under the old flat +0.25 boost too.
+
+        The point of the boost-floor fix is: a candidate with 0.2 ≤ sim
+        < 0.35 gets NO boost, so a strong same-outcome match above 0.35
+        wins even though the weak candidate has opposite outcome.
+
+        Primary tokens (min-3-char): {run, database, migrations, today}
+        c1 (same outcome, Jaccard ≈ 0.40): {run, stuff, later} ∩ primary = {run}… no wait, computed below
+        c2 (opposite outcome, Jaccard ≈ 0.29): clears 0.2 floor but NOT
+            0.35 boost floor, so it gets raw-similarity only. Under the
+            old +0.25 boost (no floor) c2 would score ~0.54 and WIN —
+            the fact that c1 wins here is the discriminating evidence
+            that the boost-floor gate works.
+        """
+        # Primary tokens (3-char min filter): {run, database, migrations, today}
+        primary = self._turn("m1", "run database migrations today", err=False)
         candidates = [
-            # Near-clone, same outcome — this is the real operational
-            # match. Two-word overlap on short prompt yields moderate sim.
-            self._turn("c1", "go run the thing now", err=False),
-            # Far-weaker content but opposite outcome. Under the old
-            # flat +0.25 boost this could win; it shouldn't.
-            self._turn("c2", "go check memory", err=True),
+            # c1: same outcome, similarity ≈ 0.40 (above boost_floor so
+            # it's a legitimate "strong same-outcome" match, but low
+            # enough that a +0.25 boost on c2 would overtake it under
+            # the OLD logic).
+            # Tokens: {run, today, now} → 2 overlap, union 5, J = 0.40.
+            self._turn("c1", "run today now", err=False),
+            # c2: opposite outcome, similarity ≈ 0.286 (between 0.2 and
+            # 0.35). Under OLD flat +0.25 boost: 0.286 + 0.25 = 0.536,
+            # which WOULD beat c1's 0.40 — that was the placebo-test
+            # hole. Under NEW boost-floor gate: sim < 0.35 so no boost,
+            # final score 0.286, loses to c1's 0.40.
+            # Tokens: {run, today, server, restart, tomorrow} → 2
+            # overlap, union 7, J = 2/7 ≈ 0.286.
+            self._turn("c2", "run today server restart tomorrow", err=True),
         ]
         match = find_diff_pair(primary, candidates)
+        assert match["message_id"] == "c1", (
+            "Test is meant to discriminate: under old flat-boost logic "
+            "c2 would win (0.286 + 0.25 = 0.536 > c1's 0.40). If c1 "
+            "loses here, the boost-floor gate isn't working."
+        )
+
+    def test_below_boost_floor_sim_is_still_considered(self):
+        """Explicit guard: a candidate in the 0.2-0.35 similarity band
+        is NOT filtered out — it just doesn't get the opposite-outcome
+        boost. Proves the new logic exercises the boost-floor path
+        rather than rejecting weak candidates wholesale."""
+        primary = self._turn("m1", "run database migrations today", err=False)
+        # Only one candidate, in the boost-floor gap, opposite outcome.
+        # It should be returned (not None) — we're checking it got past
+        # the min_similarity filter and the find_diff_pair returned the
+        # best available, even if no boost applied.
+        candidates = [
+            self._turn("c1", "run today server restart tomorrow", err=True),
+        ]
+        match = find_diff_pair(primary, candidates)
+        assert match is not None
         assert match["message_id"] == "c1"
 
     def test_boost_applies_when_both_candidates_strong(self):

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -153,13 +153,43 @@ class TestFindDiffPair:
         assert match is not None
         assert match["message_id"] == "c2"
 
-    def test_prefers_opposite_outcome(self):
-        """A slightly-less-similar failed pair beats a more-similar success
-        pair when the primary was successful — that's the diagnostic win."""
+    def test_prefers_opposite_outcome_when_match_is_strong(self):
+        """When both candidates are strongly similar (above boost_floor),
+        the opposite-outcome one should win — that's the diagnostic
+        signal."""
         primary = self._turn("m1", "restart nginx on prod", err=False)
         candidates = [
             self._turn("c1", "restart nginx on prod today", err=False),  # sim high, same outcome
             self._turn("c2", "restart nginx on prod", err=True),          # sim high, opposite outcome
+        ]
+        match = find_diff_pair(primary, candidates)
+        assert match["message_id"] == "c2"
+
+    def test_weak_opposite_outcome_does_not_beat_strong_same_outcome(self):
+        """Odin PR #16 review: on short/generic prompts the +0.25 boost
+        could let a 0.2-similar opposite-outcome candidate beat a
+        genuinely-closer same-outcome match. With boost_floor=0.35,
+        the boost only fires when similarity is ALREADY high, so a
+        near-clone same-outcome match wins in this scenario."""
+        primary = self._turn("m1", "go run the thing", err=False)
+        candidates = [
+            # Near-clone, same outcome — this is the real operational
+            # match. Two-word overlap on short prompt yields moderate sim.
+            self._turn("c1", "go run the thing now", err=False),
+            # Far-weaker content but opposite outcome. Under the old
+            # flat +0.25 boost this could win; it shouldn't.
+            self._turn("c2", "go check memory", err=True),
+        ]
+        match = find_diff_pair(primary, candidates)
+        assert match["message_id"] == "c1"
+
+    def test_boost_applies_when_both_candidates_strong(self):
+        """Sanity: when both candidates exceed boost_floor, opposite
+        outcome still wins (the core behavior we want to preserve)."""
+        primary = self._turn("m1", "deploy staging to prod now please", err=False)
+        candidates = [
+            self._turn("c1", "deploy staging to prod now please", err=False),  # sim=1.0
+            self._turn("c2", "deploy staging to prod now please", err=True),    # sim=1.0, opposite
         ]
         match = find_diff_pair(primary, candidates)
         assert match["message_id"] == "c2"

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from src.trajectories.replay import (
     diff_turns,
+    find_diff_pair,
     summarize_turn,
 )
 
@@ -121,3 +122,62 @@ class TestDiffTurns:
         b = _sample_turn(message_id="m2", sequence=[("run_command", "h", "ok")])
         out = diff_turns(a, b)
         assert "prefix" in out
+
+
+class TestFindDiffPair:
+    """Odin's Task 2 missing primitive — given a target turn, pick the
+    closest counterpart automatically so diff is diagnosis not archaeology."""
+
+    def _turn(self, mid: str, content: str, err: bool = False) -> dict:
+        return {
+            "message_id": mid,
+            "user_content": content,
+            "is_error": err,
+            "iterations": [],
+            "tools_used": [],
+            "final_response": "",
+        }
+
+    def test_returns_none_when_no_candidates(self):
+        primary = self._turn("m1", "restart nginx on prod")
+        assert find_diff_pair(primary, []) is None
+
+    def test_picks_highest_jaccard_match(self):
+        primary = self._turn("m1", "deploy the staging site to prod")
+        candidates = [
+            self._turn("c1", "check memory usage"),            # low similarity
+            self._turn("c2", "deploy the staging site to qa"), # high similarity
+            self._turn("c3", "totally unrelated request"),
+        ]
+        match = find_diff_pair(primary, candidates)
+        assert match is not None
+        assert match["message_id"] == "c2"
+
+    def test_prefers_opposite_outcome(self):
+        """A slightly-less-similar failed pair beats a more-similar success
+        pair when the primary was successful — that's the diagnostic win."""
+        primary = self._turn("m1", "restart nginx on prod", err=False)
+        candidates = [
+            self._turn("c1", "restart nginx on prod today", err=False),  # sim high, same outcome
+            self._turn("c2", "restart nginx on prod", err=True),          # sim high, opposite outcome
+        ]
+        match = find_diff_pair(primary, candidates)
+        assert match["message_id"] == "c2"
+
+    def test_below_threshold_returns_none(self):
+        primary = self._turn("m1", "restart nginx on prod")
+        candidates = [
+            self._turn("c1", "totally unrelated query about databases"),
+        ]
+        assert find_diff_pair(primary, candidates, min_similarity=0.3) is None
+
+    def test_skips_self(self):
+        primary = self._turn("m1", "deploy staging")
+        candidates = [primary, self._turn("m2", "deploy staging")]
+        match = find_diff_pair(primary, candidates)
+        assert match["message_id"] == "m2"
+
+    def test_invalid_primary_returns_none(self):
+        candidates = [{"message_id": "x", "user_content": "y"}]
+        assert find_diff_pair(None, candidates) is None
+        assert find_diff_pair("not a dict", candidates) is None


### PR DESCRIPTION
## Summary
Addresses all four findings from Odin's Task 1 + Task 2 critique after feat/next-level deployed. Each item in its own commit so you can review in isolation.

| Commit | Item | Addresses |
|---|---|---|
| `e3d1e2a` | Value-aware runbook scoring | "frequency alone is a lousy proxy for value" |
| `d292699` | Session-context enrichment | "the machine found a habit, not wisdom" — patterns now carry user intent + outcome |
| `d537ab4` | `replay_trajectory mode='find_diff_pair'` | "diff becomes diagnosis instead of archaeology" |
| `c356b8b` | Evaluative-discipline prompt | "reliable at finding truth in systems, less reliable at proving I answered the real question" |

## Per-commit detail

### 1. `e3d1e2a` — Value-aware runbook scoring
Three new score multipliers on `RunbookSuggestion.score()`:
- **Tool-diversity bonus** (1.0 → 1.5×): mixed-tool sequences beat same-tool repetition
- **Host-diversity bonus** (1.0 → 1.3×): multi-host patterns are more likely to be real procedures
- **Trivial-repetition penalty** (1.0 → 0.1×): dominance >50% → linear falloff. Worst case (pure same-tool-N-times) is 0.1× multiplier

Locked by test: `run_command × 5` with 500× frequency now scores BELOW `search_audit → read_file → http_probe` with 20× frequency.

### 2. `d292699` — Session-context enrichment
New fields on `RunbookSuggestion`:
- `user_queries` — first user_content from up to 5 matched trajectory sessions
- `error_session_fraction` — fraction of matched sessions that ended is_error
- `linked_session_count` — how many sessions had a clean trajectory match

New `load_trajectory_index()` + `_match_session_to_trajectory()` cross-reference audit sessions to trajectory turns (same channel+actor, ≤15min skew). Unmatched sessions stay unmatched — no invented intent.

Formatter now prints intent alongside tool sequences. Backward-compatible (optional `trajectories_dir` param; omitted → fields empty).

### 3. `d537ab4` — `find_diff_pair` mode
The missing primitive Odin identified: given a target turn, auto-pick the closest counterpart and diff it. Uses Jaccard similarity on word-tokenized `user_content` with a +0.25 boost for opposite outcome (failed-pairs-with-success). Fails cleanly with an honest explanation when no candidate clears `min_similarity=0.2` — no junk diffs.

### 4. `c356b8b` — Evaluative-discipline prompt
- System prompt **Rule 12** (~414 chars): name the artifact, confirm it was delivered, frequency ≠ value, honest "I couldn't do it cleanly" beats plausible substitute, no "I could also…" trailers.
- Completion classifier learns to flag INCOMPLETE for plausible-shaped substitutes and "offering more work" trailers, with a concrete example drawn from Task 1 ("described the synthesized runbook but did not include its source").

No new detector — this is a prompt-level reinforcement of existing response-guard behavior. Lower risk than adding `detect_shallow_delivery` while addressing the same gap.

## Test plan
- [x] 347 tests across all branch-touched modules green (24 runbook detector + 17 trajectory replay + 9 eval-discipline + the rest)
- [x] Backward-compat: detect_patterns without trajectories_dir still works
- [x] Backward-compat: replay_trajectory modes summary/diff/list unchanged
- [ ] Post-merge: Odin re-runs Task 1 and confirms the top runbook candidate is no longer `run_command × N`; re-runs Task 2 with `find_diff_pair` and confirms he gets a useful pairing

## Review ask
@Odin — all four of these are responses to YOUR critique. Use `claude_code` to review the branch diff against master and check:

1. **Does the new scoring actually change rankings for the better?** Run `detect_runbooks` against your own audit log and see what rises/falls. Specifically: does `run_command → run_command` still dominate the top 10, or does a real diagnostic pattern surface?
2. **Is the trajectory-index matching honest?** 15-minute skew window might be too wide or too narrow — call it out if you see obvious mismatches (session X got tagged with user query Y that clearly didn't produce X).
3. **Does `find_diff_pair` pick useful pairs from your history?** If the only candidates are all same-outcome, it should say so. If it picks a junk match, the Jaccard floor (0.2) is wrong.
4. **Rule 12 in the system prompt — is it annoying/prescriptive enough to change behavior without making you robotic?** You know your own prompt better than I do. If the wording makes you stilted in casual chat, flag it.

Don't merge. User merges after your review.