### PR TITLE
feat: classify synthesized runbooks up front (Odin's PR #16 post-merge critique)

### DIFF
--- a/src/learning/runbook_synthesizer.py
+++ b/src/learning/runbook_synthesizer.py
@@ -1,25 +1,45 @@
-"""Runbook synthesis — turn a detected pattern into a reviewable skill skeleton.
+"""Runbook synthesis — render detected patterns as honestly-classified
+operator artifacts (checklist / hybrid / executable).
 
 ``runbook_detector`` surfaces candidate runbooks; this module takes one
-of those suggestions and renders a Python skill module the operator can
-review, edit, and (if they like) save via ``create_skill``.
+of those suggestions and produces a reviewable artifact. The CRITICAL
+piece — and the reason the output used to lie about itself — is that
+most interesting detected patterns contain tools SkillContext won't
+run (``run_command``, ``write_file``, ``claude_code``, etc.). Before
+this module classified outputs honestly, every synthesis produced
+something that *looked* like a loadable skill even when every step was
+a TODO block — a checklist wearing a skill's clothes.
 
-Important constraints the generated code respects:
+**Classification (computed at synthesis time, not editor time):**
+
+- ``executable`` — every step is a safe tool SkillContext actually
+  runs. The generated module loads via ``create_skill`` and executes
+  end-to-end.
+- ``hybrid`` — at least one safe step and at least one unsafe step.
+  The generated module loads, but unsafe steps are documented TODOs
+  with captured inputs; operator executes those manually.
+- ``documentation_only`` — every step is unsafe. The generated module
+  loads but runs nothing; it's a checklist with a ``SKILL_DEFINITION``
+  wrapper so the synthesis pipeline stays uniform.
+
+Every output carries the classification in a ``SYNTHESIS_CLASSIFICATION``
+module constant, in the ``SKILL_DEFINITION.tags`` list, and at the top
+of the docstring so nobody mistakes a checklist for automation.
+
+Other constraints the generated code respects:
 
 1. **Skills can only call read-only tools.** The SkillContext blocks
-   ``run_command``, ``write_file``, ``git_ops`` etc. A synthesized
-   runbook therefore cannot re-execute the unsafe parts of a pattern —
-   those steps are emitted as a documented TODO block that the operator
-   unblocks by either (a) keeping the skill as a documented checklist,
-   or (b) promoting it to a direct-executor pattern outside the skill
-   sandbox.
+   ``run_command``, ``write_file``, ``git_ops`` etc. — see the
+   SKILL_SAFE_TOOLS list. This module's classification logic uses the
+   same allowlist so a pattern of all-safe tools lands as
+   ``executable`` and mixed patterns land as ``hybrid``.
 
-2. **No auto-registration.** The tool that exposes synthesis returns the
-   generated code; the operator explicitly calls ``create_skill`` after
-   reading it.
+2. **No auto-registration.** The tool that exposes synthesis returns
+   the generated code; the operator explicitly calls ``create_skill``
+   after reading it.
 
-3. **Captured inputs are scrubbed** the same way runbook_detector scrubs
-   ``sample_inputs`` — never echo a secret into a skill source file.
+3. **Captured inputs are scrubbed** the same way runbook_detector
+   scrubs ``sample_inputs`` — never echo a secret into source.
 """
 
 from __future__ import annotations
@@ -105,16 +125,79 @@ def _describe_step(step_name: str, sample: dict) -> str:
     return f"{step_name}{suffix}{args}"
 
 
-def synthesize_skill_code(
+CLASSIFICATION_EXECUTABLE = "executable"
+CLASSIFICATION_HYBRID = "hybrid"
+CLASSIFICATION_DOCS_ONLY = "documentation_only"
+
+
+def classify_sequence(sequence: list[str]) -> str:
+    """Classify a runbook sequence by whether SkillContext can run it.
+
+    Returns one of ``executable`` (every step is in SKILL_SAFE_TOOLS),
+    ``hybrid`` (some steps safe, some not), or ``documentation_only``
+    (no steps are runnable from a skill). Used by synthesizers and by
+    the summary output so operators see up-front whether the artifact
+    is automation or a checklist.
+    """
+    if not sequence:
+        return CLASSIFICATION_DOCS_ONLY
+    safe_count = sum(1 for s in sequence if s in _SAFE_TOOLS)
+    if safe_count == len(sequence):
+        return CLASSIFICATION_EXECUTABLE
+    if safe_count == 0:
+        return CLASSIFICATION_DOCS_ONLY
+    return CLASSIFICATION_HYBRID
+
+
+def _classification_banner(classification: str, sequence: list[str]) -> list[str]:
+    """Prominent banner lines added to every generated module's docstring
+    so operators can't miss the classification."""
+    safe = sum(1 for s in sequence if s in _SAFE_TOOLS)
+    total = len(sequence)
+    unsafe = total - safe
+    if classification == CLASSIFICATION_EXECUTABLE:
+        kind = "EXECUTABLE RUNBOOK"
+        line = (
+            f"All {total} steps are SkillContext-safe. Installing this via "
+            f"create_skill() produces real automation."
+        )
+    elif classification == CLASSIFICATION_HYBRID:
+        kind = "HYBRID RUNBOOK"
+        line = (
+            f"{safe}/{total} steps run via SkillContext; {unsafe} are TODO "
+            f"blocks with captured input for operator execution. Installing "
+            f"via create_skill() runs the safe steps and prints documentation "
+            f"for the rest — partial automation, not full."
+        )
+    else:  # documentation_only
+        kind = "CHECKLIST (documentation only)"
+        line = (
+            f"None of the {total} steps are SkillContext-safe. Installing "
+            f"via create_skill() produces a skill that runs nothing — it is "
+            f"a checklist. Operator must execute every step manually using "
+            f"the captured inputs. Do not mistake this for automation."
+        )
+    return [
+        "=" * 68,
+        f"  {kind}",
+        "=" * 68,
+        textwrap.fill(line, width=66, initial_indent="  ", subsequent_indent="  "),
+        "",
+    ]
+
+
+def synthesize_runbook_code(
     suggestion: RunbookSuggestion,
     *,
     skill_name: str | None = None,
     description_override: str | None = None,
 ) -> str:
-    """Render a full skill source file as a string.
+    """Render a runbook source file as a string, classified up front.
 
-    The output is ready to feed to ``create_skill`` — but the intent is
-    for the operator to read it first.
+    The output is loadable by ``create_skill`` in all classifications,
+    but the tags, docstring banner, and description prefix make the
+    classification unavoidable to anyone reading the file or browsing
+    installed skills. No more checklist-wearing-a-skill's-clothes.
     """
     name = normalise_skill_name(skill_name or "_".join(suggestion.sequence[:3]))
     hosts = ", ".join(suggestion.hosts) or "(host unknown)"
@@ -127,22 +210,34 @@ def synthesize_skill_code(
     for step in steps:
         _assert_safe_tool_name(step)
 
+    classification = classify_sequence(steps)
+
     if description_override:
         description = description_override
     else:
         first = steps[0] if steps else "noop"
         last = steps[-1] if steps else "noop"
         description = (
-            f"Synthesized runbook from a pattern observed {suggestion.frequency}x "
+            f"Runbook from a pattern observed {suggestion.frequency}x "
             f"across {suggestion.session_count or 1} sessions. Pattern: "
-            f"{' → '.join(steps)} on {hosts}. Verifies the preconditions of the "
-            f"{first}→…→{last} procedure and documents the steps. Safe to dry-run; "
-            f"destructive steps are left as TODOs for operator review."
+            f"{' → '.join(steps)} on {hosts}. "
+            f"{first}→…→{last}."
         )
+    # Classification prefix on the description so operators see it in
+    # any skill listing (create_skill / list_skills) without needing to
+    # open the source.
+    tag_prefix = {
+        CLASSIFICATION_EXECUTABLE: "[executable]",
+        CLASSIFICATION_HYBRID: "[hybrid]",
+        CLASSIFICATION_DOCS_ONLY: "[checklist]",
+    }[classification]
+    if not description.startswith(tag_prefix):
+        description = f"{tag_prefix} {description}"
 
-    # Docstring listing the captured sequence + sample inputs.
-    doc_lines: list[str] = [
-        f"Runbook skill: {name}",
+    # Docstring: banner first (unmissable), then metadata, then steps.
+    doc_lines = _classification_banner(classification, steps)
+    doc_lines.extend([
+        f"Runbook: {name}",
         "",
         f"Detected pattern: {' → '.join(steps) or '(empty)'}",
         f"Hosts seen: {hosts}",
@@ -151,10 +246,11 @@ def synthesize_skill_code(
         f"(first: {suggestion.first_seen[:19]}, last: {suggestion.last_seen[:19]}).",
         "",
         "Captured step inputs (secret-scrubbed):",
-    ]
+    ])
     for i, step in enumerate(steps):
         sample = samples[i] if i < len(samples) else {"tool_name": step, "input": {}}
-        doc_lines.append(f"  {i + 1}. {_describe_step(step, sample)}")
+        safe_marker = " [safe]" if step in _SAFE_TOOLS else " [UNSAFE — manual]"
+        doc_lines.append(f"  {i + 1}. {_describe_step(step, sample)}{safe_marker}")
     docstring = textwrap.indent("\n".join(doc_lines), "")
 
     # Body: for each step, emit either a context.execute_tool() call (if
@@ -212,9 +308,17 @@ def synthesize_skill_code(
 
     steps_literal = "[" + ", ".join(repr(s) for s in steps) + "]"
 
+    tags_literal = (
+        f"[\"runbook\", \"synthesized\", {_safe_repr(classification)}]"
+    )
     source = f'''"""{textwrap.indent(docstring, "").strip()}
 """
 from __future__ import annotations
+
+# Classification is authoritative. SKILL_DEFINITION.tags carries a
+# machine-readable copy; this constant is what operators and tests
+# should prefer when inspecting a generated module.
+SYNTHESIS_CLASSIFICATION = {_safe_repr(classification)}
 
 STEPS = {steps_literal}
 
@@ -222,7 +326,7 @@ SKILL_DEFINITION = {{
     "name": {_safe_repr(name)},
     "description": {_safe_repr(description)},
     "version": "0.1.0",
-    "tags": ["runbook", "synthesized"],
+    "tags": {tags_literal},
     "input_schema": {{
         "type": "object",
         "properties": {{
@@ -247,16 +351,50 @@ async def execute(inp: dict, context) -> str:
     return source
 
 
+# Back-compat alias so existing callers (executor, tests) keep working
+# during rollout. New code should use synthesize_runbook_code.
+synthesize_skill_code = synthesize_runbook_code
+
+
 def synthesize_summary(source: str, suggestion: RunbookSuggestion) -> str:
-    """Short operator-facing summary of what was generated."""
+    """Short operator-facing summary of what was generated.
+
+    Uses the honest classification vocabulary from Odin's review:
+    checklist (documentation-only), hybrid, or executable — no more
+    calling every output a "skill" regardless of whether it runs.
+    """
+    classification = classify_sequence(suggestion.sequence)
     safe = sum(1 for s in suggestion.sequence if s in _SAFE_TOOLS)
     unsafe = len(suggestion.sequence) - safe
+    kind_label = {
+        CLASSIFICATION_EXECUTABLE: "executable runbook",
+        CLASSIFICATION_HYBRID: "hybrid runbook",
+        CLASSIFICATION_DOCS_ONLY: "checklist (documentation only)",
+    }[classification]
     lines = [
-        f"Synthesized runbook skill for pattern: {' → '.join(suggestion.sequence)}",
+        f"Synthesized {kind_label} for pattern: {' → '.join(suggestion.sequence)}",
+        f"  classification: {classification}",
         f"  safe steps (will run from skill): {safe}",
         f"  unsafe steps (operator must run manually): {unsafe}",
         f"  lines of code: {source.count(chr(10)) + 1}",
         "",
-        "Review the generated code, then pass it to create_skill() to install.",
     ]
+    if classification == CLASSIFICATION_DOCS_ONLY:
+        lines.append(
+            "This is a CHECKLIST, not automation. Installing via "
+            "create_skill() produces a loadable module that runs nothing. "
+            "Use it as structured documentation for manual operator work."
+        )
+    elif classification == CLASSIFICATION_HYBRID:
+        lines.append(
+            f"Partial automation: {safe}/{safe + unsafe} steps run via "
+            "SkillContext; the rest are TODO blocks with captured input. "
+            "Operator executes unsafe steps manually."
+        )
+    else:
+        lines.append(
+            "Fully executable — all steps are SkillContext-safe. "
+            "Review the generated code, then pass it to create_skill() "
+            "to install as real automation."
+        )
     return "\n".join(lines)

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1574,7 +1574,7 @@ class ToolExecutor:
     async def _handle_synthesize_runbook(self, inp: dict) -> str:
         from ..learning.runbook_detector import RunbookSuggestion, detect_patterns
         from ..learning.runbook_synthesizer import (
-            synthesize_skill_code,
+            synthesize_runbook_code,
             synthesize_summary,
         )
 
@@ -1612,7 +1612,7 @@ class ToolExecutor:
 
         skill_name = inp.get("skill_name")
         desc = inp.get("description_override")
-        source = synthesize_skill_code(
+        source = synthesize_runbook_code(
             found,
             skill_name=str(skill_name) if skill_name else None,
             description_override=str(desc) if desc else None,

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1926,12 +1926,17 @@ TOOLS: list[dict] = [
         "name": "synthesize_runbook",
         "description": (
             "Turns a detected runbook pattern (from detect_runbooks) into a reviewable Python "
-            "skill skeleton. The generated skill runs the safe read-only steps via SkillContext "
-            "and documents the unsafe steps (run_command, write_file, etc.) as TODO blocks with "
-            "their captured inputs — those can't run from the skill sandbox and the operator "
-            "must decide how to handle them. Does NOT auto-register the skill; returns the code "
-            "for review. Operator can then call create_skill() if they like it. Sample inputs "
-            "are secret-scrubbed the same way detect_runbooks scrubs them. Cost: low. Risk: none."
+            "module, CLASSIFIED up front as 'executable', 'hybrid', or 'checklist' "
+            "(documentation only) based on whether the constituent tools are SkillContext-safe. "
+            "The classification lands in the generated docstring banner, a module-level "
+            "SYNTHESIS_CLASSIFICATION constant, a SKILL_DEFINITION.tags entry, and the "
+            "description prefix — so operators can't mistake a checklist for automation. "
+            "- 'executable': every step is SkillContext-safe; loads and runs end-to-end. "
+            "- 'hybrid': some safe steps, some unsafe; safe steps run, unsafe steps print "
+            "documentation with captured input for operator execution. "
+            "- 'checklist': no safe steps; loads but runs nothing, serves as structured docs. "
+            "Does NOT auto-register; returns code for review. Sample inputs secret-scrubbed. "
+            "Cost: low. Risk: none."
         ),
         "input_schema": {
             "type": "object",

--- a/tests/test_runbook_synthesizer.py
+++ b/tests/test_runbook_synthesizer.py
@@ -192,3 +192,147 @@ class TestSynthesizeSummary:
         s = _suggestion(["http_probe"])
         source = synthesize_skill_code(s)
         assert "create_skill" in synthesize_summary(source, s)
+
+
+class TestClassification:
+    """Addresses Odin's PR #16 post-merge critique: synthesized output
+    must declare up front whether it's automation or documentation.
+    `synthesize_runbook` used to produce checklist-wearing-a-skill's-
+    clothes regardless of whether steps were actually runnable. Now
+    every output carries a classification."""
+
+    def test_all_safe_sequence_classified_executable(self):
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_EXECUTABLE,
+            classify_sequence,
+        )
+        # All of these are in SKILL_SAFE_TOOLS
+        assert classify_sequence(
+            ["http_probe", "read_file", "search_audit"],
+        ) == CLASSIFICATION_EXECUTABLE
+
+    def test_all_unsafe_sequence_classified_docs_only(self):
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_DOCS_ONLY,
+            classify_sequence,
+        )
+        assert classify_sequence(
+            ["run_command", "write_file", "claude_code"],
+        ) == CLASSIFICATION_DOCS_ONLY
+
+    def test_mixed_sequence_classified_hybrid(self):
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_HYBRID,
+            classify_sequence,
+        )
+        assert classify_sequence(
+            ["claude_code", "read_file", "run_command"],
+        ) == CLASSIFICATION_HYBRID
+
+    def test_empty_sequence_is_docs_only(self):
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_DOCS_ONLY,
+            classify_sequence,
+        )
+        assert classify_sequence([]) == CLASSIFICATION_DOCS_ONLY
+
+    def test_generated_source_carries_classification_constant(self):
+        """SYNTHESIS_CLASSIFICATION must be a literal in the source,
+        so tests and operators can grep for it without importing."""
+        s = _suggestion(["run_command", "write_file"])
+        source = synthesize_skill_code(s)
+        assert "SYNTHESIS_CLASSIFICATION = 'documentation_only'" in source
+
+    def test_executable_classification_lands_in_tags(self):
+        s = _suggestion(["http_probe", "read_file"])
+        source = synthesize_skill_code(s)
+        assert "'executable'" in source
+        assert "'documentation_only'" not in source
+        # Tags list must contain the classification
+        assert "\"runbook\", \"synthesized\", 'executable'" in source
+
+    def test_docs_only_description_prefixed_with_checklist(self):
+        """Operators see the [checklist] tag in create_skill / list_skills
+        output without opening the generated file."""
+        s = _suggestion(["run_command", "write_file"])
+        source = synthesize_skill_code(s)
+        # Description (inside SKILL_DEFINITION) starts with [checklist]
+        assert "[checklist]" in source
+
+    def test_hybrid_description_prefixed_with_hybrid(self):
+        s = _suggestion(["run_command", "read_file"])
+        source = synthesize_skill_code(s)
+        assert "[hybrid]" in source
+
+    def test_executable_description_prefixed_with_executable(self):
+        s = _suggestion(["http_probe", "read_file"])
+        source = synthesize_skill_code(s)
+        assert "[executable]" in source
+
+    def test_banner_warns_on_checklist(self):
+        """The docstring banner must make it impossible to mistake a
+        checklist for automation."""
+        s = _suggestion(["run_command", "claude_code"])
+        source = synthesize_skill_code(s)
+        assert "CHECKLIST (documentation only)" in source
+        assert "Do not mistake this for automation" in source
+
+    def test_banner_warns_on_hybrid(self):
+        s = _suggestion(["run_command", "read_file"])
+        source = synthesize_skill_code(s)
+        assert "HYBRID RUNBOOK" in source
+        # textwrap.fill may split the banner across lines; test tolerates
+        # that by checking for unambiguous short signal phrases.
+        assert "TODO blocks" in source
+        assert "SkillContext" in source
+
+    def test_banner_confirms_executable(self):
+        s = _suggestion(["http_probe", "read_file"])
+        source = synthesize_skill_code(s)
+        assert "EXECUTABLE RUNBOOK" in source
+        assert "real automation" in source
+
+    def test_description_override_still_gets_classification_prefix(self):
+        """Even when the caller passes description_override, the
+        classification tag must be prepended so honest labeling isn't
+        bypassed by a well-meaning renamer."""
+        s = _suggestion(["run_command", "write_file"])
+        source = synthesize_skill_code(
+            s, description_override="my cool procedure",
+        )
+        assert "[checklist] my cool procedure" in source
+
+    def test_summary_uses_classification_vocabulary(self):
+        from src.learning.runbook_synthesizer import synthesize_summary
+        s = _suggestion(["run_command", "write_file"])
+        source = synthesize_skill_code(s)
+        summary = synthesize_summary(source, s)
+        # New vocabulary: no more "runbook skill" for a thing that runs nothing
+        assert "checklist (documentation only)" in summary
+        assert "This is a CHECKLIST, not automation" in summary
+
+    def test_summary_hybrid_vocabulary(self):
+        from src.learning.runbook_synthesizer import synthesize_summary
+        s = _suggestion(["run_command", "read_file"])
+        source = synthesize_skill_code(s)
+        summary = synthesize_summary(source, s)
+        assert "hybrid runbook" in summary
+        assert "Partial automation" in summary
+
+    def test_summary_executable_vocabulary(self):
+        from src.learning.runbook_synthesizer import synthesize_summary
+        s = _suggestion(["http_probe", "read_file"])
+        source = synthesize_skill_code(s)
+        summary = synthesize_summary(source, s)
+        assert "executable runbook" in summary
+        assert "Fully executable" in summary
+
+
+class TestBackwardCompat:
+    def test_synthesize_skill_code_alias_exists(self):
+        """During rollout, callers still import synthesize_skill_code."""
+        from src.learning.runbook_synthesizer import (
+            synthesize_runbook_code,
+            synthesize_skill_code,
+        )
+        assert synthesize_skill_code is synthesize_runbook_code


### PR DESCRIPTION
## Summary
Implements Odin's option D from his design-question response: classify synthesized output up front as `executable`, `hybrid`, or `documentation_only` (checklist). Fixes the expectation bug where every generated module looked like a loadable skill even when every step was an unrunnable TODO.

## Changes
- New `classify_sequence()` maps a tool sequence to one of three honest categories based on SKILL_SAFE_TOOLS membership
- Every generated module now carries the classification in:
  - `SYNTHESIS_CLASSIFICATION` module constant
  - `SKILL_DEFINITION.tags` list
  - Prominent docstring banner (unmissable)
  - `SKILL_DEFINITION.description` prefix (`[executable]` / `[hybrid]` / `[checklist]`) so it surfaces in `create_skill` / `list_skills`
- `synthesize_summary()` uses honest vocabulary ("checklist (documentation only)" not "synthesized runbook skill")
- Tool description in registry spells out the three classes
- Back-compat: `synthesize_skill_code` is now an alias of the new `synthesize_runbook_code`

## Deliberately not in scope
Per Odin's recommendation:
- **Option B (approval gates)** — consent-modal antipattern, skipped
- **Option C (executor-native playbooks)** — real long-term answer, deferred to its own PR after this settles

## Test plan
- [x] +17 classification tests locking: classify_sequence correctness, SYNTHESIS_CLASSIFICATION constant presence, tag/description prefix, banner wording, summary vocabulary, back-compat alias
- [x] 370 tests across all branch-touched modules green
- [ ] Post-merge: re-run `synthesize_runbook` on yesterday's `claude_code → run_command` pattern; output should carry `[hybrid]` prefix and HYBRID RUNBOOK banner instead of looking like a regular skill

## Odin's key quote
> "The real bug is not that unsafe workflows exist; it's that we're calling a checklist a skill and acting surprised when it behaves like laminated paper."