### PR TITLE
fix: 9 findings from Odin's self-audit (PR #18)

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -159,6 +159,13 @@ class ToolsConfig(BaseModel):
     claude_code_user: str = ""
     claude_code_dir: str = "/opt/odin"
     skill_allowed_urls: list[str] = Field(default_factory=list)
+    # Odin's PR #18 self-audit caught that these were read via
+    # getattr(..., None) with hardcoded defaults in the handlers —
+    # Pydantic silently dropped the values when operators set them,
+    # so the fields looked configurable but weren't. Declaring them
+    # here fixes the silent-drop bug and makes defaults discoverable.
+    audit_log_path: str = "./data/audit.jsonl"
+    trajectory_path: str = "./data/trajectories"
     ssh_retry: RetryConfig = RetryConfig(max_retries=2, base_delay=0.5, max_delay=10.0)
     bulkhead: BulkheadConfig = BulkheadConfig()
     ssh_pool: SSHPoolConfig = SSHPoolConfig()

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -609,6 +609,23 @@ class HealthServer:
         expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
         return hmac.compare_digest(expected, signature)
 
+    def _verify_shared_secret(self, header_value: str) -> bool:
+        """Verify a shared-secret header (e.g. Grafana X-Webhook-Secret,
+        GitLab X-Gitlab-Token) against the configured webhook secret.
+
+        **Fails closed**: returns False if no secret is configured so
+        webhooks don't accept unauthenticated POSTs when the operator
+        hasn't set one up. Odin's PR #18 self-audit finding #1: the
+        Grafana and generic webhook handlers previously gated auth on
+        ``if self._webhook_config.secret:``, silently accepting
+        everything when the secret was empty.
+        """
+        secret = self._webhook_config.secret
+        if not secret:
+            log.warning("Webhook rejected: no secret configured for shared-secret verification")
+            return False
+        return hmac.compare_digest(header_value, secret)
+
     def _get_channel_id(self, source: str) -> str | None:
         """Get the channel ID for a webhook source."""
         if source == "gitea" and self._webhook_config.gitea_channel_id:
@@ -709,11 +726,12 @@ class HealthServer:
     async def _webhook_grafana(self, request: web.Request) -> web.Response:
         body = await request.read()
 
-        # Authenticate via shared secret header (configure in Grafana contact point)
-        if self._webhook_config.secret:
-            secret_header = request.headers.get("X-Webhook-Secret", "")
-            if not hmac.compare_digest(secret_header, self._webhook_config.secret):
-                return web.json_response({"error": "invalid secret"}, status=403)
+        # Authenticate via shared secret header (configure in Grafana contact
+        # point). Fails closed — if no secret is configured server-side the
+        # request is rejected rather than accepted unauthenticated.
+        secret_header = request.headers.get("X-Webhook-Secret", "")
+        if not self._verify_shared_secret(secret_header):
+            return web.json_response({"error": "invalid secret"}, status=403)
 
         try:
             data = json.loads(body)
@@ -775,9 +793,8 @@ class HealthServer:
     async def _webhook_generic(self, request: web.Request) -> web.Response:
         body = await request.read()
         secret_header = request.headers.get("X-Webhook-Secret", "")
-        if self._webhook_config.secret and not hmac.compare_digest(
-            secret_header, self._webhook_config.secret
-        ):
+        # Fails closed — same hardening as grafana (PR #18 finding #1).
+        if not self._verify_shared_secret(secret_header):
             return web.json_response({"error": "invalid secret"}, status=403)
 
         try:

--- a/src/knowledge/store.py
+++ b/src/knowledge/store.py
@@ -36,9 +36,25 @@ class KnowledgeStore:
         self._conn: sqlite3.Connection | None = None
         self._has_vec = False
         self._fts = fts_index
+        # Odin's PR #18 self-audit finding #3: the shared SQLite
+        # connection with ``check_same_thread=False`` was being hit by
+        # concurrent writers from ``asyncio.to_thread`` call sites and
+        # threw a stream of "bad parameter or other API misuse" errors
+        # under load (proved by live stress test with 40 concurrent
+        # ingests). Two-part fix:
+        #  1. ``busy_timeout`` lets SQLite wait for contended locks
+        #     instead of failing immediately.
+        #  2. ``_write_lock`` serializes async writers (ingest, delete)
+        #     so only one to_thread-wrapped write runs at a time.
+        #     WAL mode still allows concurrent reads, so this doesn't
+        #     hurt read latency.
+        self._write_lock = asyncio.Lock()
         try:
             conn = sqlite3.connect(db_path, check_same_thread=False)
             conn.execute("PRAGMA journal_mode=WAL")
+            # 30 seconds is generous but bounded — prevents indefinite
+            # hangs while still absorbing typical contention windows.
+            conn.execute("PRAGMA busy_timeout=30000")
             self._has_vec = load_extension(conn)
             if not self._has_vec:
                 log.warning("sqlite-vec not available — vector search disabled, FTS-only mode")
@@ -202,10 +218,7 @@ class KnowledgeStore:
         old_content = await asyncio.to_thread(self.get_source_content, source)
         is_update = old_content is not None
 
-        # Remove any existing chunks for this source (blocking → offload)
-        await asyncio.to_thread(self.delete_source, source, _record_version=False)
-
-        # Embed all chunks first (async, non-blocking)
+        # Embed all chunks first (async, non-blocking — no DB state touched).
         vectors: list[list[float] | None] = []
         for chunk in chunks:
             if self._has_vec and embedder:
@@ -216,19 +229,26 @@ class KnowledgeStore:
             else:
                 vectors.append(None)
 
-        # Batch write metadata + vectors to DB (blocking → offload)
-        indexed = await asyncio.to_thread(
-            self._write_chunks_sync, chunks, vectors, doc_hash_id, source,
-            now, uploader, doc_content_hash,
-        )
+        # Serialize ALL writes (delete + insert + version record) behind
+        # the async write lock. Pre-PR #18 this section raced itself under
+        # concurrent ingest and produced silent SQLite misuse errors.
+        async with self._write_lock:
+            # Remove any existing chunks for this source (blocking → offload)
+            await asyncio.to_thread(self.delete_source, source, _record_version=False)
 
-        # Record version
-        action = "update" if is_update else "create"
-        diff_summary = self._make_diff_summary(old_content, content)
-        await asyncio.to_thread(
-            self._record_version, source, doc_content_hash, content,
-            indexed, uploader, action, diff_summary,
-        )
+            # Batch write metadata + vectors to DB (blocking → offload)
+            indexed = await asyncio.to_thread(
+                self._write_chunks_sync, chunks, vectors, doc_hash_id, source,
+                now, uploader, doc_content_hash,
+            )
+
+            # Record version
+            action = "update" if is_update else "create"
+            diff_summary = self._make_diff_summary(old_content, content)
+            await asyncio.to_thread(
+                self._record_version, source, doc_content_hash, content,
+                indexed, uploader, action, diff_summary,
+            )
 
         log.info("Ingested '%s': %d/%d chunks indexed", source, indexed, len(chunks))
         return indexed

--- a/src/learning/runbook_detector.py
+++ b/src/learning/runbook_detector.py
@@ -20,6 +20,7 @@ Principles:
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -194,6 +195,37 @@ class _TrajectoryRecord:
     is_error: bool
 
 
+_TRAJECTORY_FILENAME_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})\.jsonl$")
+
+
+def _file_is_before_cutoff(filepath: Path, since_epoch: float | None) -> bool:
+    """Odin's PR #18 self-audit finding #6: load_trajectory_index used
+    to reparse every JSONL file even when the cutoff eliminated them
+    entirely. Trajectories are written to YYYY-MM-DD.jsonl partitions,
+    so we can skip a whole file based on its filename date — no need
+    to open and scan lines we'd immediately drop.
+
+    Adds one-day slack so timezone edges and late-in-day writes don't
+    get falsely skipped.
+    """
+    if since_epoch is None:
+        return False
+    m = _TRAJECTORY_FILENAME_RE.match(filepath.name)
+    if not m:
+        return False  # unknown shape — scan it, don't silently skip
+    try:
+        file_day_end = datetime(
+            int(m.group(1)), int(m.group(2)), int(m.group(3)),
+            23, 59, 59, tzinfo=timezone.utc,
+        )
+    except ValueError:
+        return False
+    # slack: treat the file as "possibly relevant" until a full day
+    # past its date has elapsed before the cutoff.
+    slack_seconds = 86400
+    return (file_day_end.timestamp() + slack_seconds) < since_epoch
+
+
 def load_trajectory_index(
     trajectories_dir: str | Path,
     *, since_epoch: float | None = None,
@@ -213,6 +245,10 @@ def load_trajectory_index(
     except OSError as e:
         log.error("Failed to list trajectories dir %s: %s", path, e)
         return dict(out)
+    # Filename-date pre-filter: skip whole partitions whose date is
+    # well before since_epoch. Per-entry filter stays in place for
+    # edge cases in the surviving files.
+    files = [f for f in files if not _file_is_before_cutoff(f, since_epoch)]
     for filepath in files:
         try:
             with filepath.open("r") as f:
@@ -467,11 +503,26 @@ def detect_patterns(
         # caller passed a trajectories_dir). We keep only the first five
         # distinct user queries so the output doesn't balloon, and
         # compute error_session_fraction across matched sessions only.
+        #
+        # Odin's PR #18 self-audit finding #7: two different audit
+        # sessions can match to the SAME trajectory record (the matcher
+        # picks the nearest-in-time trajectory for each, and when user
+        # turns have multiple interleaved tool sessions within the skew
+        # window, several sessions share one origin turn). Naive
+        # counting treated that as "2 linked sessions" and doubled the
+        # trajectory's contribution to the error fraction. Dedupe on
+        # the trajectory identity — one trajectory contributes once.
+        seen_trajs: set[int] = set()
         linked_trajs: list[_TrajectoryRecord] = []
         for sid in distinct_sessions:
             rec = session_to_traj.get(sid)
-            if rec is not None:
-                linked_trajs.append(rec)
+            if rec is None:
+                continue
+            traj_key = id(rec)  # same object across sessions → single dedupe
+            if traj_key in seen_trajs:
+                continue
+            seen_trajs.add(traj_key)
+            linked_trajs.append(rec)
         seen_queries: list[str] = []
         for rec in linked_trajs:
             q = (rec.user_content or "").strip()

--- a/src/learning/runbook_synthesizer.py
+++ b/src/learning/runbook_synthesizer.py
@@ -130,22 +130,47 @@ CLASSIFICATION_HYBRID = "hybrid"
 CLASSIFICATION_DOCS_ONLY = "documentation_only"
 
 
-def classify_sequence(sequence: list[str]) -> str:
+def classify_sequence(
+    sequence: list[str],
+    sample_inputs: list[dict] | None = None,
+) -> str:
     """Classify a runbook sequence by whether SkillContext can run it.
 
-    Returns one of ``executable`` (every step is in SKILL_SAFE_TOOLS),
-    ``hybrid`` (some steps safe, some not), or ``documentation_only``
-    (no steps are runnable from a skill). Used by synthesizers and by
-    the summary output so operators see up-front whether the artifact
-    is automation or a checklist.
+    Returns one of ``executable`` (every step is in SKILL_SAFE_TOOLS
+    AND has captured inputs to run against), ``hybrid`` (some steps
+    safe, some not, OR safe sequence with empty inputs — operator has
+    to fill in the blanks), or ``documentation_only`` (no steps are
+    runnable from a skill). Used by synthesizers and by the summary
+    output so operators see up-front whether the artifact is automation
+    or a checklist.
+
+    Odin's PR #18 self-audit finding #9: a sequence of all-safe tools
+    paired with empty sample_inputs was classified ``executable`` even
+    though the generated skill would call tools with empty dicts and
+    produce nothing useful. When samples are missing/empty, downgrade
+    to ``hybrid`` so the classification banner reflects that operator
+    input is required.
     """
     if not sequence:
         return CLASSIFICATION_DOCS_ONLY
     safe_count = sum(1 for s in sequence if s in _SAFE_TOOLS)
-    if safe_count == len(sequence):
-        return CLASSIFICATION_EXECUTABLE
     if safe_count == 0:
         return CLASSIFICATION_DOCS_ONLY
+    if safe_count == len(sequence):
+        # Normally ``executable``, but if captured inputs are empty for
+        # every step the skill would run with empty dicts — operator
+        # must supply overrides, so this is effectively hybrid.
+        if sample_inputs is None:
+            return CLASSIFICATION_EXECUTABLE
+        if not sample_inputs:
+            return CLASSIFICATION_HYBRID
+        any_populated = any(
+            (isinstance(s, dict) and s.get("input"))
+            for s in sample_inputs
+        )
+        if not any_populated:
+            return CLASSIFICATION_HYBRID
+        return CLASSIFICATION_EXECUTABLE
     return CLASSIFICATION_HYBRID
 
 
@@ -199,9 +224,19 @@ def synthesize_runbook_code(
     classification unavoidable to anyone reading the file or browsing
     installed skills. No more checklist-wearing-a-skill's-clothes.
     """
+    steps = suggestion.sequence or []
+    # Odin's PR #18 self-audit finding #8: an empty sequence silently
+    # produced a "valid" skill shell with STEPS = [] and an empty
+    # execute body — loaded and did nothing. Fail loudly instead so
+    # the caller knows there's nothing to synthesize.
+    if not steps:
+        raise ValueError(
+            "Cannot synthesize a runbook from an empty sequence — the "
+            "generated module would load but do nothing. Provide a "
+            "non-empty sequence from detect_runbooks or another source."
+        )
     name = normalise_skill_name(skill_name or "_".join(suggestion.sequence[:3]))
     hosts = ", ".join(suggestion.hosts) or "(host unknown)"
-    steps = suggestion.sequence or []
     samples = suggestion.sample_inputs or []
     # Validate every step name BEFORE emitting source — embedding an
     # attacker-controlled string in generated code is a code-injection
@@ -210,7 +245,7 @@ def synthesize_runbook_code(
     for step in steps:
         _assert_safe_tool_name(step)
 
-    classification = classify_sequence(steps)
+    classification = classify_sequence(steps, samples)
 
     if description_override:
         description = description_override
@@ -363,7 +398,9 @@ def synthesize_summary(source: str, suggestion: RunbookSuggestion) -> str:
     checklist (documentation-only), hybrid, or executable — no more
     calling every output a "skill" regardless of whether it runs.
     """
-    classification = classify_sequence(suggestion.sequence)
+    classification = classify_sequence(
+        suggestion.sequence, suggestion.sample_inputs,
+    )
     safe = sum(1 for s in suggestion.sequence if s in _SAFE_TOOLS)
     unsafe = len(suggestion.sequence) - safe
     kind_label = {

--- a/src/trajectories/replay.py
+++ b/src/trajectories/replay.py
@@ -147,26 +147,56 @@ def _tool_io_pairs(entry: dict) -> list[tuple[str, Any, str]]:
     return pairs
 
 
+# Short tokens that carry real diagnostic meaning even though the
+# generic "tokens < 3 chars are noise" rule would drop them. Odin's
+# PR #18 self-audit finding #4: dropping "db", "io", "vm", "k8s"
+# blinded similarity matching to the technical core of operator
+# queries. Keep this list small and genuinely-technical — don't
+# pack in every abbreviation that might be signal.
+_SHORT_TECHNICAL_TOKENS: frozenset[str] = frozenset({
+    # Storage / data
+    "db", "io", "s3",
+    # Infra / virtualization
+    "vm", "k8s", "aws", "gcp", "eks", "gke", "aks",
+    # Networking
+    "ip", "dns", "tcp", "udp", "ssh", "tls", "ssl", "vpn", "lan", "wan",
+    # Protocols / APIs
+    "api", "rpc", "sql", "http",
+    # Services / systems
+    "os", "ci", "cd", "qa", "ui", "ux",
+    # File / formats (less common but useful)
+    "pr", "js", "ts", "py", "md", "yaml",
+})
+
+
 def _tokenize(text: str) -> set[str]:
-    """Cheap tokenization for intent similarity. Lowercase, word-split,
-    drop tokens <3 chars. Good enough for jaccard scoring on user queries.
+    """Cheap tokenization for intent similarity. Lowercase, word-split;
+    normally drop tokens <3 chars, but keep an allowlist of short
+    technical tokens that carry genuine signal (db, io, vm, k8s, tls…).
+
+    Good enough for jaccard scoring on user queries. Short allowlist
+    is intentionally narrow so common English shorts ("to", "of",
+    "in") don't inflate similarity.
     """
     if not isinstance(text, str):
         return set()
     tokens = set()
     buf: list[str] = []
+
+    def _maybe_add(tok: str) -> None:
+        if not tok:
+            return
+        if len(tok) >= 3 or tok in _SHORT_TECHNICAL_TOKENS:
+            tokens.add(tok)
+
     for ch in text.lower():
         if ch.isalnum() or ch == "_":
             buf.append(ch)
         elif buf:
-            tok = "".join(buf)
-            if len(tok) >= 3:
-                tokens.add(tok)
+            _maybe_add("".join(buf))
             buf = []
     if buf:
-        tok = "".join(buf)
-        if len(tok) >= 3:
-            tokens.add(tok)
+        _maybe_add("".join(buf))
     return tokens
 
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -218,7 +218,29 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/setup/complete")
     async def setup_complete(request: web.Request) -> web.Response:
-        """Receive wizard data, write config files, signal restart."""
+        """Receive wizard data, write config files, signal restart.
+
+        Gated on ``is_setup_needed()`` — once setup is done, this
+        endpoint returns ``409 Conflict`` instead of silently rewriting
+        the operator's config. Odin's PR #18 self-audit finding #2:
+        first-boot routes should stop being first-boot routes after
+        first boot.
+        """
+        config_path = Path("config.yml")
+        env_path = Path(".env")
+        if not is_setup_needed(config_path, env_path):
+            return web.json_response(
+                {
+                    "error": "setup already complete",
+                    "detail": (
+                        "The setup wizard endpoint only accepts writes on "
+                        "first boot. Use the regular config management "
+                        "endpoints to change operational settings after "
+                        "initial setup."
+                    ),
+                },
+                status=409,
+            )
         try:
             data = await request.json()
         except Exception:

--- a/tests/test_grafana_alerts.py
+++ b/tests/test_grafana_alerts.py
@@ -862,8 +862,16 @@ class TestConstants:
 # ---------------------------------------------------------------------------
 
 
+# PR #18: grafana webhook now fails closed when no secret is
+# configured. The integration tests default to a non-empty test secret
+# and pass the corresponding header on each POST. The explicit
+# auth-required test overrides this and verifies both paths.
+_TEST_WEBHOOK_SECRET = "test-webhook-secret"
+_TEST_WEBHOOK_HEADERS = {"X-Webhook-Secret": _TEST_WEBHOOK_SECRET}
+
+
 def _make_grafana_server(
-    *, rules=None, auto_remediate=False, webhook_secret=""
+    *, rules=None, auto_remediate=False, webhook_secret=_TEST_WEBHOOK_SECRET,
 ):
     wh_cfg = WebhookConfig(enabled=True, secret=webhook_secret, grafana_channel_id="chan1")
     ga_cfg = GrafanaAlertConfig(
@@ -908,6 +916,7 @@ class TestHealthServerGrafanaIntegration:
             resp = await client.post(
                 "/webhook/grafana",
                 json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
             )
             assert resp.status == 200
         assert len(sent) == 1
@@ -924,6 +933,7 @@ class TestHealthServerGrafanaIntegration:
             resp = await client.post(
                 "/webhook/grafana",
                 json=_legacy_payload(),
+                headers=_TEST_WEBHOOK_HEADERS,
             )
             assert resp.status == 200
         assert len(sent) == 1
@@ -941,7 +951,10 @@ class TestHealthServerGrafanaIntegration:
 
         payload = _unified_payload(_firing_alert())
         async with TestClient(TestServer(server._app)) as client:
-            resp = await client.post("/webhook/grafana", json=payload)
+            resp = await client.post(
+                "/webhook/grafana", json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
+            )
             assert resp.status == 200
 
         loop_callback.assert_called_once()
@@ -958,7 +971,10 @@ class TestHealthServerGrafanaIntegration:
 
         payload = _unified_payload(_firing_alert())
         async with TestClient(TestServer(server._app)) as client:
-            resp = await client.post("/webhook/grafana", json=payload)
+            resp = await client.post(
+                "/webhook/grafana", json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
+            )
             assert resp.status == 200
         assert "remediation" not in sent[0].lower()
 
@@ -972,7 +988,10 @@ class TestHealthServerGrafanaIntegration:
 
         payload = _unified_payload(_firing_alert())
         async with TestClient(TestServer(server._app)) as client:
-            resp = await client.post("/webhook/grafana", json=payload)
+            resp = await client.post(
+                "/webhook/grafana", json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
+            )
             assert resp.status == 200
 
     async def test_webhook_auth_required(self):
@@ -998,7 +1017,10 @@ class TestHealthServerGrafanaIntegration:
             resp = await client.post(
                 "/webhook/grafana",
                 data=b"not json",
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    **_TEST_WEBHOOK_HEADERS,
+                },
             )
             assert resp.status == 400
 
@@ -1014,7 +1036,10 @@ class TestHealthServerGrafanaIntegration:
 
         payload = _unified_payload(_resolved_alert())
         async with TestClient(TestServer(server._app)) as client:
-            resp = await client.post("/webhook/grafana", json=payload)
+            resp = await client.post(
+                "/webhook/grafana", json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
+            )
             assert resp.status == 200
         loop_callback.assert_not_called()
 
@@ -1026,7 +1051,10 @@ class TestHealthServerGrafanaIntegration:
 
         payload = _unified_payload(_firing_alert())
         async with TestClient(TestServer(server._app)) as client:
-            resp = await client.post("/webhook/grafana", json=payload)
+            resp = await client.post(
+                "/webhook/grafana", json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
+            )
             assert resp.status == 200
         trigger_cb.assert_called_once()
         call_args = trigger_cb.call_args
@@ -1046,7 +1074,10 @@ class TestHealthServerGrafanaIntegration:
             _firing_alert(), _resolved_alert("Other"),
         )
         async with TestClient(TestServer(server._app)) as client:
-            resp = await client.post("/webhook/grafana", json=payload)
+            resp = await client.post(
+                "/webhook/grafana", json=payload,
+                headers=_TEST_WEBHOOK_HEADERS,
+            )
             assert resp.status == 200
         event_data = trigger_cb.call_args[0][1]
         assert event_data["alert_count"] == 2

--- a/tests/test_self_audit_fixes.py
+++ b/tests/test_self_audit_fixes.py
@@ -1,0 +1,382 @@
+"""Tests for PR #18 — Odin's self-audit findings, fixed.
+
+Each class locks the behavior of one finding-and-fix pair so future
+edits can't silently regress the security/correctness properties.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ====================================================================
+# Finding #1 — Grafana webhook fail-close
+# ====================================================================
+
+class TestGrafanaWebhookFailClose:
+    """_webhook_grafana and _webhook_generic used to accept
+    unauthenticated POSTs whenever the shared secret was empty.
+    _verify_shared_secret now fails closed."""
+
+    def test_verify_shared_secret_rejects_empty_secret(self):
+        from src.health.server import HealthServer
+        from src.config.schema import WebhookConfig
+        hs = HealthServer.__new__(HealthServer)
+        hs._webhook_config = WebhookConfig(secret="")
+        assert hs._verify_shared_secret("any-value") is False
+
+    def test_verify_shared_secret_rejects_bad_token(self):
+        from src.health.server import HealthServer
+        from src.config.schema import WebhookConfig
+        hs = HealthServer.__new__(HealthServer)
+        hs._webhook_config = WebhookConfig(secret="correct-secret")
+        assert hs._verify_shared_secret("wrong") is False
+
+    def test_verify_shared_secret_accepts_matching_token(self):
+        from src.health.server import HealthServer
+        from src.config.schema import WebhookConfig
+        hs = HealthServer.__new__(HealthServer)
+        hs._webhook_config = WebhookConfig(secret="correct-secret")
+        assert hs._verify_shared_secret("correct-secret") is True
+
+    def test_verify_shared_secret_rejects_empty_header(self):
+        """An operator-supplied empty header with a real secret config
+        must also fail — empty is not 'match anything'."""
+        from src.health.server import HealthServer
+        from src.config.schema import WebhookConfig
+        hs = HealthServer.__new__(HealthServer)
+        hs._webhook_config = WebhookConfig(secret="secret")
+        assert hs._verify_shared_secret("") is False
+
+
+# ====================================================================
+# Finding #2 — /api/setup/complete gate after first boot
+# ====================================================================
+
+class TestSetupCompleteGate:
+    @pytest.mark.asyncio
+    async def test_setup_complete_returns_409_when_already_setup(self, tmp_path, monkeypatch):
+        """After first boot, the wizard endpoint must refuse to rewrite
+        config/env silently."""
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+        from src.web.api import create_api_routes
+
+        # Work in a tmpdir so is_setup_needed can see pre-configured files.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yml").write_text(
+            "discord:\n  token: real-token\n"
+            "tools:\n  hosts:\n    localhost:\n      address: 127.0.0.1\n"
+        )
+        (tmp_path / ".env").write_text("DISCORD_TOKEN=configured\n")
+
+        bot = MagicMock()
+        bot.config = MagicMock()
+        bot.config.tools = MagicMock()
+        bot.config.tools.audit_log_path = str(tmp_path / "audit.jsonl")
+        bot.tool_executor = MagicMock()
+        bot.audit = MagicMock()
+
+        app = web.Application()
+        app.router.add_routes(create_api_routes(bot))
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/setup/complete",
+                json={"discord_token": "new-token"},
+            )
+            assert resp.status == 409
+            data = await resp.json()
+            assert "setup already complete" in data["error"]
+
+
+# ====================================================================
+# Finding #3 — SQLite write serialization
+# ====================================================================
+
+class TestKnowledgeStoreConcurrency:
+    def test_busy_timeout_set(self, tmp_path):
+        """Constructor must configure busy_timeout so contended writes
+        wait instead of erroring."""
+        from src.knowledge.store import KnowledgeStore
+        store = KnowledgeStore(str(tmp_path / "k.db"))
+        try:
+            row = store._conn.execute("PRAGMA busy_timeout").fetchone()
+            assert row[0] == 30000
+        finally:
+            store.close()
+
+    def test_write_lock_exists(self, tmp_path):
+        """An asyncio.Lock must exist for write serialization."""
+        from src.knowledge.store import KnowledgeStore
+        store = KnowledgeStore(str(tmp_path / "k.db"))
+        try:
+            assert isinstance(store._write_lock, asyncio.Lock)
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_ingest_serializes_cleanly(self, tmp_path):
+        """Smoke test: 10 concurrent small ingests under the lock should
+        complete without SQLite misuse errors. This is the scenario
+        Odin's stress test showed producing a graveyard of errors."""
+        from src.knowledge.store import KnowledgeStore
+        from src.search.fts import FullTextIndex
+
+        fts = FullTextIndex(str(tmp_path / "fts.db"))
+        store = KnowledgeStore(str(tmp_path / "k.db"), fts_index=fts)
+        try:
+            async def _one(i: int) -> int:
+                return await store.ingest(
+                    f"content body {i} " * 20,
+                    source=f"source-{i}",
+                )
+            results = await asyncio.gather(*[_one(i) for i in range(10)])
+            # All ingests should have succeeded with at least 1 chunk
+            assert all(r >= 1 for r in results), (
+                f"concurrent ingests produced non-positive chunk counts: {results}"
+            )
+        finally:
+            store.close()
+
+
+# ====================================================================
+# Finding #4 — trajectory_path / audit_log_path in config schema
+# ====================================================================
+
+class TestConfigSchemaFields:
+    def test_trajectory_path_has_default(self):
+        from src.config.schema import ToolsConfig
+        cfg = ToolsConfig()
+        assert cfg.trajectory_path == "./data/trajectories"
+
+    def test_trajectory_path_honored_from_yaml(self):
+        """Explicit value survives Pydantic — no more silent drop."""
+        from src.config.schema import ToolsConfig
+        cfg = ToolsConfig(trajectory_path="/custom/traj/path")
+        assert cfg.trajectory_path == "/custom/traj/path"
+
+    def test_audit_log_path_has_default(self):
+        from src.config.schema import ToolsConfig
+        cfg = ToolsConfig()
+        assert cfg.audit_log_path == "./data/audit.jsonl"
+
+    def test_audit_log_path_honored_from_yaml(self):
+        from src.config.schema import ToolsConfig
+        cfg = ToolsConfig(audit_log_path="/custom/audit.jsonl")
+        assert cfg.audit_log_path == "/custom/audit.jsonl"
+
+
+# ====================================================================
+# Finding #5 — _tokenize preserves short technical tokens
+# ====================================================================
+
+class TestTokenizeShortTechnical:
+    def test_db_preserved(self):
+        from src.trajectories.replay import _tokenize
+        assert "db" in _tokenize("restart the db")
+
+    def test_k8s_preserved(self):
+        from src.trajectories.replay import _tokenize
+        assert "k8s" in _tokenize("check k8s pods")
+
+    def test_io_vm_tls_all_preserved(self):
+        from src.trajectories.replay import _tokenize
+        toks = _tokenize("the io on the vm is failing tls")
+        assert {"io", "vm", "tls"}.issubset(toks)
+
+    def test_common_english_shorts_still_dropped(self):
+        """'to', 'of', 'in' are noise — must not be kept."""
+        from src.trajectories.replay import _tokenize
+        toks = _tokenize("go to the office in the morning of april")
+        assert "to" not in toks
+        assert "of" not in toks
+        assert "in" not in toks
+
+
+# ====================================================================
+# Finding #6 — load_trajectory_index skips old partition files
+# ====================================================================
+
+class TestTrajectoryIndexPrefilter:
+    def test_old_partitions_skipped(self, tmp_path):
+        """Files whose YYYY-MM-DD is well before since_epoch are not opened."""
+        from src.learning.runbook_detector import load_trajectory_index
+        # Write two partitions: one very old, one current.
+        old_file = tmp_path / "2024-01-15.jsonl"
+        old_file.write_text(json.dumps({
+            "timestamp": "2024-01-15T10:00:00Z",
+            "channel_id": "c", "user_id": "a", "user_content": "ancient",
+            "is_error": False,
+        }) + "\n")
+        new_file = tmp_path / "2026-04-19.jsonl"
+        new_file.write_text(json.dumps({
+            "timestamp": "2026-04-19T10:00:00Z",
+            "channel_id": "c", "user_id": "a", "user_content": "current",
+            "is_error": False,
+        }) + "\n")
+        # since_epoch = start of 2026-04-18 UTC — old file's date is way before,
+        # new file is after.
+        cutoff = datetime(2026, 4, 18, tzinfo=timezone.utc).timestamp()
+        index = load_trajectory_index(tmp_path, since_epoch=cutoff)
+        # Only the new entry should be indexed.
+        entries = [r for recs in index.values() for r in recs]
+        assert len(entries) == 1
+        assert entries[0].user_content == "current"
+
+    def test_non_standard_filename_not_skipped(self, tmp_path):
+        """Filenames that don't match YYYY-MM-DD.jsonl are scanned (we
+        don't want to accidentally skip operator-renamed files)."""
+        from src.learning.runbook_detector import load_trajectory_index
+        odd = tmp_path / "weird-name.jsonl"
+        odd.write_text(json.dumps({
+            "timestamp": "2026-04-19T10:00:00Z",
+            "channel_id": "c", "user_id": "a", "user_content": "odd",
+            "is_error": False,
+        }) + "\n")
+        cutoff = datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp()
+        index = load_trajectory_index(tmp_path, since_epoch=cutoff)
+        entries = [r for recs in index.values() for r in recs]
+        assert any(r.user_content == "odd" for r in entries)
+
+
+# ====================================================================
+# Finding #7 — trajectory dedup in suggestion building
+# ====================================================================
+
+class TestTrajectoryDedup:
+    def test_same_trajectory_counted_once(self, tmp_path):
+        """Two audit sessions matched to the SAME trajectory should
+        contribute a single entry to linked_session_count and
+        error_session_fraction."""
+        from src.learning.runbook_detector import detect_patterns
+
+        audit = tmp_path / "audit.jsonl"
+        traj = tmp_path / "trajectories"
+        traj.mkdir()
+
+        # One trajectory turn, two sessions that will both match it.
+        t0 = datetime(2026, 4, 18, 10, 0, 0, tzinfo=timezone.utc)
+        traj_rec = {
+            "timestamp": t0.isoformat().replace("+00:00", "Z"),
+            "channel_id": "c1",
+            "user_id": "alice",
+            "user_name": "alice",
+            "user_content": "single user turn with two tool sessions",
+            "is_error": True,
+            "iterations": [],
+        }
+        (traj / "2026-04-18.jsonl").write_text(json.dumps(traj_rec) + "\n")
+
+        # Two sessions, both within the 15-min skew window of the turn.
+        rows = []
+        # Need at least min_frequency=2 distinct sessions
+        # Three sessions total so the pattern qualifies
+        for i, offset in enumerate([30, 300, 600]):
+            sess_start = t0 + timedelta(seconds=offset)
+            rows.append({
+                "timestamp": (sess_start).isoformat().replace("+00:00", "Z"),
+                "user_id": "alice", "user_name": "alice", "channel_id": "c1",
+                "tool_name": "read_file",
+                "tool_input": {"host": "hostA"},
+                "error": None,
+            })
+            rows.append({
+                "timestamp": (sess_start + timedelta(seconds=5)).isoformat().replace("+00:00", "Z"),
+                "user_id": "alice", "user_name": "alice", "channel_id": "c1",
+                "tool_name": "http_probe",
+                "tool_input": {"host": "hostA"},
+                "error": None,
+            })
+        with audit.open("w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+        now = datetime(2026, 4, 18, 15, 0, 0, tzinfo=timezone.utc)
+        # Use a long session_gap_seconds so adjacent tool runs form
+        # separate sessions (each offset is > 300s gap threshold).
+        suggestions = detect_patterns(
+            audit, min_frequency=3, lookback_days=30,
+            trajectories_dir=traj,
+            session_gap_seconds=100,  # forces 3 separate sessions
+            now=now,
+        )
+        assert suggestions
+        s = suggestions[0]
+        # Without dedup: linked_session_count would be 3 (one per session
+        # all pointing at the same trajectory). With dedup: 1.
+        assert s.linked_session_count == 1, (
+            f"trajectory dedup failed: linked_session_count = "
+            f"{s.linked_session_count}, expected 1"
+        )
+        # Error fraction also reflects the single distinct trajectory.
+        assert s.error_session_fraction == 1.0
+
+
+# ====================================================================
+# Finding #8 — empty-sequence synthesis rejected
+# ====================================================================
+
+class TestEmptySequenceRejected:
+    def test_empty_sequence_raises(self):
+        from src.learning.runbook_detector import RunbookSuggestion
+        from src.learning.runbook_synthesizer import synthesize_runbook_code
+        s = RunbookSuggestion(
+            sequence=[], frequency=0, session_count=0,
+            hosts=[], actors=[], first_seen="", last_seen="",
+            sample_inputs=[],
+        )
+        with pytest.raises(ValueError, match="empty sequence"):
+            synthesize_runbook_code(s)
+
+
+# ====================================================================
+# Finding #9 — all-safe + empty samples downgrades to hybrid
+# ====================================================================
+
+class TestClassifyEmptySamples:
+    def test_all_safe_with_populated_samples_is_executable(self):
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_EXECUTABLE,
+            classify_sequence,
+        )
+        samples = [
+            {"tool_name": "http_probe", "host": "h", "input": {"host": "h"}},
+            {"tool_name": "read_file", "host": "h", "input": {"host": "h", "path": "/x"}},
+        ]
+        assert classify_sequence(
+            ["http_probe", "read_file"], samples,
+        ) == CLASSIFICATION_EXECUTABLE
+
+    def test_all_safe_with_empty_inputs_downgrades_to_hybrid(self):
+        """Odin #9: a safe-sequence with empty captured inputs would
+        have classified executable under the old rule even though the
+        generated skill would call tools with empty dicts."""
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_HYBRID,
+            classify_sequence,
+        )
+        samples = [
+            {"tool_name": "http_probe", "host": None, "input": {}},
+            {"tool_name": "read_file", "host": None, "input": {}},
+        ]
+        assert classify_sequence(
+            ["http_probe", "read_file"], samples,
+        ) == CLASSIFICATION_HYBRID
+
+    def test_all_safe_with_missing_sample_list_still_executable(self):
+        """Back-compat: when no sample_inputs is provided at all,
+        behavior falls through to the original executable path."""
+        from src.learning.runbook_synthesizer import (
+            CLASSIFICATION_EXECUTABLE,
+            classify_sequence,
+        )
+        assert classify_sequence(
+            ["http_probe", "read_file"], None,
+        ) == CLASSIFICATION_EXECUTABLE


### PR DESCRIPTION
## Summary
Fixes every finding Odin surfaced in the self-audit task. Three security/correctness bugs Odin validated himself (one via live concurrent stress test), plus six correctness/usability issues in recent PR work.

## Changes

### Security / correctness (Odin-validated):
| # | Finding | Fix |
|---|---|---|
| 1 | Grafana webhook fail-open when secret empty (`src/health/server.py`) | New `_verify_shared_secret` helper; fails closed. Same fix applied to `_webhook_generic` (same bug). |
| 2 | `/api/setup/complete` rewrites config after first boot (`src/web/api.py`) | Returns 409 Conflict when `is_setup_needed()` is false. |
| 3 | SQLite shared connection races under concurrent ingest (`src/knowledge/store.py`) | `busy_timeout=30000` + `asyncio.Lock` serializing writes in `ingest()`. |

### Recent-PR cleanup:
| # | Finding | Fix |
|---|---|---|
| 4 | `trajectory_path`/`audit_log_path` silently dropped by Pydantic | Added to `ToolsConfig` schema with defaults. |
| 5 | `_tokenize` drops "db", "io", "vm", "k8s" | Curated technical-shorts allowlist. |
| 6 | `load_trajectory_index` reparses old files | Filename-date pre-filter via `YYYY-MM-DD.jsonl` partition regex. |
| 7 | Trajectory attributed to multiple sessions inflates error fraction | Dedup by `id(rec)` when building linked_trajs. |
| 8 | Empty-sequence synthesis produced a noop skill | `ValueError` raised up front. |
| 9 | All-safe sequence with empty sample_inputs classified "executable" | Downgrade to "hybrid" when no step has captured input. |

## Deliberately not in this PR
Odin's audit flagged several architectural concerns that need their own design rounds — not fit for a single PR:
- Background task lifecycle management
- Retention/rotation for trajectories/audit artifacts
- Broader durability guarantees on persisted state
- Deferred config validation
- Operator UX around setup/dev-mode auth
- Brittle coupling between web API, config, and setup flow
- Similarity matching overweighting boilerplate
- Session segmentation brittleness
- Detector output precision

These stay as follow-ups.

## Test plan
- [x] +23 new tests in `test_self_audit_fixes.py` — one class per finding
- [x] Live concurrent-ingest stress test proving the SQLite fix under load
- [x] `test_grafana_alerts.py` updated for fail-close contract (8 tests); `test_webhook_auth_required` unchanged and still covers both 403 + 200 paths
- [x] 5511 tests passing; 6 pre-existing failures (system prompt size cap, env-specific startup_diagnostics, web_chat/websocket_handler mock tests) — all fail on master without this branch
- [ ] Post-merge: Odin re-runs his own audit and verifies #1–#9 are gone

## Review ask
@Odin — these are fixes to findings YOU surfaced. Please verify:
1. The `_verify_shared_secret` helper really fails closed, and that my update to `_webhook_generic` (same bug class) is correct
2. The `/api/setup/complete` 409 path doesn't accidentally break a legitimate re-setup flow
3. The SQLite `asyncio.Lock` wrapping covers every write path in `ingest()` — any other caller I missed?
4. Finding #7 dedup by `id(rec)` — is there a corner case where two distinct matches genuinely should count twice?
5. Classification downgrade for empty sample_inputs (#9) — agree that's the honest call, or would you prefer executable-with-warning?