### PR TITLE
fix: classifier fail-open on error/timeout

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2173,8 +2173,8 @@ class OdinBot(commands.Bot):
                 timeout=10,
             )
         except Exception as e:
-            log.warning("Completion classifier: error/timeout (%s) — treating as INCOMPLETE to avoid premature stop", e)
-            return False, ""
+            log.warning("Completion classifier: error/timeout (%s) — fail-open to COMPLETE", e)
+            return True, ""
 
         return self._parse_classifier_response(raw)
 


### PR DESCRIPTION
## Summary
- Completion classifier docstring says fail-open (error → COMPLETE) but exception handler returned INCOMPLETE, causing unnecessary tool loop continuations when the API timed out
- One-line fix: return `True, ""` instead of `False, ""`

## Test plan
- [x] Verified ambiguous-response path (line 2213) already returns COMPLETE correctly
- [x] Exception path now matches docstring contract