### PR TITLE
fix: WebUI Operations Live page broken

### DIFF
--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -231,6 +231,9 @@ class OdinWebSocket {
     }
   }
 
+  on(channel, handler) { return this.subscribe(channel, handler); }
+  off(channel, handler) { return this.unsubscribe(channel, handler); }
+
   /** Send a chat message via WebSocket. Returns true if sent. */
   sendChat(content, { channelId, userId, username } = {}) {
     if (!this.connected) return false;


### PR DESCRIPTION
## Summary
- Operations > Live page never showed active or recent operations
- Root cause: `execution.js` called `ws.on()`/`ws.off()` but `OdinWebSocket` only had `subscribe()`/`unsubscribe()`
- Added `on()`/`off()` aliases to the WebSocket class

## Test plan
- [x] Verified only 2 callsites use `on`/`off` (both in execution.js)
- [ ] Load Operations > Live, trigger a task, confirm events appear