### PR TITLE
fix: audit schema gaps, runbook detail, execution fade

### DIFF
--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -87,13 +87,18 @@ class AuditLogger:
         metadata: dict | None = None,
     ) -> None:
         """Log a generic state-changing event (agents, schedules, permissions, etc.)."""
+        elapsed = (metadata or {}).get("elapsed_ms")
         entry = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "type": event_type,
             "action": action,
             "actor": actor,
             "detail": detail[:500],
+            "tool_name": action,
+            "user_id": actor,
         }
+        if elapsed is not None:
+            entry["execution_time_ms"] = elapsed
         if channel_id:
             entry["channel_id"] = channel_id
         if metadata:

--- a/src/learning/runbook_detector.py
+++ b/src/learning/runbook_detector.py
@@ -630,9 +630,22 @@ def format_suggestions(
             f"on {hosts} (last: {s.last_seen[:19]})"
         )
         lines.append(header)
-        # Session-context lines only appear when a trajectory index was
-        # supplied at detection time and actually matched something;
-        # otherwise the pattern is still shown but without intent hints.
+        if s.sample_inputs:
+            lines.append("      sample steps:")
+            for step in s.sample_inputs:
+                inp = step.get("input", {})
+                parts = []
+                if inp.get("command"):
+                    parts.append(f"cmd={inp['command'][:80]}")
+                if inp.get("script"):
+                    script_preview = inp["script"].split("\n")[0][:60]
+                    parts.append(f"script={script_preview}")
+                if inp.get("path"):
+                    parts.append(f"path={inp['path']}")
+                if inp.get("host"):
+                    parts.append(f"host={inp['host']}")
+                if parts:
+                    lines.append(f"        {step.get('tool_name', '?')}: {', '.join(parts)}")
         if s.user_queries:
             err_hint = (
                 f", err_sessions={s.error_session_fraction:.0%}"

--- a/ui/js/pages/audit.js
+++ b/ui/js/pages/audit.js
@@ -92,7 +92,9 @@ export default {
               <td class="text-xs text-gray-400 mobile-hide">{{ e.user || e.user_id || '—' }}</td>
               <td class="text-xs text-gray-400 font-mono mobile-hide">{{ e.host || '—' }}</td>
               <td class="text-xs text-gray-400 mobile-hide">
-                {{ e.duration ? (e.duration < 1 ? (e.duration * 1000).toFixed(0) + 'ms' : e.duration.toFixed(1) + 's') : '—' }}
+                {{ e.duration ? (e.duration < 1 ? (e.duration * 1000).toFixed(0) + 'ms' : e.duration.toFixed(1) + 's')
+                   : e.execution_time_ms != null ? (e.execution_time_ms < 1000 ? e.execution_time_ms + 'ms' : (e.execution_time_ms / 1000).toFixed(1) + 's')
+                   : '—' }}
               </td>
               <td>
                 <span v-if="e.error" class="badge badge-danger">error</span>

--- a/ui/js/pages/execution.js
+++ b/ui/js/pages/execution.js
@@ -42,11 +42,15 @@ export default {
           task.status = payload.metadata?.error ? 'error' : 'success';
           task.elapsed = payload.metadata?.elapsed_ms || (Date.now() - task.startTime);
           task.result = payload.detail || '';
-          activeTasks.value.splice(idx, 1);
-          recentHistory.value.unshift(task);
-          if (recentHistory.value.length > maxHistory) {
-            recentHistory.value.pop();
-          }
+          task.fadingOut = true;
+          setTimeout(() => {
+            const i = activeTasks.value.indexOf(task);
+            if (i >= 0) activeTasks.value.splice(i, 1);
+            recentHistory.value.unshift(task);
+            if (recentHistory.value.length > maxHistory) {
+              recentHistory.value.pop();
+            }
+          }, 5000);
         }
         return;
       }
@@ -113,14 +117,19 @@ export default {
           No active tool executions
         </div>
         <div v-for="task in activeTasks" :key="task.id"
-             class="bg-gray-900 rounded-lg p-3 mb-2 border border-blue-500/30">
+             class="bg-gray-900 rounded-lg p-3 mb-2"
+             :class="task.fadingOut
+               ? (task.status === 'error' ? 'border border-red-500/40' : 'border border-green-500/40')
+               : 'border border-blue-500/30'"
+             :style="task.fadingOut ? 'opacity: 0; transition: opacity 4.5s ease-out;' : ''">
           <div class="flex items-center justify-between mb-2">
             <div class="flex items-center gap-2">
-              <span class="animate-pulse text-blue-400">\u{23F3}</span>
+              <span v-if="task.fadingOut" :class="task.status === 'error' ? 'text-red-400' : 'text-green-400'">{{ statusIcon(task.status) }}</span>
+              <span v-else class="animate-pulse text-blue-400">\u{23F3}</span>
               <span class="text-white font-mono text-sm font-bold">{{ task.tool }}</span>
               <span class="text-gray-500 text-xs">iter {{ task.iteration }}</span>
             </div>
-            <span class="text-blue-400 font-mono text-sm">{{ formatMs(task.elapsed) }}</span>
+            <span :class="task.fadingOut ? 'text-gray-400' : 'text-blue-400'" class="font-mono text-sm">{{ formatMs(task.elapsed) }}</span>
           </div>
           <!-- Streaming output for this tool -->
           <div v-if="streamOutput[task.tool]"


### PR DESCRIPTION
## Summary
- `log_event()` now normalizes `tool_name`/`user_id`/`execution_time_ms` from existing fields so audit entries render properly in the WebUI
- Runbook `format_suggestions()` includes `sample_inputs` — actual commands, scripts, paths per step
- Execution viewer completed tasks stay visible for 5s with opacity fade-out before moving to Recent
- Audit page duration column falls back to `execution_time_ms` when `duration` is absent

## Test plan
- [ ] Trigger a tool call, check History > Audit shows tool name, user, and duration
- [ ] Check Operations > Live — completed tasks should linger 5s with fade
- [ ] Ask Odin to detect runbooks — output should now show sample commands per step