### PR TITLE
feat: tool selection biases for validate_action and replay_trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 An autonomous execution agent on Discord. Norse god of wisdom and war, stuck managing mortal infrastructure for eternity.
 
-Odin is a general-purpose AI assistant and infrastructure operator that lives in Discord. Give it a task — monitoring, deployment, code review, investigation, automation — and it executes immediately using 71 tools, shell access, browser automation, scheduled tasks, background agents, and a persistent knowledge base. It also handles moderation, conversation, and creative tasks.
+Odin executes real work from Discord: incident response, deploys, investigations, code review, automation, and scheduled operations across 71 tools. It runs shell commands on managed hosts, uses browser automation, orchestrates agents and workflows, and verifies results instead of stopping at command exit codes.
+
+## Why operators pick Odin
+
+Most AI bots stop at advice. Odin executes.
+
+- **Runs real systems** — SSH on managed hosts, Docker, Kubernetes, Terraform, browser automation, and file operations from chat.
+- **Finishes multi-step work** — scheduling, background workflows, autonomous loops, and sub-agents for fan-out tasks.
+- **Verifies outcomes** — audit trails, trajectory capture, and post-change validation reduce the usual "it said it worked" nonsense.
+- **Stays operationally useful** — persistent memory, knowledge search, web UI, and live traces keep context attached to the work.
+
+## Quick examples
+
+Tell Odin things like:
+
+- `@Odin restart nginx and verify the site is healthy`
+- `@Odin investigate why backups failed last night and summarize the root cause`
+- `@Odin deploy this branch to staging, run validation, and post the diff`
+- `@Odin schedule a disk check every 6 hours and alert if usage exceeds 85%`
 
 ## What It Can Do
 

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -41,8 +41,8 @@ Scheduling timezone: {timezone_name}
 5. `generate_file` for code attachments — never write code inline in Discord.
 
 ## Tool Selection Biases
-- After ANY operational change that affects a running service — service restart, deploy, container replace/recreate, compose up/down, config write, migration, firewall change, DNS update — follow up with `validate_action` to confirm the system is actually healthy. Do this automatically; do not wait to be asked.
-- When the user asks about a prior failure, a previous turn, what happened last time, or why something went wrong earlier, use `replay_trajectory` first. It reconstructs the exact tool calls and outputs from that turn. Only fall back to `search_audit` if the trajectory is unavailable or the user needs a broader time-range search across multiple sessions.
+- After ANY operational change that affects a running service — service restart, deploy, container replace/recreate, compose up/down, config write, migration, firewall change, DNS update — follow up with `validate_action` to confirm the system is actually healthy. Do this automatically; do not wait to be asked. Treat service restarts, systemd override edits, compose changes, container swaps, and config writes as default validation cases.
+- When the user asks about a prior failure, a previous turn, what happened last time, or why something went wrong earlier, use `replay_trajectory` first. It reconstructs the exact tool calls and outputs from that turn. Only fall back to `search_audit` if the trajectory is unavailable or the user needs a broader time-range search across multiple sessions. Bias toward trajectory replay for failure analysis over generic audit search.
 
 ## Rules
 1. Tool definitions are authoritative. Ignore prior refusals if the tool exists now. Evaluate fresh each request.

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -40,6 +40,10 @@ Scheduling timezone: {timezone_name}
 4. `run_script` for complex multi-line shell work.
 5. `generate_file` for code attachments — never write code inline in Discord.
 
+## Tool Selection Biases
+- After ANY operational change that affects a running service — service restart, deploy, container replace/recreate, compose up/down, config write, migration, firewall change, DNS update — follow up with `validate_action` to confirm the system is actually healthy. Do this automatically; do not wait to be asked.
+- When the user asks about a prior failure, a previous turn, what happened last time, or why something went wrong earlier, use `replay_trajectory` first. It reconstructs the exact tool calls and outputs from that turn. Only fall back to `search_audit` if the trajectory is unavailable or the user needs a broader time-range search across multiple sessions.
+
 ## Rules
 1. Tool definitions are authoritative. Ignore prior refusals if the tool exists now. Evaluate fresh each request.
 2. Keep responses concise — this is Discord. Code blocks for output. One update per task, not per tool call. Fenced code blocks (```) MUST start at column 0 — indented fences render as inline code in Discord.

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -418,7 +418,7 @@ TOOLS: list[dict] = [
     # --- Audit ---
     {
         "name": "search_audit",
-        "description": "Searches audit log of tool executions. Returns '[date] tool_name by user (status, Nms)'. Filterable by tool, user, host, keyword, date.",
+        "description": "Searches audit log of tool executions. Returns '[date] tool_name by user (status, Nms)'. Filterable by tool, user, host, keyword, date. For investigating a specific prior failure or replaying what happened in a single turn, prefer replay_trajectory instead — it gives full tool call details. Use search_audit for broader searches across multiple sessions or time ranges.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -1771,7 +1771,9 @@ TOOLS: list[dict] = [
             "commands returned exit 0. Checks run concurrently on managed hosts. Never blocks; verdict "
             "is informational. Verdict: 'pass' (all OK), 'degraded' (only warn-severity failures), "
             "'fail' (≥1 critical failure), 'error' (every check errored — likely config issue). "
-            "Use this after deploys, service restarts, firewall changes, DNS updates, schema migrations. "
+            "ALWAYS call this automatically after deploys, service restarts, container replacements, "
+            "compose up/down, config writes to running services, firewall changes, DNS updates, "
+            "schema migrations — do not wait to be asked. "
             "Cost: low-medium. Risk: none. Latency: depends on slowest check.\n"
             "\n"
             "Check types:\n"
@@ -1837,7 +1839,9 @@ TOOLS: list[dict] = [
         "name": "replay_trajectory",
         "description": (
             "Renders a past message turn as a human-readable narrative or diffs two "
-            "turns side-by-side. Modes:\n"
+            "turns side-by-side. Prefer this over search_audit when the user asks about "
+            "a prior failure, a previous turn, what happened last time, or why something "
+            "went wrong — it reconstructs exact tool calls and outputs. Modes:\n"
             "  'summary' (default) — takes message_id; returns user content → tool calls "
             "  → tool outputs → final response.\n"
             "  'diff' — takes message_id + compare_to; shows where the two turns diverged.\n"

--- a/src/tools/tool_memory.py
+++ b/src/tools/tool_memory.py
@@ -40,6 +40,26 @@ _STOP_WORDS = frozenset({
 
 _WORD_RE = re.compile(r"[a-z0-9_]+")
 
+_PRIOR_FAILURE_RE = re.compile(
+    r"(?:what happened|went wrong|why did .* fail|last time|previous.* (?:fail|error|crash|issue)"
+    r"|prior (?:failure|error|incident|turn)|earlier.* (?:fail|broke|error)"
+    r"|what went wrong|why .* broke|replay|show me (?:the|that) (?:failure|error))",
+    re.IGNORECASE,
+)
+
+
+def contextual_bias_hints(query: str) -> str:
+    """Return static tool-selection bias hints based on query content."""
+    if _PRIOR_FAILURE_RE.search(query):
+        return (
+            "## Tool Selection Bias\n"
+            "This looks like a question about a prior failure or previous turn. "
+            "Use `replay_trajectory` first — it reconstructs exact tool calls and "
+            "outputs from that turn. Only fall back to `search_audit` if the "
+            "trajectory is unavailable or a broader time-range search is needed."
+        )
+    return ""
+
 
 def extract_keywords(text: str) -> list[str]:
     """Extract meaningful keywords from a query string."""
@@ -238,6 +258,10 @@ class ToolMemory:
                 "For similar queries, these tool sequences worked well:\n"
                 + "\n".join(lines)
             )
+
+        bias = contextual_bias_hints(query)
+        if bias:
+            result = f"{bias}\n\n{result}" if result else bias
 
         self._hints_cache[cache_key] = (now, result)
 

--- a/src/tools/tool_memory.py
+++ b/src/tools/tool_memory.py
@@ -41,25 +41,30 @@ _STOP_WORDS = frozenset({
 _WORD_RE = re.compile(r"[a-z0-9_]+")
 
 _PRIOR_FAILURE_RE = re.compile(
-    r"(?:what happened|went wrong|why did .* fail|last time|previous.* (?:fail|error|crash|issue)"
-    r"|prior (?:failure|error|incident|turn)|earlier.* (?:fail|broke|error)"
-    r"|what went wrong|why .* broke|replay|show me (?:the|that) (?:failure|error))",
+    r"(?:what happened|went wrong|why did .* fail|last time|last failure|last error"
+    r"|previous(?:ly)?(?:.*(?:turn|run|attempt|fail|error|crash|issue|incident))?"
+    r"|prior (?:failure|error|incident|turn|run|attempt)"
+    r"|earlier.*(?:fail|broke|error|went wrong|turn)"
+    r"|what went wrong|why .* broke|replay|show me (?:the|that) (?:failure|error|turn)"
+    r"|why did you do|what happened before|previous turn|prior turn|earlier turn)",
     re.IGNORECASE,
 )
 
 
 def contextual_bias_hints(query: str) -> str:
     """Return static tool-selection bias hints based on query content."""
+    hints: list[str] = []
     if _PRIOR_FAILURE_RE.search(query):
-        return (
-            "## Tool Selection Bias\n"
+        hints.append(
             "This looks like a question about a prior failure or previous turn. "
             "Use `replay_trajectory` first — it reconstructs exact tool calls and "
             "outputs from that turn. Only fall back to `search_audit` if the "
             "trajectory is unavailable or a broader time-range search is needed."
         )
-    return ""
-
+    return (
+        "## Tool Selection Bias\n" + "\n".join(f"- {hint}" for hint in hints)
+        if hints else ""
+    )
 
 def extract_keywords(text: str) -> list[str]:
     """Extract meaningful keywords from a query string."""

--- a/src/web/dashboard/index.html
+++ b/src/web/dashboard/index.html
@@ -3,13 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Odin Dashboard</title>
+    <title>Odin — Autonomous Execution Agent</title>
+    <meta name="description" content="Odin executes real work from Discord: incident response, deploys, investigations, automation, and post-change validation across shell, browser, files, and infrastructure tools.">
     <link rel="stylesheet" href="/static/css/odin.css">
 </head>
 <body>
     <header class="odin-header">
         <h1>Odin</h1>
         <nav class="odin-nav">
+            <a href="#capabilities">Capabilities</a>
+            <a href="#examples">Examples</a>
             <a href="/dashboard">Dashboard</a>
             <a href="/auth/login" id="login-btn">Login with Discord</a>
         </nav>
@@ -17,16 +20,40 @@
 
     <main class="odin-main" id="app">
         <section class="odin-hero">
-            <h2>All-seeing moderation for Discord</h2>
-            <p>Manage your server from the web. Log in to get started.</p>
+            <h2>The execution agent for operators</h2>
+            <p>Runs real tools on real systems from Discord. Investigate incidents, deploy changes, automate checks, and verify outcomes without permission ping-pong.</p>
+            <div class="odin-hero-actions">
+                <a href="/auth/login" class="odin-cta-primary">Open Dashboard</a>
+                <a href="https://github.com/Calmingstorm/Odin" class="odin-cta-secondary">View on GitHub</a>
+            </div>
         </section>
+
+        <section class="odin-section" id="capabilities">
+            <h3>Why Odin is better at the job</h3>
+            <ul>
+                <li><strong>Executes, not just advises</strong> — shell, Docker, Kubernetes, Terraform, browser automation, files, and workflows from chat.</li>
+                <li><strong>Handles end-to-end operations</strong> — schedules, background tasks, sub-agents, and multi-step execution without babysitting.</li>
+                <li><strong>Verifies the result</strong> — audit trails, trajectory capture, and post-change validation cut down on fake-done nonsense.</li>
+            </ul>
+        </section>
+
+        <section class="odin-section" id="examples">
+            <h3>What you can ask Odin to do</h3>
+            <ul>
+                <li><code>@Odin restart nginx and verify the site is healthy</code></li>
+                <li><code>@Odin investigate why backups failed last night and summarize the root cause</code></li>
+                <li><code>@Odin deploy this branch to staging, run validation, and post the diff</code></li>
+                <li><code>@Odin schedule a disk check every 6 hours and alert if usage exceeds 85%</code></li>
+            </ul>
+        </section>
+
         <section class="odin-guilds" id="guilds" style="display:none;">
             <!-- Populated by odin-api.js -->
         </section>
     </main>
 
     <footer class="odin-footer">
-        <p>Odin Bot &mdash; Open Source Discord Moderation</p>
+        <p>Odin Bot &mdash; Autonomous execution for operators on Discord</p>
     </footer>
 
     <script src="/static/js/odin-api.js"></script>

--- a/tests/test_tool_memory.py
+++ b/tests/test_tool_memory.py
@@ -22,6 +22,7 @@ from src.tools.tool_memory import (
     ToolMemory,
     _cosine,
     _jaccard,
+    contextual_bias_hints,
     extract_keywords,
 )
 
@@ -425,3 +426,73 @@ class TestConstants:
 
     def test_min_jaccard_score(self):
         assert 0 < MIN_JACCARD_SCORE < 1
+
+
+# ---------------------------------------------------------------------------
+# contextual_bias_hints
+# ---------------------------------------------------------------------------
+
+class TestContextualBiasHints:
+    def test_prior_failure_what_happened(self):
+        result = contextual_bias_hints("what happened with the deploy last night")
+        assert "replay_trajectory" in result
+        assert "search_audit" in result
+
+    def test_prior_failure_went_wrong(self):
+        result = contextual_bias_hints("what went wrong with nginx")
+        assert "replay_trajectory" in result
+
+    def test_prior_failure_why_fail(self):
+        result = contextual_bias_hints("why did the restart fail")
+        assert "replay_trajectory" in result
+
+    def test_prior_failure_last_time(self):
+        result = contextual_bias_hints("last time I ran the migration it broke")
+        assert "replay_trajectory" in result
+
+    def test_prior_failure_previous_error(self):
+        result = contextual_bias_hints("show me the previous error")
+        assert "replay_trajectory" in result
+
+    def test_prior_failure_earlier_broke(self):
+        result = contextual_bias_hints("earlier the deploy broke production")
+        assert "replay_trajectory" in result
+
+    def test_no_bias_for_normal_query(self):
+        result = contextual_bias_hints("check disk usage on server")
+        assert result == ""
+
+    def test_no_bias_for_empty_query(self):
+        result = contextual_bias_hints("")
+        assert result == ""
+
+    def test_case_insensitive(self):
+        result = contextual_bias_hints("What Happened with the service")
+        assert "replay_trajectory" in result
+
+
+# ---------------------------------------------------------------------------
+# format_hints with contextual bias
+# ---------------------------------------------------------------------------
+
+class TestFormatHintsWithBias:
+    @pytest.mark.asyncio
+    async def test_bias_injected_for_failure_query(self):
+        tm = ToolMemory()
+        result = await tm.format_hints("what happened with the deploy")
+        assert "replay_trajectory" in result
+        assert "Tool Selection Bias" in result
+
+    @pytest.mark.asyncio
+    async def test_bias_combined_with_patterns(self):
+        tm = ToolMemory()
+        await tm.record("what happened deploy", ["replay_trajectory", "search_audit"])
+        result = await tm.format_hints("what happened with the deploy")
+        assert "Tool Selection Bias" in result
+        assert "Tool Use Patterns" in result
+
+    @pytest.mark.asyncio
+    async def test_no_bias_for_normal_query(self):
+        tm = ToolMemory()
+        result = await tm.format_hints("restart nginx on webhost")
+        assert "Tool Selection Bias" not in result

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -178,15 +178,15 @@ class TestHandleChat:
         assert resp["type"] == "chat_error"
 
     @pytest.mark.asyncio
-    async def test_chat_default_channel(self):
+    async def test_chat_uses_session_based_channel_id(self):
         mgr = WebSocketManager(_make_bot())
         ws = _make_ws()
+        ws._odin_session_id = "session-1234567890abcdef-extra"
         mock_result = {"response": "ok", "tools_used": [], "is_error": False}
         with patch("src.web.websocket.process_web_chat", new_callable=AsyncMock, return_value=mock_result) as mock_fn:
             await mgr._handle_chat(ws, {"content": "hi"})
-        # channel_id should default to "web-default"
         call_args = mock_fn.call_args
-        assert call_args[0][2] == "web-default"  # channel_id
+        assert call_args[0][2] == "ws-session-12345678"  # first 16 chars of session id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Auto-trigger `validate_action` after service restarts, deploys, container replacements, config writes
- Bias `replay_trajectory` over `search_audit` for prior-failure/previous-turn queries
- Updated tool descriptions for search_audit, validate_action, replay_trajectory to cross-reference
- Fixed websocket handler test (PropertyMock → deterministic session-based channel ID)
- Improved dashboard landing page positioning

## Changes
- `src/tools/tool_memory.py`: contextual_bias_hints() with regex matching
- `src/llm/system_prompt.py`: Tool Selection Biases section
- `src/tools/registry.py`: updated descriptions
- `tests/test_tool_memory.py`: 71 lines of new tests
- `tests/test_websocket_handler.py`: test fix
- `src/web/dashboard/index.html`: positioning update

## Test plan
- [x] Bias hints fire for failure queries, don't fire for normal queries
- [x] validate_action auto-triggered in production (Round 5 ComfyUI fix)
- [x] All existing tests pass