### PR TITLE
feat: per-guild/per-channel response config with WebUI

### DIFF
--- a/src/discord/channel_config.py
+++ b/src/discord/channel_config.py
@@ -1,0 +1,101 @@
+"""Per-guild and per-channel response configuration.
+
+Persisted to data/channel_config.json, hot-reloaded on API writes.
+Resolution order: channel override > guild default > global config.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..odin_log import get_logger
+
+log = get_logger("discord.channel_config")
+
+_DEFAULT_ENTRY = {"enabled": True, "require_mention": None}
+
+
+class ChannelConfigManager:
+    def __init__(self, path: str = "./data/channel_config.json") -> None:
+        self._path = Path(path)
+        self._guild_defaults: dict[str, dict[str, Any]] = {}
+        self._channel_overrides: dict[str, dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+            self._guild_defaults = data.get("guild_defaults", {})
+            self._channel_overrides = data.get("channel_overrides", {})
+            log.info(
+                "Loaded channel config: %d guild defaults, %d channel overrides",
+                len(self._guild_defaults), len(self._channel_overrides),
+            )
+        except Exception as e:
+            log.error("Failed to load channel config: %s", e)
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps({
+            "guild_defaults": self._guild_defaults,
+            "channel_overrides": self._channel_overrides,
+        }, indent=2))
+        tmp.replace(self._path)
+
+    def is_enabled(self, guild_id: str | None, channel_id: str, global_default: bool = True) -> bool:
+        ch = self._channel_overrides.get(channel_id, {})
+        if "enabled" in ch:
+            return ch["enabled"]
+        if guild_id:
+            gd = self._guild_defaults.get(guild_id, {})
+            if "enabled" in gd:
+                return gd["enabled"]
+        return global_default
+
+    def should_require_mention(self, guild_id: str | None, channel_id: str, global_default: bool = False) -> bool:
+        ch = self._channel_overrides.get(channel_id, {})
+        if ch.get("require_mention") is not None:
+            return ch["require_mention"]
+        if guild_id:
+            gd = self._guild_defaults.get(guild_id, {})
+            if gd.get("require_mention") is not None:
+                return gd["require_mention"]
+        return global_default
+
+    def set_guild_config(self, guild_id: str, **kwargs: Any) -> dict[str, Any]:
+        current = self._guild_defaults.get(guild_id, {})
+        for k in ("enabled", "require_mention"):
+            if k in kwargs and kwargs[k] is not None:
+                current[k] = kwargs[k]
+        self._guild_defaults[guild_id] = current
+        self._save()
+        return current
+
+    def set_channel_config(self, channel_id: str, **kwargs: Any) -> dict[str, Any]:
+        current = self._channel_overrides.get(channel_id, {})
+        for k in ("enabled", "require_mention"):
+            if k in kwargs and kwargs[k] is not None:
+                current[k] = kwargs[k]
+        if kwargs.get("clear"):
+            self._channel_overrides.pop(channel_id, None)
+            self._save()
+            return {}
+        self._channel_overrides[channel_id] = current
+        self._save()
+        return current
+
+    def get_guild_config(self, guild_id: str) -> dict[str, Any]:
+        return self._guild_defaults.get(guild_id, {})
+
+    def get_channel_config(self, channel_id: str) -> dict[str, Any]:
+        return self._channel_overrides.get(channel_id, {})
+
+    def get_all(self) -> dict[str, Any]:
+        return {
+            "guild_defaults": dict(self._guild_defaults),
+            "channel_overrides": dict(self._channel_overrides),
+        }

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -38,6 +38,7 @@ from ..tools import ToolExecutor, SkillManager, get_tool_definitions
 from ..tools.tool_memory import ToolMemory
 from ..search import LocalEmbedder, SessionVectorStore
 from ..permissions import PermissionManager
+from .channel_config import ChannelConfigManager
 from .channel_logger import ChannelLogger
 from .voice import VoiceManager, VoiceMessageProxy
 
@@ -325,6 +326,7 @@ class OdinBot(commands.Bot):
         self.sessions.load()
 
         self._memory_path = "./data/memory.json"
+        self.channel_config = ChannelConfigManager("./data/channel_config.json")
 
         # Passive channel logger — writes ALL guild messages to JSONL (zero LLM tokens)
         self.channel_logger = ChannelLogger("./data/channel_logs")
@@ -1581,11 +1583,19 @@ class OdinBot(commands.Bot):
         if not self._is_allowed_channel(message.channel.id):
             return
 
-        # require_mention: only respond when the bot is @mentioned (or in DMs)
+        # Per-channel enabled check (channel override > guild default > global)
+        guild_id = str(message.guild.id) if message.guild else None
+        channel_id_str = str(message.channel.id)
+        if not self.channel_config.is_enabled(guild_id, channel_id_str):
+            return
+
+        # Per-channel require_mention check (channel override > guild default > global)
         # Bot messages skip this gate — they go into the buffer and the mention
-        # check happens after all segments are collected (so multi-message bot
-        # responses where only the first part has the @mention still get through).
-        if self.config.discord.require_mention:
+        # check happens after all segments are collected.
+        _require_mention = self.channel_config.should_require_mention(
+            guild_id, channel_id_str, self.config.discord.require_mention,
+        )
+        if _require_mention:
             is_dm = not hasattr(message.channel, "guild") or message.channel.guild is None
             is_bot_buffered = message.author.bot and self.config.discord.respond_to_bots
             if not is_dm and not is_bot_buffered:
@@ -1636,7 +1646,12 @@ class OdinBot(commands.Bot):
                 combined = combine_bot_messages(parts)
                 log.info("Bot buffer flushed: %d messages from %s combined", len(parts), orig_msg.author)
                 # require_mention for bots: check if ANY buffered part mentions us
-                if self.config.discord.require_mention and self.user:
+                _bot_guild_id = str(orig_msg.guild.id) if orig_msg.guild else None
+                _bot_channel_id = str(orig_msg.channel.id)
+                _bot_require = self.channel_config.should_require_mention(
+                    _bot_guild_id, _bot_channel_id, self.config.discord.require_mention,
+                )
+                if _bot_require and self.user:
                     mention_str = f"<@{self.user.id}>"
                     mention_nick = f"<@!{self.user.id}>"
                     if not any(mention_str in p or mention_nick in p for p in parts):

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -399,6 +399,71 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "monitoring": monitoring,
         })
 
+    # ------------------------------------------------------------------
+    # Discord per-guild/per-channel config
+    # ------------------------------------------------------------------
+
+    @routes.get("/api/discord/guilds")
+    async def discord_guilds(_request: web.Request) -> web.Response:
+        result = []
+        cc = bot.channel_config
+        for g in bot.guilds:
+            gid = str(g.id)
+            guild_cfg = cc.get_guild_config(gid)
+            channels = []
+            for ch in sorted(g.text_channels, key=lambda c: c.position):
+                cid = str(ch.id)
+                ch_cfg = cc.get_channel_config(cid)
+                effective_mention = cc.should_require_mention(
+                    gid, cid, bot.config.discord.require_mention,
+                )
+                effective_enabled = cc.is_enabled(gid, cid)
+                channels.append({
+                    "id": cid,
+                    "name": ch.name,
+                    "category": ch.category.name if ch.category else None,
+                    "config": ch_cfg,
+                    "effective": {"enabled": effective_enabled, "require_mention": effective_mention},
+                })
+            result.append({
+                "id": gid,
+                "name": g.name,
+                "member_count": g.member_count or 0,
+                "icon_url": str(g.icon.url) if g.icon else None,
+                "config": guild_cfg,
+                "channels": channels,
+            })
+        return web.json_response(result)
+
+    @routes.put("/api/discord/guild/{guild_id}/config")
+    async def update_guild_config(request: web.Request) -> web.Response:
+        gid = request.match_info["guild_id"]
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON body"}, status=400)
+        cfg = bot.channel_config.set_guild_config(
+            gid,
+            enabled=data.get("enabled"),
+            require_mention=data.get("require_mention"),
+        )
+        return web.json_response({"guild_id": gid, "config": cfg})
+
+    @routes.put("/api/discord/channel/{channel_id}/config")
+    async def update_channel_config(request: web.Request) -> web.Response:
+        cid = request.match_info["channel_id"]
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON body"}, status=400)
+        cfg = bot.channel_config.set_channel_config(
+            cid,
+            enabled=data.get("enabled"),
+            require_mention=data.get("require_mention"),
+            clear=data.get("clear", False),
+        )
+        return web.json_response({"channel_id": cid, "config": cfg})
+
     @routes.get("/api/health/components")
     async def get_health_components(_request: web.Request) -> web.Response:
         from ..health.checker import check_all

--- a/ui/js/pages/discord-config.js
+++ b/ui/js/pages/discord-config.js
@@ -1,0 +1,189 @@
+/**
+ * Discord per-guild/per-channel configuration page.
+ * Toggle response enabled + require_mention per guild and channel.
+ */
+import { api } from '../api.js';
+
+const { ref, computed, onMounted } = Vue;
+
+export default {
+  template: `
+    <div class="p-6 page-fade-in">
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold">Discord Channels</h1>
+        <button @click="fetchGuilds" class="btn btn-ghost text-xs" :disabled="loading">
+          {{ loading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+      <p class="text-xs text-gray-500 mb-4">
+        Configure response behavior per guild and channel. Channel overrides take priority over guild defaults.
+        Changes take effect immediately.
+      </p>
+
+      <div v-if="loading && guilds.length === 0" class="space-y-2">
+        <div v-for="n in 3" :key="n" class="skeleton skeleton-row"></div>
+      </div>
+      <div v-else-if="error" class="hm-card border-red-900 error-state">
+        <p class="text-red-400">{{ error }}</p>
+        <button @click="fetchGuilds" class="btn btn-ghost text-xs">Retry</button>
+      </div>
+
+      <div v-else class="space-y-4">
+        <div v-for="guild in guilds" :key="guild.id" class="hm-card">
+          <!-- Guild header -->
+          <div class="flex items-center justify-between mb-3">
+            <div class="flex items-center gap-3">
+              <img v-if="guild.icon_url" :src="guild.icon_url + '?size=32'" class="w-8 h-8 rounded-full" />
+              <div v-else class="w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center text-xs text-gray-400">
+                {{ guild.name.charAt(0) }}
+              </div>
+              <div>
+                <span class="text-white font-medium">{{ guild.name }}</span>
+                <span class="text-gray-500 text-xs ml-2">{{ guild.member_count }} members</span>
+              </div>
+            </div>
+            <div class="flex items-center gap-4">
+              <label class="flex items-center gap-2 text-xs text-gray-400">
+                Enabled
+                <label class="toggle-switch">
+                  <input type="checkbox"
+                    :checked="guildEnabled(guild)"
+                    @change="setGuildConfig(guild.id, 'enabled', $event.target.checked)" />
+                  <span class="toggle-slider"></span>
+                </label>
+              </label>
+              <label class="flex items-center gap-2 text-xs text-gray-400">
+                Require @mention
+                <label class="toggle-switch">
+                  <input type="checkbox"
+                    :checked="guildMention(guild)"
+                    @change="setGuildConfig(guild.id, 'require_mention', $event.target.checked)" />
+                  <span class="toggle-slider"></span>
+                </label>
+              </label>
+              <button @click="toggleGuild(guild.id)" class="btn btn-ghost text-xs">
+                {{ expanded[guild.id] ? 'Hide channels' : 'Show channels' }}
+              </button>
+            </div>
+          </div>
+
+          <!-- Channel list -->
+          <div v-if="expanded[guild.id]">
+            <table class="hm-table">
+              <thead>
+                <tr>
+                  <th>Channel</th>
+                  <th>Category</th>
+                  <th class="text-center" style="width:100px">Enabled</th>
+                  <th class="text-center" style="width:120px">Require @mention</th>
+                  <th class="text-center" style="width:80px">Override</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="ch in guild.channels" :key="ch.id"
+                    :class="{'opacity-40': !ch.effective.enabled}">
+                  <td class="font-mono text-sm">#{{ ch.name }}</td>
+                  <td class="text-xs text-gray-500">{{ ch.category || '—' }}</td>
+                  <td class="text-center">
+                    <label class="toggle-switch">
+                      <input type="checkbox"
+                        :checked="ch.effective.enabled"
+                        @change="setChannelConfig(ch.id, guild.id, 'enabled', $event.target.checked)" />
+                      <span class="toggle-slider"></span>
+                    </label>
+                  </td>
+                  <td class="text-center">
+                    <label class="toggle-switch">
+                      <input type="checkbox"
+                        :checked="ch.effective.require_mention"
+                        @change="setChannelConfig(ch.id, guild.id, 'require_mention', $event.target.checked)" />
+                      <span class="toggle-slider"></span>
+                    </label>
+                  </td>
+                  <td class="text-center">
+                    <span v-if="hasOverride(ch)" class="badge badge-warning text-xs cursor-pointer"
+                          @click="clearOverride(ch.id, guild.id)" title="Click to clear override">
+                      custom
+                    </span>
+                    <span v-else class="text-gray-600 text-xs">inherit</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+
+  setup() {
+    const guilds = ref([]);
+    const loading = ref(true);
+    const error = ref(null);
+    const expanded = ref({});
+
+    function guildEnabled(guild) {
+      if (guild.config && guild.config.enabled !== undefined) return guild.config.enabled;
+      return true;
+    }
+
+    function guildMention(guild) {
+      if (guild.config && guild.config.require_mention !== undefined) return guild.config.require_mention;
+      return false;
+    }
+
+    function hasOverride(ch) {
+      return ch.config && Object.keys(ch.config).length > 0;
+    }
+
+    function toggleGuild(id) {
+      expanded.value[id] = !expanded.value[id];
+    }
+
+    async function fetchGuilds() {
+      loading.value = true;
+      error.value = null;
+      try {
+        guilds.value = await api.get('/api/discord/guilds');
+      } catch (e) {
+        error.value = e.message;
+      }
+      loading.value = false;
+    }
+
+    async function setGuildConfig(guildId, key, value) {
+      try {
+        await api.put('/api/discord/guild/' + guildId + '/config', { [key]: value });
+        await fetchGuilds();
+      } catch (e) {
+        error.value = e.message;
+      }
+    }
+
+    async function setChannelConfig(channelId, guildId, key, value) {
+      try {
+        await api.put('/api/discord/channel/' + channelId + '/config', { [key]: value });
+        await fetchGuilds();
+      } catch (e) {
+        error.value = e.message;
+      }
+    }
+
+    async function clearOverride(channelId, guildId) {
+      try {
+        await api.put('/api/discord/channel/' + channelId + '/config', { clear: true });
+        await fetchGuilds();
+      } catch (e) {
+        error.value = e.message;
+      }
+    }
+
+    onMounted(fetchGuilds);
+
+    return {
+      guilds, loading, error, expanded,
+      guildEnabled, guildMention, hasOverride, toggleGuild,
+      fetchGuilds, setGuildConfig, setChannelConfig, clearOverride,
+    };
+  },
+};

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -3,6 +3,7 @@ import HealthPage from './health.js';
 import ResourcesPage from './resources.js';
 import LogsPage from './logs.js';
 import ConfigPage from './config.js';
+import DiscordConfigPage from './discord-config.js';
 import InternalsPage from './internals.js';
 
 export default {
@@ -13,6 +14,7 @@ export default {
       { id: 'resources', label: 'Resources', component: ResourcesPage },
       { id: 'logs', label: 'Logs', component: LogsPage },
       { id: 'config', label: 'Config', component: ConfigPage },
+      { id: 'discord', label: 'Discord', component: DiscordConfigPage },
       { id: 'internals', label: 'Internals', component: InternalsPage },
     ];
     return { tabs };


### PR DESCRIPTION
Per-guild and per-channel toggles for enabled + require_mention. Hot-reload, no restart needed. New Discord tab in System WebUI.