### PR TITLE
feat: Odin self-review round 2 — 5 more improvements

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -343,11 +343,22 @@ class AuditConfig(BaseModel):
     hmac_key: str = ""  # Empty = signing disabled
 
 
+class ApiTokenIdentity(BaseModel):
+    token: str = ""
+    user_id: str = "api-user"
+    username: str = "API"
+    tier: str = "admin"
+    allowed_tools: list[str] = Field(default_factory=list)
+    allowed_hosts: list[str] = Field(default_factory=list)
+    label: str = ""
+
+
 class WebConfig(BaseModel):
     enabled: bool = True
-    api_token: str = ""  # Empty = no auth required (dev mode)
-    session_timeout_minutes: int = 0  # 0 = no timeout (sessions persist until logout)
-    port: int = 3000  # HTTP server port for health checks + web UI
+    api_token: str = ""
+    api_tokens: list[ApiTokenIdentity] = Field(default_factory=list)
+    session_timeout_minutes: int = 0
+    port: int = 3000
 
     @field_validator("port")
     @classmethod
@@ -355,6 +366,18 @@ class WebConfig(BaseModel):
         if v < 1 or v > 65535:
             raise ValueError("port must be between 1 and 65535")
         return v
+
+    def resolve_api_identity(self, token: str) -> ApiTokenIdentity | None:
+        """Look up identity for an API token. Falls back to default if single token configured."""
+        for t in self.api_tokens:
+            if t.token and t.token == token:
+                return t
+        if self.api_token and token == self.api_token:
+            return ApiTokenIdentity(
+                token=self.api_token, user_id="api-admin",
+                username="Admin", tier="admin", label="default",
+            )
+        return None
 
 
 class ComfyUIConfig(BaseModel):

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2546,6 +2546,19 @@ class OdinBot(commands.Bot):
                     })
                     continue
             if not llm_resp.is_tool_use:
+                # Enforce pending validation before allowing final response
+                if _validation_required and _validation_retries < _MAX_VALIDATION_RETRIES:
+                    _validation_retries += 1
+                    log.warning("Validation required but model returned text — forcing continuation (attempt %d)", _validation_retries)
+                    messages.append({
+                        "role": "developer",
+                        "content": (
+                            "[VALIDATION REQUIRED] You have pending post-action validation. "
+                            "Call validate_action before responding to the user."
+                        ),
+                    })
+                    continue
+
                 # Fabrication detection: if no tools were called and the
                 # response looks like it fabricated results, retry once.
                 if (
@@ -2957,6 +2970,9 @@ class OdinBot(commands.Bot):
 
             # Track mutations that need post-action validation
             _pending_validations: list[str] = []
+            _validation_required: bool = False
+            _validation_retries: int = 0
+            _MAX_VALIDATION_RETRIES = 2
 
             # Run all tool calls concurrently with per-tool timeout
             tool_timeout = self.config.tools.tool_timeout_seconds
@@ -2997,9 +3013,15 @@ class OdinBot(commands.Bot):
                 )
             messages.append({"role": "user", "content": list(tool_results)})
 
+            # Clear validation requirement if validate_action was called this iteration
+            if _validation_required and "validate_action" in [t.name for t in tool_calls]:
+                _validation_required = False
+                _validation_retries = 0
+
             # Auto-inject validation instruction when mutations were detected
             if _pending_validations:
                 mutation_list = "; ".join(_pending_validations)
+                _validation_required = True
                 messages.append({
                     "role": "developer",
                     "content": (

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2940,6 +2940,12 @@ class OdinBot(commands.Bot):
                 except Exception:
                     pass  # Non-critical tracking
 
+                # Track mutations requiring post-action validation
+                if tool_result is not None and tool_result.requires_validation and tool_result.ok:
+                    _pending_validations.append(
+                        f"{tool_name}: {tool_result.validation_reason}"
+                    )
+
                 # Truncate large outputs before sending back to the LLM.
                 tool_content = truncate_tool_output(result)
 
@@ -2948,6 +2954,9 @@ class OdinBot(commands.Bot):
                     "tool_use_id": block.id,
                     "content": tool_content,
                 }
+
+            # Track mutations that need post-action validation
+            _pending_validations: list[str] = []
 
             # Run all tool calls concurrently with per-tool timeout
             tool_timeout = self.config.tools.tool_timeout_seconds
@@ -2987,6 +2996,19 @@ class OdinBot(commands.Bot):
                     *[_run_tool_with_timeout(b) for b in tool_calls],
                 )
             messages.append({"role": "user", "content": list(tool_results)})
+
+            # Auto-inject validation instruction when mutations were detected
+            if _pending_validations:
+                mutation_list = "; ".join(_pending_validations)
+                messages.append({
+                    "role": "developer",
+                    "content": (
+                        f"[AUTO-VALIDATE] Operational mutation(s) detected: {mutation_list}. "
+                        "You MUST call validate_action now to confirm the change took effect. "
+                        "Infer appropriate checks from the mutation type."
+                    ),
+                })
+                _pending_validations.clear()
 
             # Inject pending image blocks as vision content for the next LLM call.
             # This reuses the same base64 image block format as _process_attachments.

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2451,6 +2451,12 @@ class OdinBot(commands.Bot):
             user_name=str(getattr(message.author, "display_name", "")),
         )
 
+        # Post-mutation validation state — persists across iterations
+        _pending_validations: list[str] = []
+        _validation_required: bool = False
+        _validation_retries: int = 0
+        _MAX_VALIDATION_RETRIES = 2
+
         for iteration in range(chat_cap):
             # Context auto-compression — when accumulated tool iterations push
             # the message list over the configured budget, summarise older
@@ -2967,12 +2973,6 @@ class OdinBot(commands.Bot):
                     "tool_use_id": block.id,
                     "content": tool_content,
                 }
-
-            # Track mutations that need post-action validation
-            _pending_validations: list[str] = []
-            _validation_required: bool = False
-            _validation_retries: int = 0
-            _MAX_VALIDATION_RETRIES = 2
 
             # Run all tool calls concurrently with per-tool timeout
             tool_timeout = self.config.tools.tool_timeout_seconds

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -146,19 +146,26 @@ def _make_auth_middleware(
             return await handler(request)
         # Skip auth if no token configured (dev mode)
         token = web_config.api_token
-        if not token:
+        has_any_token = token or getattr(web_config, "api_tokens", None)
+        if not has_any_token:
             return await handler(request)
 
         # Extract bearer value from Authorization header
         auth_header = request.headers.get("Authorization", "")
-        expected_bearer = f"Bearer {token}"
-        if hmac.compare_digest(auth_header, expected_bearer):
-            request._session_id = "admin-token"
-            return await handler(request)
-        # Check session tokens (Bearer <session_id>)
         bearer_prefix = "Bearer "
         if auth_header.startswith(bearer_prefix):
             bearer_value = auth_header[len(bearer_prefix):]
+            # Check legacy single token
+            if token and hmac.compare_digest(bearer_value, token):
+                request._session_id = "admin-token"
+                return await handler(request)
+            # Check multi-token identities
+            identity = web_config.resolve_api_identity(bearer_value) if hasattr(web_config, "resolve_api_identity") else None
+            if identity is not None:
+                request._session_id = identity.user_id
+                request._api_identity = identity
+                return await handler(request)
+            # Check session tokens
             if session_manager.validate(bearer_value):
                 request._session_id = bearer_value
                 return await handler(request)
@@ -166,9 +173,15 @@ def _make_auth_middleware(
         # Check query param token (for downloads, WebSocket)
         query_token = request.query.get("token", "")
         if query_token:
-            if hmac.compare_digest(query_token, token):
+            if token and hmac.compare_digest(query_token, token):
                 request._session_id = "admin-token"
                 return await handler(request)
+            if hasattr(web_config, "resolve_api_identity"):
+                identity = web_config.resolve_api_identity(query_token)
+                if identity is not None:
+                    request._session_id = identity.user_id
+                    request._api_identity = identity
+                    return await handler(request)
             if session_manager.validate(query_token):
                 request._session_id = query_token
                 return await handler(request)

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -31,6 +31,8 @@ For real-world state or actions — checking, running, creating, modifying anyth
 
 On errors: try reasonable alternatives before reporting failure. Assume tools are available unless a call proves otherwise — try first. Report what succeeded and what failed.
 
+Messages marked HISTORY_READ_ONLY are completed interactions — context, not pending work. Only act on the CURRENT_REQUEST.
+
 ## Current Date and Time
 {current_datetime}
 Scheduling timezone: {timezone_name}

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -77,6 +77,25 @@ def _tokenize(text: str) -> set[str]:
     return {t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOP_WORDS and len(t) > 1}
 
 
+_IMPERATIVE_RE = re.compile(
+    r"^(?:run|execute|restart|deploy|check|install|update|delete|create|stop|start|kill|push|merge|build)\s+",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _sanitize_summary(summary: str) -> str:
+    """Reframe imperative tool requests in summaries as completed facts.
+
+    Prevents the model from re-executing commands that appear in
+    conversation summaries as if they were pending tasks.
+    """
+    summary = _IMPERATIVE_RE.sub(
+        lambda m: f"[completed] {m.group(0)}",
+        summary,
+    )
+    return summary
+
+
 def _lerp(low: float, high: float, t: float) -> float:
     """Linear interpolation between low and high, t clamped to [0, 1]."""
     t = max(0.0, min(1.0, t))
@@ -611,11 +630,23 @@ class SessionManager:
 
         messages = [{"role": m.role, "content": m.content} for m in filtered]
 
+        # Mark all history messages as read-only context
+        if len(messages) > 1:
+            messages.insert(0, {
+                "role": "developer",
+                "content": (
+                    "[HISTORY_READ_ONLY] The messages below until the CURRENT_REQUEST marker "
+                    "are prior conversation context. They are completed interactions, not pending work. "
+                    "Do not re-execute tool calls or commands mentioned in history."
+                ),
+            })
+
         # Prepend summary if available
         if session.summary:
+            sanitized = _sanitize_summary(session.summary)
             messages.insert(0, {
                 "role": "user",
-                "content": f"[Previous conversation summary: {session.summary}]",
+                "content": f"[Previous conversation summary: {sanitized}]",
             })
             messages.insert(1, {
                 "role": "assistant",

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -630,27 +630,27 @@ class SessionManager:
 
         messages = [{"role": m.role, "content": m.content} for m in filtered]
 
-        # Mark all history messages as read-only context
-        if len(messages) > 1:
-            messages.insert(0, {
-                "role": "developer",
-                "content": (
-                    "[HISTORY_READ_ONLY] The messages below until the CURRENT_REQUEST marker "
-                    "are prior conversation context. They are completed interactions, not pending work. "
-                    "Do not re-execute tool calls or commands mentioned in history."
-                ),
-            })
-
         # Prepend summary if available
         if session.summary:
             sanitized = _sanitize_summary(session.summary)
             messages.insert(0, {
                 "role": "user",
-                "content": f"[Previous conversation summary: {sanitized}]",
+                "content": f"[COMPLETED SUMMARY] {sanitized}",
             })
             messages.insert(1, {
                 "role": "assistant",
                 "content": "Understood, I have context from our previous conversation.",
+            })
+
+        # Mark ALL history (including summary) as read-only — must be first
+        if len(messages) > 1:
+            messages.insert(0, {
+                "role": "developer",
+                "content": (
+                    "[HISTORY_READ_ONLY] Everything below until the CURRENT_REQUEST marker "
+                    "is prior conversation context — completed interactions, not pending work. "
+                    "Do not re-execute tool calls or commands mentioned in history or summaries."
+                ),
             })
 
         # Enforce token budget — drop oldest first, keep recent BUDGET_KEEP_RECENT

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -231,6 +231,7 @@ def summarize_tool_response(
 
 
 _SUMMARY_PREFIX = "[Previous conversation summary:"
+_PROTECTED_PREFIXES = ("[HISTORY_READ_ONLY]", "[COMPLETED SUMMARY]", _SUMMARY_PREFIX)
 
 
 def _content_text(m: dict) -> str:
@@ -265,13 +266,16 @@ def apply_token_budget(
     recent = messages[-keep_n:]
     older = messages[:-keep_n] if keep_n < len(messages) else []
 
-    # Detect summary pair at the start of older messages
-    has_summary = (
-        len(older) >= 2
-        and _content_text(older[0]).startswith(_SUMMARY_PREFIX)
-    )
-    summary_pair = older[:2] if has_summary else []
-    droppable = older[2:] if has_summary else list(older)
+    # Detect protected metadata at the start (marker + summary pair)
+    protected_count = 0
+    for m in older:
+        text = _content_text(m)
+        if any(text.startswith(p) for p in _PROTECTED_PREFIXES) or text == "Understood, I have context from our previous conversation.":
+            protected_count += 1
+        else:
+            break
+    summary_pair = older[:protected_count] if protected_count else []
+    droppable = older[protected_count:] if protected_count else list(older)
 
     def _older_tokens() -> int:
         return sum(estimate_tokens(_content_text(m)) for m in summary_pair + droppable)

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -393,6 +393,20 @@ class ToolExecutor:
             return f"Command failed (exit {code}):\n{output}"
         return output
 
+    def _govern_command(self, command: str, host: str | None = None) -> tuple[bool, str, str]:
+        """Shared governor check. Returns (allowed, denial_message, governor_note)."""
+        if not getattr(self, "command_governor", None):
+            return True, "", ""
+        check = self.command_governor.check(
+            command, user_tier=getattr(self, "_current_user_tier", None), host=host,
+        )
+        if not check.allowed:
+            return False, check.denial_message(), ""
+        note = ""
+        if check.risk.value in ("high", "critical"):
+            note = f"[governor: allowed — {check.risk.value} risk, {check.reason}]\n"
+        return True, "", note
+
     async def _handle_run_command(self, inp: dict) -> str:
         command = inp.get("command")
         host = inp.get("host")
@@ -401,15 +415,9 @@ class ToolExecutor:
         if not host:
             return "Error: 'host' is required for run_command."
 
-        governor_note = ""
-        if getattr(self, "command_governor", None):
-            check = self.command_governor.check(
-                command, user_tier=getattr(self, "_current_user_tier", None), host=host,
-            )
-            if not check.allowed:
-                return check.denial_message()
-            if check.risk.value in ("high", "critical"):
-                governor_note = f"[governor: allowed — {check.risk.value} risk, {check.reason}]\n"
+        allowed, denial, governor_note = self._govern_command(command, host)
+        if not allowed:
+            return denial
 
         # Stream output if enabled for this tool
         on_output = None
@@ -453,15 +461,9 @@ class ToolExecutor:
             return "Error: 'script' is required for run_script."
         interpreter = inp.get("interpreter", "bash")
 
-        governor_note = ""
-        if getattr(self, "command_governor", None):
-            check = self.command_governor.check(
-                script, user_tier=getattr(self, "_current_user_tier", None), host=host,
-            )
-            if not check.allowed:
-                return check.denial_message()
-            if check.risk.value in ("high", "critical"):
-                governor_note = f"[governor: allowed — {check.risk.value} risk, {check.reason}]\n"
+        allowed, denial, governor_note = self._govern_command(script, host)
+        if not allowed:
+            return denial
 
         # Map interpreter to file extension
         ext_map = {
@@ -557,23 +559,34 @@ class ToolExecutor:
         hosts = inp["hosts"]
         command = inp["command"]
 
-        # Expand "all"
         if hosts == ["all"] or hosts == "all":
             hosts = list(self.config.hosts.keys())
+
+        # Per-host governor check before launching parallel tasks
+        blocked_hosts = []
+        allowed_hosts = []
+        for h in hosts:
+            allowed, denial, _ = self._govern_command(command, h)
+            if not allowed:
+                blocked_hosts.append((h, denial))
+            else:
+                allowed_hosts.append(h)
 
         async def _run_one(alias: str) -> str:
             result = await self._run_on_host(alias, command)
             result = _truncate_lines(result)
             return f"### {alias}\n```\n{result.strip()}\n```"
 
-        tasks = [_run_one(h) for h in hosts]
+        tasks = [_run_one(h) for h in allowed_hosts]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         parts = []
-        for h, r in zip(hosts, results):
+        for h, r in zip(allowed_hosts, results):
             if isinstance(r, Exception):
                 parts.append(f"### {h}\n```\nError: {r}\n```")
             else:
                 parts.append(r)
+        for h, denial in blocked_hosts:
+            parts.append(f"### {h}\n```\n{denial}\n```")
         return "\n\n".join(parts)
 
     # --- Browser tools (text-returning, screenshot handled in client.py) ---
@@ -741,12 +754,9 @@ class ToolExecutor:
                 return "command is required for start action."
             if not host:
                 return "host is required for start action."
-            if getattr(self, "command_governor", None):
-                check = self.command_governor.check(
-                    command, user_tier=getattr(self, "_current_user_tier", None), host=host,
-                )
-                if not check.allowed:
-                    return check.denial_message()
+            allowed, denial, _ = self._govern_command(command, host)
+            if not allowed:
+                return denial
             # Validate host against configured hosts
             resolved = self._resolve_host(host)
             if not resolved:

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -214,8 +214,12 @@ class ToolExecutor:
                         raw_result = retry_result
                     is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
 
+        mutation_detected = False
+        mutation_reason = ""
         if not is_error and isinstance(raw_result, str):
             raw_result, _mutation = annotate_if_mutation(tool_name, tool_input, raw_result)
+            mutation_detected = _mutation.detected
+            mutation_reason = _mutation.reason
 
         outcome = validate_tool_result(tool_name, raw_result, stats=self.validation_stats)
 
@@ -236,6 +240,8 @@ class ToolExecutor:
             tool_name=tool_name,
             risk_level=assessment.level.value,
             risk_reason=assessment.reason,
+            requires_validation=mutation_detected,
+            validation_reason=mutation_reason,
         )
 
     async def _try_tool(

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1380,6 +1380,9 @@ class ToolExecutor:
 
         if action == "push":
             freshness_cmd, push_cmd = cmds
+            allowed, denial, _ = self._govern_command(push_cmd, host)
+            if not allowed:
+                return denial
             code, output = await self._exec_command(
                 address, freshness_cmd, ssh_user,
             )
@@ -1395,6 +1398,9 @@ class ToolExecutor:
             return _truncate_lines(output) if output.strip() else "Push completed successfully."
         else:
             cmd = cmds
+            allowed, denial, _ = self._govern_command(cmd, host)
+            if not allowed:
+                return denial
             code, output = await self._exec_command(address, cmd, ssh_user)
             if code != 0:
                 return f"git {action} failed (exit {code}):\n{_truncate_lines(output)}"
@@ -1422,6 +1428,10 @@ class ToolExecutor:
             cmd = build_kubectl_command(action, params)
         except ValueError as e:
             return f"kubectl error: {e}"
+
+        allowed, denial, _ = self._govern_command(cmd, host)
+        if not allowed:
+            return denial
 
         code, output = await self._exec_command(address, cmd, ssh_user)
         if code != 0:
@@ -1451,6 +1461,10 @@ class ToolExecutor:
         except ValueError as e:
             return f"docker_ops error: {e}"
 
+        allowed, denial, _ = self._govern_command(cmd, host)
+        if not allowed:
+            return denial
+
         code, output = await self._exec_command(address, cmd, ssh_user)
         if code != 0:
             return f"docker {action} failed (exit {code}):\n{_truncate_lines(output)}"
@@ -1478,6 +1492,10 @@ class ToolExecutor:
             cmd = build_terraform_command(action, params)
         except ValueError as e:
             return f"terraform_ops error: {e}"
+
+        allowed, denial, _ = self._govern_command(cmd, host)
+        if not allowed:
+            return denial
 
         code, output = await self._exec_command(address, cmd, ssh_user)
         if code != 0:

--- a/src/tools/post_validation.py
+++ b/src/tools/post_validation.py
@@ -554,8 +554,9 @@ _MUTATION_PATTERNS: list[tuple[re.Pattern, str]] = [
 ]
 
 _MUTATION_TOOL_ACTIONS: dict[str, frozenset[str]] = {
-    "docker_ops": frozenset({"start", "stop", "restart", "rm", "rmi", "up", "down", "build", "recreate"}),
-    "deploy": frozenset(),
+    "docker_ops": frozenset({"run", "build", "pull", "stop", "rm", "compose_up", "compose_down"}),
+    "kubectl": frozenset({"apply", "delete", "rollout", "scale", "patch"}),
+    "terraform_ops": frozenset({"apply", "destroy"}),
 }
 
 _VALIDATION_HINT = (

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1886,6 +1886,8 @@ MUTATING_TOOLS: frozenset[str] = frozenset({
     "delegate_task", "cancel_task",
     "create_digest", "create_poll",
     "generate_image",
+    "issue_tracker", "execute_plan",
+    "send_to_agent", "spawn_loop_agents",
 })
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1868,20 +1868,24 @@ TOOL_MAP: dict[str, dict] = {t["name"]: t for t in TOOLS}
 MUTATING_TOOLS: frozenset[str] = frozenset({
     "run_command", "run_script", "run_command_multi",
     "write_file", "generate_file",
-    "docker_ops", "git_ops", "kubectl",
+    "docker_ops", "git_ops", "kubectl", "terraform_ops",
     "manage_process",
     "ingest_document", "bulk_ingest_knowledge",
     "delete_knowledge",
-    "memory_manage",
+    "memory_manage", "manage_list",
     "set_permission",
     "schedule_task", "update_schedule", "delete_schedule",
     "start_loop", "stop_loop",
     "spawn_agent", "kill_agent",
     "create_skill", "edit_skill", "delete_skill",
     "enable_skill", "disable_skill", "install_skill",
+    "invoke_skill",
     "browser_click", "browser_fill", "browser_evaluate",
-    "add_reaction", "purge_messages",
+    "add_reaction", "purge_messages", "post_file",
     "validate_action",
+    "delegate_task", "cancel_task",
+    "create_digest", "create_poll",
+    "generate_image",
 })
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1863,6 +1863,31 @@ TOOLS: list[dict] = [
 
 TOOL_MAP: dict[str, dict] = {t["name"]: t for t in TOOLS}
 
+# Tools that modify external state (services, files, infrastructure).
+# Used by mutation detection, governor policy, and audit classification.
+MUTATING_TOOLS: frozenset[str] = frozenset({
+    "run_command", "run_script", "run_command_multi",
+    "write_file", "generate_file",
+    "docker_ops", "git_ops", "kubectl",
+    "manage_process",
+    "ingest_document", "bulk_ingest_knowledge",
+    "delete_knowledge",
+    "memory_manage",
+    "set_permission",
+    "schedule_task", "update_schedule", "delete_schedule",
+    "start_loop", "stop_loop",
+    "spawn_agent", "kill_agent",
+    "create_skill", "edit_skill", "delete_skill",
+    "enable_skill", "disable_skill", "install_skill",
+    "browser_click", "browser_fill", "browser_evaluate",
+    "add_reaction", "purge_messages",
+    "validate_action",
+})
+
+READ_ONLY_TOOLS: frozenset[str] = frozenset(
+    t["name"] for t in TOOLS if t["name"] not in MUTATING_TOOLS
+)
+
 
 # Cache for get_tool_definitions — avoids rebuilding dicts on every message.
 _tool_defs_cache: list[dict] | None = None

--- a/src/tools/result_validator.py
+++ b/src/tools/result_validator.py
@@ -92,6 +92,8 @@ class ToolResult:
     tool_name: str = ""
     risk_level: str = "low"
     risk_reason: str = ""
+    requires_validation: bool = False
+    validation_reason: str = ""
 
     def __str__(self) -> str:
         return self.output

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -639,10 +639,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
         channel_id = f"api-{uuid.uuid4().hex[:12]}"
 
-        # Resolve identity from API token
-        auth_header = request.headers.get("Authorization", "")
-        bearer_token = auth_header[7:] if auth_header.startswith("Bearer ") else ""
-        identity = bot.config.web.resolve_api_identity(bearer_token)
+        # Resolve identity from middleware or fallback
+        identity = getattr(request, "_api_identity", None)
+        if identity is None:
+            auth_header = request.headers.get("Authorization", "")
+            bearer_token = auth_header[7:] if auth_header.startswith("Bearer ") else ""
+            identity = bot.config.web.resolve_api_identity(bearer_token)
         user_id = identity.user_id if identity else "api-user"
         username = identity.username if identity else "API"
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -639,9 +639,16 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
         channel_id = f"api-{uuid.uuid4().hex[:12]}"
 
+        # Resolve identity from API token
+        auth_header = request.headers.get("Authorization", "")
+        bearer_token = auth_header[7:] if auth_header.startswith("Bearer ") else ""
+        identity = bot.config.web.resolve_api_identity(bearer_token)
+        user_id = identity.user_id if identity else "api-user"
+        username = identity.username if identity else "API"
+
         result = await process_web_chat(
             bot, content, channel_id,
-            user_id="api-user", username="API",
+            user_id=user_id, username=username,
         )
 
         bot.sessions.reset(channel_id)
@@ -651,7 +658,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "response": result["response"],
             "tools_used": result["tools_used"],
             "is_error": result["is_error"],
+            "source": "web_api",
         }
+        if identity and identity.label:
+            resp["token_label"] = identity.label
         files = result.get("files", [])
         if files:
             resp["files"] = files

--- a/tests/test_execute_api.py
+++ b/tests/test_execute_api.py
@@ -220,7 +220,7 @@ class TestRealHandler:
             "is_error": False,
             "files": [],
         }
-        with patch("src.web.chat.process_web_chat", new_callable=AsyncMock, return_value=mock_result):
+        with patch("src.web.api.process_web_chat", new_callable=AsyncMock, return_value=mock_result):
             from src.web.api import setup_api
             app = web.Application()
             setup_api(app, bot)
@@ -230,7 +230,7 @@ class TestRealHandler:
                     json={"prompt": "test", "user_id": "admin", "username": "root"},
                 )
                 assert resp.status == 200
-                from src.web.chat import process_web_chat
+                from src.web.api import process_web_chat
                 process_web_chat.assert_awaited_once()
                 assert process_web_chat.call_args.kwargs["user_id"] == "api-user"
                 assert process_web_chat.call_args.kwargs["username"] == "API"
@@ -247,7 +247,7 @@ class TestRealHandler:
             "is_error": False,
             "files": [],
         }
-        with patch("src.web.chat.process_web_chat", new_callable=AsyncMock, return_value=mock_result):
+        with patch("src.web.api.process_web_chat", new_callable=AsyncMock, return_value=mock_result):
             from src.web.api import setup_api
             app = web.Application()
             setup_api(app, bot)

--- a/tests/test_execute_api.py
+++ b/tests/test_execute_api.py
@@ -213,6 +213,7 @@ class TestRealHandler:
         bot = _make_bot()
         bot.config = MagicMock()
         bot.config.web.api_token = ""
+        bot.config.web.resolve_api_identity.return_value = None
         mock_result = {
             "response": "ok",
             "tools_used": [],
@@ -239,6 +240,7 @@ class TestRealHandler:
         bot = _make_bot()
         bot.config = MagicMock()
         bot.config.web.api_token = ""
+        bot.config.web.resolve_api_identity.return_value = None
         mock_result = {
             "response": "done",
             "tools_used": [],

--- a/tests/test_executor_integration_smoke.py
+++ b/tests/test_executor_integration_smoke.py
@@ -776,6 +776,30 @@ class TestInvokeSkillTool:
         assert result.allowed
 
     @pytest.mark.asyncio
+    async def test_run_command_multi_per_host_governor(self):
+        """run_command_multi checks governor per-host before parallel dispatch."""
+        from src.tools.executor import ToolExecutor
+        from src.config.schema import ToolsConfig, GovernorConfig
+        from unittest.mock import AsyncMock
+
+        cfg = ToolsConfig(
+            governor=GovernorConfig(host_overrides={"prod": "strict"}),
+        )
+        cfg.hosts = {
+            "dev": type("H", (), {"address": "localhost", "ssh_user": "root", "os": "linux"})(),
+            "prod": type("H", (), {"address": "localhost", "ssh_user": "root", "os": "linux"})(),
+        }
+        exe = ToolExecutor(config=cfg)
+        exe._run_on_host = AsyncMock(return_value="ok")
+        result = await exe._handle_run_command_multi({
+            "hosts": ["dev", "prod"],
+            "command": "systemctl restart nginx",
+        })
+        assert "ok" in result
+        assert "strict" in result
+        exe._run_on_host.assert_called_once_with("dev", "systemctl restart nginx")
+
+    @pytest.mark.asyncio
     async def test_memory_manage_get_action(self, tmp_path):
         """memory_manage supports 'get' action — a single-key lookup."""
         from src.tools.executor import ToolExecutor

--- a/tests/test_history_replay.py
+++ b/tests/test_history_replay.py
@@ -1,0 +1,82 @@
+"""Tests for history replay protection."""
+from __future__ import annotations
+
+import pytest
+from src.sessions.manager import _sanitize_summary
+
+
+class TestSanitizeSummary:
+    def test_reframes_imperative_restart(self):
+        summary = "restart cron on server"
+        result = _sanitize_summary(summary)
+        assert "[completed]" in result
+        assert "restart" in result
+
+    def test_reframes_imperative_deploy(self):
+        summary = "deploy latest to production"
+        result = _sanitize_summary(summary)
+        assert "[completed]" in result
+
+    def test_leaves_non_imperative_alone(self):
+        summary = "The disk was at 85% usage on the server."
+        result = _sanitize_summary(summary)
+        assert "[completed]" not in result
+        assert result == summary
+
+    def test_reframes_multiple_imperatives(self):
+        summary = "run df -h on all hosts\ncheck nginx status"
+        result = _sanitize_summary(summary)
+        assert result.count("[completed]") == 2
+
+    def test_handles_empty_summary(self):
+        assert _sanitize_summary("") == ""
+
+    def test_preserves_completed_facts(self):
+        summary = "Odin restarted cron successfully. Disk usage dropped to 42%."
+        result = _sanitize_summary(summary)
+        assert "42%" in result
+
+
+class TestHistoryReadOnlyMarker:
+    @pytest.mark.asyncio
+    async def test_history_gets_readonly_marker(self, tmp_path):
+        from src.sessions.manager import SessionManager
+        mgr = SessionManager(
+            max_history=100, max_age_hours=24,
+            persist_dir=str(tmp_path / "sessions"),
+        )
+        mgr.add_message("ch1", "user", "restart cron")
+        mgr.add_message("ch1", "assistant", "Done, cron restarted.")
+        mgr.add_message("ch1", "user", "what time is it")
+
+        messages = await mgr.get_task_history("ch1")
+        developer_msgs = [m for m in messages if m["role"] == "developer"]
+        assert any("HISTORY_READ_ONLY" in m["content"] for m in developer_msgs)
+
+    @pytest.mark.asyncio
+    async def test_single_message_no_marker(self, tmp_path):
+        from src.sessions.manager import SessionManager
+        mgr = SessionManager(
+            max_history=100, max_age_hours=24,
+            persist_dir=str(tmp_path / "sessions"),
+        )
+        mgr.add_message("ch1", "user", "hello")
+
+        messages = await mgr.get_task_history("ch1")
+        developer_msgs = [m for m in messages if m["role"] == "developer"]
+        assert not any("HISTORY_READ_ONLY" in m.get("content", "") for m in developer_msgs)
+
+    @pytest.mark.asyncio
+    async def test_summary_sanitized(self, tmp_path):
+        from src.sessions.manager import SessionManager
+        mgr = SessionManager(
+            max_history=100, max_age_hours=24,
+            persist_dir=str(tmp_path / "sessions"),
+        )
+        session = mgr.get_or_create("ch1")
+        session.summary = "restart nginx and deploy latest build"
+        mgr.add_message("ch1", "user", "what happened earlier?")
+
+        messages = await mgr.get_task_history("ch1")
+        summary_msgs = [m for m in messages if "summary" in m.get("content", "").lower()]
+        assert any("[completed]" in m["content"] for m in summary_msgs)

--- a/tests/test_history_replay.py
+++ b/tests/test_history_replay.py
@@ -78,5 +78,32 @@ class TestHistoryReadOnlyMarker:
         mgr.add_message("ch1", "user", "what happened earlier?")
 
         messages = await mgr.get_task_history("ch1")
-        summary_msgs = [m for m in messages if "summary" in m.get("content", "").lower()]
+        summary_msgs = [m for m in messages if "COMPLETED SUMMARY" in m.get("content", "")]
         assert any("[completed]" in m["content"] for m in summary_msgs)
+
+    @pytest.mark.asyncio
+    async def test_marker_before_summary(self, tmp_path):
+        """HISTORY_READ_ONLY marker must appear before summary in message list."""
+        from src.sessions.manager import SessionManager
+        mgr = SessionManager(
+            max_history=100, max_age_hours=24,
+            persist_dir=str(tmp_path / "sessions"),
+        )
+        session = mgr.get_or_create("ch1")
+        session.summary = "deploy latest build"
+        mgr.add_message("ch1", "user", "old message")
+        mgr.add_message("ch1", "assistant", "done")
+        mgr.add_message("ch1", "user", "what happened?")
+
+        messages = await mgr.get_task_history("ch1")
+        marker_idx = None
+        summary_idx = None
+        for i, m in enumerate(messages):
+            content = m.get("content", "")
+            if "HISTORY_READ_ONLY" in content:
+                marker_idx = i
+            if "COMPLETED SUMMARY" in content:
+                summary_idx = i
+        assert marker_idx is not None, "HISTORY_READ_ONLY marker missing"
+        assert summary_idx is not None, "Summary missing"
+        assert marker_idx < summary_idx, f"Marker at {marker_idx} must be before summary at {summary_idx}"

--- a/tests/test_post_validation.py
+++ b/tests/test_post_validation.py
@@ -638,17 +638,37 @@ class TestMutationDetection:
         assert result.detected
         assert "config write" in result.reason
 
-    def test_detects_mutation_tool_action(self):
+    def test_detects_docker_ops_compose_up(self):
         from src.tools.post_validation import detect_mutation
-        result = detect_mutation("docker_ops", {"action": "restart"})
+        result = detect_mutation("docker_ops", {"action": "compose_up"})
         assert result.detected
-        assert "restart" in result.reason
+        assert "compose_up" in result.reason
+
+    def test_detects_docker_ops_compose_down(self):
+        from src.tools.post_validation import detect_mutation
+        result = detect_mutation("docker_ops", {"action": "compose_down"})
+        assert result.detected
+
+    def test_detects_docker_ops_build(self):
+        from src.tools.post_validation import detect_mutation
+        result = detect_mutation("docker_ops", {"action": "build"})
+        assert result.detected
 
     def test_ignores_docker_ops_read_actions(self):
         from src.tools.post_validation import detect_mutation
-        for action in ("ps", "logs", "inspect", "stats"):
+        for action in ("ps", "logs", "inspect", "stats", "compose_ps", "compose_logs"):
             result = detect_mutation("docker_ops", {"action": action})
             assert not result.detected, f"docker_ops {action} should not be a mutation"
+
+    def test_detects_kubectl_apply(self):
+        from src.tools.post_validation import detect_mutation
+        result = detect_mutation("kubectl", {"action": "apply"})
+        assert result.detected
+
+    def test_ignores_kubectl_get(self):
+        from src.tools.post_validation import detect_mutation
+        result = detect_mutation("kubectl", {"action": "get"})
+        assert not result.detected
 
     def test_ignores_read_commands(self):
         from src.tools.post_validation import detect_mutation

--- a/tests/test_registry_schema.py
+++ b/tests/test_registry_schema.py
@@ -1,0 +1,60 @@
+"""Schema consistency tests — generated from the tool registry."""
+from __future__ import annotations
+
+import pytest
+from src.tools.registry import TOOLS, TOOL_MAP, MUTATING_TOOLS, READ_ONLY_TOOLS
+
+
+class TestRegistryConsistency:
+    def test_every_tool_has_name(self):
+        for t in TOOLS:
+            assert "name" in t, f"Tool missing name: {t}"
+            assert isinstance(t["name"], str)
+            assert len(t["name"]) > 0
+
+    def test_every_tool_has_input_schema(self):
+        for t in TOOLS:
+            assert "input_schema" in t, f"Tool {t['name']} missing input_schema"
+            assert t["input_schema"]["type"] == "object"
+
+    def test_every_tool_has_description(self):
+        for t in TOOLS:
+            assert "description" in t, f"Tool {t['name']} missing description"
+            assert len(t["description"]) > 10
+
+    def test_tool_map_matches_tools(self):
+        assert len(TOOL_MAP) == len(TOOLS)
+        for t in TOOLS:
+            assert t["name"] in TOOL_MAP
+
+    def test_no_duplicate_names(self):
+        names = [t["name"] for t in TOOLS]
+        assert len(names) == len(set(names)), f"Duplicate tool names: {[n for n in names if names.count(n) > 1]}"
+
+    def test_mutating_tools_are_registered(self):
+        registered = {t["name"] for t in TOOLS}
+        for name in MUTATING_TOOLS:
+            assert name in registered, f"Mutating tool '{name}' not in registry"
+
+    def test_read_only_tools_are_registered(self):
+        registered = {t["name"] for t in TOOLS}
+        for name in READ_ONLY_TOOLS:
+            assert name in registered, f"Read-only tool '{name}' not in registry"
+
+    def test_mutating_and_readonly_are_disjoint(self):
+        overlap = MUTATING_TOOLS & READ_ONLY_TOOLS
+        assert not overlap, f"Tools in both sets: {overlap}"
+
+    def test_mutating_and_readonly_cover_all(self):
+        registered = {t["name"] for t in TOOLS}
+        covered = MUTATING_TOOLS | READ_ONLY_TOOLS
+        assert covered == registered, f"Uncovered tools: {registered - covered}"
+
+    def test_executor_handles_shell_tools(self):
+        """Shell execution tools must have _handle_ methods in ToolExecutor."""
+        from src.tools.executor import ToolExecutor
+        exe = ToolExecutor()
+        shell_tools = {"run_command", "run_script", "run_command_multi", "read_file", "write_file"}
+        for name in shell_tools:
+            handler = getattr(exe, f"_handle_{name}", None)
+            assert handler is not None, f"Shell tool '{name}' has no _handle_{name} in ToolExecutor"

--- a/tests/test_web_auth_policy.py
+++ b/tests/test_web_auth_policy.py
@@ -18,6 +18,8 @@ def _make_bot():
     bot = MagicMock()
     bot.config = MagicMock()
     bot.config.web.api_token = "test-secret-token"
+    bot.config.web.api_tokens = []
+    bot.config.web.resolve_api_identity.return_value = None
     bot.sessions = MagicMock()
     bot.sessions.count.return_value = 0
     bot.sessions.ids.return_value = []


### PR DESCRIPTION
## Summary
Implements all 5 improvements from Odin's second self-review:

1. **Auto-execute validation after mutations** — `ToolResult` now carries `requires_validation` and `validation_reason`. The Discord tool loop auto-injects a developer message instructing the model to call `validate_action` when mutations are detected. Moves from advisory hint to structured enforcement.

2. **Governor coverage for all execution paths** — Extracted `_govern_command()` shared helper. Applied to `run_command`, `run_script`, `run_command_multi`, and `manage_process`. Multi-host commands evaluate per-host policy before parallel dispatch — strict hosts are blocked individually.

3. **API identity/scope binding** — `ApiTokenIdentity` config: each API token maps to `user_id`, `username`, `tier`, `allowed_tools`, `allowed_hosts`, `label`. The `/api/execute` endpoint resolves identity from Bearer token. Response includes `source=web_api` and `token_label`.

4. **MUTATING_TOOLS/READ_ONLY_TOOLS classification** — Explicit mutating vs read-only classification in the registry. 10 auto-generated schema consistency tests verify names, schemas, descriptions, no duplicates, mutating/readonly coverage, and handler existence.

5. **History replay protection** — `HISTORY_READ_ONLY` developer message marks prior conversation as completed context. Summary sanitizer reframes imperative tool requests as completed facts. System prompt reinforcement. 9 tests including summary sanitization and marker injection.

## Test plan
- [x] 5464 tests pass (6 pre-existing failures unrelated)
- [x] 9 new history replay tests
- [x] 10 new registry schema tests
- [x] 1 new multi-host governor test
- [ ] Odin review