### PR TITLE
feat: self-review round 3 — security pipeline, error propagation, scope enforcement

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2427,12 +2427,9 @@ class OdinBot(commands.Bot):
             tools = self.permissions.filter_tools(user_id, tools)
             # Apply API token allowed_tools scope if present
             api_allowed = getattr(message, "allowed_tools", None)
-            if api_allowed and tools:
+            if api_allowed is not None and tools:
                 allowed_set = set(api_allowed)
                 tools = [t for t in tools if t["name"] in allowed_set]
-            # Normalize empty tool list to None
-            if tools is not None and not tools:
-                tools = None
 
         # Collect image blocks from analyze_image calls for vision injection
         pending_image_blocks: list[dict] = []

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2425,6 +2425,11 @@ class OdinBot(commands.Bot):
         is_test_wh = message.webhook_id and str(message.webhook_id) in _ALLOWED_WEBHOOK_IDS
         if tools is not None and not is_test_wh:
             tools = self.permissions.filter_tools(user_id, tools)
+            # Apply API token allowed_tools scope if present
+            api_allowed = getattr(message, "allowed_tools", None)
+            if api_allowed and tools:
+                allowed_set = set(api_allowed)
+                tools = [t for t in tools if t["name"] in allowed_set]
             # Normalize empty tool list to None
             if tools is not None and not tools:
                 tools = None

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1567,10 +1567,17 @@ class ToolExecutor:
         return _truncate_lines(output) if output.strip() else "http_probe: no response received"
 
     async def _handle_execute_plan(self, inp: dict) -> str:
-        """Execute a DAG plan using the Odin planner."""
-        from src.tools.plan_runner import PlanRunner
+        """Execute a DAG plan using the Odin planner.
 
-        runner = PlanRunner()
+        Routes shell/file tools through ToolExecutor so they inherit
+        governor, RBAC, audit, and mutation detection.
+        """
+        from src.tools.plan_runner import PlanRunner
+        from src.tools.plan_executor_bridge import create_executor_backed_registry
+
+        default_host = list(self.config.hosts.keys())[0] if self.config.hosts else "localhost"
+        registry = create_executor_backed_registry(self, default_host=default_host)
+        runner = PlanRunner(registry=registry)
         return await runner.run(inp)
 
     async def _handle_validate_action(self, inp: dict) -> str:

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -231,6 +231,13 @@ class ToolExecutor:
             mutation_detected = _mutation.detected
             mutation_reason = _mutation.reason
 
+        # Propagate nested mutation state from execute_plan
+        plan_tracker = getattr(self, "_plan_mutation_tracker", None)
+        if plan_tracker and plan_tracker.detected:
+            mutation_detected = True
+            mutation_reason = mutation_reason or "; ".join(plan_tracker.reasons)
+            del self._plan_mutation_tracker
+
         outcome = validate_tool_result(tool_name, raw_result, stats=self.validation_stats)
 
         # Extract exit code from string if handler didn't return one
@@ -1566,19 +1573,34 @@ class ToolExecutor:
             return f"http_probe failed (exit {code}): curl returned no output"
         return _truncate_lines(output) if output.strip() else "http_probe: no response received"
 
-    async def _handle_execute_plan(self, inp: dict) -> str:
+    async def _handle_execute_plan(self, inp: dict) -> str | tuple[str, int]:
         """Execute a DAG plan using the Odin planner.
 
         Routes shell/file tools through ToolExecutor so they inherit
-        governor, RBAC, audit, and mutation detection.
+        governor, RBAC, audit, and mutation detection.  Propagates
+        nested mutation validation requirements to the outer result.
         """
         from src.tools.plan_runner import PlanRunner
         from src.tools.plan_executor_bridge import create_executor_backed_registry
 
         default_host = list(self.config.hosts.keys())[0] if self.config.hosts else "localhost"
-        registry = create_executor_backed_registry(self, default_host=default_host)
+        registry, tracker = create_executor_backed_registry(self, default_host=default_host)
         runner = PlanRunner(registry=registry)
-        return await runner.run(inp)
+        output = await runner.run(inp)
+
+        # Propagate nested mutation validation to the outer ToolResult
+        if tracker.detected:
+            self._plan_mutation_tracker = tracker
+
+        # Check if the plan itself failed
+        try:
+            import json as _json
+            parsed = _json.loads(output)
+            if not parsed.get("success", True):
+                return output, 1
+        except (ValueError, TypeError):
+            pass
+        return output, 0
 
     async def _handle_validate_action(self, inp: dict) -> str:
         from .post_validation import (

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1586,21 +1586,12 @@ class ToolExecutor:
         default_host = list(self.config.hosts.keys())[0] if self.config.hosts else "localhost"
         registry, tracker = create_executor_backed_registry(self, default_host=default_host)
         runner = PlanRunner(registry=registry)
-        output = await runner.run(inp)
+        output, success = await runner.run(inp)
 
-        # Propagate nested mutation validation to the outer ToolResult
         if tracker.detected:
             self._plan_mutation_tracker = tracker
 
-        # Check if the plan itself failed
-        try:
-            import json as _json
-            parsed = _json.loads(output)
-            if not parsed.get("success", True):
-                return output, 1
-        except (ValueError, TypeError):
-            pass
-        return output, 0
+        return output, (0 if success else 1)
 
     async def _handle_validate_action(self, inp: dict) -> str:
         from .post_validation import (

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -172,10 +172,17 @@ class ToolExecutor:
 
         timeout = self.config.get_tool_timeout(tool_name)
         t0 = asyncio.get_event_loop().time()
-        raw_result = await self._try_tool(tool_name, handler, tool_input, timeout, user_id)
+        raw = await self._try_tool(tool_name, handler, tool_input, timeout, user_id)
         duration_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
 
-        is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
+        # Unpack structured (output, exit_code) returns from handlers
+        if isinstance(raw, tuple):
+            raw_result, exit_code = raw[0], raw[1]
+            is_error = exit_code != 0
+        else:
+            raw_result = raw
+            exit_code = None
+            is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
 
         if self._recovery_enabled:
             category = self._check_recoverable(raw_result)
@@ -204,15 +211,18 @@ class ToolExecutor:
                     log.info("Recovery for %s (%s): retrying after %.1fs", tool_name, category.value, delay)
                     if delay > 0:
                         await asyncio.sleep(delay)
-                    retry_result = await self._try_tool(tool_name, handler, tool_input, timeout, user_id)
-                    retry_cat = self._check_recoverable(retry_result)
+                    retry_raw = await self._try_tool(tool_name, handler, tool_input, timeout, user_id)
+                    if isinstance(retry_raw, tuple):
+                        raw_result, exit_code = retry_raw[0], retry_raw[1]
+                        is_error = exit_code != 0
+                    else:
+                        raw_result = retry_raw
+                    retry_cat = self._check_recoverable(raw_result)
                     if retry_cat is not None:
                         self.recovery_stats.record_failure(tool_name, category, snippet)
-                        raw_result = retry_result
                     else:
                         self.recovery_stats.record_success(tool_name, category, snippet)
-                        raw_result = retry_result
-                    is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
+                        is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
 
         mutation_detected = False
         mutation_reason = ""
@@ -223,8 +233,8 @@ class ToolExecutor:
 
         outcome = validate_tool_result(tool_name, raw_result, stats=self.validation_stats)
 
-        exit_code: int | None = None
-        if isinstance(raw_result, str):
+        # Extract exit code from string if handler didn't return one
+        if exit_code is None and isinstance(raw_result, str):
             import re as _re
             m = _re.search(r"\(exit (\d+)\)", raw_result)
             if m:
@@ -247,8 +257,13 @@ class ToolExecutor:
     async def _try_tool(
         self, tool_name: str, handler, tool_input: dict,
         timeout: int, user_id: str | None,
-    ) -> str:
-        """Single attempt at executing a tool handler."""
+    ) -> str | tuple[str, int]:
+        """Single attempt at executing a tool handler.
+
+        Handlers may return either a plain string or a (output, exit_code)
+        tuple.  Tuples propagate exit codes into ToolResult without
+        string-prefix parsing.
+        """
         try:
             self._current_tool_timeout = timeout
             if tool_name in ("memory_manage", "manage_list"):
@@ -264,12 +279,12 @@ class ToolExecutor:
             self._metrics[tool_name]["errors"] += 1
             self._metrics[tool_name]["timeouts"] += 1
             log.error("Tool %s timed out after %ds", tool_name, timeout)
-            return f"Error: tool '{tool_name}' timed out after {timeout}s"
+            return f"Error: tool '{tool_name}' timed out after {timeout}s", -1
         except Exception as e:
             self._metrics.setdefault(tool_name, {"calls": 0, "errors": 0, "timeouts": 0})
             self._metrics[tool_name]["errors"] += 1
             log.error("Tool %s failed: %s", tool_name, e)
-            return f"Error executing {tool_name}: {e}"
+            return f"Error executing {tool_name}: {e}", -1
 
     # Categories excluded from tool-level recovery (they have their own
     # retry logic or the cost of retrying exceeds the benefit).
@@ -389,15 +404,15 @@ class ToolExecutor:
                 return 1, "Error: SSH bulkhead full — too many concurrent SSH commands"
         return await run_ssh_command(**ssh_kwargs)
 
-    async def _run_on_host(self, alias: str, command: str) -> str:
+    async def _run_on_host(self, alias: str, command: str) -> str | tuple[str, int]:
         resolved = self._resolve_host(alias)
         if not resolved:
             return f"Unknown or disallowed host: {alias}"
         address, ssh_user, _os = resolved
         code, output = await self._exec_command(address, command, ssh_user)
         if code != 0:
-            return f"Command failed (exit {code}):\n{output}"
-        return output
+            return f"Command failed (exit {code}):\n{output}", code
+        return output, 0
 
     def _govern_command(self, command: str, host: str | None = None) -> tuple[bool, str, str]:
         """Shared governor check. Returns (allowed, denial_message, governor_note)."""
@@ -455,7 +470,8 @@ class ToolExecutor:
         output = _truncate_lines(output)
         if self._branch_freshness_enabled and is_test_command(command) and is_test_failure(output):
             output = await self._annotate_with_freshness(output, host, "run_command", command)
-        return f"{governor_note}{output}" if governor_note else output
+        text = f"{governor_note}{output}" if governor_note else output
+        return text, code
 
     async def _handle_run_script(self, inp: dict) -> str:
         """Write a script to a temp file, execute it, and clean up."""
@@ -522,9 +538,11 @@ class ToolExecutor:
             result = f"Script failed (exit {code}):\n{_truncate_lines(output)}"
             if self._branch_freshness_enabled and is_test_command(script) and is_test_failure(result):
                 result = await self._annotate_with_freshness(result, host, "run_script", script[:120])
-            return f"{governor_note}{result}" if governor_note else result
+            text = f"{governor_note}{result}" if governor_note else result
+            return text, code
         output = _truncate_lines(output)
-        return f"{governor_note}{output}" if governor_note else output
+        text = f"{governor_note}{output}" if governor_note else output
+        return text, 0
 
     async def _handle_read_file(self, inp: dict) -> str:
         path = inp.get("path")
@@ -579,9 +597,10 @@ class ToolExecutor:
                 allowed_hosts.append(h)
 
         async def _run_one(alias: str) -> str:
-            result = await self._run_on_host(alias, command)
-            result = _truncate_lines(result)
-            return f"### {alias}\n```\n{result.strip()}\n```"
+            raw = await self._run_on_host(alias, command)
+            text = raw[0] if isinstance(raw, tuple) else raw
+            text = _truncate_lines(text)
+            return f"### {alias}\n```\n{text.strip()}\n```"
 
         tasks = [_run_one(h) for h in allowed_hosts]
         results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -1387,15 +1406,15 @@ class ToolExecutor:
                 address, freshness_cmd, ssh_user,
             )
             if code != 0:
-                return f"Branch freshness check failed (exit {code}):\n{output}"
+                return f"Branch freshness check failed (exit {code}):\n{output}", code
             if output.strip().startswith("STALE:"):
-                return f"Push blocked — {output.strip().split(':', 1)[1].strip()}"
+                return f"Push blocked — {output.strip().split(':', 1)[1].strip()}", 1
             code, output = await self._exec_command(
                 address, push_cmd, ssh_user,
             )
             if code != 0:
-                return f"Push failed (exit {code}):\n{_truncate_lines(output)}"
-            return _truncate_lines(output) if output.strip() else "Push completed successfully."
+                return f"Push failed (exit {code}):\n{_truncate_lines(output)}", code
+            return (_truncate_lines(output) if output.strip() else "Push completed successfully."), 0
         else:
             cmd = cmds
             allowed, denial, _ = self._govern_command(cmd, host)
@@ -1403,8 +1422,8 @@ class ToolExecutor:
                 return denial
             code, output = await self._exec_command(address, cmd, ssh_user)
             if code != 0:
-                return f"git {action} failed (exit {code}):\n{_truncate_lines(output)}"
-            return _truncate_lines(output) if output.strip() else f"git {action} completed successfully."
+                return f"git {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+            return (_truncate_lines(output) if output.strip() else f"git {action} completed successfully."), 0
 
     async def _handle_kubectl(self, inp: dict) -> str:
         from .kubectl_ops import ALLOWED_ACTIONS as KUBECTL_ACTIONS, build_kubectl_command
@@ -1435,8 +1454,8 @@ class ToolExecutor:
 
         code, output = await self._exec_command(address, cmd, ssh_user)
         if code != 0:
-            return f"kubectl {action} failed (exit {code}):\n{_truncate_lines(output)}"
-        return _truncate_lines(output) if output.strip() else f"kubectl {action} completed successfully."
+            return f"kubectl {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+        return (_truncate_lines(output) if output.strip() else f"kubectl {action} completed successfully."), 0
 
     async def _handle_docker_ops(self, inp: dict) -> str:
         from .docker_ops import ALLOWED_ACTIONS as DOCKER_ACTIONS, build_docker_command
@@ -1467,8 +1486,8 @@ class ToolExecutor:
 
         code, output = await self._exec_command(address, cmd, ssh_user)
         if code != 0:
-            return f"docker {action} failed (exit {code}):\n{_truncate_lines(output)}"
-        return _truncate_lines(output) if output.strip() else f"docker {action} completed successfully."
+            return f"docker {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+        return (_truncate_lines(output) if output.strip() else f"docker {action} completed successfully."), 0
 
     async def _handle_terraform_ops(self, inp: dict) -> str:
         from .terraform_ops import ALLOWED_ACTIONS as TF_ACTIONS, build_terraform_command
@@ -1499,8 +1518,8 @@ class ToolExecutor:
 
         code, output = await self._exec_command(address, cmd, ssh_user)
         if code != 0:
-            return f"terraform {action} failed (exit {code}):\n{_truncate_lines(output)}"
-        return _truncate_lines(output) if output.strip() else f"terraform {action} completed successfully."
+            return f"terraform {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+        return (_truncate_lines(output) if output.strip() else f"terraform {action} completed successfully."), 0
 
     async def _handle_issue_tracker(self, inp: dict) -> str:
         action = inp.get("action", "")

--- a/src/tools/plan_executor_bridge.py
+++ b/src/tools/plan_executor_bridge.py
@@ -105,7 +105,12 @@ class ExecutorReadFileTool(BaseTool):
 
 
 class ExecutorWriteFileTool(BaseTool):
-    """Write file tool routed through ToolExecutor."""
+    """Write file tool routed through ToolExecutor.
+
+    All plan write_file operations are considered mutations regardless
+    of path, since they execute within a plan context where any file
+    write is an intentional state change worth validating.
+    """
 
     def __init__(self, executor: ToolExecutor, default_host: str = "localhost",
                  mutation_tracker: MutationTracker | None = None) -> None:
@@ -115,12 +120,17 @@ class ExecutorWriteFileTool(BaseTool):
 
     async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
         host = params.get("host", self._default_host)
+        path = params["path"]
         result = await self._executor.execute("write_file", {
             "host": host,
-            "path": params["path"],
+            "path": path,
             "content": params["content"],
         })
-        if self._tracker:
+        # All plan write_file operations are mutations
+        if self._tracker and result.ok:
+            self._tracker.detected = True
+            self._tracker.reasons.append(f"plan write_file: {path}")
+        elif self._tracker:
             self._tracker.track(result)
         if not result.ok:
             raise RuntimeError(f"write_file failed: {result.error or result.output[:200]}")

--- a/src/tools/plan_executor_bridge.py
+++ b/src/tools/plan_executor_bridge.py
@@ -1,0 +1,115 @@
+"""Bridge between DAG planner tools and ToolExecutor security pipeline.
+
+Replaces the raw ShellTool/WriteFileTool/ReadFileTool in the plan
+registry with adapter tools that route through ToolExecutor.execute(),
+inheriting governor checks, RBAC, audit logging, and mutation detection.
+"""
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from src.odin.tools.base import BaseTool
+from src.odin.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from src.odin.context import ExecutionContext
+    from src.tools.executor import ToolExecutor
+
+
+class ExecutorShellTool(BaseTool):
+    """Shell tool that routes through ToolExecutor.execute('run_command')."""
+
+    def __init__(self, executor: ToolExecutor, default_host: str = "localhost") -> None:
+        self._executor = executor
+        self._default_host = default_host
+
+    async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
+        host = params.get("host", self._default_host)
+        command = params["command"]
+        result = await self._executor.execute("run_command", {
+            "host": host,
+            "command": command,
+        })
+        return {
+            "returncode": result.exit_code or (0 if result.ok else 1),
+            "stdout": result.output,
+            "stderr": result.error or "",
+        }
+
+    @classmethod
+    def param_schema(cls) -> dict[str, Any]:
+        return {
+            "command": {"type": "string", "required": True},
+            "host": {"type": "string"},
+        }
+
+
+class ExecutorReadFileTool(BaseTool):
+    """Read file tool routed through ToolExecutor."""
+
+    def __init__(self, executor: ToolExecutor, default_host: str = "localhost") -> None:
+        self._executor = executor
+        self._default_host = default_host
+
+    async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
+        host = params.get("host", self._default_host)
+        result = await self._executor.execute("read_file", {
+            "host": host,
+            "path": params["path"],
+            "lines": params.get("lines", 200),
+        })
+        return str(result)
+
+    @classmethod
+    def param_schema(cls) -> dict[str, Any]:
+        return {"path": {"type": "string", "required": True}}
+
+
+class ExecutorWriteFileTool(BaseTool):
+    """Write file tool routed through ToolExecutor."""
+
+    def __init__(self, executor: ToolExecutor, default_host: str = "localhost") -> None:
+        self._executor = executor
+        self._default_host = default_host
+
+    async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
+        host = params.get("host", self._default_host)
+        result = await self._executor.execute("write_file", {
+            "host": host,
+            "path": params["path"],
+            "content": params["content"],
+        })
+        return str(result)
+
+    @classmethod
+    def param_schema(cls) -> dict[str, Any]:
+        return {
+            "path": {"type": "string", "required": True},
+            "content": {"type": "string", "required": True},
+        }
+
+
+def create_executor_backed_registry(
+    executor: ToolExecutor,
+    default_host: str = "localhost",
+) -> ToolRegistry:
+    """Create a tool registry where shell/file tools route through ToolExecutor."""
+    from src.odin.tools.file_ops import ListDirTool
+    from src.odin.tools.http import HttpRequestTool
+
+    reg = ToolRegistry()
+    reg.register("shell", type(
+        "BoundShellTool", (ExecutorShellTool,),
+        {"__init__": lambda self, *a, **kw: ExecutorShellTool.__init__(self, executor, default_host)},
+    ))
+    reg.register("read_file", type(
+        "BoundReadFileTool", (ExecutorReadFileTool,),
+        {"__init__": lambda self, *a, **kw: ExecutorReadFileTool.__init__(self, executor, default_host)},
+    ))
+    reg.register("write_file", type(
+        "BoundWriteFileTool", (ExecutorWriteFileTool,),
+        {"__init__": lambda self, *a, **kw: ExecutorWriteFileTool.__init__(self, executor, default_host)},
+    ))
+    reg.register("list_dir", ListDirTool)
+    reg.register("http_request", HttpRequestTool)
+    return reg

--- a/src/tools/plan_executor_bridge.py
+++ b/src/tools/plan_executor_bridge.py
@@ -16,12 +16,41 @@ if TYPE_CHECKING:
     from src.tools.executor import ToolExecutor
 
 
+class MutationTracker:
+    """Accumulates mutation metadata from nested tool calls."""
+    __slots__ = ("detected", "reasons")
+
+    def __init__(self):
+        self.detected = False
+        self.reasons: list[str] = []
+
+    def track(self, result) -> None:
+        if result.requires_validation:
+            self.detected = True
+            if result.validation_reason:
+                self.reasons.append(result.validation_reason)
+
+
+def _result_to_dict(result) -> dict:
+    """Convert ToolResult to a structured dict for the planner."""
+    return {
+        "ok": result.ok,
+        "output": result.output,
+        "error": result.error,
+        "exit_code": result.exit_code,
+        "requires_validation": result.requires_validation,
+        "validation_reason": result.validation_reason,
+    }
+
+
 class ExecutorShellTool(BaseTool):
     """Shell tool that routes through ToolExecutor.execute('run_command')."""
 
-    def __init__(self, executor: ToolExecutor, default_host: str = "localhost") -> None:
+    def __init__(self, executor: ToolExecutor, default_host: str = "localhost",
+                 mutation_tracker: MutationTracker | None = None) -> None:
         self._executor = executor
         self._default_host = default_host
+        self._tracker = mutation_tracker
 
     async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
         host = params.get("host", self._default_host)
@@ -30,11 +59,15 @@ class ExecutorShellTool(BaseTool):
             "host": host,
             "command": command,
         })
-        return {
-            "returncode": result.exit_code or (0 if result.ok else 1),
-            "stdout": result.output,
-            "stderr": result.error or "",
-        }
+        if self._tracker:
+            self._tracker.track(result)
+        if not result.ok:
+            raise RuntimeError(f"Command failed (exit {result.exit_code}): {result.output[:500]}")
+        d = _result_to_dict(result)
+        d["returncode"] = result.exit_code or 0
+        d["stdout"] = result.output
+        d["stderr"] = result.error or ""
+        return d
 
     @classmethod
     def param_schema(cls) -> dict[str, Any]:
@@ -47,9 +80,11 @@ class ExecutorShellTool(BaseTool):
 class ExecutorReadFileTool(BaseTool):
     """Read file tool routed through ToolExecutor."""
 
-    def __init__(self, executor: ToolExecutor, default_host: str = "localhost") -> None:
+    def __init__(self, executor: ToolExecutor, default_host: str = "localhost",
+                 mutation_tracker: MutationTracker | None = None) -> None:
         self._executor = executor
         self._default_host = default_host
+        self._tracker = mutation_tracker
 
     async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
         host = params.get("host", self._default_host)
@@ -58,7 +93,11 @@ class ExecutorReadFileTool(BaseTool):
             "path": params["path"],
             "lines": params.get("lines", 200),
         })
-        return str(result)
+        if self._tracker:
+            self._tracker.track(result)
+        if not result.ok:
+            raise RuntimeError(f"read_file failed: {result.error or result.output[:200]}")
+        return _result_to_dict(result)
 
     @classmethod
     def param_schema(cls) -> dict[str, Any]:
@@ -68,9 +107,11 @@ class ExecutorReadFileTool(BaseTool):
 class ExecutorWriteFileTool(BaseTool):
     """Write file tool routed through ToolExecutor."""
 
-    def __init__(self, executor: ToolExecutor, default_host: str = "localhost") -> None:
+    def __init__(self, executor: ToolExecutor, default_host: str = "localhost",
+                 mutation_tracker: MutationTracker | None = None) -> None:
         self._executor = executor
         self._default_host = default_host
+        self._tracker = mutation_tracker
 
     async def execute(self, params: dict[str, Any], ctx: "ExecutionContext") -> Any:
         host = params.get("host", self._default_host)
@@ -79,7 +120,11 @@ class ExecutorWriteFileTool(BaseTool):
             "path": params["path"],
             "content": params["content"],
         })
-        return str(result)
+        if self._tracker:
+            self._tracker.track(result)
+        if not result.ok:
+            raise RuntimeError(f"write_file failed: {result.error or result.output[:200]}")
+        return _result_to_dict(result)
 
     @classmethod
     def param_schema(cls) -> dict[str, Any]:
@@ -92,24 +137,29 @@ class ExecutorWriteFileTool(BaseTool):
 def create_executor_backed_registry(
     executor: ToolExecutor,
     default_host: str = "localhost",
-) -> ToolRegistry:
-    """Create a tool registry where shell/file tools route through ToolExecutor."""
+) -> tuple[ToolRegistry, MutationTracker]:
+    """Create a tool registry where shell/file tools route through ToolExecutor.
+
+    Returns (registry, mutation_tracker) — caller can inspect tracker
+    after plan execution to propagate validation requirements.
+    """
     from src.odin.tools.file_ops import ListDirTool
     from src.odin.tools.http import HttpRequestTool
 
+    tracker = MutationTracker()
     reg = ToolRegistry()
     reg.register("shell", type(
         "BoundShellTool", (ExecutorShellTool,),
-        {"__init__": lambda self, *a, **kw: ExecutorShellTool.__init__(self, executor, default_host)},
+        {"__init__": lambda self, *a, **kw: ExecutorShellTool.__init__(self, executor, default_host, tracker)},
     ))
     reg.register("read_file", type(
         "BoundReadFileTool", (ExecutorReadFileTool,),
-        {"__init__": lambda self, *a, **kw: ExecutorReadFileTool.__init__(self, executor, default_host)},
+        {"__init__": lambda self, *a, **kw: ExecutorReadFileTool.__init__(self, executor, default_host, tracker)},
     ))
     reg.register("write_file", type(
         "BoundWriteFileTool", (ExecutorWriteFileTool,),
-        {"__init__": lambda self, *a, **kw: ExecutorWriteFileTool.__init__(self, executor, default_host)},
+        {"__init__": lambda self, *a, **kw: ExecutorWriteFileTool.__init__(self, executor, default_host, tracker)},
     ))
     reg.register("list_dir", ListDirTool)
     reg.register("http_request", HttpRequestTool)
-    return reg
+    return reg, tracker

--- a/src/tools/plan_runner.py
+++ b/src/tools/plan_runner.py
@@ -38,23 +38,17 @@ class PlanRunner:
     def registry(self) -> ToolRegistry:
         return self._registry
 
-    async def run(self, args: dict[str, Any]) -> str:
+    async def run(self, args: dict[str, Any]) -> tuple[str, bool]:
         """Parse, validate, execute, and format a plan.
-
-        Parameters
-        ----------
-        args : dict
-            Must contain ``plan`` (JSON string or dict).
-            Optional ``format`` key: ``"summary"`` (default), ``"json"``, or ``"dict"``.
 
         Returns
         -------
-        str
-            Formatted result suitable for display to a user or LLM.
+        tuple[str, bool]
+            (formatted_output, success) — success is from PlanResult directly.
         """
         plan_source = args.get("plan")
         if plan_source is None:
-            return "Error: 'plan' argument is required"
+            return "Error: 'plan' argument is required", False
 
         fmt = args.get("format", "summary")
 
@@ -65,14 +59,14 @@ class PlanRunner:
             elif isinstance(plan_source, dict):
                 plan = load_plan(plan_source)
             else:
-                return f"Error: 'plan' must be a JSON string or dict, got {type(plan_source).__name__}"
+                return f"Error: 'plan' must be a JSON string or dict, got {type(plan_source).__name__}", False
         except (ValueError, Exception) as exc:
-            return f"Error parsing plan: {exc}"
+            return f"Error parsing plan: {exc}", False
 
         # Validate
         errors = self._planner.validate(plan)
         if errors:
-            return "Plan validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+            return "Plan validation failed:\n" + "\n".join(f"  - {e}" for e in errors), False
 
         # Execute
         log.info("Executing plan '%s' (%d steps)", plan.name, len(plan.steps))
@@ -80,10 +74,10 @@ class PlanRunner:
         try:
             result = await self._planner.execute(plan)
         except PlanValidationError as exc:
-            return f"Plan validation error: {exc}"
+            return f"Plan validation error: {exc}", False
         except Exception as exc:
             log.exception("Plan execution failed")
-            return f"Plan execution error: {exc}"
+            return f"Plan execution error: {exc}", False
 
         elapsed = time.time() - start
         log.info(
@@ -93,7 +87,7 @@ class PlanRunner:
             "SUCCESS" if result.success else "FAILED",
         )
 
-        return self._format(result, fmt)
+        return self._format(result, fmt), result.success
 
     @staticmethod
     def _format(result: PlanResult, fmt: str) -> str:

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -647,7 +647,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             identity = bot.config.web.resolve_api_identity(bearer_token)
         user_id = identity.user_id if identity else "api-user"
         username = identity.username if identity else "API"
-        token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
+        token_tools = identity.allowed_tools if identity is not None else None
 
         result = await process_web_chat(
             bot, content, channel_id,

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -647,10 +647,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             identity = bot.config.web.resolve_api_identity(bearer_token)
         user_id = identity.user_id if identity else "api-user"
         username = identity.username if identity else "API"
+        token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
 
         result = await process_web_chat(
             bot, content, channel_id,
             user_id=user_id, username=username,
+            allowed_tools=token_tools,
         )
 
         bot.sessions.reset(channel_id)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -124,7 +124,8 @@ class WebMessage:
     from a discord.Message object.
     """
 
-    def __init__(self, channel_id: str, user_id: str, username: str, content: str = ""):
+    def __init__(self, channel_id: str, user_id: str, username: str, content: str = "",
+                 allowed_tools: list[str] | None = None):
         self.id = next(_msg_id_counter)
         self.content = content
         self.channel = _WebChannel(channel_id)
@@ -132,6 +133,7 @@ class WebMessage:
         self.webhook_id = None
         self.attachments = []
         self.guild = None
+        self.allowed_tools = allowed_tools
 
 
 # Re-use the same scrubbing function applied to Discord responses.
@@ -149,6 +151,7 @@ async def process_web_chat(
     channel_id: str,
     user_id: str = "web-user",
     username: str = "WebUser",
+    allowed_tools: list[str] | None = None,
 ) -> dict:
     """Process a web chat message through the Codex tool loop.
 
@@ -157,7 +160,8 @@ async def process_web_chat(
       - tools_used: list[str] — tool names called during processing
       - is_error: bool — whether an error occurred
     """
-    msg = WebMessage(channel_id=channel_id, user_id=user_id, username=username, content=content)
+    msg = WebMessage(channel_id=channel_id, user_id=user_id, username=username, content=content,
+                     allowed_tools=allowed_tools)
     web_channel = msg.channel  # type: _WebChannel
     tagged = f"[{username}]: {content}"
     bot.sessions.add_message(channel_id, "user", tagged, user_id=user_id)

--- a/tests/test_branch_freshness.py
+++ b/tests/test_branch_freshness.py
@@ -566,8 +566,8 @@ class TestExecutorFreshnessIntegration:
         executor._resolve_host = lambda alias: ("127.0.0.1", "root", "linux")
 
         result = await executor._handle_run_command({"host": "local", "command": "pytest tests/ -q"})
-        assert "[STALE BRANCH]" in result
-        assert "5 commit(s) behind" in result
+        assert "[STALE BRANCH]" in (result[0] if isinstance(result, tuple) else result)
+        assert "5 commit(s) behind" in (result[0] if isinstance(result, tuple) else result)
         assert executor.freshness_stats.get_summary()["total_checks"] == 1
         assert executor.freshness_stats.get_summary()["stale_found"] == 1
 
@@ -589,7 +589,7 @@ class TestExecutorFreshnessIntegration:
         executor._resolve_host = lambda alias: ("127.0.0.1", "root", "linux")
 
         result = await executor._handle_run_command({"host": "local", "command": "pytest tests/"})
-        assert "[STALE BRANCH]" not in result
+        assert "[STALE BRANCH]" not in (result[0] if isinstance(result, tuple) else result)
         assert executor.freshness_stats.get_summary()["total_checks"] == 1
         assert executor.freshness_stats.get_summary()["stale_found"] == 0
 
@@ -602,7 +602,7 @@ class TestExecutorFreshnessIntegration:
         executor._run_on_host = mock_run_on_host
 
         result = await executor._handle_run_command({"host": "local", "command": "ls /nonexistent"})
-        assert "[STALE BRANCH]" not in result
+        assert "[STALE BRANCH]" not in (result[0] if isinstance(result, tuple) else result)
         assert executor.freshness_stats.get_summary()["total_checks"] == 0
 
     @pytest.mark.asyncio
@@ -614,7 +614,7 @@ class TestExecutorFreshnessIntegration:
         executor._run_on_host = mock_run_on_host
 
         result = await executor._handle_run_command({"host": "local", "command": "pytest tests/"})
-        assert "[STALE BRANCH]" not in result
+        assert "[STALE BRANCH]" not in (result[0] if isinstance(result, tuple) else result)
         assert executor.freshness_stats.get_summary()["total_checks"] == 0
 
     @pytest.mark.asyncio
@@ -628,7 +628,7 @@ class TestExecutorFreshnessIntegration:
         executor._run_on_host = mock_run_on_host
 
         result = await executor._handle_run_command({"host": "local", "command": "pytest tests/"})
-        assert "[STALE BRANCH]" not in result
+        assert "[STALE BRANCH]" not in (result[0] if isinstance(result, tuple) else result)
         assert executor.freshness_stats.get_summary()["total_checks"] == 0
 
     @pytest.mark.asyncio
@@ -643,8 +643,8 @@ class TestExecutorFreshnessIntegration:
         executor._resolve_host = lambda alias: ("127.0.0.1", "root", "linux")
 
         result = await executor._handle_run_command({"host": "local", "command": "pytest tests/"})
-        assert "3 failed" in result
-        assert "[STALE BRANCH]" not in result
+        assert "3 failed" in (result[0] if isinstance(result, tuple) else result)
+        assert "[STALE BRANCH]" not in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_fetch_failure_tracked(self, executor):
@@ -696,9 +696,9 @@ class TestExecutorRunScriptFreshness:
             "script": "#!/bin/bash\npytest tests/ -q",
             "interpreter": "bash",
         })
-        assert "Script failed" in result
-        assert "[STALE BRANCH]" in result
-        assert "3 commit(s) behind" in result
+        assert "Script failed" in (result[0] if isinstance(result, tuple) else result)
+        assert "[STALE BRANCH]" in (result[0] if isinstance(result, tuple) else result)
+        assert "3 commit(s) behind" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_script_non_test_not_annotated(self, executor):
@@ -714,8 +714,8 @@ class TestExecutorRunScriptFreshness:
             "script": "#!/bin/bash\nls /nonexistent",
             "interpreter": "bash",
         })
-        assert "Script failed" in result
-        assert "[STALE BRANCH]" not in result
+        assert "Script failed" in (result[0] if isinstance(result, tuple) else result)
+        assert "[STALE BRANCH]" not in (result[0] if isinstance(result, tuple) else result)
 
 
 # ====================================================================

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -719,19 +719,19 @@ class TestHandleDockerOps:
     async def test_unknown_host(self):
         ex = _make_executor()
         result = await ex._handle_docker_ops({"host": "nope", "action": "ps"})
-        assert "Unknown or disallowed host" in result
+        assert "Unknown or disallowed host" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_unknown_action(self):
         ex = _make_executor()
         result = await ex._handle_docker_ops({"host": "prod", "action": "nope"})
-        assert "Unknown docker action" in result
+        assert "Unknown docker action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_missing_action(self):
         ex = _make_executor()
         result = await ex._handle_docker_ops({"host": "prod"})
-        assert "Unknown docker action" in result
+        assert "Unknown docker action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_ps_dispatch(self):
@@ -739,7 +739,7 @@ class TestHandleDockerOps:
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "CONTAINER ID  IMAGE  STATUS\nabc  nginx  Up")
             result = await ex._handle_docker_ops({"host": "prod", "action": "ps"})
-        assert "nginx" in result
+        assert "nginx" in (result[0] if isinstance(result, tuple) else result)
         mock_exec.assert_awaited_once()
         cmd_arg = mock_exec.call_args[0][1]
         assert cmd_arg.startswith("docker ps")
@@ -753,7 +753,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "run",
                 "params": {"image": "nginx", "detach": True},
             })
-        assert "abc123" in result
+        assert "abc123" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_exec_dispatch(self):
@@ -764,7 +764,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "exec",
                 "params": {"container": "web", "command": "ls"},
             })
-        assert "file.txt" in result
+        assert "file.txt" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_logs_dispatch(self):
@@ -775,7 +775,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "logs",
                 "params": {"container": "web"},
             })
-        assert "log line" in result
+        assert "log line" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_build_dispatch(self):
@@ -786,7 +786,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "build",
                 "params": {"tag": "myapp:latest"},
             })
-        assert "Successfully built" in result
+        assert "Successfully built" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_pull_dispatch(self):
@@ -797,7 +797,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "pull",
                 "params": {"image": "nginx:latest"},
             })
-        assert "Downloaded" in result
+        assert "Downloaded" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_stop_dispatch(self):
@@ -808,7 +808,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "stop",
                 "params": {"container": "web"},
             })
-        assert "web" in result
+        assert "web" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_rm_dispatch(self):
@@ -819,7 +819,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "rm",
                 "params": {"container": "web"},
             })
-        assert "web" in result
+        assert "web" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_inspect_dispatch(self):
@@ -830,7 +830,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "inspect",
                 "params": {"target": "web"},
             })
-        assert "running" in result
+        assert "running" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_stats_dispatch(self):
@@ -841,7 +841,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "stats",
                 "params": {},
             })
-        assert "CPU%" in result
+        assert "CPU%" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_compose_up_dispatch(self):
@@ -852,7 +852,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "compose_up",
                 "params": {},
             })
-        assert "Creating" in result
+        assert "Creating" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_compose_down_dispatch(self):
@@ -863,7 +863,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "compose_down",
                 "params": {},
             })
-        assert "Stopping" in result
+        assert "Stopping" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_compose_ps_dispatch(self):
@@ -874,7 +874,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "compose_ps",
                 "params": {},
             })
-        assert "running" in result
+        assert "running" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_compose_logs_dispatch(self):
@@ -885,7 +885,7 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "compose_logs",
                 "params": {},
             })
-        assert "Starting" in result
+        assert "Starting" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_command_failure(self):
@@ -896,8 +896,8 @@ class TestHandleDockerOps:
                 "host": "prod", "action": "logs",
                 "params": {"container": "web"},
             })
-        assert "failed" in result
-        assert "exit 1" in result
+        assert "failed" in (result[0] if isinstance(result, tuple) else result)
+        assert "exit 1" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_validation_error(self):
@@ -905,7 +905,7 @@ class TestHandleDockerOps:
         result = await ex._handle_docker_ops({
             "host": "prod", "action": "run", "params": {},
         })
-        assert "docker_ops error" in result
+        assert "docker_ops error" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_empty_output(self):
@@ -915,7 +915,7 @@ class TestHandleDockerOps:
             result = await ex._handle_docker_ops({
                 "host": "prod", "action": "ps", "params": {},
             })
-        assert "completed successfully" in result
+        assert "completed successfully" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_no_params_default(self):
@@ -925,7 +925,7 @@ class TestHandleDockerOps:
             result = await ex._handle_docker_ops({
                 "host": "prod", "action": "ps",
             })
-        assert "docker ps output" in result
+        assert "docker ps output" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_correct_ssh_user(self):

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -13,8 +13,11 @@ from src.tools.executor import ToolExecutor
 
 @pytest.mark.asyncio
 async def test_execute_plan_via_tool_executor():
-    """The execute_plan tool works through the main ToolExecutor dispatch."""
-    executor = ToolExecutor()
+    """The execute_plan tool routes shell commands through ToolExecutor security pipeline."""
+    from src.config.schema import ToolHost
+    cfg = ToolsConfig()
+    cfg.hosts = {"localhost": ToolHost(address="localhost", ssh_user="", os="linux")}
+    executor = ToolExecutor(config=cfg)
     plan = json.dumps({
         "name": "via-executor",
         "steps": [

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -31,6 +31,40 @@ async def test_execute_plan_via_tool_executor():
 
 
 @pytest.mark.asyncio
+async def test_execute_plan_failed_step_summary_format():
+    """Failed plan step marks ToolResult.ok=False even with default summary format."""
+    from src.config.schema import ToolHost
+    cfg = ToolsConfig()
+    cfg.hosts = {"localhost": ToolHost(address="localhost", ssh_user="", os="linux")}
+    executor = ToolExecutor(config=cfg)
+    plan = json.dumps({
+        "name": "fail-test",
+        "steps": [
+            {"id": "s1", "tool": "shell", "params": {"command": "false"}},
+        ],
+    })
+    result = await executor.execute("execute_plan", {"plan": plan})
+    assert not result.ok, f"Failed plan should have ok=False, got ok={result.ok}"
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_failed_step_dict_format():
+    """Failed plan step marks ToolResult.ok=False with dict format."""
+    from src.config.schema import ToolHost
+    cfg = ToolsConfig()
+    cfg.hosts = {"localhost": ToolHost(address="localhost", ssh_user="", os="linux")}
+    executor = ToolExecutor(config=cfg)
+    plan = json.dumps({
+        "name": "fail-dict",
+        "steps": [
+            {"id": "s1", "tool": "shell", "params": {"command": "false"}},
+        ],
+    })
+    result = await executor.execute("execute_plan", {"plan": plan, "format": "dict"})
+    assert not result.ok
+
+
+@pytest.mark.asyncio
 async def test_execute_unknown_tool():
     executor = ToolExecutor()
     result = await executor.execute("nonexistent_tool", {})

--- a/tests/test_plan_runner.py
+++ b/tests/test_plan_runner.py
@@ -22,7 +22,7 @@ async def test_run_simple_plan(runner):
         "name": "simple",
         "steps": [{"id": "a", "tool": "echo", "params": {"msg": "hello"}}],
     })
-    result = await runner.run({"plan": plan_json})
+    result, _ok = await runner.run({"plan": plan_json})
     assert "SUCCESS" in result
     assert "simple" in result
 
@@ -34,7 +34,7 @@ async def test_run_plan_json_format(runner):
         "name": "json-out",
         "steps": [{"id": "a", "tool": "echo", "params": {"x": 1}}],
     })
-    result = await runner.run({"plan": plan, "format": "json"})
+    result, _ok = await runner.run({"plan": plan, "format": "json"})
     parsed = json.loads(result)
     assert parsed["success"] is True
     assert parsed["name"] == "json-out"
@@ -55,7 +55,7 @@ async def test_run_plan_with_deps(runner):
             },
         ],
     })
-    result = await runner.run({"plan": plan, "format": "json"})
+    result, _ok = await runner.run({"plan": plan, "format": "json"})
     parsed = json.loads(result)
     assert parsed["success"] is True
     assert parsed["steps"]["second"]["output"]["prev"] == "one"
@@ -70,7 +70,7 @@ async def test_run_plan_failure(runner):
             {"id": "boom", "tool": "fail", "params": {"message": "test error"}},
         ],
     })
-    result = await runner.run({"plan": plan})
+    result, _ok = await runner.run({"plan": plan})
     assert "FAILED" in result
 
 
@@ -84,7 +84,7 @@ async def test_run_plan_cascade_skip(runner):
             {"id": "b", "tool": "echo", "depends_on": "a"},
         ],
     })
-    result = await runner.run({"plan": plan, "format": "json"})
+    result, _ok = await runner.run({"plan": plan, "format": "json"})
     parsed = json.loads(result)
     assert parsed["steps"]["a"]["status"] == "failed"
     assert parsed["steps"]["b"]["status"] == "skipped"
@@ -99,19 +99,19 @@ async def test_run_plan_validation_error(runner):
             {"id": "a", "tool": "ts", "depends_on": "missing"},
         ],
     })
-    result = await runner.run({"plan": plan})
+    result, _ok = await runner.run({"plan": plan})
     assert "validation failed" in result.lower()
 
 
 @pytest.mark.asyncio
 async def test_run_missing_plan_arg(runner):
-    result = await runner.run({})
+    result, _ok = await runner.run({})
     assert "required" in result.lower()
 
 
 @pytest.mark.asyncio
 async def test_run_bad_json(runner):
-    result = await runner.run({"plan": "{not valid"})
+    result, _ok = await runner.run({"plan": "{not valid"})
     assert "error" in result.lower()
 
 
@@ -122,7 +122,7 @@ async def test_run_plan_dict_input(runner):
         "name": "dict-plan",
         "steps": [{"id": "a", "tool": "echo", "params": {"k": "v"}}],
     }
-    result = await runner.run({"plan": plan, "format": "json"})
+    result, _ok = await runner.run({"plan": plan, "format": "json"})
     parsed = json.loads(result)
     assert parsed["success"] is True
 
@@ -137,7 +137,7 @@ async def test_run_plan_with_shell(ts_registry):
             {"id": "hw", "tool": "shell", "params": {"command": "echo hello-world"}},
         ],
     })
-    result = await runner.run({"plan": plan, "format": "json"})
+    result, _ok = await runner.run({"plan": plan, "format": "json"})
     parsed = json.loads(result)
     assert parsed["success"] is True
     assert "hello-world" in parsed["steps"]["hw"]["output"]["stdout"]

--- a/tests/test_terraform_ops.py
+++ b/tests/test_terraform_ops.py
@@ -663,7 +663,7 @@ class TestHandleTerraformOps:
             "host": "nohost",
             "action": "plan",
         })
-        assert "Unknown or disallowed host" in result
+        assert "Unknown or disallowed host" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_unknown_action(self, executor):
@@ -671,14 +671,14 @@ class TestHandleTerraformOps:
             "host": "infra",
             "action": "deploy",
         })
-        assert "Unknown terraform action" in result
+        assert "Unknown terraform action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_missing_action(self, executor):
         result = await executor._handle_terraform_ops({
             "host": "infra",
         })
-        assert "Unknown terraform action" in result
+        assert "Unknown terraform action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_init_dispatch(self, executor):
@@ -689,7 +689,7 @@ class TestHandleTerraformOps:
         executor._exec_command.assert_called_once()
         cmd = executor._exec_command.call_args[0][1]
         assert cmd.startswith("terraform init")
-        assert "Success" in result or "completed successfully" in result
+        assert "Success" in result or "completed successfully" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_plan_dispatch(self, executor):
@@ -720,8 +720,8 @@ class TestHandleTerraformOps:
             "action": "apply",
             "params": {},
         })
-        assert "terraform_ops error" in result
-        assert "plan_file" in result
+        assert "terraform_ops error" in (result[0] if isinstance(result, tuple) else result)
+        assert "plan_file" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_output_dispatch(self, executor):
@@ -803,8 +803,8 @@ class TestHandleTerraformOps:
             "host": "infra",
             "action": "init",
         })
-        assert "terraform init failed" in result
-        assert "exit 1" in result
+        assert "terraform init failed" in (result[0] if isinstance(result, tuple) else result)
+        assert "exit 1" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_empty_output(self, executor):
@@ -813,7 +813,7 @@ class TestHandleTerraformOps:
             "host": "infra",
             "action": "validate",
         })
-        assert "completed successfully" in result
+        assert "completed successfully" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_no_params_default(self, executor):
@@ -841,8 +841,8 @@ class TestHandleTerraformOps:
             "action": "state",
             "params": {"subaction": "show"},
         })
-        assert "terraform_ops error" in result
-        assert "address" in result
+        assert "terraform_ops error" in (result[0] if isinstance(result, tuple) else result)
+        assert "address" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_import_validation_error(self, executor):
@@ -851,8 +851,8 @@ class TestHandleTerraformOps:
             "action": "import",
             "params": {"address": "aws_instance.web"},
         })
-        assert "terraform_ops error" in result
-        assert "id" in result
+        assert "terraform_ops error" in (result[0] if isinstance(result, tuple) else result)
+        assert "id" in (result[0] if isinstance(result, tuple) else result)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements 3 improvements from Odin's third self-review (items 1, 3, 5):

### 1. execute_plan routes through ToolExecutor security pipeline
- Created `ExecutorBackedRegistry` with adapter tools that route `shell`/`read_file`/`write_file` through `ToolExecutor.execute()` instead of raw `asyncio.create_subprocess_shell()`
- Plan execution now inherits governor, RBAC, audit logging, and mutation detection
- Closes the security bypass where `execute_plan` provided an ungoverned shell surface

### 2. API token scope enforcement (allowed_tools)
- `process_web_chat` accepts `allowed_tools` parameter
- `WebMessage` carries scope, `_process_with_tools` filters tool list against token's `allowed_tools` before presenting to LLM
- `/api/execute` passes resolved `ApiTokenIdentity.allowed_tools` through the pipeline

### 3. Structured error propagation via (output, exit_code) tuples
- `run_command`, `run_script`, `docker_ops`, `kubectl`, `terraform_ops`, `git_ops` now return `(str, int)` tuples with exit codes
- `execute()` unpacks tuples to set `ToolResult.ok` from exit codes directly
- Eliminates string-prefix parsing for handler-specific failures like `"kubectl apply failed"`
- Backward compatible — string returns still work via prefix detection

## Test plan
- [x] 5464+ tests pass
- [x] execute_plan test updated to configure hosts for executor routing
- [x] All ops handler tests updated for tuple returns
- [ ] Odin review