### PR TITLE
feat: attachment processor — context-first, archive support, no ingestion nudges

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -367,6 +367,18 @@ class WebConfig(BaseModel):
             raise ValueError("port must be between 1 and 65535")
         return v
 
+
+class AttachmentsConfig(BaseModel):
+    temp_directory: str = "/tmp/odin-attachments"
+    inline_text_max_bytes: int = 100_000
+    preview_max_chars: int = 12_000
+    large_preview_chars: int = 4_000
+    archive_max_bytes: int = 50 * 1024 * 1024
+    archive_max_files: int = 500
+    archive_extract_max_bytes: int = 200 * 1024 * 1024
+    archive_preview_total_chars: int = 20_000
+    retention_hours: int = 24
+
     def resolve_api_identity(self, token: str) -> ApiTokenIdentity | None:
         """Look up identity for an API token. Falls back to default if single token configured."""
         for t in self.api_tokens:
@@ -512,6 +524,7 @@ class Config(BaseModel):
     permissions: PermissionsConfig = PermissionsConfig()
     comfyui: ComfyUIConfig = ComfyUIConfig()
     web: WebConfig = WebConfig()
+    attachments: AttachmentsConfig = AttachmentsConfig()
     reaction_triggers: ReactionTriggerConfig = ReactionTriggerConfig()
     message_triggers: MessageTriggerConfig = MessageTriggerConfig()
     mcp: MCPConfig = MCPConfig()

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -368,17 +368,6 @@ class WebConfig(BaseModel):
         return v
 
 
-class AttachmentsConfig(BaseModel):
-    temp_directory: str = "/tmp/odin-attachments"
-    inline_text_max_bytes: int = 100_000
-    preview_max_chars: int = 12_000
-    large_preview_chars: int = 4_000
-    archive_max_bytes: int = 50 * 1024 * 1024
-    archive_max_files: int = 500
-    archive_extract_max_bytes: int = 200 * 1024 * 1024
-    archive_preview_total_chars: int = 20_000
-    retention_hours: int = 24
-
     def resolve_api_identity(self, token: str) -> ApiTokenIdentity | None:
         """Look up identity for an API token. Falls back to default if single token configured."""
         for t in self.api_tokens:
@@ -390,6 +379,21 @@ class AttachmentsConfig(BaseModel):
                 username="Admin", tier="admin", label="default",
             )
         return None
+
+
+class AttachmentsConfig(BaseModel):
+    temp_directory: str = "/tmp/odin-attachments"
+    inline_text_max_bytes: int = 100_000
+    preview_max_chars: int = 12_000
+    large_preview_chars: int = 4_000
+    archive_max_bytes: int = 50 * 1024 * 1024
+    archive_max_files: int = 500
+    archive_extract_max_bytes: int = 200 * 1024 * 1024
+    archive_preview_total_chars: int = 20_000
+    image_max_bytes: int = 5 * 1024 * 1024
+    pdf_max_bytes: int = 25 * 1024 * 1024
+    archive_preview_file_max_bytes: int = 64_000
+    retention_hours: int = 24
 
 
 class ComfyUIConfig(BaseModel):

--- a/src/discord/attachments.py
+++ b/src/discord/attachments.py
@@ -1,0 +1,502 @@
+"""Discord attachment processor.
+
+Handles file attachments sent via Discord messages. Policy:
+- Attachments are current-task context by default.
+- Knowledge ingestion happens only when explicitly requested.
+- Archives are unpacked/listed safely into a temp workspace.
+- Large files are previewed (head+tail) and saved, not shoved
+  wholesale into the model context.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import os
+import re
+import shutil
+import time
+import zipfile
+import tarfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..odin_log import get_logger
+
+log = get_logger("attachments")
+
+_IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
+_IMAGE_MEDIA_TYPES = frozenset({"image/png", "image/jpeg", "image/gif", "image/webp"})
+
+_TEXT_EXTENSIONS = frozenset({
+    ".txt", ".md", ".yml", ".yaml", ".json", ".toml", ".ini",
+    ".cfg", ".conf", ".py", ".sh", ".bash", ".js", ".ts",
+    ".html", ".css", ".xml", ".csv", ".log", ".env",
+    ".service", ".timer", ".sql", ".php", ".rb", ".go",
+    ".rs", ".java", ".c", ".h", ".cpp", ".hpp", ".lua",
+    ".mk", ".makefile", ".dockerfile", ".gitignore",
+})
+
+_ARCHIVE_EXTENSIONS = frozenset({".zip", ".tar", ".tar.gz", ".tgz", ".gz"})
+
+_INGEST_PATTERNS = re.compile(
+    r"\b(ingest|index|add to knowledge|remember this|save.*(for later|to knowledge))\b",
+    re.IGNORECASE,
+)
+_TASK_PATTERNS = re.compile(
+    r"\b(debug|analyze|review|look at|check|here are the|logs?|config|fix|help|explain|what.*(wrong|happening))\b",
+    re.IGNORECASE,
+)
+
+
+class AttachmentIntent(str, Enum):
+    CURRENT_TASK = "current_task"
+    INGEST_KNOWLEDGE = "ingest_knowledge"
+    STORE_ONLY = "store_only"
+
+
+@dataclass
+class SavedAttachment:
+    filename: str
+    path: str
+    size: int
+    sha256: str
+    content_type: str | None = None
+    kind: str = "binary"
+
+
+@dataclass
+class AttachmentResult:
+    inline_text: str = ""
+    image_blocks: list[dict] = field(default_factory=list)
+    saved_files: list[SavedAttachment] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    processing_ms: int = 0
+
+
+def infer_attachment_intent(
+    message_content: str,
+    recent_assistant_text: str | None = None,
+) -> AttachmentIntent:
+    if _INGEST_PATTERNS.search(message_content):
+        return AttachmentIntent.INGEST_KNOWLEDGE
+    if _TASK_PATTERNS.search(message_content):
+        return AttachmentIntent.CURRENT_TASK
+    if recent_assistant_text and re.search(
+        r"\b(attach|upload|send|share|paste|provide).*(file|log|config|output)\b",
+        recent_assistant_text, re.IGNORECASE,
+    ):
+        return AttachmentIntent.CURRENT_TASK
+    return AttachmentIntent.CURRENT_TASK
+
+
+def _safe_filename(name: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", name)[:200]
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _detect_image_type(data: bytes) -> str | None:
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:4] == b"GIF8":
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _preview_text(text: str, ext: str, max_chars: int = 12000) -> str:
+    if len(text) <= max_chars:
+        return text
+    if ext in (".log", ".csv"):
+        head_chars = max_chars // 2
+        tail_chars = max_chars // 2
+        omitted = len(text) - max_chars
+        return (
+            text[:head_chars]
+            + f"\n\n[... {omitted:,} chars omitted — showing head and tail ...]\n\n"
+            + text[-tail_chars:]
+        )
+    return text[:max_chars] + f"\n\n[... truncated at {max_chars:,} chars ...]"
+
+
+def _is_text_file(filename: str, content_type: str | None) -> bool:
+    ext = _get_ext(filename)
+    return ext in _TEXT_EXTENSIONS or (content_type and "text" in content_type)
+
+
+def _get_ext(filename: str) -> str:
+    if filename.endswith(".tar.gz"):
+        return ".tar.gz"
+    return "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+
+
+def _is_archive(filename: str) -> bool:
+    return _get_ext(filename) in _ARCHIVE_EXTENSIONS
+
+
+class AttachmentProcessor:
+    def __init__(
+        self,
+        temp_dir: str = "/tmp/odin-attachments",
+        inline_max_bytes: int = 100_000,
+        preview_max_chars: int = 12_000,
+        large_preview_chars: int = 4_000,
+        archive_max_bytes: int = 50 * 1024 * 1024,
+        archive_max_files: int = 500,
+        archive_extract_max_bytes: int = 200 * 1024 * 1024,
+        archive_preview_total_chars: int = 20_000,
+        image_max_bytes: int = 5 * 1024 * 1024,
+        pdf_max_bytes: int = 25 * 1024 * 1024,
+        retention_hours: int = 24,
+    ) -> None:
+        self.temp_dir = Path(temp_dir)
+        self.inline_max_bytes = inline_max_bytes
+        self.preview_max_chars = preview_max_chars
+        self.large_preview_chars = large_preview_chars
+        self.archive_max_bytes = archive_max_bytes
+        self.archive_max_files = archive_max_files
+        self.archive_extract_max_bytes = archive_extract_max_bytes
+        self.archive_preview_total_chars = archive_preview_total_chars
+        self.image_max_bytes = image_max_bytes
+        self.pdf_max_bytes = pdf_max_bytes
+        self.retention_hours = retention_hours
+
+    def _workspace(self, channel_id: str, message_id: str) -> Path:
+        ws = self.temp_dir / channel_id / message_id
+        ws.mkdir(parents=True, exist_ok=True)
+        return ws
+
+    async def process(
+        self,
+        attachments: list[Any],
+        channel_id: str,
+        message_id: str,
+        intent: AttachmentIntent = AttachmentIntent.CURRENT_TASK,
+    ) -> AttachmentResult:
+        t0 = time.monotonic()
+        result = AttachmentResult()
+        text_parts: list[str] = []
+
+        for att in attachments:
+            filename = att.filename
+            ext = _get_ext(filename)
+            size = att.size
+
+            # Images
+            is_image = ext in _IMAGE_EXTENSIONS or (
+                att.content_type and att.content_type in _IMAGE_MEDIA_TYPES
+            )
+            if is_image:
+                await self._handle_image(att, ext, text_parts, result)
+                continue
+
+            # PDFs
+            if ext == ".pdf":
+                await self._handle_pdf(att, text_parts, result)
+                continue
+
+            # Archives
+            if _is_archive(filename):
+                await self._handle_archive(att, channel_id, message_id, text_parts, result)
+                continue
+
+            # Text files
+            if _is_text_file(filename, att.content_type):
+                await self._handle_text(att, ext, intent, channel_id, message_id, text_parts, result)
+                continue
+
+            # Unknown binary
+            await self._handle_binary(att, channel_id, message_id, text_parts, result)
+
+        result.inline_text = "\n\n".join(text_parts) if text_parts else ""
+        result.processing_ms = int((time.monotonic() - t0) * 1000)
+        return result
+
+    async def _handle_image(
+        self, att: Any, ext: str,
+        text_parts: list[str], result: AttachmentResult,
+    ) -> None:
+        if att.size > self.image_max_bytes:
+            text_parts.append(
+                f"[Image: {att.filename} ({att.size / 1024 / 1024:.1f} MB, exceeds limit)]"
+            )
+            return
+        try:
+            data = await att.read()
+            b64 = base64.b64encode(data).decode("ascii")
+            media_type = _detect_image_type(data) or att.content_type or f"image/{ext.lstrip('.')}"
+            if media_type == "image/jpg":
+                media_type = "image/jpeg"
+            result.image_blocks.append({
+                "type": "image",
+                "source": {"type": "base64", "media_type": media_type, "data": b64},
+            })
+            text_parts.append(f"[User shared image: {att.filename}]")
+            log.info("Processed image: %s (%d KB)", att.filename, att.size // 1024)
+        except Exception as e:
+            text_parts.append(f"[Image: {att.filename} (failed: {e})]")
+
+    async def _handle_pdf(
+        self, att: Any, text_parts: list[str], result: AttachmentResult,
+    ) -> None:
+        if att.size > self.pdf_max_bytes:
+            text_parts.append(
+                f"[PDF: {att.filename} ({att.size / 1024 / 1024:.1f} MB, exceeds limit)]"
+            )
+            return
+        try:
+            import fitz
+            data = await att.read()
+            doc = fitz.open(stream=data, filetype="pdf")
+            try:
+                pages = [f"Page {i+1}: {p.get_text()}" for i, p in enumerate(doc)]
+                full = "\n".join(pages)
+                preview = _preview_text(full, ".pdf", self.preview_max_chars)
+                text_parts.append(
+                    f"**Attached PDF: {att.filename}** ({doc.page_count} pages)\n"
+                    f"```\n{preview}\n```\n"
+                    f"[PDF text extracted for current task.]"
+                )
+            finally:
+                doc.close()
+        except Exception as e:
+            text_parts.append(f"[PDF: {att.filename} (failed: {e})]")
+
+    async def _handle_text(
+        self, att: Any, ext: str, intent: AttachmentIntent,
+        channel_id: str, message_id: str,
+        text_parts: list[str], result: AttachmentResult,
+    ) -> None:
+        try:
+            data = await att.read()
+            text = data.decode("utf-8", errors="replace")
+            digest = _sha256(data)
+
+            if att.size <= self.inline_max_bytes:
+                preview = _preview_text(text, ext, self.preview_max_chars)
+                text_parts.append(
+                    f"**Attached file: {att.filename}**\n```\n{preview}\n```\n"
+                    f"[File read for current task.]"
+                )
+            else:
+                ws = self._workspace(channel_id, message_id)
+                safe = _safe_filename(att.filename)
+                save_path = ws / safe
+                save_path.write_bytes(data)
+
+                preview = _preview_text(text, ext, self.large_preview_chars)
+                text_parts.append(
+                    f"**Attached file: {att.filename}** ({att.size:,} bytes)\n"
+                    f"Saved to: `{save_path}`\n"
+                    f"SHA256: `{digest[:16]}...`\n"
+                    f"```\n{preview}\n```\n"
+                    f"[Large file previewed for current task. "
+                    f"Full file available at the saved path for shell tools.]"
+                )
+                result.saved_files.append(SavedAttachment(
+                    filename=att.filename, path=str(save_path),
+                    size=att.size, sha256=digest,
+                    content_type=att.content_type, kind="text",
+                ))
+            log.info("Processed text: %s (%d bytes)", att.filename, att.size)
+        except Exception as e:
+            text_parts.append(f"[Attachment: {att.filename} (failed: {e})]")
+
+    async def _handle_archive(
+        self, att: Any, channel_id: str, message_id: str,
+        text_parts: list[str], result: AttachmentResult,
+    ) -> None:
+        if att.size > self.archive_max_bytes:
+            text_parts.append(
+                f"[Archive: {att.filename} ({att.size / 1024 / 1024:.1f} MB, exceeds limit)]"
+            )
+            return
+        try:
+            data = await att.read()
+            digest = _sha256(data)
+            ws = self._workspace(channel_id, message_id)
+            safe = _safe_filename(att.filename)
+            archive_path = ws / safe
+            archive_path.write_bytes(data)
+
+            ext = _get_ext(att.filename)
+            manifest_lines = []
+            extract_dir = ws / safe.rsplit(".", 1)[0]
+
+            if ext == ".zip":
+                manifest_lines, extracted = await asyncio.to_thread(
+                    self._extract_zip, archive_path, extract_dir,
+                )
+            elif ext in (".tar", ".tar.gz", ".tgz", ".gz"):
+                manifest_lines, extracted = await asyncio.to_thread(
+                    self._extract_tar, archive_path, extract_dir,
+                )
+            else:
+                manifest_lines = ["Unknown archive format"]
+                extracted = False
+
+            manifest = "\n".join(manifest_lines[:50])
+            extract_note = f"Extracted to: `{extract_dir}`" if extracted else "Not extracted (limits exceeded or unsupported)"
+
+            # Preview small text files from the archive
+            file_previews = ""
+            if extracted:
+                file_previews = self._preview_archive_files(extract_dir)
+
+            text_parts.append(
+                f"**Attached archive: {att.filename}** ({att.size:,} bytes)\n"
+                f"Saved: `{archive_path}`\n"
+                f"{extract_note}\n"
+                f"SHA256: `{digest[:16]}...`\n"
+                f"```\n{manifest}\n```"
+                + (f"\n{file_previews}" if file_previews else "")
+                + "\n[Archive processed for current task. Use shell tools to inspect further.]"
+            )
+            result.saved_files.append(SavedAttachment(
+                filename=att.filename, path=str(archive_path),
+                size=att.size, sha256=digest,
+                content_type=att.content_type, kind="archive",
+            ))
+            log.info("Processed archive: %s (%d bytes, extracted=%s)", att.filename, att.size, extracted)
+        except Exception as e:
+            text_parts.append(f"[Archive: {att.filename} (failed: {e})]")
+
+    def _extract_zip(self, archive_path: Path, extract_dir: Path) -> tuple[list[str], bool]:
+        manifest = []
+        with zipfile.ZipFile(archive_path) as zf:
+            entries = zf.infolist()
+            manifest.append(f"Entries: {len(entries)}")
+            total_uncompressed = sum(e.file_size for e in entries)
+            manifest.append(f"Uncompressed: {total_uncompressed / 1024 / 1024:.1f} MB")
+
+            if len(entries) > self.archive_max_files:
+                manifest.append(f"Too many files ({len(entries)} > {self.archive_max_files})")
+                return manifest, False
+            if total_uncompressed > self.archive_extract_max_bytes:
+                manifest.append(f"Too large uncompressed ({total_uncompressed:,} > {self.archive_extract_max_bytes:,})")
+                return manifest, False
+
+            # Security: check for path traversal
+            for entry in entries:
+                if entry.filename.startswith("/") or ".." in entry.filename:
+                    manifest.append(f"BLOCKED: unsafe path '{entry.filename}'")
+                    return manifest, False
+
+            top_dirs = sorted({e.filename.split("/")[0] for e in entries if "/" in e.filename})
+            manifest.append(f"Top-level: {', '.join(top_dirs[:10])}")
+
+            extract_dir.mkdir(parents=True, exist_ok=True)
+            zf.extractall(extract_dir)
+            return manifest, True
+
+    def _extract_tar(self, archive_path: Path, extract_dir: Path) -> tuple[list[str], bool]:
+        manifest = []
+        mode = "r:gz" if str(archive_path).endswith((".tar.gz", ".tgz")) else "r"
+        with tarfile.open(archive_path, mode) as tf:
+            members = tf.getmembers()
+            manifest.append(f"Entries: {len(members)}")
+            total_size = sum(m.size for m in members if m.isfile())
+            manifest.append(f"Uncompressed: {total_size / 1024 / 1024:.1f} MB")
+
+            if len(members) > self.archive_max_files:
+                manifest.append(f"Too many files ({len(members)} > {self.archive_max_files})")
+                return manifest, False
+            if total_size > self.archive_extract_max_bytes:
+                manifest.append(f"Too large uncompressed")
+                return manifest, False
+
+            for m in members:
+                if m.name.startswith("/") or ".." in m.name or m.issym() or m.islnk():
+                    manifest.append(f"BLOCKED: unsafe entry '{m.name}'")
+                    return manifest, False
+
+            top_dirs = sorted({m.name.split("/")[0] for m in members if "/" in m.name})
+            manifest.append(f"Top-level: {', '.join(top_dirs[:10])}")
+
+            extract_dir.mkdir(parents=True, exist_ok=True)
+            tf.extractall(extract_dir, filter="data")
+            return manifest, True
+
+    def _preview_archive_files(self, extract_dir: Path) -> str:
+        previews = []
+        total_chars = 0
+        for p in sorted(extract_dir.rglob("*")):
+            if not p.is_file():
+                continue
+            if not _is_text_file(p.name, None):
+                continue
+            if p.stat().st_size > 64_000:
+                continue
+            try:
+                content = p.read_text(errors="replace")[:2000]
+                rel = p.relative_to(extract_dir)
+                preview = f"--- {rel} ---\n{content}"
+                if total_chars + len(preview) > self.archive_preview_total_chars:
+                    break
+                previews.append(preview)
+                total_chars += len(preview)
+            except Exception:
+                continue
+        if not previews:
+            return ""
+        return "**File previews:**\n```\n" + "\n\n".join(previews) + "\n```"
+
+    async def _handle_binary(
+        self, att: Any, channel_id: str, message_id: str,
+        text_parts: list[str], result: AttachmentResult,
+    ) -> None:
+        try:
+            data = await att.read()
+            digest = _sha256(data)
+            ws = self._workspace(channel_id, message_id)
+            safe = _safe_filename(att.filename)
+            save_path = ws / safe
+            save_path.write_bytes(data)
+
+            text_parts.append(
+                f"[Attachment saved: `{save_path}` "
+                f"({att.content_type or 'binary'}, {att.size:,} bytes, "
+                f"SHA256: `{digest[:16]}...`)]"
+            )
+            result.saved_files.append(SavedAttachment(
+                filename=att.filename, path=str(save_path),
+                size=att.size, sha256=digest,
+                content_type=att.content_type, kind="binary",
+            ))
+            log.info("Saved binary: %s (%d bytes)", att.filename, att.size)
+        except Exception as e:
+            text_parts.append(f"[Attachment: {att.filename} (failed: {e})]")
+
+    def cleanup_old_workspaces(self) -> int:
+        if not self.temp_dir.exists():
+            return 0
+        cutoff = time.time() - self.retention_hours * 3600
+        removed = 0
+        for channel_dir in self.temp_dir.iterdir():
+            if not channel_dir.is_dir():
+                continue
+            for msg_dir in channel_dir.iterdir():
+                if not msg_dir.is_dir():
+                    continue
+                try:
+                    if msg_dir.stat().st_mtime < cutoff:
+                        shutil.rmtree(msg_dir)
+                        removed += 1
+                except Exception:
+                    continue
+            try:
+                if not any(channel_dir.iterdir()):
+                    channel_dir.rmdir()
+            except Exception:
+                continue
+        if removed:
+            log.info("Cleaned up %d old attachment workspace(s)", removed)
+        return removed

--- a/src/discord/attachments.py
+++ b/src/discord/attachments.py
@@ -37,9 +37,10 @@ _TEXT_EXTENSIONS = frozenset({
     ".service", ".timer", ".sql", ".php", ".rb", ".go",
     ".rs", ".java", ".c", ".h", ".cpp", ".hpp", ".lua",
     ".mk", ".makefile", ".dockerfile", ".gitignore",
+    ".patch", ".diff", ".properties", ".gradle",
 })
 
-_ARCHIVE_EXTENSIONS = frozenset({".zip", ".tar", ".tar.gz", ".tgz", ".gz"})
+_ARCHIVE_EXTENSIONS = frozenset({".zip", ".tar", ".tar.gz", ".tgz"})
 
 _INGEST_PATTERNS = re.compile(
     r"\b(ingest|index|add to knowledge|remember this|save.*(for later|to knowledge))\b",
@@ -133,9 +134,10 @@ def _is_text_file(filename: str, content_type: str | None) -> bool:
 
 
 def _get_ext(filename: str) -> str:
-    if filename.endswith(".tar.gz"):
+    lower = filename.lower()
+    if lower.endswith(".tar.gz"):
         return ".tar.gz"
-    return "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    return "." + lower.rsplit(".", 1)[-1] if "." in lower else ""
 
 
 def _is_archive(filename: str) -> bool:
@@ -280,11 +282,15 @@ class AttachmentProcessor:
             text = data.decode("utf-8", errors="replace")
             digest = _sha256(data)
 
+            intent_note = ""
+            if intent == AttachmentIntent.INGEST_KNOWLEDGE:
+                intent_note = " User requested knowledge ingestion; use ingest_document if appropriate."
+
             if att.size <= self.inline_max_bytes:
                 preview = _preview_text(text, ext, self.preview_max_chars)
                 text_parts.append(
                     f"**Attached file: {att.filename}**\n```\n{preview}\n```\n"
-                    f"[File read for current task.]"
+                    f"[File read for current task.{intent_note}]"
                 )
             else:
                 ws = self._workspace(channel_id, message_id)
@@ -384,17 +390,24 @@ class AttachmentProcessor:
                 manifest.append(f"Too large uncompressed ({total_uncompressed:,} > {self.archive_extract_max_bytes:,})")
                 return manifest, False
 
-            # Security: check for path traversal
-            for entry in entries:
-                if entry.filename.startswith("/") or ".." in entry.filename:
-                    manifest.append(f"BLOCKED: unsafe path '{entry.filename}'")
-                    return manifest, False
-
             top_dirs = sorted({e.filename.split("/")[0] for e in entries if "/" in e.filename})
             manifest.append(f"Top-level: {', '.join(top_dirs[:10])}")
 
             extract_dir.mkdir(parents=True, exist_ok=True)
-            zf.extractall(extract_dir)
+            base = extract_dir.resolve()
+            for entry in entries:
+                from pathlib import PurePosixPath
+                parts = PurePosixPath(entry.filename).parts
+                if entry.filename.startswith("/") or ".." in parts:
+                    manifest.append(f"BLOCKED: unsafe path '{entry.filename}'")
+                    shutil.rmtree(extract_dir, ignore_errors=True)
+                    return manifest, False
+                target = (extract_dir / entry.filename).resolve()
+                if target != base and base not in target.parents:
+                    manifest.append(f"BLOCKED: path escapes workspace '{entry.filename}'")
+                    shutil.rmtree(extract_dir, ignore_errors=True)
+                    return manifest, False
+                zf.extract(entry, extract_dir)
             return manifest, True
 
     def _extract_tar(self, archive_path: Path, extract_dir: Path) -> tuple[list[str], bool]:
@@ -413,16 +426,24 @@ class AttachmentProcessor:
                 manifest.append(f"Too large uncompressed")
                 return manifest, False
 
-            for m in members:
-                if m.name.startswith("/") or ".." in m.name or m.issym() or m.islnk():
-                    manifest.append(f"BLOCKED: unsafe entry '{m.name}'")
-                    return manifest, False
-
             top_dirs = sorted({m.name.split("/")[0] for m in members if "/" in m.name})
             manifest.append(f"Top-level: {', '.join(top_dirs[:10])}")
 
             extract_dir.mkdir(parents=True, exist_ok=True)
-            tf.extractall(extract_dir, filter="data")
+            base = extract_dir.resolve()
+            for m in members:
+                from pathlib import PurePosixPath
+                parts = PurePosixPath(m.name).parts
+                if m.name.startswith("/") or ".." in parts or m.issym() or m.islnk():
+                    manifest.append(f"BLOCKED: unsafe entry '{m.name}'")
+                    shutil.rmtree(extract_dir, ignore_errors=True)
+                    return manifest, False
+                target = (extract_dir / m.name).resolve()
+                if target != base and base not in target.parents:
+                    manifest.append(f"BLOCKED: path escapes workspace '{m.name}'")
+                    shutil.rmtree(extract_dir, ignore_errors=True)
+                    return manifest, False
+                tf.extract(m, extract_dir, filter="data")
             return manifest, True
 
     def _preview_archive_files(self, extract_dir: Path) -> str:

--- a/src/discord/attachments.py
+++ b/src/discord/attachments.py
@@ -155,6 +155,7 @@ class AttachmentProcessor:
         archive_max_files: int = 500,
         archive_extract_max_bytes: int = 200 * 1024 * 1024,
         archive_preview_total_chars: int = 20_000,
+        archive_preview_file_max_bytes: int = 64_000,
         image_max_bytes: int = 5 * 1024 * 1024,
         pdf_max_bytes: int = 25 * 1024 * 1024,
         retention_hours: int = 24,
@@ -167,6 +168,7 @@ class AttachmentProcessor:
         self.archive_max_files = archive_max_files
         self.archive_extract_max_bytes = archive_extract_max_bytes
         self.archive_preview_total_chars = archive_preview_total_chars
+        self.archive_preview_file_max_bytes = archive_preview_file_max_bytes
         self.image_max_bytes = image_max_bytes
         self.pdf_max_bytes = pdf_max_bytes
         self.retention_hours = retention_hours
@@ -454,7 +456,7 @@ class AttachmentProcessor:
                 continue
             if not _is_text_file(p.name, None):
                 continue
-            if p.stat().st_size > 64_000:
+            if p.stat().st_size > self.archive_preview_file_max_bytes:
                 continue
             try:
                 content = p.read_text(errors="replace")[:2000]

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -973,6 +973,15 @@ class OdinBot(commands.Bot):
         if hasattr(self, "agent_manager"):
             self.agent_manager.check_health()
 
+        # Clean up old attachment workspaces
+        try:
+            from .attachments import AttachmentProcessor
+            cfg = self.config.attachments if hasattr(self.config, "attachments") else None
+            proc = AttachmentProcessor(**({"temp_dir": cfg.temp_directory, "retention_hours": cfg.retention_hours} if cfg else {}))
+            proc.cleanup_old_workspaces()
+        except Exception:
+            pass
+
         # Clean up loop-agent bridge records for finished loops
         if hasattr(self, "loop_agent_bridge"):
             for loop_id in list(self.loop_agent_bridge._loop_agents):
@@ -1736,7 +1745,7 @@ class OdinBot(commands.Bot):
             content = content.replace(f"<@!{self.user.id}>", "").strip()
 
         # Handle file attachments — append file contents to the message
-        attachment_text, image_blocks = await self._process_attachments(message)
+        attachment_text, image_blocks = await self._process_attachments(message, content)
         if attachment_text:
             attachment_text = scrub_output_secrets(attachment_text)
             content = f"{content}\n\n{attachment_text}" if content else attachment_text
@@ -1796,188 +1805,52 @@ class OdinBot(commands.Bot):
 
         await self._handle_message(message, content, image_blocks=image_blocks, voice_callback=vc_callback)
 
-    async def _process_attachments(self, message: discord.Message) -> tuple[str, list[dict]]:
-        """Download attachments and return (text_parts, image_blocks).
+    async def _process_attachments(self, message: discord.Message, content: str = "") -> tuple[str, list[dict]]:
+        """Process attachments via AttachmentProcessor.
 
-        Text files are returned as formatted strings.
-        Images are returned as image content blocks (base64).
+        Returns (inline_text, image_blocks).
         """
-        text_parts = []
-        image_blocks = []
+        if not message.attachments:
+            return "", []
 
-        _image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
-        _image_media_types = {"image/png", "image/jpeg", "image/gif", "image/webp"}
+        from .attachments import AttachmentProcessor, infer_attachment_intent
 
-        for att in message.attachments:
-            ext = "." + att.filename.rsplit(".", 1)[-1].lower() if "." in att.filename else ""
+        cfg = self.config.attachments if hasattr(self.config, "attachments") else None
+        processor = AttachmentProcessor(
+            **({"temp_dir": cfg.temp_directory,
+                "inline_max_bytes": cfg.inline_text_max_bytes,
+                "preview_max_chars": cfg.preview_max_chars,
+                "large_preview_chars": cfg.large_preview_chars,
+                "archive_max_bytes": cfg.archive_max_bytes,
+                "archive_max_files": cfg.archive_max_files,
+                "archive_extract_max_bytes": cfg.archive_extract_max_bytes,
+                "archive_preview_total_chars": cfg.archive_preview_total_chars,
+                "retention_hours": cfg.retention_hours,
+                } if cfg else {})
+        )
 
-            # Image attachments — send to Claude as vision content blocks
-            is_image = ext in _image_extensions or (att.content_type and att.content_type in _image_media_types)
-            if is_image:
-                # Image size limit: 5MB per image (base64-encoded)
-                if att.size > 5 * 1024 * 1024:
-                    text_parts.append(f"[Image: {att.filename} ({att.size / 1024 / 1024:.1f} MB, exceeds 5 MB limit)]")
-                    continue
-                try:
-                    data = await att.read()
-                    b64 = base64.b64encode(data).decode("ascii")
-                    # Detect actual media type from file magic bytes, don't trust Discord's content_type
-                    media_type = self._detect_image_type(data) or att.content_type or f"image/{ext.lstrip('.')}"
-                    if media_type == "image/jpg":
-                        media_type = "image/jpeg"
-                    image_blocks.append({
-                        "type": "image",
-                        "source": {
-                            "type": "base64",
-                            "media_type": media_type,
-                            "data": b64,
-                        },
-                    })
-                    text_parts.append(f"[User shared image: {att.filename}]")
-                    log.info("Processed image attachment: %s (%d KB)", att.filename, att.size // 1024)
-                except Exception as e:
-                    text_parts.append(f"[Image: {att.filename} (failed to read: {e})]")
-                continue
+        recent_assistant = None
+        session = self.sessions.get(str(message.channel.id))
+        if session and session.messages:
+            for m in reversed(session.messages):
+                if m.role == "assistant":
+                    recent_assistant = m.content
+                    break
 
-            # PDF attachments — extract text inline
-            if ext == ".pdf":
-                if att.size > 25 * 1024 * 1024:
-                    text_parts.append(f"[PDF: {att.filename} ({att.size / 1024 / 1024:.1f} MB, exceeds 25 MB limit)]")
-                    continue
-                try:
-                    import fitz
-                    data = await att.read()
-                    doc = fitz.open(stream=data, filetype="pdf")
-                    try:
-                        pages_text = []
-                        for i, page in enumerate(doc):
-                            pages_text.append(f"Page {i + 1}: {page.get_text()}")
-                        full_text = "\n".join(pages_text)
-                        if len(full_text) > 8000:
-                            full_text = full_text[:8000] + "\n[... truncated ...]"
-                        text_parts.append(
-                            f"**Attached PDF: {att.filename}** ({doc.page_count} pages)\n```\n{full_text}\n```\n"
-                            f"[This is a PDF. Text has been extracted. For detailed analysis, use analyze_pdf tool.]"
-                        )
-                    finally:
-                        doc.close()
-                except Exception as e:
-                    text_parts.append(f"[PDF: {att.filename} (failed to extract text: {e})]")
-                continue
+        intent = infer_attachment_intent(content, recent_assistant)
 
-            # Text files — read and inline
-            text_extensions = {
-                ".txt", ".md", ".yml", ".yaml", ".json", ".toml", ".ini",
-                ".cfg", ".conf", ".py", ".sh", ".bash", ".js", ".ts",
-                ".html", ".css", ".xml", ".csv", ".log", ".env",
-                ".service", ".timer", ".sql", ".php", ".rb", ".go",
-                ".rs", ".java", ".c", ".h", ".cpp", ".hpp",
-            }
+        result = await processor.process(
+            message.attachments,
+            channel_id=str(message.channel.id),
+            message_id=str(message.id),
+            intent=intent,
+        )
 
-            is_text = ext in text_extensions or (att.content_type and "text" in att.content_type)
+        if result.warnings:
+            for w in result.warnings:
+                log.warning("Attachment warning: %s", w)
 
-            # Large text files (>100KB) — preview + suggest knowledge base ingestion
-            if att.size > 100_000 and is_text:
-                try:
-                    data = await att.read()
-                    text = data.decode("utf-8", errors="replace")
-                    preview = text[:2000]
-                    text_parts.append(
-                        f"**Attached file: {att.filename}** ({att.size:,} bytes — too large to fully inline, showing first 2KB)\n"
-                        f"```\n{preview}\n```\n"
-                        f"[This file is {att.size:,} bytes. You should offer to ingest it into the knowledge base "
-                        f"using the ingest_document tool so it can be searched later.]"
-                    )
-                except Exception as e:
-                    text_parts.append(f"[Attachment: {att.filename} (failed to read: {e})]")
-                continue
-
-            if att.size > 100_000:
-                text_parts.append(f"[Attachment: {att.filename} ({att.size} bytes, too large to read)]")
-                continue
-
-            if is_text:
-                try:
-                    data = await att.read()
-                    text = data.decode("utf-8", errors="replace")
-                    text_parts.append(f"**Attached file: {att.filename}**\n```\n{text}\n```")
-                    # Append smart context hints based on file type and size
-                    hint = self._get_attachment_hint(att.filename, ext, att.size)
-                    if hint:
-                        text_parts.append(hint)
-                except Exception as e:
-                    text_parts.append(f"[Attachment: {att.filename} (failed to read: {e})]")
-            else:
-                try:
-                    data = await att.read()
-                    save_path = Path(f"/tmp/{att.filename}")
-                    save_path.write_bytes(data)
-                    text_parts.append(
-                        f"[Attachment saved: /tmp/{att.filename} ({att.content_type or 'binary'}, {att.size:,} bytes)]"
-                    )
-                    log.info("Saved binary attachment: /tmp/%s (%d bytes)", att.filename, att.size)
-                except Exception as e:
-                    text_parts.append(f"[Attachment: {att.filename} (failed to save: {e})]")
-
-        return "\n\n".join(text_parts) if text_parts else "", image_blocks
-
-    @staticmethod
-    def _get_attachment_hint(filename: str, ext: str, size: int) -> str:
-        """Return a context hint for the LLM based on file type and size.
-
-        Hints guide the LLM to suggest appropriate actions (ingest, create skill, deploy).
-        Returns empty string if no special hint applies.
-        """
-        hints = []
-
-        # Python files — suggest creating as a skill
-        if ext == ".py":
-            hints.append(
-                "[This is a Python file. If it looks like a bot skill/tool "
-                "(has SKILL_DEFINITION and execute function), offer to create it as a skill "
-                "using the create_skill tool. Otherwise, offer to ingest it as documentation.]"
-            )
-
-        # YAML/JSON config files — suggest deploying or ingesting
-        elif ext in {".yml", ".yaml", ".json", ".toml", ".ini", ".cfg", ".conf"}:
-            hints.append(
-                "[This is a configuration file. You can offer to: "
-                "(1) deploy it to a host using write_file, "
-                "(2) ingest it into the knowledge base as documentation using ingest_document, "
-                "or (3) analyze it and suggest improvements.]"
-            )
-
-        # Shell scripts — suggest deploying or reviewing
-        elif ext in {".sh", ".bash"}:
-            hints.append(
-                "[This is a shell script. You can offer to: "
-                "(1) deploy it to a host using write_file, "
-                "(2) review it for issues, or "
-                "(3) run it on a specific host using run_command.]"
-            )
-
-        # Systemd units — suggest deploying
-        elif ext in {".service", ".timer"}:
-            hints.append(
-                "[This is a systemd unit file. You can offer to deploy it to a host "
-                "using write_file (to /etc/systemd/system/) and enable it.]"
-            )
-
-        # Documentation files — suggest knowledge base ingestion
-        elif ext in {".md", ".txt"}:
-            hints.append(
-                "[This is a documentation file. You can offer to ingest it into the "
-                "knowledge base using the ingest_document tool so it can be searched later.]"
-            )
-
-        # Large files (>50KB) — always suggest knowledge base ingestion
-        if size > 50_000:
-            hints.append(
-                "[This file is large. You should offer to ingest it into the knowledge base "
-                "using the ingest_document tool for future reference.]"
-            )
-
-        return "\n".join(hints)
+        return result.inline_text, result.image_blocks
 
     async def _on_voice_transcription(
         self, text: str, member: discord.Member, transcript_channel: discord.TextChannel,

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -1825,6 +1825,8 @@ class OdinBot(commands.Bot):
                 "archive_max_files": cfg.archive_max_files,
                 "archive_extract_max_bytes": cfg.archive_extract_max_bytes,
                 "archive_preview_total_chars": cfg.archive_preview_total_chars,
+                "image_max_bytes": cfg.image_max_bytes,
+                "pdf_max_bytes": cfg.pdf_max_bytes,
                 "retention_hours": cfg.retention_hours,
                 } if cfg else {})
         )

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -1825,6 +1825,7 @@ class OdinBot(commands.Bot):
                 "archive_max_files": cfg.archive_max_files,
                 "archive_extract_max_bytes": cfg.archive_extract_max_bytes,
                 "archive_preview_total_chars": cfg.archive_preview_total_chars,
+                "archive_preview_file_max_bytes": cfg.archive_preview_file_max_bytes,
                 "image_max_bytes": cfg.image_max_bytes,
                 "pdf_max_bytes": cfg.pdf_max_bytes,
                 "retention_hours": cfg.retention_hours,

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,192 @@
+"""Tests for the Discord attachment processor."""
+from __future__ import annotations
+
+import zipfile
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.discord.attachments import (
+    AttachmentIntent,
+    AttachmentProcessor,
+    AttachmentResult,
+    infer_attachment_intent,
+    _safe_filename,
+    _preview_text,
+)
+
+
+def _mock_attachment(filename, size, content_type=None, data=b"test content"):
+    att = MagicMock()
+    att.filename = filename
+    att.size = size
+    att.content_type = content_type
+    att.read = AsyncMock(return_value=data)
+    return att
+
+
+class TestIntentClassifier:
+    def test_ingest_keyword(self):
+        assert infer_attachment_intent("ingest this file") == AttachmentIntent.INGEST_KNOWLEDGE
+
+    def test_add_to_knowledge(self):
+        assert infer_attachment_intent("add to knowledge base") == AttachmentIntent.INGEST_KNOWLEDGE
+
+    def test_remember_this(self):
+        assert infer_attachment_intent("remember this for later") == AttachmentIntent.INGEST_KNOWLEDGE
+
+    def test_debug_keyword(self):
+        assert infer_attachment_intent("debug this crash") == AttachmentIntent.CURRENT_TASK
+
+    def test_here_are_logs(self):
+        assert infer_attachment_intent("here are the logs you asked for") == AttachmentIntent.CURRENT_TASK
+
+    def test_review_keyword(self):
+        assert infer_attachment_intent("review this code") == AttachmentIntent.CURRENT_TASK
+
+    def test_neutral_message(self):
+        assert infer_attachment_intent("hey check this out") == AttachmentIntent.CURRENT_TASK
+
+    def test_assistant_asked_for_file(self):
+        assert infer_attachment_intent(
+            "here you go", recent_assistant_text="please attach the log file"
+        ) == AttachmentIntent.CURRENT_TASK
+
+
+class TestSafeFilename:
+    def test_normal(self):
+        assert _safe_filename("test.txt") == "test.txt"
+
+    def test_spaces(self):
+        assert _safe_filename("my file.txt") == "my_file.txt"
+
+    def test_path_traversal(self):
+        result = _safe_filename("../../../etc/passwd")
+        assert "/" not in result or result.startswith("_")
+
+    def test_long_name(self):
+        assert len(_safe_filename("a" * 500)) <= 200
+
+
+class TestPreviewText:
+    def test_short_text_unchanged(self):
+        assert _preview_text("hello", ".txt") == "hello"
+
+    def test_log_head_tail(self):
+        text = "line\n" * 10000
+        preview = _preview_text(text, ".log", max_chars=200)
+        assert "head and tail" in preview
+
+    def test_txt_truncation(self):
+        text = "x" * 50000
+        preview = _preview_text(text, ".txt", max_chars=1000)
+        assert "truncated" in preview
+        assert len(preview) < 1100
+
+
+class TestAttachmentProcessor:
+    @pytest.mark.asyncio
+    async def test_small_text_inlined_no_ingestion(self):
+        proc = AttachmentProcessor()
+        att = _mock_attachment("notes.txt", 500, "text/plain", b"hello world")
+        result = await proc.process([att], "ch1", "msg1")
+        assert "hello world" in result.inline_text
+        assert "ingest" not in result.inline_text.lower()
+        assert "knowledge" not in result.inline_text.lower()
+        assert "current task" in result.inline_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_md_no_ingestion_hint(self):
+        proc = AttachmentProcessor()
+        att = _mock_attachment("README.md", 200, "text/markdown", b"# Hello")
+        result = await proc.process([att], "ch1", "msg1")
+        assert "ingest" not in result.inline_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_log_head_tail_preview(self):
+        log_content = ("line %d\n" % i for i in range(5000))
+        data = "".join(log_content).encode()
+        proc = AttachmentProcessor(inline_max_bytes=100, large_preview_chars=500)
+        att = _mock_attachment("app.log", len(data), "text/plain", data)
+        result = await proc.process([att], "ch1", "msg1")
+        assert "head and tail" in result.inline_text
+        assert "ingest" not in result.inline_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_zip_saved_and_listed(self, tmp_path):
+        zf_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zf_path, "w") as zf:
+            zf.writestr("hello.txt", "world")
+            zf.writestr("src/main.py", "print('hi')")
+        data = zf_path.read_bytes()
+        proc = AttachmentProcessor(temp_dir=str(tmp_path / "workspace"))
+        att = _mock_attachment("test.zip", len(data), "application/zip", data)
+        result = await proc.process([att], "ch1", "msg1")
+        assert "Entries:" in result.inline_text
+        assert "SHA256:" in result.inline_text
+        assert len(result.saved_files) == 1
+        assert result.saved_files[0].kind == "archive"
+
+    @pytest.mark.asyncio
+    async def test_zip_path_traversal_blocked(self, tmp_path):
+        zf_path = tmp_path / "evil.zip"
+        with zipfile.ZipFile(zf_path, "w") as zf:
+            zf.writestr("../../../etc/evil", "pwned")
+        data = zf_path.read_bytes()
+        proc = AttachmentProcessor(temp_dir=str(tmp_path / "workspace"))
+        att = _mock_attachment("evil.zip", len(data), "application/zip", data)
+        result = await proc.process([att], "ch1", "msg1")
+        assert "BLOCKED" in result.inline_text
+
+    @pytest.mark.asyncio
+    async def test_binary_saved_to_workspace(self, tmp_path):
+        proc = AttachmentProcessor(temp_dir=str(tmp_path / "workspace"))
+        att = _mock_attachment("firmware.bin", 1024, "application/octet-stream", b"\x00" * 1024)
+        result = await proc.process([att], "ch1", "msg1")
+        assert len(result.saved_files) == 1
+        assert result.saved_files[0].kind == "binary"
+        assert Path(result.saved_files[0].path).exists()
+
+    @pytest.mark.asyncio
+    async def test_image_produces_vision_block(self):
+        png_header = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        proc = AttachmentProcessor()
+        att = _mock_attachment("screenshot.png", len(png_header), "image/png", png_header)
+        result = await proc.process([att], "ch1", "msg1")
+        assert len(result.image_blocks) == 1
+        assert result.image_blocks[0]["type"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_intent_does_not_auto_ingest(self):
+        proc = AttachmentProcessor()
+        att = _mock_attachment("data.txt", 50, "text/plain", b"some data")
+        result = await proc.process(
+            [att], "ch1", "msg1", intent=AttachmentIntent.INGEST_KNOWLEDGE,
+        )
+        assert "ingest" not in result.inline_text.lower()
+        assert "current task" in result.inline_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_filename_sanitized_in_workspace(self, tmp_path):
+        proc = AttachmentProcessor(temp_dir=str(tmp_path / "workspace"))
+        att = _mock_attachment("my evil file!@#.bin", 100, None, b"\x00" * 100)
+        result = await proc.process([att], "ch1", "msg1")
+        assert len(result.saved_files) == 1
+        saved = result.saved_files[0].path
+        assert "!" not in Path(saved).name
+        assert "@" not in Path(saved).name
+
+
+class TestWorkspaceCleanup:
+    def test_cleanup_old_dirs(self, tmp_path):
+        proc = AttachmentProcessor(temp_dir=str(tmp_path), retention_hours=0)
+        ws = tmp_path / "ch1" / "msg1"
+        ws.mkdir(parents=True)
+        (ws / "file.txt").write_text("old")
+        import os
+        os.utime(ws, (0, 0))
+        removed = proc.cleanup_old_workspaces()
+        assert removed >= 1
+        assert not ws.exists()

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -159,14 +159,14 @@ class TestAttachmentProcessor:
         assert result.image_blocks[0]["type"] == "image"
 
     @pytest.mark.asyncio
-    async def test_intent_does_not_auto_ingest(self):
+    async def test_ingest_intent_produces_marker_not_auto_ingest(self):
         proc = AttachmentProcessor()
         att = _mock_attachment("data.txt", 50, "text/plain", b"some data")
         result = await proc.process(
             [att], "ch1", "msg1", intent=AttachmentIntent.INGEST_KNOWLEDGE,
         )
-        assert "ingest" not in result.inline_text.lower()
         assert "current task" in result.inline_text.lower()
+        assert "ingest_document" in result.inline_text
 
     @pytest.mark.asyncio
     async def test_filename_sanitized_in_workspace(self, tmp_path):


### PR DESCRIPTION
## Summary
Full refactor of Discord attachment handling per Odin's design proposal.

### Core policy change
Attachments are current-task context by default. Knowledge ingestion only happens when explicitly requested.

### New: `src/discord/attachments.py`
- `AttachmentProcessor` with configurable limits
- `AttachmentIntent` enum with classifier (`infer_attachment_intent`)
- `AttachmentResult` / `SavedAttachment` dataclasses

### File type handling
- **Text/md/log**: Read inline for current task, no ingestion hints
- **Log files**: Head+tail preview (not just first 2KB)
- **Zip/tar archives**: Save, extract safely, list contents, preview small text files
- **Images**: Vision blocks (unchanged)
- **PDFs**: Extract text inline (unchanged, hint updated)
- **Binary**: Save to unique workspace with SHA256

### Security
- Archive path traversal / zip-slip blocked
- Symlink escape blocked
- File count and decompression bomb limits
- Filename sanitization

### Config
- `AttachmentsConfig` in schema with tunable limits (temp_dir, inline_max, archive limits, retention)
- Workspace cleanup in periodic cache eviction

### Removed
- `_get_attachment_hint()` and all ingestion nudge logic
- Inline `_process_attachments()` replaced with processor delegation

## Test plan
- [x] 25 new tests covering all file types, security, intent, cleanup
- [x] 216 broader tests pass
- [ ] Odin review