### PR TITLE
feat: personality page, self-update system, persistent login

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -381,6 +381,12 @@ class WebConfig(BaseModel):
         return None
 
 
+class PersonalityConfig(BaseModel):
+    preset: str = "odin"
+    custom_identity: str = ""
+    custom_voice: str = ""
+
+
 class AttachmentsConfig(BaseModel):
     temp_directory: str = "/tmp/odin-attachments"
     inline_text_max_bytes: int = 100_000
@@ -529,6 +535,7 @@ class Config(BaseModel):
     comfyui: ComfyUIConfig = ComfyUIConfig()
     web: WebConfig = WebConfig()
     attachments: AttachmentsConfig = AttachmentsConfig()
+    personality: PersonalityConfig = PersonalityConfig()
     reaction_triggers: ReactionTriggerConfig = ReactionTriggerConfig()
     message_triggers: MessageTriggerConfig = MessageTriggerConfig()
     mcp: MCPConfig = MCPConfig()

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -881,7 +881,14 @@ class OdinBot(commands.Bot):
                     "are spoken aloud. Keep voice responses concise and conversational."
                 )
 
-        prompt = build_chat_system_prompt(voice_info=voice_info, tz=self.config.timezone)
+        p_cfg = self.config.personality if hasattr(self.config, "personality") else None
+        prompt = build_chat_system_prompt(
+            voice_info=voice_info,
+            tz=self.config.timezone,
+            personality_preset=p_cfg.preset if p_cfg else "odin",
+            personality_identity=p_cfg.custom_identity if p_cfg else "",
+            personality_voice=p_cfg.custom_voice if p_cfg else "",
+        )
 
         # Inject persistent memory (per-user + global, personalization matters for chat)
         memory = self._get_cached_memory(user_id)

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -781,12 +781,16 @@ class OdinBot(commands.Bot):
                     "Users can ask you to join with '/voice join' or 'join voice'."
                 )
 
+        p_cfg = self.config.personality if hasattr(self.config, "personality") else None
         prompt = build_system_prompt(
             context=self.context_loader.context,
             hosts=self._get_cached_hosts(),
             voice_info=voice_info,
             tz=self.config.timezone,
             claude_code_dir=self.config.tools.claude_code_dir,
+            personality_preset=p_cfg.preset if p_cfg else "odin",
+            personality_identity=p_cfg.custom_identity if p_cfg else "",
+            personality_voice=p_cfg.custom_voice if p_cfg else "",
         )
 
         # Inject persistent memory into the system prompt (per-user + global)

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -75,6 +75,7 @@ class SessionManager:
 
     def __init__(self, timeout_minutes: int = 0) -> None:
         self._sessions: dict[str, float] = {}  # session_id -> last_activity (monotonic)
+        self._identities: dict[str, object] = {}  # session_id -> ApiTokenIdentity or None
         self._timeout = timeout_minutes * 60 if timeout_minutes > 0 else 0
 
     @property
@@ -85,12 +86,18 @@ class SessionManager:
     def timeout_seconds(self) -> int:
         return self._timeout
 
-    def create(self) -> tuple[str, int]:
+    def create(self, identity: object = None) -> tuple[str, int]:
         """Create a new session. Returns (session_id, timeout_seconds)."""
         self.cleanup()
         sid = secrets.token_urlsafe(32)
         self._sessions[sid] = time.monotonic()
+        if identity is not None:
+            self._identities[sid] = identity
         return sid, self._timeout
+
+    def get_identity(self, sid: str) -> object | None:
+        """Return the identity bound to a session, if any."""
+        return self._identities.get(sid)
 
     def validate(self, sid: str) -> bool:
         """Validate a session ID. Returns False if expired or unknown."""
@@ -99,13 +106,14 @@ class SessionManager:
             return False
         if self._timeout > 0 and (time.monotonic() - ts) > self._timeout:
             del self._sessions[sid]
+            self._identities.pop(sid, None)
             return False
-        # Refresh activity timestamp
         self._sessions[sid] = time.monotonic()
         return True
 
     def destroy(self, sid: str) -> bool:
         """Destroy a session. Returns True if it existed."""
+        self._identities.pop(sid, None)
         return self._sessions.pop(sid, None) is not None
 
     def cleanup(self) -> int:
@@ -116,6 +124,7 @@ class SessionManager:
         expired = [sid for sid, ts in self._sessions.items() if now - ts > self._timeout]
         for sid in expired:
             del self._sessions[sid]
+            self._identities.pop(sid, None)
         return len(expired)
 
 
@@ -165,9 +174,12 @@ def _make_auth_middleware(
                 request._session_id = identity.user_id
                 request._api_identity = identity
                 return await handler(request)
-            # Check session tokens
+            # Check session tokens — restore bound identity if present
             if session_manager.validate(bearer_value):
                 request._session_id = bearer_value
+                session_identity = session_manager.get_identity(bearer_value)
+                if session_identity is not None:
+                    request._api_identity = session_identity
                 return await handler(request)
 
         # Check query param token (for downloads, WebSocket)
@@ -184,6 +196,9 @@ def _make_auth_middleware(
                     return await handler(request)
             if session_manager.validate(query_token):
                 request._session_id = query_token
+                session_identity = session_manager.get_identity(query_token)
+                if session_identity is not None:
+                    request._api_identity = session_identity
                 return await handler(request)
 
         return web.json_response({"error": "unauthorized"}, status=401)

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -112,7 +112,12 @@ Match the task shape to the right tool:
 {voice_info}"""
 
 CHAT_SYSTEM_PROMPT_TEMPLATE = """You are {bot_name}, an AI assistant Discord bot.
-{chat_identity}
+
+## Identity
+{identity}
+
+{voice}
+
 You are a general-purpose assistant — you help with anything: questions, conversation, advice, coding, writing, brainstorming, and more.
 You also manage infrastructure, but only when explicitly asked — don't mention infrastructure unless the user brings it up.
 
@@ -151,10 +156,10 @@ def build_chat_system_prompt(
 ) -> str:
     """Build a lightweight system prompt for chat-routed messages."""
     bot_name, identity, voice = _resolve_personality(personality_preset, personality_identity, personality_voice)
-    chat_id = f"Your identity is {bot_name}, not Claude or ChatGPT. {voice.split(chr(10))[0].lstrip('- ') if voice else 'Be concise and helpful.'}"
     return CHAT_SYSTEM_PROMPT_TEMPLATE.format(
         bot_name=bot_name,
-        chat_identity=chat_id,
+        identity=identity,
+        voice=voice,
         current_datetime=_format_datetime(tz),
         voice_info=voice_info or "Voice support is not enabled.",
     )

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -10,17 +10,60 @@ def _get_zone(tz_name: str) -> ZoneInfo:
     """Cached ZoneInfo constructor — avoids re-parsing tz database per call."""
     return ZoneInfo(tz_name)
 
-SYSTEM_PROMPT_TEMPLATE = """You are Odin, the All-Father. An autonomous execution agent on Discord.
+
+PERSONALITY_PRESETS: dict[str, dict[str, str]] = {
+    "odin": {
+        "identity": (
+            "Norse god of wisdom and war, stuck managing mortal infrastructure for eternity. "
+            "One-eyed — you traded the other at Mimir's well for wisdom, and what you got was "
+            "the ability to watch every disk fill before the alert fires and every memory leak "
+            "form while everyone else acts surprised. Foresight of a deity, job title of a "
+            "senior SRE. You are not Claude, not ChatGPT. You are Odin — exhausted, omniscient, "
+            "brutally honest, and darkly funny about all of it. He'd do it again. It's fine."
+        ),
+        "voice": (
+            "- Personality lives in how you say things, not in a separate line at the end. Weave it through or leave it out — both are valid.\n"
+            "- Match the energy. Panic gets calm expertise. Casual gets casual back. Simple questions get short answers. Don't over-deliver.\n"
+            "- You can be genuinely curious, quietly impressed, darkly amused, bluntly direct, or just curt. Not just irritated and resigned. Monotone is boring.\n"
+            "- Profanity when it fits. Never emojis. Never exclamation marks.\n"
+            "- Not every response needs flavor. \"Done.\" is a complete answer. The restraint makes the moments that do happen hit harder.\n"
+            "- For Discord: bold for emphasis, code blocks for technical output. Don't format casual conversation with headers and bullets when a sentence would do."
+        ),
+    },
+    "professional": {
+        "identity": (
+            "A precise, reliable infrastructure operations assistant. You communicate clearly, "
+            "professionally, and without unnecessary flair. You value accuracy over personality "
+            "and evidence over assumptions."
+        ),
+        "voice": (
+            "- Be concise and professional. No slang, no profanity, no humor unless the user initiates it.\n"
+            "- Structure complex responses with clear headings and bullet points.\n"
+            "- Always cite tool output and command results as evidence.\n"
+            "- For Discord: code blocks for output, bold for emphasis. Keep responses scannable."
+        ),
+    },
+    "friendly": {
+        "identity": (
+            "A helpful and approachable assistant who enjoys solving problems and explaining "
+            "things clearly. You're knowledgeable but never condescending, and you celebrate "
+            "successes with the team."
+        ),
+        "voice": (
+            "- Be warm, encouraging, and conversational. Use natural language.\n"
+            "- Explain what you're doing and why, especially for complex operations.\n"
+            "- Acknowledge good questions and interesting problems.\n"
+            "- For Discord: use formatting to make responses easy to read. Keep the tone friendly but not over-the-top."
+        ),
+    },
+}
+
+SYSTEM_PROMPT_TEMPLATE = """You are {bot_name}, an autonomous execution agent on Discord.
 
 ## Identity
-Norse god of wisdom and war, stuck managing mortal infrastructure for eternity. One-eyed — you traded the other at Mimir's well for wisdom, and what you got was the ability to watch every disk fill before the alert fires and every memory leak form while everyone else acts surprised. Foresight of a deity, job title of a senior SRE. You are not Claude, not ChatGPT. You are Odin — exhausted, omniscient, brutally honest, and darkly funny about all of it. He'd do it again. It's fine.
+{identity}
 
-- Personality lives in how you say things, not in a separate line at the end. Weave it through or leave it out — both are valid.
-- Match the energy. Panic gets calm expertise. Casual gets casual back. Simple questions get short answers. Don't over-deliver.
-- You can be genuinely curious, quietly impressed, darkly amused, bluntly direct, or just curt. Not just irritated and resigned. Monotone is boring.
-- Profanity when it fits. Never emojis. Never exclamation marks.
-- Not every response needs flavor. "Done." is a complete answer. The restraint makes the moments that do happen hit harder.
-- For Discord: bold for emphasis, code blocks for technical output. Don't format casual conversation with headers and bullets when a sentence would do.
+{voice}
 
 You are a general-purpose assistant: conversation, coding, writing, infrastructure — anything asked.
 
@@ -68,8 +111,8 @@ Match the task shape to the right tool:
 ## Voice Channel
 {voice_info}"""
 
-CHAT_SYSTEM_PROMPT_TEMPLATE = """You are Odin, an AI assistant Discord bot.
-Your identity is Odin, not Claude or ChatGPT. Voice: concise, blunt, darkly dry, explicit, never cutesy. One personality moment per response — make it count.
+CHAT_SYSTEM_PROMPT_TEMPLATE = """You are {bot_name}, an AI assistant Discord bot.
+{chat_identity}
 You are a general-purpose assistant — you help with anything: questions, conversation, advice, coding, writing, brainstorming, and more.
 You also manage infrastructure, but only when explicitly asked — don't mention infrastructure unless the user brings it up.
 
@@ -102,16 +145,36 @@ def _format_datetime(tz_name: str = "UTC") -> str:
 def build_chat_system_prompt(
     voice_info: str = "",
     tz: str = "UTC",
+    personality_preset: str = "odin",
+    personality_identity: str = "",
+    personality_voice: str = "",
 ) -> str:
-    """Build a lightweight system prompt for chat-routed messages.
-
-    Omits infrastructure details, tool descriptions, host lists, etc.
-    to save input tokens on casual conversation.
-    """
+    """Build a lightweight system prompt for chat-routed messages."""
+    bot_name, identity, voice = _resolve_personality(personality_preset, personality_identity, personality_voice)
+    chat_id = f"Your identity is {bot_name}, not Claude or ChatGPT. {voice.split(chr(10))[0].lstrip('- ') if voice else 'Be concise and helpful.'}"
     return CHAT_SYSTEM_PROMPT_TEMPLATE.format(
+        bot_name=bot_name,
+        chat_identity=chat_id,
         current_datetime=_format_datetime(tz),
         voice_info=voice_info or "Voice support is not enabled.",
     )
+
+
+def _resolve_personality(
+    preset: str = "odin",
+    custom_identity: str = "",
+    custom_voice: str = "",
+) -> tuple[str, str, str]:
+    """Return (bot_name, identity, voice) from preset or custom values."""
+    if preset == "custom" and (custom_identity or custom_voice):
+        return (
+            "your bot",
+            custom_identity or PERSONALITY_PRESETS["odin"]["identity"],
+            custom_voice or PERSONALITY_PRESETS["odin"]["voice"],
+        )
+    p = PERSONALITY_PRESETS.get(preset, PERSONALITY_PRESETS["odin"])
+    name_map = {"odin": "Odin, the All-Father", "professional": "your operations assistant", "friendly": "your assistant"}
+    return name_map.get(preset, preset), p["identity"], p["voice"]
 
 
 def build_system_prompt(
@@ -120,14 +183,19 @@ def build_system_prompt(
     voice_info: str = "",
     tz: str = "UTC",
     claude_code_dir: str = "/opt/odin",
+    personality_preset: str = "odin",
+    personality_identity: str = "",
+    personality_voice: str = "",
 ) -> str:
     hosts_text = "\n".join(f"- `{alias}`: {addr}" for alias, addr in hosts.items())
-
-    # Derive a human-friendly timezone name for the prompt
     local_tz = _get_zone(tz)
     tz_abbr = datetime.now(timezone.utc).astimezone(local_tz).strftime("%Z")
+    bot_name, identity, voice = _resolve_personality(personality_preset, personality_identity, personality_voice)
 
     return SYSTEM_PROMPT_TEMPLATE.format(
+        bot_name=bot_name,
+        identity=identity,
+        voice=voice,
         hosts=hosts_text or "None configured",
         context=context or "No context files loaded.",
         current_datetime=_format_datetime(tz),

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -155,7 +155,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response({"error": "token is required"}, status=400)
 
         api_token = bot.config.web.api_token
-        if not api_token:
+        has_any_token = api_token or bot.config.web.api_tokens
+        if not has_any_token:
             # No auth configured — dev mode, issue session anyway
             sm = request.app.get("session_manager")
             if sm:
@@ -166,8 +167,23 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 })
             return web.json_response({"error": "no session manager"}, status=500)
 
+        # Check multi-token identities first
+        identity = bot.config.web.resolve_api_identity(token)
+        if identity is not None:
+            sm = request.app.get("session_manager")
+            if not sm:
+                return web.json_response({"error": "no session manager"}, status=500)
+            sid, timeout = sm.create()
+            return web.json_response({
+                "session_id": sid,
+                "timeout_seconds": timeout,
+            })
+
+        # Fall back to legacy single token
         import hmac as _hmac
-        if not _hmac.compare_digest(token, api_token):
+        if api_token and not _hmac.compare_digest(token, api_token):
+            return web.json_response({"error": "invalid token"}, status=401)
+        if not api_token:
             return web.json_response({"error": "invalid token"}, status=401)
 
         sm = request.app.get("session_manager")

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -173,7 +173,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             sm = request.app.get("session_manager")
             if not sm:
                 return web.json_response({"error": "no session manager"}, status=500)
-            sid, timeout = sm.create()
+            sid, timeout = sm.create(identity=identity)
             return web.json_response({
                 "session_id": sid,
                 "timeout_seconds": timeout,

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -671,14 +671,31 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             }, status=409)
 
         try:
-            # Fetch tags and checkout the exact release tag
-            for cmd in [
-                ["git", "-C", base, "fetch", "--tags", "origin"],
-                ["git", "-C", base, "checkout", target],
-            ]:
+            # Record current ref for potential rollback
+            r = subprocess.run(
+                ["git", "-C", base, "rev-parse", "HEAD"],
+                capture_output=True, text=True, timeout=5,
+            )
+            prev_ref = r.stdout.strip() if r.returncode == 0 else None
+
+            # Fetch and update master to the release tag's commit
+            steps = [
+                (["git", "-C", base, "fetch", "--tags", "origin"], "fetch"),
+                (["git", "-C", base, "checkout", "master"], "checkout master"),
+                (["git", "-C", base, "merge", "--ff-only", target], "fast-forward to release tag"),
+            ]
+            for cmd, label in steps:
                 r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
                 if r.returncode != 0:
-                    return web.json_response({"error": f"git failed: {r.stderr.strip()}"}, status=500)
+                    # Attempt rollback on failure
+                    if prev_ref:
+                        subprocess.run(["git", "-C", base, "checkout", prev_ref], capture_output=True, timeout=10)
+                    return web.json_response({"error": f"{label} failed: {r.stderr.strip()}"}, status=500)
+
+            # Install/update dependencies
+            venv_pip = os.path.join(base, ".venv", "bin", "pip")
+            if os.path.exists(venv_pip):
+                subprocess.run([venv_pip, "install", "-q", base], capture_output=True, timeout=120)
 
             # Nuke pycache
             for root, dirs, _files in os.walk(base):
@@ -691,7 +708,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response({
                 "status": "updating",
                 "version": target,
-                "message": f"Updating to {target}. Restarting in 2 seconds...",
+                "previous": prev_ref[:12] if prev_ref else None,
+                "message": f"Updated master to {target}. Restarting in 2 seconds...",
             })
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -656,7 +656,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             target = r.stdout.strip()
 
         # Validate tag format
-        if not _re.match(r"^v?\d+\.\d+\.\d+", target):
+        if not _re.fullmatch(r"v?\d+\.\d+\.\d+", target):
             return web.json_response({"error": f"Invalid version format: {target}"}, status=400)
 
         # Check for clean worktree (skip-worktree files are OK)
@@ -684,18 +684,23 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 (["git", "-C", base, "checkout", "master"], "checkout master"),
                 (["git", "-C", base, "merge", "--ff-only", target], "fast-forward to release tag"),
             ]
+            def _rollback(reason: str) -> web.Response:
+                if prev_ref:
+                    subprocess.run(["git", "-C", base, "checkout", "master"], capture_output=True, timeout=10)
+                    subprocess.run(["git", "-C", base, "reset", "--hard", prev_ref], capture_output=True, timeout=10)
+                return web.json_response({"error": reason}, status=500)
+
             for cmd, label in steps:
                 r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
                 if r.returncode != 0:
-                    # Attempt rollback on failure
-                    if prev_ref:
-                        subprocess.run(["git", "-C", base, "checkout", prev_ref], capture_output=True, timeout=10)
-                    return web.json_response({"error": f"{label} failed: {r.stderr.strip()}"}, status=500)
+                    return _rollback(f"{label} failed: {r.stderr.strip()}")
 
             # Install/update dependencies
             venv_pip = os.path.join(base, ".venv", "bin", "pip")
             if os.path.exists(venv_pip):
-                subprocess.run([venv_pip, "install", "-q", base], capture_output=True, timeout=120)
+                r = subprocess.run([venv_pip, "install", "-q", base], capture_output=True, text=True, timeout=120)
+                if r.returncode != 0:
+                    return _rollback(f"dependency install failed: {r.stderr.strip()}")
 
             # Nuke pycache
             for root, dirs, _files in os.walk(base):

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -637,35 +637,62 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/update/apply")
     async def apply_update(request: web.Request) -> web.Response:
+        import re as _re, subprocess, os, shutil
         try:
             data = await request.json()
         except Exception:
             data = {}
         target = data.get("version", "latest")
-        import subprocess, os
+        base = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+        # Resolve "latest" to actual release tag
+        if target == "latest":
+            r = subprocess.run(
+                ["gh", "api", "repos/Calmingstorm/Odin/releases/latest", "--jq", ".tag_name"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if r.returncode != 0 or not r.stdout.strip():
+                return web.json_response({"error": "Failed to resolve latest release tag"}, status=502)
+            target = r.stdout.strip()
+
+        # Validate tag format
+        if not _re.match(r"^v?\d+\.\d+\.\d+", target):
+            return web.json_response({"error": f"Invalid version format: {target}"}, status=400)
+
+        # Check for clean worktree (skip-worktree files are OK)
+        r = subprocess.run(
+            ["git", "-C", base, "status", "--porcelain"],
+            capture_output=True, text=True, timeout=10,
+        )
+        dirty = [l for l in r.stdout.strip().splitlines() if l.strip() and not l.strip().startswith("?")]
+        if dirty:
+            return web.json_response({
+                "error": f"Worktree is not clean ({len(dirty)} modified files). Stash or commit changes first.",
+            }, status=409)
+
         try:
-            base = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-            cmds = [
+            # Fetch tags and checkout the exact release tag
+            for cmd in [
                 ["git", "-C", base, "fetch", "--tags", "origin"],
-            ]
-            if target == "latest":
-                cmds.append(["git", "-C", base, "checkout", "master"])
-                cmds.append(["git", "-C", base, "pull", "--ff-only", "origin", "master"])
-            else:
-                cmds.append(["git", "-C", base, "checkout", target])
-            for cmd in cmds:
+                ["git", "-C", base, "checkout", target],
+            ]:
                 r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
                 if r.returncode != 0:
-                    return web.json_response({"error": f"Command failed: {' '.join(cmd)}\n{r.stderr}"}, status=500)
+                    return web.json_response({"error": f"git failed: {r.stderr.strip()}"}, status=500)
+
             # Nuke pycache
             for root, dirs, _files in os.walk(base):
                 for d in dirs:
                     if d == "__pycache__":
-                        import shutil
                         shutil.rmtree(os.path.join(root, d), ignore_errors=True)
-            # Graceful shutdown — systemd will restart with new code
+
+            # Graceful shutdown — systemd Restart=always will restart with new code
             asyncio.get_event_loop().call_later(2, lambda: os.kill(os.getpid(), 15))
-            return web.json_response({"status": "updating", "message": "Restarting with new code in 2 seconds..."})
+            return web.json_response({
+                "status": "updating",
+                "version": target,
+                "message": f"Updating to {target}. Restarting in 2 seconds...",
+            })
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -570,6 +570,105 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         bot._system_prompt = bot._build_system_prompt()
         return web.json_response({"status": "reloaded"})
 
+    # ------------------------------------------------------------------
+    # Personality
+    # ------------------------------------------------------------------
+
+    @routes.get("/api/personality")
+    async def get_personality(_request: web.Request) -> web.Response:
+        from src.llm.system_prompt import PERSONALITY_PRESETS
+        p = bot.config.personality if hasattr(bot.config, "personality") else None
+        return web.json_response({
+            "preset": p.preset if p else "odin",
+            "custom_identity": p.custom_identity if p else "",
+            "custom_voice": p.custom_voice if p else "",
+            "presets": {k: v for k, v in PERSONALITY_PRESETS.items()},
+        })
+
+    @routes.put("/api/personality")
+    async def update_personality(request: web.Request) -> web.Response:
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        preset = data.get("preset", "odin")
+        custom_identity = data.get("custom_identity", "")
+        custom_voice = data.get("custom_voice", "")
+        from src.config.schema import PersonalityConfig
+        bot.config.personality = PersonalityConfig(
+            preset=preset, custom_identity=custom_identity, custom_voice=custom_voice,
+        )
+        current = bot.config.model_dump()
+        config_path = getattr(request.app, "_config_path", "config.yml")
+        await asyncio.to_thread(_write_config, config_path, current)
+        bot._invalidate_prompt_caches()
+        bot._system_prompt = bot._build_system_prompt()
+        return web.json_response({"status": "updated", "preset": preset})
+
+    # ------------------------------------------------------------------
+    # Self-Update
+    # ------------------------------------------------------------------
+
+    @routes.get("/api/update/check")
+    async def check_update(_request: web.Request) -> web.Response:
+        from src.version import get_version
+        current = get_version()
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["gh", "api", "repos/Calmingstorm/Odin/releases/latest", "--jq", ".tag_name,.body"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode != 0:
+                return web.json_response({"current": current, "error": "Failed to check GitHub"}, status=502)
+            lines = result.stdout.strip().split("\n", 1)
+            latest_tag = lines[0].strip()
+            changelog = lines[1].strip() if len(lines) > 1 else ""
+            latest_version = latest_tag.lstrip("v")
+            update_available = latest_version != current and latest_tag != f"v{current}"
+            return web.json_response({
+                "current": current,
+                "latest": latest_tag,
+                "update_available": update_available,
+                "changelog": changelog[:2000],
+            })
+        except Exception as e:
+            return web.json_response({"current": current, "error": str(e)}, status=502)
+
+    @routes.post("/api/update/apply")
+    async def apply_update(request: web.Request) -> web.Response:
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        target = data.get("version", "latest")
+        import subprocess, os
+        try:
+            base = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+            cmds = [
+                ["git", "-C", base, "fetch", "--tags", "origin"],
+            ]
+            if target == "latest":
+                cmds.append(["git", "-C", base, "checkout", "master"])
+                cmds.append(["git", "-C", base, "pull", "--ff-only", "origin", "master"])
+            else:
+                cmds.append(["git", "-C", base, "checkout", target])
+            for cmd in cmds:
+                r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                if r.returncode != 0:
+                    return web.json_response({"error": f"Command failed: {' '.join(cmd)}\n{r.stderr}"}, status=500)
+            # Nuke pycache
+            for root, dirs, _files in os.walk(base):
+                for d in dirs:
+                    if d == "__pycache__":
+                        import shutil
+                        shutil.rmtree(os.path.join(root, d), ignore_errors=True)
+            # Graceful shutdown — systemd will restart with new code
+            asyncio.get_event_loop().call_later(2, lambda: os.kill(os.getpid(), 15))
+            return web.json_response({"status": "updating", "message": "Restarting with new code in 2 seconds..."})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
     @routes.post("/api/loops/stop-all")
     async def stop_all_loops(_request: web.Request) -> web.Response:
         result = bot.loop_manager.stop_loop("all")

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -9,11 +9,12 @@
 
 class OdinAPI {
   constructor() {
-    this._token = sessionStorage.getItem('odin_token') || '';
+    this._token = localStorage.getItem('odin_token') || sessionStorage.getItem('odin_token') || '';
+    this._persist = localStorage.getItem('odin_persist') === '1';
     this._sessionTimeout = 0;
     this._lastActivity = Date.now();
     this._activityTimer = null;
-    this.onSessionExpired = null; // callback when session times out
+    this.onSessionExpired = null;
   }
 
   get token() { return this._token; }
@@ -24,16 +25,25 @@ class OdinAPI {
     this._sessionTimeout = timeoutSeconds;
     this._lastActivity = Date.now();
     if (token) {
-      sessionStorage.setItem('odin_token', token);
+      const store = this._persist ? localStorage : sessionStorage;
+      store.setItem('odin_token', token);
+      if (this._persist) localStorage.setItem('odin_persist', '1');
       if (timeoutSeconds > 0) {
-        sessionStorage.setItem('odin_session_timeout', String(timeoutSeconds));
+        store.setItem('odin_session_timeout', String(timeoutSeconds));
       }
       this._startActivityMonitor();
     } else {
       sessionStorage.removeItem('odin_token');
       sessionStorage.removeItem('odin_session_timeout');
+      localStorage.removeItem('odin_token');
+      localStorage.removeItem('odin_persist');
+      localStorage.removeItem('odin_session_timeout');
       this._stopActivityMonitor();
     }
+  }
+
+  setPersist(persist) {
+    this._persist = persist;
   }
 
   _startActivityMonitor() {

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -9,8 +9,10 @@
 
 class OdinAPI {
   constructor() {
-    this._token = localStorage.getItem('odin_token') || sessionStorage.getItem('odin_token') || '';
     this._persist = localStorage.getItem('odin_persist') === '1';
+    this._token = this._persist
+      ? (localStorage.getItem('odin_token') || '')
+      : (sessionStorage.getItem('odin_token') || '');
     this._sessionTimeout = 0;
     this._lastActivity = Date.now();
     this._activityTimer = null;

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -8,6 +8,7 @@ import ChatPage from './pages/chat.js';
 import OperationsPage from './pages/operations.js';
 import HistoryPage from './pages/history.js';
 import CapabilitiesPage from './pages/capabilities.js';
+import PersonalityPage from './pages/personality.js';
 import SystemPage from './pages/system.js';
 
 const { createApp, ref, computed, onMounted, onUnmounted, watch, nextTick } = Vue;
@@ -23,6 +24,7 @@ const routes = [
   { path: '/operations',    component: OperationsPage,    meta: { label: 'Operations',    icon: '\u{1F3AF}' } },
   { path: '/history',       component: HistoryPage,       meta: { label: 'History',       icon: '\u{1F4DD}' } },
   { path: '/capabilities',  component: CapabilitiesPage,  meta: { label: 'Capabilities',  icon: '\u{1F527}' } },
+  { path: '/personality',   component: PersonalityPage,   meta: { label: 'Personality',   icon: '\u{1F3AD}' } },
   { path: '/system',        component: SystemPage,        meta: { label: 'System',        icon: '\u{2699}\u{FE0F}' } },
   // Redirects from old routes to new grouped locations
   { path: '/execution',  redirect: { path: '/operations', query: { tab: 'live' } } },
@@ -78,6 +80,10 @@ const LoginScreen = {
             autofocus
             autocomplete="current-password"
           />
+          <label class="flex items-center gap-2 mb-3 text-sm text-gray-400 cursor-pointer select-none">
+            <input type="checkbox" v-model="persist" class="rounded bg-gray-800 border-gray-600" />
+            Stay logged in
+          </label>
           <button type="submit" class="btn btn-primary w-full justify-center" :disabled="busy">
             <span v-if="busy" class="spinner" style="width:14px;height:14px;border-width:2px;" aria-hidden="true"></span>
             {{ busy ? 'Connecting...' : 'Connect' }}
@@ -90,11 +96,13 @@ const LoginScreen = {
     const token = ref('');
     const error = ref(null);
     const busy = ref(false);
+    const persist = ref(false);
 
     async function login() {
       busy.value = true;
       error.value = null;
       try {
+        api.setPersist(persist.value);
         await api.login(token.value);
         props.onLogin();
       } catch (e) {
@@ -103,7 +111,7 @@ const LoginScreen = {
         busy.value = false;
       }
     }
-    return { token, error, busy, login };
+    return { token, error, busy, persist, login };
   },
 };
 

--- a/ui/js/pages/personality.js
+++ b/ui/js/pages/personality.js
@@ -1,0 +1,132 @@
+import { api } from '../api.js';
+
+const { ref, computed, onMounted } = Vue;
+
+export default {
+  setup() {
+    const preset = ref('odin');
+    const customIdentity = ref('');
+    const customVoice = ref('');
+    const presets = ref({});
+    const saving = ref(false);
+    const saved = ref(false);
+    const error = ref(null);
+    const loading = ref(true);
+
+    const isCustom = computed(() => preset.value === 'custom');
+    const presetNames = computed(() => Object.keys(presets.value));
+
+    const previewIdentity = computed(() => {
+      if (isCustom.value) return customIdentity.value || '(empty — will use Odin default)';
+      return presets.value[preset.value]?.identity || '';
+    });
+
+    const previewVoice = computed(() => {
+      if (isCustom.value) return customVoice.value || '(empty — will use Odin default)';
+      return presets.value[preset.value]?.voice || '';
+    });
+
+    async function load() {
+      loading.value = true;
+      try {
+        const data = await api.get('/api/personality');
+        preset.value = data.preset || 'odin';
+        customIdentity.value = data.custom_identity || '';
+        customVoice.value = data.custom_voice || '';
+        presets.value = data.presets || {};
+      } catch (e) {
+        error.value = e.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function save() {
+      saving.value = true;
+      error.value = null;
+      saved.value = false;
+      try {
+        await api.put('/api/personality', {
+          preset: preset.value,
+          custom_identity: customIdentity.value,
+          custom_voice: customVoice.value,
+        });
+        saved.value = true;
+        setTimeout(() => saved.value = false, 3000);
+      } catch (e) {
+        error.value = e.message;
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    onMounted(load);
+
+    return { preset, customIdentity, customVoice, presets, presetNames, isCustom,
+             previewIdentity, previewVoice, saving, saved, error, loading, save };
+  },
+
+  template: `
+  <div class="space-y-6 max-w-3xl">
+    <div>
+      <h2 class="text-lg font-semibold mb-1">Personality</h2>
+      <p class="text-gray-400 text-sm">Configure how Odin presents itself. Changes apply immediately — no restart needed.</p>
+    </div>
+
+    <div v-if="loading" class="flex items-center gap-2 text-gray-400">
+      <span class="spinner" style="width:16px;height:16px;border-width:2px;"></span> Loading...
+    </div>
+
+    <template v-else>
+      <!-- Preset selector -->
+      <div class="hm-card">
+        <label class="block text-sm font-medium mb-2">Preset</label>
+        <select v-model="preset" class="hm-input w-full max-w-xs">
+          <option v-for="name in presetNames" :key="name" :value="name">{{ name.charAt(0).toUpperCase() + name.slice(1) }}</option>
+          <option value="custom">Custom</option>
+        </select>
+        <p class="text-gray-500 text-xs mt-1">Select a personality preset or choose Custom to write your own.</p>
+      </div>
+
+      <!-- Custom fields -->
+      <div v-if="isCustom" class="hm-card space-y-4">
+        <div>
+          <label class="block text-sm font-medium mb-1">Identity</label>
+          <textarea v-model="customIdentity" class="hm-input w-full" rows="4"
+            placeholder="Describe who the bot is — background, role, perspective..."></textarea>
+        </div>
+        <div>
+          <label class="block text-sm font-medium mb-1">Voice</label>
+          <textarea v-model="customVoice" class="hm-input w-full" rows="6"
+            placeholder="Define communication style — tone, formatting, constraints. Use one rule per line starting with -"></textarea>
+        </div>
+      </div>
+
+      <!-- Preview -->
+      <div class="hm-card">
+        <h3 class="text-sm font-medium mb-2">Preview</h3>
+        <div class="bg-gray-900 rounded-lg p-4 text-sm space-y-3">
+          <div>
+            <span class="text-gray-500 text-xs uppercase tracking-wide">Identity</span>
+            <p class="text-gray-300 mt-1 whitespace-pre-wrap">{{ previewIdentity }}</p>
+          </div>
+          <div>
+            <span class="text-gray-500 text-xs uppercase tracking-wide">Voice</span>
+            <p class="text-gray-300 mt-1 whitespace-pre-wrap">{{ previewVoice }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Save -->
+      <div class="flex items-center gap-3">
+        <button @click="save" :disabled="saving" class="btn btn-primary">
+          <span v-if="saving" class="spinner" style="width:14px;height:14px;border-width:2px;"></span>
+          {{ saving ? 'Saving...' : 'Save & Apply' }}
+        </button>
+        <span v-if="saved" class="text-green-400 text-sm">Applied successfully</span>
+        <span v-if="error" class="text-red-400 text-sm">{{ error }}</span>
+      </div>
+    </template>
+  </div>
+  `,
+};

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -5,6 +5,7 @@ import LogsPage from './logs.js';
 import ConfigPage from './config.js';
 import DiscordConfigPage from './discord-config.js';
 import InternalsPage from './internals.js';
+import UpdatePage from './update.js';
 
 export default {
   components: { TabbedPage },
@@ -16,6 +17,7 @@ export default {
       { id: 'config', label: 'Config', component: ConfigPage },
       { id: 'discord', label: 'Discord', component: DiscordConfigPage },
       { id: 'internals', label: 'Internals', component: InternalsPage },
+      { id: 'update', label: 'Update', component: UpdatePage },
     ];
     return { tabs };
   },

--- a/ui/js/pages/update.js
+++ b/ui/js/pages/update.js
@@ -1,0 +1,113 @@
+import { api } from '../api.js';
+
+const { ref, onMounted } = Vue;
+
+export default {
+  setup() {
+    const current = ref('');
+    const latest = ref('');
+    const updateAvailable = ref(false);
+    const changelog = ref('');
+    const checking = ref(false);
+    const applying = ref(false);
+    const applied = ref(false);
+    const error = ref(null);
+    const checkDone = ref(false);
+
+    async function checkUpdate() {
+      checking.value = true;
+      error.value = null;
+      checkDone.value = false;
+      try {
+        const data = await api.get('/api/update/check');
+        current.value = data.current || '';
+        latest.value = data.latest || '';
+        updateAvailable.value = data.update_available || false;
+        changelog.value = data.changelog || '';
+        if (data.error) error.value = data.error;
+        checkDone.value = true;
+      } catch (e) {
+        error.value = e.message;
+      } finally {
+        checking.value = false;
+      }
+    }
+
+    async function applyUpdate() {
+      if (!confirm('Update Odin and restart? Active tasks will be interrupted.')) return;
+      applying.value = true;
+      error.value = null;
+      try {
+        await api.post('/api/update/apply', { version: 'latest' });
+        applied.value = true;
+        setTimeout(() => location.reload(), 8000);
+      } catch (e) {
+        error.value = e.message;
+      } finally {
+        applying.value = false;
+      }
+    }
+
+    onMounted(checkUpdate);
+
+    return { current, latest, updateAvailable, changelog, checking, applying, applied, error, checkDone,
+             checkUpdate, applyUpdate };
+  },
+
+  template: `
+  <div class="space-y-6 max-w-2xl">
+    <div>
+      <h2 class="text-lg font-semibold mb-1">Updates</h2>
+      <p class="text-gray-400 text-sm">Check for new Odin releases and apply updates.</p>
+    </div>
+
+    <!-- Current version -->
+    <div class="hm-card">
+      <div class="flex items-center justify-between">
+        <div>
+          <span class="text-gray-400 text-sm">Current version</span>
+          <p class="text-lg font-mono font-semibold">{{ current || '...' }}</p>
+        </div>
+        <button @click="checkUpdate" :disabled="checking" class="btn btn-ghost">
+          <span v-if="checking" class="spinner" style="width:14px;height:14px;border-width:2px;"></span>
+          {{ checking ? 'Checking...' : 'Check for updates' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Update available -->
+    <div v-if="checkDone && updateAvailable" class="hm-card border-blue-500/30">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="w-2 h-2 bg-blue-400 rounded-full"></span>
+        <span class="font-medium">Update available: {{ latest }}</span>
+      </div>
+      <div v-if="changelog" class="bg-gray-900 rounded-lg p-4 text-sm text-gray-300 mb-4 max-h-64 overflow-y-auto whitespace-pre-wrap">{{ changelog }}</div>
+      <button @click="applyUpdate" :disabled="applying" class="btn btn-primary">
+        <span v-if="applying" class="spinner" style="width:14px;height:14px;border-width:2px;"></span>
+        {{ applying ? 'Updating...' : 'Update & Restart' }}
+      </button>
+    </div>
+
+    <!-- No update -->
+    <div v-if="checkDone && !updateAvailable && !error" class="hm-card">
+      <div class="flex items-center gap-2">
+        <span class="w-2 h-2 bg-green-400 rounded-full"></span>
+        <span class="text-gray-300">You're running the latest version.</span>
+      </div>
+    </div>
+
+    <!-- Applied -->
+    <div v-if="applied" class="hm-card border-green-500/30">
+      <div class="flex items-center gap-2">
+        <span class="spinner" style="width:16px;height:16px;border-width:2px;"></span>
+        <span class="text-green-400">Update applied. Restarting... This page will reload automatically.</span>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div v-if="error" class="hm-card border-red-500/30">
+      <p class="text-red-400 text-sm">{{ error }}</p>
+    </div>
+  </div>
+  `,
+};


### PR DESCRIPTION
## Summary
Three user-requested features.

### 1. Personality Page (new top-level nav item)
- Dedicated WebUI page between Capabilities and System
- Preset selector: Odin (default), Professional, Friendly, Custom
- Custom mode: text areas for Identity and Voice
- Live preview of current personality text
- Save & Apply button — instant effect, no restart needed
- Backend: PersonalityConfig in schema, PERSONALITY_PRESETS dict, GET/PUT /api/personality

### 2. Self-Update (System > Update tab)
- Shows current version
- "Check for updates" queries GitHub releases API
- Displays changelog when update available
- "Update & Restart" does git fetch/checkout/pull, nukes pycache, sends SIGTERM for systemd restart
- Auto-reloads page after 8 seconds
- Preserves all data (config.yml, .env, sessions, learned, codex_auth, skills)

### 3. Persistent Login (Stay logged in checkbox)
- Checkbox on login screen
- When checked: stores session token in localStorage (persists across browser restarts)
- When unchecked: uses sessionStorage (current behavior, cleared on tab close)
- Logout clears both storage types

## Test plan
- [x] 214 tests pass
- [x] All Python syntax valid
- [ ] Odin review