### PR TITLE
fix: personality page padding + custom presets

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -381,10 +381,16 @@ class WebConfig(BaseModel):
         return None
 
 
+class PersonalityPreset(BaseModel):
+    identity: str = ""
+    voice: str = ""
+
+
 class PersonalityConfig(BaseModel):
     preset: str = "odin"
     custom_identity: str = ""
     custom_voice: str = ""
+    user_presets: dict[str, PersonalityPreset] = Field(default_factory=dict)
 
 
 class AttachmentsConfig(BaseModel):

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -566,6 +566,14 @@ class OdinBot(commands.Bot):
         # health checker always reads the live value, even if the underlying
         # attribute gets reassigned during a reload or reinit.
 
+        # Register user-created personality presets from config before first prompt build
+        if hasattr(self.config, "personality") and self.config.personality.user_presets:
+            from src.llm.system_prompt import register_user_presets
+            register_user_presets({
+                k: {"identity": v.identity, "voice": v.voice}
+                for k, v in self.config.personality.user_presets.items()
+            })
+
         self._system_prompt = self._build_system_prompt()
         self._register_commands()
         self._init_allowed_webhook_ids()

--- a/src/llm/system_prompt.py
+++ b/src/llm/system_prompt.py
@@ -165,6 +165,15 @@ def build_chat_system_prompt(
     )
 
 
+_USER_PRESETS: dict[str, dict[str, str]] = {}
+
+
+def register_user_presets(presets: dict[str, dict[str, str]]) -> None:
+    """Register user-created presets from config."""
+    _USER_PRESETS.clear()
+    _USER_PRESETS.update(presets)
+
+
 def _resolve_personality(
     preset: str = "odin",
     custom_identity: str = "",
@@ -177,6 +186,9 @@ def _resolve_personality(
             custom_identity or PERSONALITY_PRESETS["odin"]["identity"],
             custom_voice or PERSONALITY_PRESETS["odin"]["voice"],
         )
+    if preset in _USER_PRESETS:
+        p = _USER_PRESETS[preset]
+        return preset, p.get("identity", ""), p.get("voice", "")
     p = PERSONALITY_PRESETS.get(preset, PERSONALITY_PRESETS["odin"])
     name_map = {"odin": "Odin, the All-Father", "professional": "your operations assistant", "friendly": "your assistant"}
     return name_map.get(preset, preset), p["identity"], p["voice"]

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -594,11 +594,16 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     async def get_personality(_request: web.Request) -> web.Response:
         from src.llm.system_prompt import PERSONALITY_PRESETS
         p = bot.config.personality if hasattr(bot.config, "personality") else None
+        user_presets = {k: {"identity": v.identity, "voice": v.voice}
+                       for k, v in (p.user_presets.items() if p else {})}
+        all_presets = {**{k: v for k, v in PERSONALITY_PRESETS.items()}, **user_presets}
         return web.json_response({
             "preset": p.preset if p else "odin",
             "custom_identity": p.custom_identity if p else "",
             "custom_voice": p.custom_voice if p else "",
-            "presets": {k: v for k, v in PERSONALITY_PRESETS.items()},
+            "presets": all_presets,
+            "builtin_presets": list(PERSONALITY_PRESETS.keys()),
+            "user_presets": list(user_presets.keys()),
         })
 
     @routes.put("/api/personality")
@@ -611,15 +616,64 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         custom_identity = data.get("custom_identity", "")
         custom_voice = data.get("custom_voice", "")
         from src.config.schema import PersonalityConfig
+        existing_user_presets = bot.config.personality.user_presets if hasattr(bot.config, "personality") else {}
         bot.config.personality = PersonalityConfig(
             preset=preset, custom_identity=custom_identity, custom_voice=custom_voice,
+            user_presets=existing_user_presets,
         )
+        from src.llm.system_prompt import register_user_presets
+        register_user_presets({k: {"identity": v.identity, "voice": v.voice} for k, v in existing_user_presets.items()})
         current = bot.config.model_dump()
         config_path = getattr(request.app, "_config_path", "config.yml")
         await asyncio.to_thread(_write_config, config_path, current)
         bot._invalidate_prompt_caches()
         bot._system_prompt = bot._build_system_prompt()
         return web.json_response({"status": "updated", "preset": preset})
+
+    @routes.post("/api/personality/presets")
+    async def save_preset(request: web.Request) -> web.Response:
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        name = (data.get("name") or "").strip().lower().replace(" ", "_")
+        if not name:
+            return web.json_response({"error": "name is required"}, status=400)
+        from src.llm.system_prompt import PERSONALITY_PRESETS
+        if name in PERSONALITY_PRESETS:
+            return web.json_response({"error": f"cannot overwrite built-in preset '{name}'"}, status=400)
+        identity = data.get("identity", "")
+        voice = data.get("voice", "")
+        if not identity and not voice:
+            return web.json_response({"error": "identity or voice is required"}, status=400)
+        from src.config.schema import PersonalityPreset
+        bot.config.personality.user_presets[name] = PersonalityPreset(identity=identity, voice=voice)
+        from src.llm.system_prompt import register_user_presets
+        register_user_presets({k: {"identity": v.identity, "voice": v.voice} for k, v in bot.config.personality.user_presets.items()})
+        current = bot.config.model_dump()
+        config_path = getattr(request.app, "_config_path", "config.yml")
+        await asyncio.to_thread(_write_config, config_path, current)
+        return web.json_response({"status": "saved", "name": name})
+
+    @routes.delete("/api/personality/presets/{name}")
+    async def delete_preset(request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        from src.llm.system_prompt import PERSONALITY_PRESETS
+        if name in PERSONALITY_PRESETS:
+            return web.json_response({"error": f"cannot delete built-in preset '{name}'"}, status=400)
+        if name not in bot.config.personality.user_presets:
+            return web.json_response({"error": "preset not found"}, status=404)
+        del bot.config.personality.user_presets[name]
+        from src.llm.system_prompt import register_user_presets
+        register_user_presets({k: {"identity": v.identity, "voice": v.voice} for k, v in bot.config.personality.user_presets.items()})
+        if bot.config.personality.preset == name:
+            bot.config.personality.preset = "odin"
+            bot._invalidate_prompt_caches()
+            bot._system_prompt = bot._build_system_prompt()
+        current = bot.config.model_dump()
+        config_path = getattr(request.app, "_config_path", "config.yml")
+        await asyncio.to_thread(_write_config, config_path, current)
+        return web.json_response({"status": "deleted", "name": name})
 
     # ------------------------------------------------------------------
     # Self-Update

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -636,9 +636,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             data = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
+        import re as _re
         name = (data.get("name") or "").strip().lower().replace(" ", "_")
         if not name:
             return web.json_response({"error": "name is required"}, status=400)
+        if not _re.fullmatch(r"[a-z0-9_-]+", name):
+            return web.json_response({"error": "preset name must contain only lowercase letters, numbers, hyphens, and underscores"}, status=400)
         from src.llm.system_prompt import PERSONALITY_PRESETS
         if name in PERSONALITY_PRESETS:
             return web.json_response({"error": f"cannot overwrite built-in preset '{name}'"}, status=400)

--- a/ui/js/pages/personality.js
+++ b/ui/js/pages/personality.js
@@ -8,13 +8,19 @@ export default {
     const customIdentity = ref('');
     const customVoice = ref('');
     const presets = ref({});
+    const builtinPresets = ref([]);
+    const userPresets = ref([]);
     const saving = ref(false);
     const saved = ref(false);
     const error = ref(null);
     const loading = ref(true);
+    const newPresetName = ref('');
+    const showSavePreset = ref(false);
+    const savingPreset = ref(false);
 
     const isCustom = computed(() => preset.value === 'custom');
-    const presetNames = computed(() => Object.keys(presets.value));
+    const presetNames = computed(() => [...builtinPresets.value, ...userPresets.value]);
+    const isUserPreset = computed(() => userPresets.value.includes(preset.value));
 
     const previewIdentity = computed(() => {
       if (isCustom.value) return customIdentity.value || '(empty — will use Odin default)';
@@ -34,6 +40,8 @@ export default {
         customIdentity.value = data.custom_identity || '';
         customVoice.value = data.custom_voice || '';
         presets.value = data.presets || {};
+        builtinPresets.value = data.builtin_presets || [];
+        userPresets.value = data.user_presets || [];
       } catch (e) {
         error.value = e.message;
       } finally {
@@ -60,14 +68,50 @@ export default {
       }
     }
 
+    async function saveAsPreset() {
+      const name = newPresetName.value.trim();
+      if (!name) return;
+      savingPreset.value = true;
+      error.value = null;
+      try {
+        await api.post('/api/personality/presets', {
+          name,
+          identity: previewIdentity.value,
+          voice: previewVoice.value,
+        });
+        showSavePreset.value = false;
+        newPresetName.value = '';
+        await load();
+        preset.value = name.toLowerCase().replace(/ /g, '_');
+      } catch (e) {
+        error.value = e.message;
+      } finally {
+        savingPreset.value = false;
+      }
+    }
+
+    async function deletePreset() {
+      if (!confirm(`Delete preset "${preset.value}"?`)) return;
+      error.value = null;
+      try {
+        await api.del(`/api/personality/presets/${preset.value}`);
+        await load();
+        preset.value = 'odin';
+      } catch (e) {
+        error.value = e.message;
+      }
+    }
+
     onMounted(load);
 
-    return { preset, customIdentity, customVoice, presets, presetNames, isCustom,
-             previewIdentity, previewVoice, saving, saved, error, loading, save };
+    return { preset, customIdentity, customVoice, presets, presetNames, isCustom, isUserPreset,
+             previewIdentity, previewVoice, saving, saved, error, loading, save,
+             showSavePreset, newPresetName, savingPreset, saveAsPreset, deletePreset,
+             builtinPresets, userPresets };
   },
 
   template: `
-  <div class="space-y-6 max-w-3xl">
+  <div class="p-6 space-y-6 max-w-3xl">
     <div>
       <h2 class="text-lg font-semibold mb-1">Personality</h2>
       <p class="text-gray-400 text-sm">Configure how Odin presents itself. Changes apply immediately — no restart needed.</p>
@@ -81,10 +125,20 @@ export default {
       <!-- Preset selector -->
       <div class="hm-card">
         <label class="block text-sm font-medium mb-2">Preset</label>
-        <select v-model="preset" class="hm-input w-full max-w-xs">
-          <option v-for="name in presetNames" :key="name" :value="name">{{ name.charAt(0).toUpperCase() + name.slice(1) }}</option>
-          <option value="custom">Custom</option>
-        </select>
+        <div class="flex items-center gap-2">
+          <select v-model="preset" class="hm-input max-w-xs">
+            <optgroup label="Built-in">
+              <option v-for="name in builtinPresets" :key="name" :value="name">{{ name.charAt(0).toUpperCase() + name.slice(1) }}</option>
+            </optgroup>
+            <optgroup v-if="userPresets.length" label="Custom presets">
+              <option v-for="name in userPresets" :key="name" :value="name">{{ name.charAt(0).toUpperCase() + name.slice(1) }}</option>
+            </optgroup>
+            <optgroup label="Other">
+              <option value="custom">Custom</option>
+            </optgroup>
+          </select>
+          <button v-if="isUserPreset" @click="deletePreset" class="btn btn-ghost text-red-400 text-xs">Delete</button>
+        </div>
         <p class="text-gray-500 text-xs mt-1">Select a personality preset or choose Custom to write your own.</p>
       </div>
 
@@ -117,14 +171,30 @@ export default {
         </div>
       </div>
 
-      <!-- Save -->
-      <div class="flex items-center gap-3">
+      <!-- Save actions -->
+      <div class="flex items-center gap-3 flex-wrap">
         <button @click="save" :disabled="saving" class="btn btn-primary">
           <span v-if="saving" class="spinner" style="width:14px;height:14px;border-width:2px;"></span>
           {{ saving ? 'Saving...' : 'Save & Apply' }}
         </button>
+        <button @click="showSavePreset = !showSavePreset" class="btn btn-ghost text-sm">
+          {{ showSavePreset ? 'Cancel' : 'Save as preset...' }}
+        </button>
         <span v-if="saved" class="text-green-400 text-sm">Applied successfully</span>
         <span v-if="error" class="text-red-400 text-sm">{{ error }}</span>
+      </div>
+
+      <!-- Save as preset form -->
+      <div v-if="showSavePreset" class="hm-card">
+        <label class="block text-sm font-medium mb-2">New preset name</label>
+        <div class="flex items-center gap-2">
+          <input v-model="newPresetName" class="hm-input max-w-xs" placeholder="e.g. incident-commander"
+            @keyup.enter="saveAsPreset" />
+          <button @click="saveAsPreset" :disabled="savingPreset || !newPresetName.trim()" class="btn btn-primary text-sm">
+            {{ savingPreset ? 'Saving...' : 'Save preset' }}
+          </button>
+        </div>
+        <p class="text-gray-500 text-xs mt-1">Saves the current preview as a reusable preset.</p>
       </div>
     </template>
   </div>


### PR DESCRIPTION
## Summary
- Fix personality page padding (was flush against sidebar)
- Add user-created presets: save current personality as a named preset, delete user presets
- Presets stored in config.yml under `personality.user_presets`
- Grouped preset selector (Built-in / Custom presets / Custom)

## Test plan
- [x] 140 tests pass
- [ ] Odin review