### PR TITLE
fix: load .env before config.yml — DISCORD_TOKEN works for new users

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,6 @@
-"""Odin — Discord moderation and utility bot with web dashboard."""
+"""Odin — autonomous execution agent on Discord."""
 
-__version__ = "2.0.0"
+from .version import get_version as _get_version
+
+__version__ = _get_version()
 __project__ = "Odin"

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -27,6 +27,12 @@ def main() -> None:
         print(f"Config file not found: {config_path}")
         sys.exit(1)
 
+    # Load .env before config.yml so ${DISCORD_TOKEN} substitution works
+    from dotenv import load_dotenv
+    env_path = Path(".env")
+    if env_path.exists():
+        load_dotenv(env_path)
+
     from src.config import load_config
     from src.discord.client import OdinBot, scrub_response_secrets
     from src.health import HealthServer


### PR DESCRIPTION
## Summary
New users following the install guide couldn't start Odin because `.env` was never loaded before `config.yml` parsing.

### Root cause
`__main__.py` calls `load_config()` which substitutes `${DISCORD_TOKEN}` from `os.environ`, but `dotenv.load_dotenv()` was only called inside `OdinConfig.from_env()` — a legacy path not used by `__main__.py`.

### Fix
- Load `.env` in `__main__.py` before `load_config()` so env var substitution works
- `__version__` in `src/__init__.py` now reads from `get_version()` instead of hardcoded `2.0.0`

## Test plan
- [x] Syntax valid
- [ ] Odin review