### PR TITLE
fix: disable default help command — prevents mention confusion

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -215,7 +215,7 @@ class OdinBot(commands.Bot):
         super().__init__(
             command_prefix=self._resolve_prefix,
             intents=intents,
-            help_command=commands.DefaultHelpCommand(no_category="General"),
+            help_command=None,
         )
 
         self.config = config


### PR DESCRIPTION
## Summary
`@Bot help me do something` was triggering discord.py's DefaultHelpCommand, which parsed `me` as a command name and responded `No command called "me" found.`

Setting `help_command=None` removes this. Users interact via mentions + LLM routing or slash commands.

## Test plan
- [x] 181 tests pass
- [ ] Odin review