### PR TITLE
fix: self-update preserves config.yml/.env automatically

### DIFF
--- a/src/web/api.py
+++ b/src/web/api.py
@@ -735,18 +735,21 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not _re.fullmatch(r"v?\d+\.\d+\.\d+", target):
             return web.json_response({"error": f"Invalid version format: {target}"}, status=400)
 
-        # Check for clean worktree (skip-worktree files are OK)
-        r = subprocess.run(
-            ["git", "-C", base, "status", "--porcelain"],
-            capture_output=True, text=True, timeout=10,
-        )
-        dirty = [l for l in r.stdout.strip().splitlines() if l.strip() and not l.strip().startswith("?")]
-        if dirty:
-            return web.json_response({
-                "error": f"Worktree is not clean ({len(dirty)} modified files). Stash or commit changes first.",
-            }, status=409)
-
         try:
+            # Backup user-modified config files before updating
+            _preserve = ["config.yml", ".env"]
+            _backups: dict[str, bytes] = {}
+            for fname in _preserve:
+                fpath = os.path.join(base, fname)
+                if os.path.exists(fpath):
+                    _backups[fname] = open(fpath, "rb").read()
+
+            # Reset tracked files to allow clean pull (config.yml etc)
+            subprocess.run(
+                ["git", "-C", base, "checkout", "."],
+                capture_output=True, timeout=10,
+            )
+
             # Record current ref for potential rollback
             r = subprocess.run(
                 ["git", "-C", base, "rev-parse", "HEAD"],
@@ -764,12 +767,19 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 if prev_ref:
                     subprocess.run(["git", "-C", base, "checkout", "master"], capture_output=True, timeout=10)
                     subprocess.run(["git", "-C", base, "reset", "--hard", prev_ref], capture_output=True, timeout=10)
+                # Restore config backups even on failure
+                for fname, data in _backups.items():
+                    open(os.path.join(base, fname), "wb").write(data)
                 return web.json_response({"error": reason}, status=500)
 
             for cmd, label in steps:
                 r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
                 if r.returncode != 0:
                     return _rollback(f"{label} failed: {r.stderr.strip()}")
+
+            # Restore user config files after update
+            for fname, data in _backups.items():
+                open(os.path.join(base, fname), "wb").write(data)
 
             # Install/update dependencies
             venv_pip = os.path.join(base, ".venv", "bin", "pip")

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -737,18 +737,36 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
         try:
             # Backup user-modified config files before updating
-            _preserve = ["config.yml", ".env"]
+            _preserve = {"config.yml", ".env"}
             _backups: dict[str, bytes] = {}
             for fname in _preserve:
                 fpath = os.path.join(base, fname)
                 if os.path.exists(fpath):
                     _backups[fname] = open(fpath, "rb").read()
 
-            # Reset tracked files to allow clean pull (config.yml etc)
-            subprocess.run(
-                ["git", "-C", base, "checkout", "."],
-                capture_output=True, timeout=10,
+            # Check for unexpected dirty files (anything besides config.yml/.env)
+            r = subprocess.run(
+                ["git", "-C", base, "status", "--porcelain"],
+                capture_output=True, text=True, timeout=10,
             )
+            dirty = []
+            for line in r.stdout.strip().splitlines():
+                if not line.strip() or line.strip().startswith("?"):
+                    continue
+                fname = line[3:].strip().split(" -> ")[-1]
+                if fname not in _preserve:
+                    dirty.append(fname)
+            if dirty:
+                return web.json_response({
+                    "error": f"Worktree has unexpected modifications ({', '.join(dirty[:5])}). Only config.yml and .env are preserved automatically.",
+                }, status=409)
+
+            # Reset only the preserved config files for clean pull
+            for fname in _preserve:
+                subprocess.run(
+                    ["git", "-C", base, "checkout", "--", fname],
+                    capture_output=True, timeout=10,
+                )
 
             # Record current ref for potential rollback
             r = subprocess.run(

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -746,16 +746,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
             # Check for unexpected dirty files (anything besides config.yml/.env)
             r = subprocess.run(
-                ["git", "-C", base, "status", "--porcelain"],
+                ["git", "-C", base, "diff", "--name-only", "HEAD"],
                 capture_output=True, text=True, timeout=10,
             )
-            dirty = []
-            for line in r.stdout.strip().splitlines():
-                if not line.strip() or line.strip().startswith("?"):
-                    continue
-                fname = line[3:].strip().split(" -> ")[-1]
-                if fname not in _preserve:
-                    dirty.append(fname)
+            dirty = [f for f in r.stdout.strip().splitlines() if f.strip() and f.strip() not in _preserve]
             if dirty:
                 return web.json_response({
                     "error": f"Worktree has unexpected modifications ({', '.join(dirty[:5])}). Only config.yml and .env are preserved automatically.",


### PR DESCRIPTION
## Summary
Self-update was blocking with "Worktree is not clean" because users modify config.yml (as expected). 

Now the update endpoint automatically backs up config.yml and .env, resets for a clean pull, updates, then restores user configs. On failure, configs are restored before returning the error.

Users no longer need to know about git internals to update.

## Test plan
- [x] 122 tests pass
- [ ] Odin review