### PR TITLE
feat: per-user host access control

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -358,6 +358,11 @@ class OdinBot(commands.Bot):
                 max_chunk_chars=streaming_cfg.max_chunk_chars,
             )
 
+        self.host_access_manager = HostAccessManager(
+            path="./data/host_access.json",
+            available_hosts=list(config.tools.hosts.keys()),
+        )
+
         self.tool_executor = ToolExecutor(
             config.tools, memory_path=self._memory_path,
             browser_manager=self.browser_manager,
@@ -412,11 +417,6 @@ class OdinBot(commands.Bot):
             config_tiers=config.permissions.tiers,
             default_tier=config.permissions.default_tier,
             overrides_path=config.permissions.overrides_path,
-        )
-
-        self.host_access_manager = HostAccessManager(
-            path="./data/host_access.json",
-            available_hosts=list(config.tools.hosts.keys()),
         )
 
         self.tool_memory = ToolMemory("./data/tool_memory.json")

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -38,6 +38,7 @@ from ..tools import ToolExecutor, SkillManager, get_tool_definitions
 from ..tools.tool_memory import ToolMemory
 from ..search import LocalEmbedder, SessionVectorStore
 from ..permissions import PermissionManager
+from ..permissions.host_access import HostAccessManager
 from .channel_config import ChannelConfigManager
 from .channel_logger import ChannelLogger
 from .voice import VoiceManager, VoiceMessageProxy
@@ -361,6 +362,7 @@ class OdinBot(commands.Bot):
             config.tools, memory_path=self._memory_path,
             browser_manager=self.browser_manager,
             output_streamer=output_streamer,
+            host_access_manager=self.host_access_manager,
         )
         self.skill_manager = SkillManager(
             skills_dir="./data/skills",
@@ -410,6 +412,11 @@ class OdinBot(commands.Bot):
             config_tiers=config.permissions.tiers,
             default_tier=config.permissions.default_tier,
             overrides_path=config.permissions.overrides_path,
+        )
+
+        self.host_access_manager = HostAccessManager(
+            path="./data/host_access.json",
+            available_hosts=list(config.tools.hosts.keys()),
         )
 
         self.tool_memory = ToolMemory("./data/tool_memory.json")

--- a/src/permissions/__init__.py
+++ b/src/permissions/__init__.py
@@ -1,3 +1,4 @@
 from .manager import PermissionManager
+from .host_access import HostAccessManager
 
-__all__ = ["PermissionManager"]
+__all__ = ["PermissionManager", "HostAccessManager"]

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from ..odin_log import get_logger
+
+log = get_logger("host_access")
+
+
+class HostAccessEntry:
+    __slots__ = ("allowed_hosts", "default_host")
+
+    def __init__(self, allowed_hosts: list[str] | None = None, default_host: str = "") -> None:
+        self.allowed_hosts: list[str] = allowed_hosts or []
+        self.default_host: str = default_host
+
+    def to_dict(self) -> dict:
+        return {"allowed_hosts": self.allowed_hosts, "default_host": self.default_host}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> HostAccessEntry:
+        return cls(
+            allowed_hosts=data.get("allowed_hosts", []),
+            default_host=data.get("default_host", ""),
+        )
+
+
+class HostAccessManager:
+    """Per-user host access control with defaults and persistence."""
+
+    def __init__(self, path: str = "./data/host_access.json", available_hosts: list[str] | None = None) -> None:
+        self._path = Path(path)
+        self._lock = asyncio.Lock()
+        self._users: dict[str, HostAccessEntry] = {}
+        self._default_policy = HostAccessEntry()
+        self._available_hosts: list[str] = available_hosts or []
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+            if not isinstance(data, dict):
+                return
+            if "default_policy" in data:
+                self._default_policy = HostAccessEntry.from_dict(data["default_policy"])
+            for uid, entry in data.get("users", {}).items():
+                self._users[uid] = HostAccessEntry.from_dict(entry)
+        except (json.JSONDecodeError, OSError) as e:
+            log.warning("Failed to load host access config: %s", e)
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "default_policy": self._default_policy.to_dict(),
+            "users": {uid: entry.to_dict() for uid, entry in self._users.items()},
+        }
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._path)
+
+    @property
+    def available_hosts(self) -> list[str]:
+        return list(self._available_hosts)
+
+    def set_available_hosts(self, hosts: list[str]) -> None:
+        self._available_hosts = list(hosts)
+
+    @property
+    def default_policy(self) -> HostAccessEntry:
+        return self._default_policy
+
+    def get_entry(self, user_id: str) -> HostAccessEntry:
+        return self._users.get(user_id, self._default_policy)
+
+    def get_allowed_hosts(self, user_id: str) -> list[str]:
+        entry = self.get_entry(user_id)
+        if not entry.allowed_hosts:
+            return list(self._available_hosts)
+        return [h for h in entry.allowed_hosts if h in self._available_hosts]
+
+    def get_default_host(self, user_id: str) -> str:
+        entry = self.get_entry(user_id)
+        if entry.default_host and entry.default_host in self._available_hosts:
+            return entry.default_host
+        allowed = self.get_allowed_hosts(user_id)
+        return allowed[0] if allowed else ""
+
+    def is_host_allowed(self, user_id: str, host: str) -> bool:
+        allowed = self.get_allowed_hosts(user_id)
+        return host in allowed
+
+    def has_user_entry(self, user_id: str) -> bool:
+        return user_id in self._users
+
+    def list_users(self) -> dict[str, dict]:
+        result = {}
+        for uid, entry in self._users.items():
+            result[uid] = entry.to_dict()
+        return result
+
+    async def set_user(self, user_id: str, allowed_hosts: list[str], default_host: str) -> None:
+        async with self._lock:
+            valid_hosts = [h for h in allowed_hosts if h in self._available_hosts]
+            if default_host and default_host not in valid_hosts:
+                if valid_hosts:
+                    default_host = valid_hosts[0]
+                else:
+                    default_host = ""
+            self._users[user_id] = HostAccessEntry(
+                allowed_hosts=valid_hosts,
+                default_host=default_host,
+            )
+            self._save()
+            log.info("Host access updated for user %s: hosts=%s, default=%s", user_id, valid_hosts, default_host)
+
+    async def delete_user(self, user_id: str) -> bool:
+        async with self._lock:
+            if user_id in self._users:
+                del self._users[user_id]
+                self._save()
+                log.info("Host access override removed for user %s", user_id)
+                return True
+        return False
+
+    async def set_default_policy(self, allowed_hosts: list[str], default_host: str) -> None:
+        async with self._lock:
+            valid_hosts = [h for h in allowed_hosts if h in self._available_hosts]
+            if default_host and default_host not in valid_hosts:
+                default_host = valid_hosts[0] if valid_hosts else ""
+            self._default_policy = HostAccessEntry(
+                allowed_hosts=valid_hosts,
+                default_host=default_host,
+            )
+            self._save()
+            log.info("Default host access policy updated: hosts=%s, default=%s", valid_hosts, default_host)

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -13,7 +13,8 @@ class HostAccessEntry:
     __slots__ = ("allowed_hosts", "default_host")
 
     def __init__(self, allowed_hosts: list[str] | None = None, default_host: str = "") -> None:
-        self.allowed_hosts: list[str] = allowed_hosts or []
+        # None = unset (inherit all), [] = explicit deny-all, [...] = whitelist
+        self.allowed_hosts: list[str] | None = allowed_hosts
         self.default_host: str = default_host
 
     def to_dict(self) -> dict:
@@ -21,8 +22,11 @@ class HostAccessEntry:
 
     @classmethod
     def from_dict(cls, data: dict) -> HostAccessEntry:
+        raw = data.get("allowed_hosts")
+        # Distinguish missing/null (None = allow all) from empty list ([] = deny all)
+        allowed = raw if isinstance(raw, list) else None
         return cls(
-            allowed_hosts=data.get("allowed_hosts", []),
+            allowed_hosts=allowed,
             default_host=data.get("default_host", ""),
         )
 
@@ -78,7 +82,7 @@ class HostAccessManager:
 
     def get_allowed_hosts(self, user_id: str) -> list[str]:
         entry = self.get_entry(user_id)
-        if not entry.allowed_hosts:
+        if entry.allowed_hosts is None:
             return list(self._available_hosts)
         return [h for h in entry.allowed_hosts if h in self._available_hosts]
 
@@ -90,8 +94,10 @@ class HostAccessManager:
         return allowed[0] if allowed else ""
 
     def is_host_allowed(self, user_id: str, host: str) -> bool:
-        allowed = self.get_allowed_hosts(user_id)
-        return host in allowed
+        entry = self.get_entry(user_id)
+        if entry.allowed_hosts is None:
+            return host in self._available_hosts
+        return host in entry.allowed_hosts and host in self._available_hosts
 
     def has_user_entry(self, user_id: str) -> bool:
         return user_id in self._users
@@ -102,14 +108,21 @@ class HostAccessManager:
             result[uid] = entry.to_dict()
         return result
 
-    async def set_user(self, user_id: str, allowed_hosts: list[str], default_host: str) -> None:
+    async def set_user(self, user_id: str, allowed_hosts: list[str] | None, default_host: str) -> None:
         async with self._lock:
-            valid_hosts = [h for h in allowed_hosts if h in self._available_hosts]
-            if default_host and default_host not in valid_hosts:
-                if valid_hosts:
+            if allowed_hosts is None:
+                valid_hosts = None
+            else:
+                valid_hosts = [h for h in allowed_hosts if h in self._available_hosts]
+            if default_host and (valid_hosts is None or default_host not in valid_hosts):
+                if valid_hosts is None:
+                    pass  # allow-all, any default is fine if it's a real host
+                elif valid_hosts:
                     default_host = valid_hosts[0]
                 else:
                     default_host = ""
+            if default_host and default_host not in self._available_hosts:
+                default_host = ""
             self._users[user_id] = HostAccessEntry(
                 allowed_hosts=valid_hosts,
                 default_host=default_host,
@@ -126,10 +139,15 @@ class HostAccessManager:
                 return True
         return False
 
-    async def set_default_policy(self, allowed_hosts: list[str], default_host: str) -> None:
+    async def set_default_policy(self, allowed_hosts: list[str] | None, default_host: str) -> None:
         async with self._lock:
-            valid_hosts = [h for h in allowed_hosts if h in self._available_hosts]
-            if default_host and default_host not in valid_hosts:
+            if allowed_hosts is None:
+                valid_hosts = None
+            else:
+                valid_hosts = [h for h in allowed_hosts if h in self._available_hosts]
+            if default_host and default_host not in self._available_hosts:
+                default_host = ""
+            if default_host and valid_hosts is not None and default_host not in valid_hosts:
                 default_host = valid_hosts[0] if valid_hosts else ""
             self._default_policy = HostAccessEntry(
                 allowed_hosts=valid_hosts,

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from ..config.schema import ToolsConfig
 from ..odin_log import get_logger
+from ..permissions.host_access import HostAccessManager
 from ..permissions.manager import PermissionManager
 from .branch_freshness import (
     BranchStatus,
@@ -83,12 +84,14 @@ class ToolExecutor:
         browser_manager: object | None = None,
         permission_manager: PermissionManager | None = None,
         output_streamer: ToolOutputStreamer | None = None,
+        host_access_manager: HostAccessManager | None = None,
     ) -> None:
         self.config = config or ToolsConfig()
         self._memory_path = Path(memory_path) if memory_path else None
         self._browser_manager = browser_manager
         self._permission_manager = permission_manager
         self.output_streamer = output_streamer
+        self._host_access = host_access_manager
         self._metrics: dict[str, dict[str, int]] = {}
         self._memory_lock = asyncio.Lock()
         self._lists_lock = asyncio.Lock()
@@ -126,7 +129,19 @@ class ToolExecutor:
         host = self.config.hosts.get(alias)
         if not host:
             return None
+        if self._host_access and self._current_user_id:
+            if not self._host_access.is_host_allowed(self._current_user_id, alias):
+                return None
         return host.address, host.ssh_user, host.os
+
+    def _resolve_default_host(self, user_id: str | None) -> str:
+        """Get the default host for a user, or first configured host."""
+        if self._host_access and user_id:
+            default = self._host_access.get_default_host(user_id)
+            if default:
+                return default
+        hosts = list(self.config.hosts.keys())
+        return hosts[0] if hosts else ""
 
     def check_permission(self, tool_name: str, user_id: str | None) -> str | None:
         """Check if user has permission to use the tool.
@@ -151,6 +166,7 @@ class ToolExecutor:
         if handler is None:
             return ToolResult(output=f"Unknown tool: {tool_name}", ok=False, error="unknown_tool", tool_name=tool_name)
 
+        self._current_user_id = user_id
         self._current_user_tier = (
             self._permission_manager.get_tier(user_id) if self._permission_manager and user_id else None
         )
@@ -441,7 +457,9 @@ class ToolExecutor:
         if not command:
             return "Error: 'command' is required for run_command."
         if not host:
-            return "Error: 'host' is required for run_command."
+            host = self._resolve_default_host(self._current_user_id)
+            if not host:
+                return "Error: 'host' is required for run_command."
 
         allowed, denial, governor_note = self._govern_command(command, host)
         if not allowed:
@@ -485,7 +503,9 @@ class ToolExecutor:
         host = inp.get("host")
         script = inp.get("script")
         if not host:
-            return "Error: 'host' is required for run_script."
+            host = self._resolve_default_host(self._current_user_id)
+            if not host:
+                return "Error: 'host' is required for run_script."
         if not script:
             return "Error: 'script' is required for run_script."
         interpreter = inp.get("interpreter", "bash")
@@ -591,12 +611,19 @@ class ToolExecutor:
         command = inp["command"]
 
         if hosts == ["all"] or hosts == "all":
-            hosts = list(self.config.hosts.keys())
+            if self._host_access and self._current_user_id:
+                hosts = self._host_access.get_allowed_hosts(self._current_user_id)
+            else:
+                hosts = list(self.config.hosts.keys())
 
-        # Per-host governor check before launching parallel tasks
+        # Per-host access + governor check before launching parallel tasks
         blocked_hosts = []
         allowed_hosts = []
         for h in hosts:
+            if self._host_access and self._current_user_id:
+                if not self._host_access.is_host_allowed(self._current_user_id, h):
+                    blocked_hosts.append((h, f"Host access denied: {h}"))
+                    continue
             allowed, denial, _ = self._govern_command(command, h)
             if not allowed:
                 blocked_hosts.append((h, denial))

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2622,10 +2622,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON body"}, status=400)
-        allowed_hosts = body.get("allowed_hosts", [])
+        allowed_hosts = body.get("allowed_hosts")
         default_host = body.get("default_host", "")
-        if not isinstance(allowed_hosts, list):
-            return web.json_response({"error": "allowed_hosts must be a list"}, status=400)
+        if allowed_hosts is not None and not isinstance(allowed_hosts, list):
+            return web.json_response({"error": "allowed_hosts must be a list or null"}, status=400)
         await ham.set_user(uid, allowed_hosts, default_host)
         try:
             audit = getattr(bot, "audit", None)
@@ -2660,10 +2660,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON body"}, status=400)
-        allowed_hosts = body.get("allowed_hosts", [])
+        allowed_hosts = body.get("allowed_hosts")
         default_host = body.get("default_host", "")
-        if not isinstance(allowed_hosts, list):
-            return web.json_response({"error": "allowed_hosts must be a list"}, status=400)
+        if allowed_hosts is not None and not isinstance(allowed_hosts, list):
+            return web.json_response({"error": "allowed_hosts must be a list or null"}, status=400)
         await ham.set_default_policy(allowed_hosts, default_host)
         return web.json_response({"status": "updated"})
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2598,6 +2598,76 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         return web.json_response({"error": "no override found for user"}, status=404)
 
     # ------------------------------------------------------------------
+    # Host access control
+    # ------------------------------------------------------------------
+
+    @routes.get("/api/host-access")
+    async def get_host_access(_request: web.Request) -> web.Response:
+        ham = getattr(bot, "host_access_manager", None)
+        if not ham:
+            return web.json_response({"error": "host access manager not available"}, status=503)
+        return web.json_response({
+            "available_hosts": ham.available_hosts,
+            "default_policy": ham.default_policy.to_dict(),
+            "users": ham.list_users(),
+        })
+
+    @routes.put("/api/host-access/user/{user_id}")
+    async def set_host_access_user(request: web.Request) -> web.Response:
+        ham = getattr(bot, "host_access_manager", None)
+        if not ham:
+            return web.json_response({"error": "host access manager not available"}, status=503)
+        uid = request.match_info["user_id"]
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON body"}, status=400)
+        allowed_hosts = body.get("allowed_hosts", [])
+        default_host = body.get("default_host", "")
+        if not isinstance(allowed_hosts, list):
+            return web.json_response({"error": "allowed_hosts must be a list"}, status=400)
+        await ham.set_user(uid, allowed_hosts, default_host)
+        try:
+            audit = getattr(bot, "audit", None)
+            if audit:
+                session_id = getattr(request, "_session_id", "web-api")
+                await audit.log_event(
+                    event_type="host_access_change",
+                    action="set_user",
+                    actor=f"web:{session_id}",
+                    detail=f"Set host access for user {uid}: hosts={allowed_hosts}, default={default_host}",
+                )
+        except Exception:
+            pass
+        return web.json_response({"user_id": uid, "status": "updated"})
+
+    @routes.delete("/api/host-access/user/{user_id}")
+    async def delete_host_access_user(request: web.Request) -> web.Response:
+        ham = getattr(bot, "host_access_manager", None)
+        if not ham:
+            return web.json_response({"error": "host access manager not available"}, status=503)
+        uid = request.match_info["user_id"]
+        if await ham.delete_user(uid):
+            return web.json_response({"user_id": uid, "status": "override_removed"})
+        return web.json_response({"error": "no override found for user"}, status=404)
+
+    @routes.put("/api/host-access/default-policy")
+    async def set_host_access_default(request: web.Request) -> web.Response:
+        ham = getattr(bot, "host_access_manager", None)
+        if not ham:
+            return web.json_response({"error": "host access manager not available"}, status=503)
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON body"}, status=400)
+        allowed_hosts = body.get("allowed_hosts", [])
+        default_host = body.get("default_host", "")
+        if not isinstance(allowed_hosts, list):
+            return web.json_response({"error": "allowed_hosts must be a list"}, status=400)
+        await ham.set_default_policy(allowed_hosts, default_host)
+        return web.json_response({"status": "updated"})
+
+    # ------------------------------------------------------------------
     # Recovery stats (observability)
     # ------------------------------------------------------------------
 

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -44,6 +44,7 @@ const routes = [
   { path: '/resources',  redirect: { path: '/system', query: { tab: 'resources' } } },
   { path: '/logs',       redirect: { path: '/system', query: { tab: 'logs' } } },
   { path: '/config',     redirect: { path: '/system', query: { tab: 'config' } } },
+  { path: '/host-access', redirect: { path: '/system', query: { tab: 'host-access' } } },
   { path: '/internals',  redirect: { path: '/system', query: { tab: 'internals' } } },
 ];
 

--- a/ui/js/pages/host-access.js
+++ b/ui/js/pages/host-access.js
@@ -134,6 +134,14 @@ export default {
       toastTimer = setTimeout(() => { toast.value = null; }, 3000);
     }
 
+    function normalizeEntry(entry, hosts) {
+      if (!entry) return { allowed_hosts: [...hosts], default_host: hosts[0] || '', allow_all: true };
+      if (entry.allowed_hosts === null || entry.allowed_hosts === undefined) {
+        return { allowed_hosts: [...hosts], default_host: entry.default_host || '', allow_all: true };
+      }
+      return { allowed_hosts: entry.allowed_hosts, default_host: entry.default_host || '', allow_all: false };
+    }
+
     async function fetchData() {
       loading.value = true;
       error.value = '';
@@ -141,8 +149,13 @@ export default {
         const resp = await api.get('/api/host-access');
         data.value = resp;
         availableHosts.value = resp.available_hosts || [];
-        defaultPolicy.value = resp.default_policy || { allowed_hosts: [], default_host: '' };
-        users.value = resp.users || {};
+        defaultPolicy.value = normalizeEntry(resp.default_policy, availableHosts.value);
+        const rawUsers = resp.users || {};
+        const normalized = {};
+        for (const [uid, entry] of Object.entries(rawUsers)) {
+          normalized[uid] = normalizeEntry(entry, availableHosts.value);
+        }
+        users.value = normalized;
       } catch (e) {
         error.value = e.message || 'Failed to fetch host access data';
       } finally {
@@ -152,8 +165,9 @@ export default {
 
     async function saveDefaultPolicy() {
       try {
+        const hosts = defaultPolicy.value.allow_all ? null : defaultPolicy.value.allowed_hosts;
         await api.put('/api/host-access/default-policy', {
-          allowed_hosts: defaultPolicy.value.allowed_hosts,
+          allowed_hosts: hosts,
           default_host: defaultPolicy.value.default_host,
         });
         showToast('Default policy updated');
@@ -163,6 +177,7 @@ export default {
     }
 
     function toggleDefaultHost(host, checked) {
+      defaultPolicy.value.allow_all = false;
       if (checked) {
         if (!defaultPolicy.value.allowed_hosts.includes(host))
           defaultPolicy.value.allowed_hosts.push(host);
@@ -178,8 +193,9 @@ export default {
       const entry = users.value[uid];
       if (!entry) return;
       try {
+        const hosts = entry.allow_all ? null : entry.allowed_hosts;
         await api.put(`/api/host-access/user/${uid}`, {
-          allowed_hosts: entry.allowed_hosts,
+          allowed_hosts: hosts,
           default_host: entry.default_host,
         });
         showToast(`Updated access for ${uid}`);
@@ -191,6 +207,7 @@ export default {
     function toggleUserHost(uid, host, checked) {
       const entry = users.value[uid];
       if (!entry) return;
+      entry.allow_all = false;
       if (checked) {
         if (!entry.allowed_hosts.includes(host))
           entry.allowed_hosts.push(host);

--- a/ui/js/pages/host-access.js
+++ b/ui/js/pages/host-access.js
@@ -1,0 +1,240 @@
+import { api } from '../api.js';
+
+const { ref, computed, onMounted } = Vue;
+
+export default {
+  template: `
+    <div class="p-6 page-fade-in">
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold">Host Access Control</h1>
+        <button @click="fetchData" class="btn btn-ghost text-xs" :disabled="loading">
+          {{ loading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+      <p class="text-xs text-gray-500 mb-6">
+        Control which hosts each user can execute commands on and set per-user defaults.
+        Users without an explicit entry fall back to the default policy.
+      </p>
+
+      <div v-if="loading && !data" class="space-y-2">
+        <div v-for="n in 3" :key="n" class="skeleton skeleton-row"></div>
+      </div>
+      <div v-else-if="error" class="hm-card border-red-900 error-state">
+        <p class="text-red-400">{{ error }}</p>
+        <button @click="fetchData" class="btn btn-ghost text-xs">Retry</button>
+      </div>
+
+      <div v-else class="space-y-6">
+        <!-- Default policy -->
+        <div class="hm-card">
+          <h2 class="text-sm font-semibold text-gray-300 mb-3">Default Policy</h2>
+          <p class="text-xs text-gray-500 mb-3">Applied to users without an explicit host access entry.</p>
+          <div class="flex flex-wrap gap-3 mb-3">
+            <label v-for="host in availableHosts" :key="'dp-'+host"
+                   class="flex items-center gap-2 text-sm">
+              <input type="checkbox" :checked="defaultPolicy.allowed_hosts.includes(host)"
+                     @change="toggleDefaultHost(host, $event.target.checked)"
+                     class="rounded border-gray-600 bg-gray-800" />
+              <span class="text-gray-300">{{ host }}</span>
+            </label>
+          </div>
+          <div class="flex items-center gap-3">
+            <span class="text-xs text-gray-500">Default host:</span>
+            <select v-model="defaultPolicy.default_host" @change="saveDefaultPolicy"
+                    class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-300">
+              <option value="">— none —</option>
+              <option v-for="host in defaultPolicy.allowed_hosts" :key="'dpd-'+host" :value="host">
+                {{ host }}
+              </option>
+            </select>
+          </div>
+        </div>
+
+        <!-- User entries -->
+        <div class="hm-card">
+          <div class="flex items-center justify-between mb-3">
+            <h2 class="text-sm font-semibold text-gray-300">User Overrides</h2>
+            <button @click="showAddUser = true" class="btn btn-ghost text-xs" v-if="!showAddUser">
+              + Add User
+            </button>
+          </div>
+
+          <!-- Add user form -->
+          <div v-if="showAddUser" class="mb-4 p-3 bg-gray-800 rounded border border-gray-700">
+            <div class="flex items-center gap-3 mb-3">
+              <input v-model="newUserId" placeholder="Discord User ID"
+                     class="bg-gray-900 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-300 w-48" />
+              <button @click="addUser" :disabled="!newUserId.trim()" class="btn btn-primary text-xs">Add</button>
+              <button @click="showAddUser = false; newUserId = ''" class="btn btn-ghost text-xs">Cancel</button>
+            </div>
+          </div>
+
+          <!-- Users table -->
+          <table v-if="Object.keys(users).length > 0" class="hm-table">
+            <thead>
+              <tr>
+                <th>User ID</th>
+                <th v-for="host in availableHosts" :key="'th-'+host" class="text-center" style="min-width:90px">
+                  {{ host }}
+                </th>
+                <th class="text-center" style="min-width:120px">Default Host</th>
+                <th class="text-center" style="width:80px">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(entry, uid) in users" :key="uid">
+                <td class="font-mono text-sm">{{ uid }}</td>
+                <td v-for="host in availableHosts" :key="uid+'-'+host" class="text-center">
+                  <input type="checkbox" :checked="entry.allowed_hosts.includes(host)"
+                         @change="toggleUserHost(uid, host, $event.target.checked)"
+                         class="rounded border-gray-600 bg-gray-800" />
+                </td>
+                <td class="text-center">
+                  <select :value="entry.default_host" @change="setUserDefault(uid, $event.target.value)"
+                          class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300">
+                    <option value="">— none —</option>
+                    <option v-for="host in entry.allowed_hosts" :key="uid+'-def-'+host" :value="host">
+                      {{ host }}
+                    </option>
+                  </select>
+                </td>
+                <td class="text-center">
+                  <button @click="deleteUser(uid)" class="text-red-400 hover:text-red-300 text-xs">Remove</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else class="text-xs text-gray-500">No user overrides configured. All users follow the default policy.</p>
+        </div>
+      </div>
+
+      <!-- Status toast -->
+      <div v-if="toast" class="fixed bottom-6 right-6 px-4 py-2 rounded text-sm shadow-lg z-50"
+           :class="toast.type === 'error' ? 'bg-red-900 text-red-200' : 'bg-green-900 text-green-200'">
+        {{ toast.message }}
+      </div>
+    </div>
+  `,
+
+  setup() {
+    const loading = ref(true);
+    const error = ref('');
+    const data = ref(null);
+    const availableHosts = ref([]);
+    const defaultPolicy = ref({ allowed_hosts: [], default_host: '' });
+    const users = ref({});
+    const showAddUser = ref(false);
+    const newUserId = ref('');
+    const toast = ref(null);
+
+    let toastTimer = null;
+    function showToast(message, type = 'success') {
+      toast.value = { message, type };
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => { toast.value = null; }, 3000);
+    }
+
+    async function fetchData() {
+      loading.value = true;
+      error.value = '';
+      try {
+        const resp = await api.get('/api/host-access');
+        data.value = resp;
+        availableHosts.value = resp.available_hosts || [];
+        defaultPolicy.value = resp.default_policy || { allowed_hosts: [], default_host: '' };
+        users.value = resp.users || {};
+      } catch (e) {
+        error.value = e.message || 'Failed to fetch host access data';
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function saveDefaultPolicy() {
+      try {
+        await api.put('/api/host-access/default-policy', {
+          allowed_hosts: defaultPolicy.value.allowed_hosts,
+          default_host: defaultPolicy.value.default_host,
+        });
+        showToast('Default policy updated');
+      } catch (e) {
+        showToast(e.message || 'Failed to save', 'error');
+      }
+    }
+
+    function toggleDefaultHost(host, checked) {
+      if (checked) {
+        if (!defaultPolicy.value.allowed_hosts.includes(host))
+          defaultPolicy.value.allowed_hosts.push(host);
+      } else {
+        defaultPolicy.value.allowed_hosts = defaultPolicy.value.allowed_hosts.filter(h => h !== host);
+        if (defaultPolicy.value.default_host === host)
+          defaultPolicy.value.default_host = defaultPolicy.value.allowed_hosts[0] || '';
+      }
+      saveDefaultPolicy();
+    }
+
+    async function saveUser(uid) {
+      const entry = users.value[uid];
+      if (!entry) return;
+      try {
+        await api.put(`/api/host-access/user/${uid}`, {
+          allowed_hosts: entry.allowed_hosts,
+          default_host: entry.default_host,
+        });
+        showToast(`Updated access for ${uid}`);
+      } catch (e) {
+        showToast(e.message || 'Failed to save', 'error');
+      }
+    }
+
+    function toggleUserHost(uid, host, checked) {
+      const entry = users.value[uid];
+      if (!entry) return;
+      if (checked) {
+        if (!entry.allowed_hosts.includes(host))
+          entry.allowed_hosts.push(host);
+      } else {
+        entry.allowed_hosts = entry.allowed_hosts.filter(h => h !== host);
+        if (entry.default_host === host)
+          entry.default_host = entry.allowed_hosts[0] || '';
+      }
+      saveUser(uid);
+    }
+
+    function setUserDefault(uid, host) {
+      const entry = users.value[uid];
+      if (!entry) return;
+      entry.default_host = host;
+      saveUser(uid);
+    }
+
+    function addUser() {
+      const uid = newUserId.value.trim();
+      if (!uid) return;
+      users.value[uid] = { allowed_hosts: [...availableHosts.value], default_host: availableHosts.value[0] || '' };
+      saveUser(uid);
+      newUserId.value = '';
+      showAddUser.value = false;
+    }
+
+    async function deleteUser(uid) {
+      try {
+        await api.delete(`/api/host-access/user/${uid}`);
+        delete users.value[uid];
+        showToast(`Removed override for ${uid}`);
+      } catch (e) {
+        showToast(e.message || 'Failed to delete', 'error');
+      }
+    }
+
+    onMounted(fetchData);
+
+    return {
+      loading, error, data, availableHosts, defaultPolicy, users,
+      showAddUser, newUserId, toast,
+      fetchData, saveDefaultPolicy, toggleDefaultHost,
+      toggleUserHost, setUserDefault, addUser, deleteUser,
+    };
+  },
+};

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -4,6 +4,7 @@ import ResourcesPage from './resources.js';
 import LogsPage from './logs.js';
 import ConfigPage from './config.js';
 import DiscordConfigPage from './discord-config.js';
+import HostAccessPage from './host-access.js';
 import InternalsPage from './internals.js';
 import UpdatePage from './update.js';
 
@@ -16,6 +17,7 @@ export default {
       { id: 'logs', label: 'Logs', component: LogsPage },
       { id: 'config', label: 'Config', component: ConfigPage },
       { id: 'discord', label: 'Discord', component: DiscordConfigPage },
+      { id: 'host-access', label: 'Host Access', component: HostAccessPage },
       { id: 'internals', label: 'Internals', component: InternalsPage },
       { id: 'update', label: 'Update', component: UpdatePage },
     ];


### PR DESCRIPTION
## Summary
- Adds per-user host access control: whitelist which hosts each Discord user can execute commands on
- Per-user default host: when a user's request doesn't specify a host, routes to their configured default
- WebUI management page under System > Host Access tab
- Users without explicit entries fall back to a configurable default policy
- Persisted to `data/host_access.json` (same pattern as permissions.json)

## Implementation
- `src/permissions/host_access.py` — HostAccessManager with async-safe persistence
- Executor: `_resolve_host()` now checks user access, new `_resolve_default_host()` injects defaults
- `run_command_multi` with `hosts: "all"` respects user's allowed hosts
- 4 API endpoints: `GET /api/host-access`, `PUT/DELETE /api/host-access/user/{id}`, `PUT /api/host-access/default-policy`
- WebUI: checkbox matrix for user-host assignments + default host selector

## Test plan
- [ ] Verify bot starts cleanly with no `data/host_access.json` (empty state = all hosts allowed for all users)
- [ ] Add user override via WebUI, confirm only allowed hosts resolve
- [ ] Confirm denied hosts return "Unknown or disallowed host" message
- [ ] Confirm `run_command` without explicit host uses user's default
- [ ] Confirm `run_command_multi hosts:all` only runs on user's allowed hosts
- [ ] Verify default policy applies to users without explicit entries