### PR TITLE
feat: configurable default checkpoint for ComfyUI

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -413,6 +413,7 @@ class AttachmentsConfig(BaseModel):
 class ComfyUIConfig(BaseModel):
     enabled: bool = False
     url: str = "http://localhost:8188"
+    default_checkpoint: str = ""
 
 
 class ReactionTriggerConfig(BaseModel):

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -4646,7 +4646,7 @@ class OdinBot(commands.Bot):
 
         from ..tools.comfyui import ComfyUIClient
 
-        client = ComfyUIClient(self.config.comfyui.url)
+        client = ComfyUIClient(self.config.comfyui.url, default_checkpoint=self.config.comfyui.default_checkpoint)
         image_bytes = await client.generate(
             prompt=prompt_text,
             negative=negative,

--- a/src/tools/comfyui.py
+++ b/src/tools/comfyui.py
@@ -60,8 +60,9 @@ _DEFAULT_WORKFLOW = {
 class ComfyUIClient:
     """Async HTTP client for ComfyUI image generation."""
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, default_checkpoint: str = "") -> None:
         self.base_url = base_url.rstrip("/")
+        self._default_checkpoint = default_checkpoint
 
     async def generate(
         self,
@@ -80,8 +81,8 @@ class ComfyUIClient:
 
         workflow = copy.deepcopy(_DEFAULT_WORKFLOW)
 
-        # Use specified model or auto-detect from available checkpoints
-        ckpt = model if model else workflow["4"]["inputs"]["ckpt_name"]
+        # Priority: explicit model param > config default > workflow hardcoded fallback
+        ckpt = model or self._default_checkpoint or workflow["4"]["inputs"]["ckpt_name"]
         resolved = await self._resolve_checkpoint(ckpt)
         if not resolved:
             log.warning("No checkpoints available on ComfyUI")


### PR DESCRIPTION
## Summary
- Adds `comfyui.default_checkpoint` to config.yml schema
- ComfyUIClient uses it as the default when no explicit model is requested
- Priority: tool call model param > config default > hardcoded fallback
- Persists across deploys since config.yml is skip-worktree'd

## Test plan
- [ ] Bot starts with empty `default_checkpoint` (uses hardcoded fallback)
- [ ] Setting `default_checkpoint: juggernautXL_v9.safetensors` uses that model
- [ ] Explicit model param in generate_image still overrides the default
- [ ] Non-existent checkpoint name falls back via _resolve_checkpoint