### PR TITLE
fix: WebUI bugs from source-code review

### DIFF
--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -13,10 +13,14 @@ class OdinAPI {
     this._token = this._persist
       ? (localStorage.getItem('odin_token') || '')
       : (sessionStorage.getItem('odin_token') || '');
-    this._sessionTimeout = 0;
+    const store = this._persist ? localStorage : sessionStorage;
+    this._sessionTimeout = parseInt(store.getItem('odin_session_timeout') || '0', 10);
     this._lastActivity = Date.now();
     this._activityTimer = null;
     this.onSessionExpired = null;
+    if (this._token && this._sessionTimeout > 0) {
+      this._startActivityMonitor();
+    }
   }
 
   get token() { return this._token; }

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -295,6 +295,7 @@ const App = {
       };
       ws.connect();
       fetchStatus();
+      if (statusInterval) clearInterval(statusInterval);
       statusInterval = setInterval(fetchStatus, 15000);
     }
 

--- a/ui/js/pages/agents.js
+++ b/ui/js/pages/agents.js
@@ -208,7 +208,7 @@ export default {
       try {
         await api.del(`/api/agents/${encodeURIComponent(agentId)}`);
         await fetchAgents();
-      } catch { /* ignore */ }
+      } catch (e) { error.value = e.message || 'Failed to kill agent'; }
       killing.value = null;
     }
 

--- a/ui/js/pages/dashboard.js
+++ b/ui/js/pages/dashboard.js
@@ -404,6 +404,7 @@ export default {
     }
 
     async function clearSessions() {
+      if (!confirm('Clear all conversation sessions? This cannot be undone.')) return;
       actionLoading.value = { ...actionLoading.value, clearSessions: true };
       // Optimistic: immediately set sessions to 0
       const prevSessions = status.value.session_count;
@@ -421,6 +422,7 @@ export default {
     }
 
     async function stopAllLoops() {
+      if (!confirm('Stop all running loops?')) return;
       actionLoading.value = { ...actionLoading.value, stopLoops: true };
       // Optimistic: immediately set loops to 0
       const prevLoops = status.value.loop_count;

--- a/ui/js/pages/host-access.js
+++ b/ui/js/pages/host-access.js
@@ -350,7 +350,7 @@ export default {
 
     async function deleteUser(uid) {
       try {
-        await api.delete(`/api/host-access/user/${uid}`);
+        await api.del(`/api/host-access/user/${uid}`);
         delete users.value[uid];
         const m = getMember(uid);
         showToast(`Removed override for ${m ? m.display_name : uid}`);

--- a/ui/js/pages/learned.js
+++ b/ui/js/pages/learned.js
@@ -124,7 +124,7 @@ export default {
 
     async function saveEdit(key) {
       try {
-        await api.put('/api/learned/' + key, { content: editContent.value });
+        await api.put('/api/learned/' + encodeURIComponent(key), { content: editContent.value });
         editing.value = null;
         await fetchEntries();
       } catch (e) {
@@ -134,7 +134,7 @@ export default {
 
     async function deleteEntry(key) {
       try {
-        await api.del('/api/learned/' + key);
+        await api.del('/api/learned/' + encodeURIComponent(key));
         await fetchEntries();
       } catch (e) {
         error.value = e.message;

--- a/ui/js/pages/loops.js
+++ b/ui/js/pages/loops.js
@@ -327,7 +327,7 @@ export default {
       try {
         await api.del(`/api/loops/${encodeURIComponent(stopTarget.value)}`);
         await fetchLoops();
-      } catch { /* ignore */ }
+      } catch (e) { error.value = e.message || 'Failed to stop loop'; }
       stopping.value = false;
       stopTarget.value = null;
     }
@@ -337,7 +337,7 @@ export default {
       try {
         await api.post(`/api/loops/${encodeURIComponent(loopId)}/restart`);
         await fetchLoops();
-      } catch { /* ignore */ }
+      } catch (e) { error.value = e.message || 'Failed to restart loop'; }
       restartingId.value = null;
     }
 

--- a/ui/js/pages/personality.js
+++ b/ui/js/pages/personality.js
@@ -103,7 +103,7 @@ export default {
       if (!confirm(`Delete preset "${preset.value}"?`)) return;
       error.value = null;
       try {
-        await api.del(`/api/personality/presets/${preset.value}`);
+        await api.del(`/api/personality/presets/${encodeURIComponent(preset.value)}`);
         await load();
         preset.value = 'odin';
       } catch (e) {

--- a/ui/js/pages/processes.js
+++ b/ui/js/pages/processes.js
@@ -195,7 +195,7 @@ export default {
       try {
         await api.del(`/api/processes/${killTarget.value}`);
         await fetchProcesses();
-      } catch { /* ignore */ }
+      } catch (e) { error.value = e.message || 'Failed to kill process'; }
       killing.value = false;
       killTarget.value = null;
     }

--- a/ui/js/pages/sessions.js
+++ b/ui/js/pages/sessions.js
@@ -674,7 +674,7 @@ export default {
       detailLoading.value = true;
       collapsedThreads.value = new Set();
       try {
-        detail.value = await api.get(`/api/sessions/${channelId}`);
+        detail.value = await api.get(`/api/sessions/${encodeURIComponent(channelId)}`);
       } catch (e) {
         detail.value = { messages: [], summary: '' };
       }
@@ -706,14 +706,14 @@ export default {
       if (!clearTarget.value) return;
       clearing.value = true;
       try {
-        await api.del(`/api/sessions/${clearTarget.value}`);
+        await api.del(`/api/sessions/${encodeURIComponent(clearTarget.value)}`);
         if (expandedId.value === clearTarget.value) {
           expandedId.value = null;
           detail.value = null;
         }
         selected.value.delete(clearTarget.value);
         await fetchSessions();
-      } catch { /* ignore */ }
+      } catch (e) { error.value = e.message || 'Failed to clear session'; }
       clearing.value = false;
       clearTarget.value = null;
     }
@@ -736,7 +736,7 @@ export default {
         }
         selected.value = new Set();
         await fetchSessions();
-      } catch { /* ignore */ }
+      } catch (e) { error.value = e.message || 'Failed to clear sessions'; }
       clearing.value = false;
       bulkClearing.value = false;
     }
@@ -762,7 +762,7 @@ export default {
         debounceTimer = setTimeout(() => {
           fetchSessions();
           if (expandedId.value && data.payload.channel_id === expandedId.value) {
-            api.get(`/api/sessions/${expandedId.value}`)
+            api.get(`/api/sessions/${encodeURIComponent(expandedId.value)}`)
               .then(d => { detail.value = d; })
               .catch(() => {});
           }

--- a/ui/js/pages/tools.js
+++ b/ui/js/pages/tools.js
@@ -1,24 +1,10 @@
 /**
- * Odin Management UI — Tools Page (Round 39 Redesign)
- * Card layout with usage sparklines, categorized tool grid
+ * Odin Management UI — Tools Page
+ * Card layout, categorized tool grid
  */
 import { api } from '../api.js';
 
 const { ref, computed, onMounted } = Vue;
-
-/**
- * Generate a tiny SVG sparkline from an array of values.
- * Returns an SVG string (inline, no external deps).
- */
-function sparklineSVG(values, width, height, color) {
-  if (!values || values.length < 2) return '';
-  const max = Math.max(...values, 1);
-  const step = width / (values.length - 1);
-  const points = values.map((v, i) => `${(i * step).toFixed(1)},${(height - (v / max) * (height - 2) - 1).toFixed(1)}`).join(' ');
-  return `<svg class="tl-sparkline" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">` +
-    `<polyline points="${points}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
-    `</svg>`;
-}
 
 /** Category mapping for tools — groups tools by functional area */
 const TOOL_CATEGORIES = [
@@ -211,58 +197,10 @@ export default {
     const expanded = ref({});
     const viewMode = ref('cards');
     const activeCategory = ref(null);
-    const usageHistory = ref([]);
 
     const coreCount = computed(() => tools.value.filter(t => t.is_core).length);
     const skillCount = computed(() => tools.value.filter(t => !t.is_core).length);
     const totalUsage = computed(() => Object.values(stats.value).reduce((a, b) => a + b, 0));
-
-    /** Generate sparkline data from stats — bucketize tools by usage tier */
-    const toolSparklines = computed(() => {
-      const result = {};
-      for (const t of tools.value) {
-        const count = stats.value[t.name] || 0;
-        if (count > 0) {
-          // Generate a simple sparkline from the tool's relative usage
-          const buckets = generateUsageBuckets(t.name, count);
-          if (buckets.length > 1) {
-            result[t.name] = sparklineSVG(buckets, 48, 16, 'rgba(217, 119, 6, 0.7)');
-          }
-        }
-      }
-      return result;
-    });
-
-    const totalSparkline = computed(() => {
-      if (usageHistory.value.length < 2) return '';
-      return sparklineSVG(usageHistory.value, 64, 20, 'rgba(217, 119, 6, 0.8)');
-    });
-
-    /** Generate pseudo-historical buckets from a single count (deterministic) */
-    function generateUsageBuckets(name, total) {
-      if (total < 2) return [];
-      const seed = hashCode(name);
-      const buckets = [];
-      const numBuckets = 7;
-      let remaining = total;
-      for (let i = 0; i < numBuckets - 1; i++) {
-        const ratio = (0.5 + 0.5 * Math.abs(Math.sin(seed + i * 1.7))) / (numBuckets - i);
-        const val = Math.max(0, Math.round(remaining * ratio));
-        buckets.push(val);
-        remaining -= val;
-      }
-      buckets.push(remaining);
-      return buckets;
-    }
-
-    function hashCode(str) {
-      let hash = 0;
-      for (let i = 0; i < str.length; i++) {
-        hash = ((hash << 5) - hash) + str.charCodeAt(i);
-        hash |= 0;
-      }
-      return hash;
-    }
 
     /** Categorize a tool based on its name */
     function categorize(name) {
@@ -338,7 +276,6 @@ export default {
         stats.value = statsData || {};
         // Build usage history from stats for total sparkline
         const vals = Object.values(statsData || {}).filter(v => v > 0).sort((a, b) => a - b);
-        usageHistory.value = vals.length > 1 ? vals.slice(-10) : [];
       } catch (e) {
         error.value = e.message;
       }
@@ -353,7 +290,7 @@ export default {
 
     return {
       tools, loading, error, search, stats, expanded, viewMode,
-      activeCategory, usageHistory,
+      activeCategory,
       coreCount, skillCount, totalUsage, filteredTools, groupedTools,
       usedCategories,
       truncate, toggleExpand, refresh,

--- a/ui/js/pages/tools.js
+++ b/ui/js/pages/tools.js
@@ -90,7 +90,6 @@ export default {
           <div class="tl-stat-card">
             <div class="tl-stat-value">{{ totalUsage.toLocaleString() }}</div>
             <div class="tl-stat-label">Total Executions</div>
-            <div v-if="usageHistory.length > 1" class="tl-stat-spark" v-html="totalSparkline"></div>
           </div>
         </div>
 
@@ -132,7 +131,6 @@ export default {
                     <span v-else class="tl-tool-usage-zero">\u2014</span>
                     <span class="tl-tool-usage-label">uses</span>
                   </div>
-                  <div v-if="toolSparklines[t.name]" class="tl-tool-spark" v-html="toolSparklines[t.name]"></div>
                 </div>
                 <!-- Expanded detail -->
                 <div v-if="expanded[t.name]" class="tl-tool-detail">
@@ -178,7 +176,6 @@ export default {
                     <td class="text-gray-400 text-sm mobile-hide">{{ truncate(t.description, 100) }}</td>
                     <td class="text-right">
                       <div class="flex items-center justify-end gap-2">
-                        <span v-if="toolSparklines[t.name]" v-html="toolSparklines[t.name]"></span>
                         <span v-if="stats[t.name]" class="text-gray-300 text-sm font-mono">{{ stats[t.name].toLocaleString() }}</span>
                         <span v-else class="text-gray-600 text-sm">\u2014</span>
                       </div>
@@ -358,7 +355,7 @@ export default {
       tools, loading, error, search, stats, expanded, viewMode,
       activeCategory, usageHistory,
       coreCount, skillCount, totalUsage, filteredTools, groupedTools,
-      usedCategories, toolSparklines, totalSparkline,
+      usedCategories,
       truncate, toggleExpand, refresh,
     };
   },

--- a/ui/js/pages/traces.js
+++ b/ui/js/pages/traces.js
@@ -482,7 +482,7 @@ export default {
       expandedIterations.value = {};
       try {
         if (selectedFile.value) {
-          const data = await api.get(`/api/trajectories/${selectedFile.value}?limit=${filters.value.limit}`);
+          const data = await api.get(`/api/trajectories/${encodeURIComponent(selectedFile.value)}?limit=${filters.value.limit}`);
           let results = data.entries || [];
           if (filters.value.tool_name) {
             results = results.filter(e => (e.tools_used || []).includes(filters.value.tool_name));


### PR DESCRIPTION
## Summary
Fixes validated from Odin's source-code review of the WebUI.

### P0 — Actually broken
- `api.delete()` → `api.del()` in host-access.js (user removal was non-functional)
- Session timeout restored from storage on page reload (was always reset to 0)
- `startLive()` clears existing interval before creating new one (prevents stacking)

### P1 — Correctness
- `encodeURIComponent()` on all dynamic URL path segments (learned, personality, sessions, traces)
- Confirmation dialogs on dashboard "Clear Sessions" and "Stop All Loops"
- Destructive action failures now surface errors instead of silently swallowing (agents, loops, processes, sessions)

### P2 — Misleading UI
- Removed fabricated sparklines from tools page (sine-wave pseudo-history from single aggregate counts)

### Validated but not addressed (intentional)
- WS token in query string: confirmed at api.js:266, but this is a browser WebSocket limitation — can't set headers on WS connections. Session ID only, localhost-only, low risk.
- Silently swallowed format/parse helpers (date formatting, JSON parsing) left as-is — correct behavior for non-action code.

## Test plan
- [ ] Host Access: remove user override works (was broken before)
- [ ] Login with "Stay logged in", reload page — session timeout still monitored
- [ ] Dashboard: clear sessions / stop loops require confirmation click
- [ ] Kill agent / stop loop / kill process shows error on failure
- [ ] Tools page: no sparklines shown (removed)