### PR TITLE
feat: OAuth improvements — URL encoding, device flow, WebUI, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ python -m src
 
 The web UI starts automatically at the configured port (default 3000). Set `web.api_token` in config.yml to require authentication.
 
+## Codex Authentication
+
+Odin uses OpenAI Codex (ChatGPT subscription) for its LLM backend. Authentication requires a one-time OAuth login that generates tokens stored in `data/codex_auth.json`.
+
+**Browser login** (machine with a browser):
+```bash
+python scripts/codex_login.py
+```
+
+**Device login** (headless servers):
+```bash
+python scripts/codex_login.py --device
+```
+This displays a code to enter at `https://auth.openai.com/codex/device` — no local browser needed.
+
+**WebUI**: System > Codex Auth tab shows account status and supports device flow login.
+
+**Multi-account**: Store multiple credential sets as a JSON array in `data/codex_auth.json`. Odin rotates between them on rate limits automatically.
+
+Tokens auto-refresh at runtime. Re-run the login script if the bot is offline for more than ~8 days (refresh token expiry).
+
 ## Configuration
 
 | File | Purpose |

--- a/scripts/codex_login.py
+++ b/scripts/codex_login.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """
-One-time OAuth login script for OpenAI Codex (ChatGPT subscription).
+OAuth login script for OpenAI Codex (ChatGPT subscription).
 
-Run this on a machine with a web browser to authenticate.
-Saves tokens to data/codex_auth.json which the bot reads at runtime.
+Supports two modes:
+  Browser:  Opens a local browser and captures the callback (default)
+  Device:   Displays a code to enter at openai.com (for headless servers)
 
 Usage:
     python scripts/codex_login.py [--credentials-path PATH]
+    python scripts/codex_login.py --device [--credentials-path PATH]
 """
 
 import argparse
@@ -17,7 +19,6 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs
 
-# Add parent dir to path so we can import from src
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -58,8 +59,77 @@ class CallbackHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def log_message(self, format, *args):
-        # Suppress default HTTP server logging
         pass
+
+
+def _save_creds(creds: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(creds, indent=2))
+    path.chmod(0o600)
+
+    email = creds.get("email", "unknown")
+    account_id = creds.get("account_id", "unknown")
+
+    print(f"\nAuthentication successful!")
+    print(f"  Email: {email}")
+    print(f"  Account ID: {account_id}")
+    print(f"  Credentials saved to: {path}")
+    print(f"\nThe bot will auto-refresh tokens at runtime.")
+    print(f"If tokens expire (bot down >8 days), re-run this script.")
+
+
+def browser_login(creds_path: Path) -> None:
+    """Standard browser-based OAuth login."""
+    auth_url, code_verifier = CodexAuth.build_auth_url()
+
+    print("\n=== OpenAI Codex Login (Browser) ===\n")
+    print("Opening browser for authentication...")
+    print(f"\nIf the browser doesn't open, visit this URL:\n{auth_url}\n")
+
+    webbrowser.open(auth_url)
+
+    print("Waiting for authentication callback on port 1455...")
+    server = HTTPServer(("127.0.0.1", 1455), CallbackHandler)
+    server.timeout = 120
+
+    while CallbackHandler.auth_code is None:
+        server.handle_request()
+        if CallbackHandler.auth_code is None:
+            print("Timed out waiting for callback. Try again.")
+            sys.exit(1)
+
+    server.server_close()
+    print("Got authorization code, exchanging for tokens...")
+
+    creds = asyncio.run(CodexAuth.exchange_code(CallbackHandler.auth_code, code_verifier))
+    _save_creds(creds, creds_path)
+
+
+def device_login(creds_path: Path) -> None:
+    """Device code flow for headless servers."""
+    print("\n=== OpenAI Codex Login (Device) ===\n")
+    print("Requesting device code...")
+
+    device_info = asyncio.run(CodexAuth.request_device_code())
+
+    print(f"\n  1. Open:  {device_info['verify_url']}")
+    print(f"  2. Enter: {device_info['user_code']}")
+    print(f"\nWaiting for authorization (up to 15 minutes)...\n")
+
+    try:
+        creds = asyncio.run(CodexAuth.poll_device_auth(
+            device_info["device_auth_id"],
+            device_info["user_code"],
+            interval=device_info["interval"],
+        ))
+    except TimeoutError:
+        print("Timed out waiting for authorization. Try again.")
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Authentication failed: {e}")
+        sys.exit(1)
+
+    _save_creds(creds, creds_path)
 
 
 def main():
@@ -69,52 +139,19 @@ def main():
         default="data/codex_auth.json",
         help="Path to save credentials (default: data/codex_auth.json)",
     )
+    parser.add_argument(
+        "--device",
+        action="store_true",
+        help="Use device code flow (for headless servers without a browser)",
+    )
     args = parser.parse_args()
 
     creds_path = Path(args.credentials_path)
 
-    # Generate auth URL
-    auth_url, code_verifier = CodexAuth.build_auth_url()
-
-    print("\n=== OpenAI Codex Login ===\n")
-    print("Opening browser for authentication...")
-    print(f"\nIf the browser doesn't open, visit this URL:\n{auth_url}\n")
-
-    webbrowser.open(auth_url)
-
-    # Start callback server
-    print("Waiting for authentication callback on port 1455...")
-    server = HTTPServer(("127.0.0.1", 1455), CallbackHandler)
-    server.timeout = 120  # 2 minute timeout
-
-    while CallbackHandler.auth_code is None:
-        server.handle_request()
-        if CallbackHandler.auth_code is None:
-            print("Timed out waiting for callback. Try again.")
-            sys.exit(1)
-
-    server.server_close()
-
-    auth_code = CallbackHandler.auth_code
-    print("Got authorization code, exchanging for tokens...")
-
-    # Exchange code for tokens
-    creds = asyncio.run(CodexAuth.exchange_code(auth_code, code_verifier))
-
-    # Save
-    creds_path.parent.mkdir(parents=True, exist_ok=True)
-    creds_path.write_text(json.dumps(creds, indent=2))
-    creds_path.chmod(0o600)
-
-    email = creds.get("email", "unknown")
-    account_id = creds.get("account_id", "unknown")
-
-    print(f"\nAuthentication successful!")
-    print(f"  Email: {email}")
-    print(f"  Account ID: {account_id}")
-    print(f"  Credentials saved to: {creds_path}")
-    print(f"\nThe bot will auto-refresh tokens at runtime.")
-    print(f"If tokens expire (bot down >8 days), re-run this script.")
+    if args.device:
+        device_login(creds_path)
+    else:
+        browser_login(creds_path)
 
 
 if __name__ == "__main__":

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -291,8 +291,6 @@ class CodexAuth:
 
         raise TimeoutError("Device authorization timed out — user did not complete login")
 
-        return creds
-
 
 class CodexAuthPool:
     """Manages multiple CodexAuth credential sets with automatic rotation.

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -32,6 +32,10 @@ CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 AUTH_URL = "https://auth.openai.com/oauth/authorize"
 TOKEN_URL = "https://auth.openai.com/oauth/token"
 REDIRECT_URI = "http://localhost:1455/auth/callback"
+DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback"
+DEVICE_USERCODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
+DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token"
+DEVICE_VERIFY_URL = "https://auth.openai.com/codex/device"
 SCOPES = "openid profile email offline_access"
 
 # Refresh 5 minutes before expiry
@@ -195,11 +199,11 @@ class CodexAuth:
             "codex_cli_simplified_flow": "true",
             "originator": "pi",
         }
-        query = "&".join(f"{k}={v}" for k, v in params.items())
-        return f"{AUTH_URL}?{query}", code_verifier
+        from urllib.parse import urlencode
+        return f"{AUTH_URL}?{urlencode(params)}", code_verifier
 
     @staticmethod
-    async def exchange_code(code: str, code_verifier: str) -> dict:
+    async def exchange_code(code: str, code_verifier: str, redirect_uri: str = REDIRECT_URI) -> dict:
         """Exchange authorization code for tokens."""
         async with aiohttp.ClientSession(auto_decompress=False, timeout=aiohttp.ClientTimeout(total=30)) as session:
             async with session.post(
@@ -207,7 +211,7 @@ class CodexAuth:
                 data={
                     "grant_type": "authorization_code",
                     "code": code,
-                    "redirect_uri": REDIRECT_URI,
+                    "redirect_uri": redirect_uri,
                     "client_id": CLIENT_ID,
                     "code_verifier": code_verifier,
                 },
@@ -233,6 +237,57 @@ class CodexAuth:
             creds["account_id"] = payload["chatgpt_account_id"]
         if "email" in payload:
             creds["email"] = payload["email"]
+
+    @staticmethod
+    async def request_device_code() -> dict:
+        """Request a device code for headless authentication.
+
+        Returns dict with device_auth_id, user_code, interval, and verify_url.
+        """
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+            async with session.post(
+                DEVICE_USERCODE_URL,
+                json={"client_id": CLIENT_ID},
+            ) as resp:
+                if resp.status != 200:
+                    body = (await resp.read()).decode("utf-8", errors="replace")
+                    raise RuntimeError(f"Device code request failed ({resp.status}): {body}")
+                data = json.loads(await resp.read())
+
+        return {
+            "device_auth_id": data["device_auth_id"],
+            "user_code": data["user_code"],
+            "interval": int(data.get("interval", 5)),
+            "verify_url": DEVICE_VERIFY_URL,
+        }
+
+    @staticmethod
+    async def poll_device_auth(device_auth_id: str, user_code: str, interval: int = 5, timeout: int = 900) -> dict:
+        """Poll for device authorization completion, then exchange for tokens.
+
+        Returns credentials dict on success, raises on timeout/error.
+        """
+        deadline = time.time() + timeout
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+            while time.time() < deadline:
+                await asyncio.sleep(interval)
+                async with session.post(
+                    DEVICE_TOKEN_URL,
+                    json={"device_auth_id": device_auth_id, "user_code": user_code},
+                ) as resp:
+                    if resp.status == 200:
+                        data = json.loads(await resp.read())
+                        return await CodexAuth.exchange_code(
+                            data["authorization_code"],
+                            data["code_verifier"],
+                            redirect_uri=DEVICE_REDIRECT_URI,
+                        )
+                    if resp.status in (403, 404):
+                        continue
+                    body = (await resp.read()).decode("utf-8", errors="replace")
+                    raise RuntimeError(f"Device auth polling failed ({resp.status}): {body}")
+
+        raise TimeoutError("Device authorization timed out — user did not complete login")
 
         return creds
 

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -238,6 +238,8 @@ class CodexAuth:
         if "email" in payload:
             creds["email"] = payload["email"]
 
+        return creds
+
     @staticmethod
     async def request_device_code() -> dict:
         """Request a device code for headless authentication.

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2686,7 +2686,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
-        creds_path = body.get("credentials_path", "./data/codex_auth.json")
+        creds_path = bot.config.openai_codex.credentials_path
         save_index = body.get("save_index")
 
         import json as _json

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2616,6 +2616,109 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         return web.json_response({"error": "no override found for user"}, status=404)
 
     # ------------------------------------------------------------------
+    # Codex OAuth management
+    # ------------------------------------------------------------------
+
+    @routes.get("/api/codex/status")
+    async def codex_status(_request: web.Request) -> web.Response:
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool is None:
+            pool = getattr(bot, "_codex_auth_pool", None)
+        if pool is None:
+            return web.json_response({"configured": False, "accounts": []})
+
+        import time as _time
+        from ..llm.codex_auth import _decode_jwt_payload
+
+        accounts = []
+        for i, auth in enumerate(pool._accounts):
+            try:
+                creds = auth._load()
+                payload = _decode_jwt_payload(creds.get("access_token", ""))
+                expires_at = creds.get("expires_at", 0)
+                accounts.append({
+                    "index": i,
+                    "email": creds.get("email", payload.get("email", "unknown")),
+                    "account_id": creds.get("account_id", ""),
+                    "expires_at": expires_at,
+                    "expired": _time.time() >= expires_at,
+                    "rate_limited": auth.is_rate_limited(),
+                    "is_current": i == pool._current_index,
+                })
+            except Exception as e:
+                accounts.append({"index": i, "error": str(e)})
+
+        return web.json_response({
+            "configured": True,
+            "account_count": pool.account_count,
+            "current_index": pool._current_index,
+            "accounts": accounts,
+        })
+
+    @routes.post("/api/codex/device-code")
+    async def codex_device_code(_request: web.Request) -> web.Response:
+        from ..llm.codex_auth import CodexAuth
+        try:
+            result = await CodexAuth.request_device_code()
+            return web.json_response(result)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    @routes.post("/api/codex/device-poll")
+    async def codex_device_poll(request: web.Request) -> web.Response:
+        from ..llm.codex_auth import CodexAuth
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON body"}, status=400)
+
+        device_auth_id = body.get("device_auth_id", "")
+        user_code = body.get("user_code", "")
+        interval = body.get("interval", 5)
+        if not device_auth_id or not user_code:
+            return web.json_response({"error": "device_auth_id and user_code required"}, status=400)
+
+        try:
+            creds = await CodexAuth.poll_device_auth(device_auth_id, user_code, interval=interval)
+        except TimeoutError:
+            return web.json_response({"error": "Authorization timed out"}, status=408)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+        creds_path = body.get("credentials_path", "./data/codex_auth.json")
+        save_index = body.get("save_index")
+
+        import json as _json
+        from pathlib import Path as _Path
+        from ..llm.codex_auth import _atomic_write_secure
+
+        path = _Path(creds_path)
+        if save_index is not None and path.exists():
+            try:
+                raw = _json.loads(path.read_text())
+                if isinstance(raw, list) and 0 <= save_index < len(raw):
+                    raw[save_index] = creds
+                    _atomic_write_secure(path, _json.dumps(raw, indent=2))
+                elif isinstance(raw, list):
+                    raw.append(creds)
+                    _atomic_write_secure(path, _json.dumps(raw, indent=2))
+                else:
+                    _atomic_write_secure(path, _json.dumps(creds, indent=2))
+            except Exception as e:
+                return web.json_response({"error": f"Saved but failed to update pool: {e}",
+                                          "email": creds.get("email", "")}, status=207)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write_secure(path, _json.dumps(creds, indent=2))
+
+        return web.json_response({
+            "status": "authenticated",
+            "email": creds.get("email", "unknown"),
+            "account_id": creds.get("account_id", ""),
+        })
+
+    # ------------------------------------------------------------------
     # Host access control
     # ------------------------------------------------------------------
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2716,6 +2716,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "status": "authenticated",
             "email": creds.get("email", "unknown"),
             "account_id": creds.get("account_id", ""),
+            "restart_required": True,
+            "message": "Credentials saved. Restart Odin to load into the active pool.",
         })
 
     # ------------------------------------------------------------------

--- a/ui/js/pages/codex-auth.js
+++ b/ui/js/pages/codex-auth.js
@@ -1,0 +1,204 @@
+import { api } from '../api.js';
+
+const { ref, computed, onMounted, onUnmounted } = Vue;
+
+export default {
+  template: `
+    <div class="p-6 page-fade-in">
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold">Codex Authentication</h1>
+        <button @click="fetchStatus" class="btn btn-ghost text-xs" :disabled="loading">
+          {{ loading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+      <p class="text-xs text-gray-500 mb-6">
+        Manage OpenAI Codex OAuth credentials. Odin uses ChatGPT subscription tokens with automatic refresh and pool rotation.
+      </p>
+
+      <div v-if="loading && !data" class="space-y-2">
+        <div v-for="n in 3" :key="n" class="skeleton skeleton-row"></div>
+      </div>
+      <div v-else-if="error" class="hm-card border-red-900 error-state">
+        <p class="text-red-400">{{ error }}</p>
+        <button @click="fetchStatus" class="btn btn-ghost text-xs">Retry</button>
+      </div>
+
+      <div v-else class="space-y-6">
+        <!-- Status overview -->
+        <div class="hm-card">
+          <h2 class="text-sm font-semibold text-gray-300 mb-3">Status</h2>
+          <div v-if="!data.configured" class="text-yellow-400 text-sm">
+            No Codex credentials configured. Use the device login below or run
+            <code class="bg-gray-800 px-1 rounded">python scripts/codex_login.py</code>
+          </div>
+          <div v-else class="text-sm text-gray-300">
+            {{ data.account_count }} account{{ data.account_count !== 1 ? 's' : '' }} configured,
+            active: #{{ data.current_index + 1 }}
+          </div>
+        </div>
+
+        <!-- Accounts table -->
+        <div v-if="data.configured && data.accounts.length" class="hm-card">
+          <h2 class="text-sm font-semibold text-gray-300 mb-3">Accounts</h2>
+          <table class="hm-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Email</th>
+                <th>Account ID</th>
+                <th class="text-center">Status</th>
+                <th class="text-center">Active</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="a in data.accounts" :key="a.index">
+                <td class="text-gray-400">{{ a.index + 1 }}</td>
+                <td class="text-gray-200">{{ a.email || '—' }}</td>
+                <td class="font-mono text-xs text-gray-400">{{ a.account_id ? a.account_id.slice(0, 16) + '...' : '—' }}</td>
+                <td class="text-center">
+                  <span v-if="a.error" class="text-red-400 text-xs">Error</span>
+                  <span v-else-if="a.expired" class="text-red-400 text-xs">Expired</span>
+                  <span v-else-if="a.rate_limited" class="text-yellow-400 text-xs">Rate limited</span>
+                  <span v-else class="text-green-400 text-xs">Active</span>
+                </td>
+                <td class="text-center">
+                  <span v-if="a.is_current" class="text-xs px-1 rounded bg-indigo-900 text-indigo-300">Current</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Device login -->
+        <div class="hm-card">
+          <h2 class="text-sm font-semibold text-gray-300 mb-3">Add Account (Device Login)</h2>
+          <p class="text-xs text-gray-500 mb-3">
+            Authenticate a new Codex account without a local browser. Works on headless servers.
+          </p>
+
+          <div v-if="!deviceState">
+            <button @click="startDeviceLogin" class="btn btn-primary text-xs" :disabled="deviceLoading">
+              {{ deviceLoading ? 'Requesting code...' : 'Start Device Login' }}
+            </button>
+          </div>
+
+          <div v-else-if="deviceState === 'pending'" class="p-4 bg-gray-800 rounded border border-gray-700">
+            <div class="text-sm text-gray-300 mb-3">
+              <p class="mb-2">1. Open: <a :href="deviceInfo.verify_url" target="_blank"
+                   class="text-indigo-400 hover:text-indigo-300 underline">{{ deviceInfo.verify_url }}</a></p>
+              <p>2. Enter code: <code class="bg-gray-900 px-2 py-1 rounded text-lg font-bold text-white">{{ deviceInfo.user_code }}</code></p>
+            </div>
+            <div class="flex items-center gap-3">
+              <div class="text-xs text-gray-500">
+                Waiting for authorization...
+                <span class="inline-block animate-pulse ml-1">●</span>
+              </div>
+              <button @click="cancelDeviceLogin" class="btn btn-ghost text-xs">Cancel</button>
+            </div>
+          </div>
+
+          <div v-else-if="deviceState === 'success'" class="p-4 bg-green-900/30 rounded border border-green-800">
+            <p class="text-green-400 text-sm">Authenticated as {{ deviceResult.email }}.</p>
+            <p class="text-xs text-gray-400 mt-1">Restart Odin to load the new credentials into the active pool.</p>
+            <button @click="deviceState = null" class="btn btn-ghost text-xs mt-2">Done</button>
+          </div>
+
+          <div v-else-if="deviceState === 'error'" class="p-4 bg-red-900/30 rounded border border-red-800">
+            <p class="text-red-400 text-sm">{{ deviceError }}</p>
+            <button @click="deviceState = null" class="btn btn-ghost text-xs mt-2">Try Again</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Toast -->
+      <div v-if="toast" class="fixed bottom-6 right-6 px-4 py-2 rounded text-sm shadow-lg z-50"
+           :class="toast.type === 'error' ? 'bg-red-900 text-red-200' : 'bg-green-900 text-green-200'">
+        {{ toast.message }}
+      </div>
+    </div>
+  `,
+
+  setup() {
+    const loading = ref(true);
+    const error = ref('');
+    const data = ref({ configured: false, accounts: [] });
+    const toast = ref(null);
+
+    const deviceState = ref(null);
+    const deviceLoading = ref(false);
+    const deviceInfo = ref(null);
+    const deviceResult = ref(null);
+    const deviceError = ref('');
+    let pollController = null;
+
+    let toastTimer = null;
+    function showToast(message, type = 'success') {
+      toast.value = { message, type };
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => { toast.value = null; }, 3000);
+    }
+
+    async function fetchStatus() {
+      loading.value = true;
+      error.value = '';
+      try {
+        data.value = await api.get('/api/codex/status');
+      } catch (e) {
+        error.value = e.message || 'Failed to fetch Codex status';
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function startDeviceLogin() {
+      deviceLoading.value = true;
+      try {
+        const info = await api.post('/api/codex/device-code');
+        deviceInfo.value = info;
+        deviceState.value = 'pending';
+        pollForAuth(info);
+      } catch (e) {
+        showToast(e.message || 'Failed to request device code', 'error');
+      } finally {
+        deviceLoading.value = false;
+      }
+    }
+
+    async function pollForAuth(info) {
+      pollController = { cancelled: false };
+      const ctrl = pollController;
+      try {
+        const result = await api.post('/api/codex/device-poll', {
+          device_auth_id: info.device_auth_id,
+          user_code: info.user_code,
+          interval: info.interval,
+        });
+        if (ctrl.cancelled) return;
+        deviceResult.value = result;
+        deviceState.value = 'success';
+        fetchStatus();
+      } catch (e) {
+        if (ctrl.cancelled) return;
+        deviceError.value = e.message || 'Device login failed';
+        deviceState.value = 'error';
+      }
+    }
+
+    function cancelDeviceLogin() {
+      if (pollController) pollController.cancelled = true;
+      deviceState.value = null;
+      deviceInfo.value = null;
+    }
+
+    onMounted(fetchStatus);
+    onUnmounted(() => {
+      if (pollController) pollController.cancelled = true;
+    });
+
+    return {
+      loading, error, data, toast,
+      deviceState, deviceLoading, deviceInfo, deviceResult, deviceError,
+      fetchStatus, startDeviceLogin, cancelDeviceLogin,
+    };
+  },
+};

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -5,6 +5,7 @@ import LogsPage from './logs.js';
 import ConfigPage from './config.js';
 import DiscordConfigPage from './discord-config.js';
 import HostAccessPage from './host-access.js';
+import CodexAuthPage from './codex-auth.js';
 import InternalsPage from './internals.js';
 import UpdatePage from './update.js';
 
@@ -18,6 +19,7 @@ export default {
       { id: 'config', label: 'Config', component: ConfigPage },
       { id: 'discord', label: 'Discord', component: DiscordConfigPage },
       { id: 'host-access', label: 'Host Access', component: HostAccessPage },
+      { id: 'codex', label: 'Codex Auth', component: CodexAuthPage },
       { id: 'internals', label: 'Internals', component: InternalsPage },
       { id: 'update', label: 'Update', component: UpdatePage },
     ];


### PR DESCRIPTION
## Summary
Comprehensive OAuth improvements for Codex authentication.

### 1. URL encoding fix
`build_auth_url()` was manually concatenating query params with raw spaces in the scope value. Now uses `urllib.parse.urlencode`.

### 2. Device flow authentication
For headless servers without a browser:
- `CodexAuth.request_device_code()` → gets user code from OpenAI
- `CodexAuth.poll_device_auth()` → polls until user completes login, exchanges for tokens
- Uses OpenAI's custom device flow (not standard RFC 8628)
- CLI: `python scripts/codex_login.py --device`

### 3. WebUI (System > Codex Auth tab)
- Account status table: email, expiry, rate-limited status, active indicator
- Device login flow from the browser with live polling
- API endpoints: `GET /api/codex/status`, `POST /api/codex/device-code`, `POST /api/codex/device-poll`

### 4. Documentation
- New "Codex Authentication" section in README covering all login methods

## Test plan
- [ ] `build_auth_url()` produces properly encoded URL (no raw spaces)
- [ ] `--device` flag on codex_login.py shows user code and verify URL
- [ ] WebUI Codex Auth tab shows account status
- [ ] WebUI device login flow requests code and polls for completion
- [ ] Existing browser login still works
- [ ] Token refresh still works after re-encoding change