### PR TITLE
fix: Codex Auth — JWT claims, account delete, re-auth

### DIFF
--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -52,19 +52,33 @@ def _generate_pkce() -> tuple[str, str]:
 
 
 def _decode_jwt_payload(token: str) -> dict:
-    """Decode the payload section of a JWT without verification."""
+    """Decode the payload section of a JWT without verification.
+
+    Flattens OpenAI's nested claim objects (https://api.openai.com/profile,
+    https://api.openai.com/auth) into top-level keys for easier access.
+    """
     parts = token.split(".")
     if len(parts) < 2:
         return {}
     payload = parts[1]
-    # Add padding
     padding = 4 - len(payload) % 4
     if padding != 4:
         payload += "=" * padding
     try:
-        return json.loads(base64.urlsafe_b64decode(payload))
+        data = json.loads(base64.urlsafe_b64decode(payload))
     except Exception:
         return {}
+    profile = data.get("https://api.openai.com/profile", {})
+    auth = data.get("https://api.openai.com/auth", {})
+    if isinstance(profile, dict):
+        for k, v in profile.items():
+            if k not in data:
+                data[k] = v
+    if isinstance(auth, dict):
+        for k, v in auth.items():
+            if k not in data:
+                data[k] = v
+    return data
 
 
 class CodexAuth:

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -334,15 +334,24 @@ class CodexAuthPool:
             return
 
         if isinstance(raw, list):
-            # Multi-account format — split into individual files
+            # Multi-account format — canonical file is source of truth.
+            # Always sync shadow files and clean up stale ones.
+            valid_count = 0
             for i, creds in enumerate(raw):
                 if not isinstance(creds, dict) or not creds.get("access_token"):
                     continue
                 individual_path = self._path.parent / f"codex_auth_{i}.json"
-                if not individual_path.exists():
-                    _atomic_write_secure(individual_path, json.dumps(creds, indent=2))
+                _atomic_write_secure(individual_path, json.dumps(creds, indent=2))
                 auth = CodexAuth(str(individual_path))
                 self._accounts.append(auth)
+                valid_count = i + 1
+            # Remove stale shadow files from previous larger pools
+            for j in range(valid_count, valid_count + 20):
+                stale = self._path.parent / f"codex_auth_{j}.json"
+                if stale.exists():
+                    stale.unlink()
+                else:
+                    break
             log.info("Codex auth pool: %d account(s) loaded", len(self._accounts))
         elif isinstance(raw, dict) and raw.get("access_token"):
             # Single account (backward compat) — use the file directly

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2720,6 +2720,45 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "message": "Credentials saved. Restart Odin to load into the active pool.",
         })
 
+    @routes.delete("/api/codex/account/{index}")
+    async def codex_delete_account(request: web.Request) -> web.Response:
+        import json as _json
+        from pathlib import Path as _Path
+        from ..llm.codex_auth import _atomic_write_secure
+
+        try:
+            index = int(request.match_info["index"])
+        except ValueError:
+            return web.json_response({"error": "index must be an integer"}, status=400)
+
+        path = _Path(bot.config.openai_codex.credentials_path)
+        if not path.exists():
+            return web.json_response({"error": "no credentials file"}, status=404)
+
+        try:
+            raw = _json.loads(path.read_text())
+        except Exception:
+            return web.json_response({"error": "failed to read credentials"}, status=500)
+
+        if isinstance(raw, list):
+            if index < 0 or index >= len(raw):
+                return web.json_response({"error": f"index {index} out of range (0-{len(raw)-1})"}, status=400)
+            removed = raw.pop(index)
+            _atomic_write_secure(path, _json.dumps(raw, indent=2))
+            email = removed.get("email", "unknown")
+        elif isinstance(raw, dict) and index == 0:
+            email = raw.get("email", "unknown")
+            _atomic_write_secure(path, _json.dumps([], indent=2))
+        else:
+            return web.json_response({"error": "invalid index"}, status=400)
+
+        return web.json_response({
+            "status": "deleted",
+            "email": email,
+            "restart_required": True,
+            "message": "Account removed. Restart Odin to apply.",
+        })
+
     # ------------------------------------------------------------------
     # Host access control
     # ------------------------------------------------------------------

--- a/ui/js/pages/codex-auth.js
+++ b/ui/js/pages/codex-auth.js
@@ -48,6 +48,7 @@ export default {
                 <th>Account ID</th>
                 <th class="text-center">Status</th>
                 <th class="text-center">Active</th>
+                <th class="text-center">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -63,6 +64,12 @@ export default {
                 </td>
                 <td class="text-center">
                   <span v-if="a.is_current" class="text-xs px-1 rounded bg-indigo-900 text-indigo-300">Current</span>
+                </td>
+                <td class="text-center">
+                  <button v-if="a.expired || a.error" @click="startReauth(a.index)"
+                          class="text-indigo-400 hover:text-indigo-300 text-xs mr-2">Re-auth</button>
+                  <button @click="deleteAccount(a.index, a.email)"
+                          class="text-red-400 hover:text-red-300 text-xs">Delete</button>
                 </td>
               </tr>
             </tbody>
@@ -164,15 +171,36 @@ export default {
       }
     }
 
+    const reauthIndex = ref(null);
+
+    function startReauth(index) {
+      reauthIndex.value = index;
+      startDeviceLogin();
+    }
+
+    async function deleteAccount(index, email) {
+      const label = email && email !== '—' ? email : `account #${index + 1}`;
+      if (!confirm(`Delete ${label}? Requires restart to apply.`)) return;
+      try {
+        await api.del(`/api/codex/account/${index}`);
+        showToast(`Deleted ${label}. Restart required.`);
+        fetchStatus();
+      } catch (e) {
+        showToast(e.message || 'Failed to delete account', 'error');
+      }
+    }
+
     async function pollForAuth(info) {
       pollController = { cancelled: false };
       const ctrl = pollController;
       try {
-        const result = await api.post('/api/codex/device-poll', {
+        const payload = {
           device_auth_id: info.device_auth_id,
           user_code: info.user_code,
           interval: info.interval,
-        });
+        };
+        if (reauthIndex.value !== null) payload.save_index = reauthIndex.value;
+        const result = await api.post('/api/codex/device-poll', payload);
         if (ctrl.cancelled) return;
         deviceResult.value = result;
         deviceState.value = 'success';
@@ -188,6 +216,7 @@ export default {
       if (pollController) pollController.cancelled = true;
       deviceState.value = null;
       deviceInfo.value = null;
+      reauthIndex.value = null;
     }
 
     onMounted(fetchStatus);
@@ -199,6 +228,7 @@ export default {
       loading, error, data, toast,
       deviceState, deviceLoading, deviceInfo, deviceResult, deviceError,
       fetchStatus, startDeviceLogin, cancelDeviceLogin,
+      deleteAccount, startReauth,
     };
   },
 };


### PR DESCRIPTION
## Summary
Fixes three issues with the Codex Auth WebUI (v3.24.0):

### 1. Email/Account ID showing "unknown"
OpenAI's JWT stores email under `https://api.openai.com/profile` and account_id under `https://api.openai.com/auth` as nested claim objects. The JWT decoder was only checking top-level keys. Now flattens nested claims into top-level keys.

### 2. No way to delete accounts
Added `DELETE /api/codex/account/{index}` — removes an account from the credential pool file. WebUI shows a delete button per account with confirmation.

### 3. No way to re-auth a specific expired account
WebUI shows a "Re-auth" button on expired/errored accounts. Initiates device flow with `save_index` targeting the specific slot, so the new credentials replace the expired ones instead of appending.

## Test plan
- [ ] Codex Auth tab shows real email and account ID
- [ ] Delete button removes account from pool (requires restart)
- [ ] Re-auth button on expired account initiates device flow targeting that slot