### PR TITLE
feat: Codex Auth — account labels, plan type, refresh

### DIFF
--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -185,6 +185,14 @@ class CodexAuth:
         elif creds.get("email"):
             new_creds["email"] = creds["email"]
 
+        if "chatgpt_plan_type" in payload:
+            new_creds["plan_type"] = payload["chatgpt_plan_type"]
+        elif creds.get("plan_type"):
+            new_creds["plan_type"] = creds["plan_type"]
+
+        if creds.get("label"):
+            new_creds["label"] = creds["label"]
+
         self._save(new_creds)
         log.info("Codex tokens refreshed successfully")
 
@@ -251,6 +259,8 @@ class CodexAuth:
             creds["account_id"] = payload["chatgpt_account_id"]
         if "email" in payload:
             creds["email"] = payload["email"]
+        if "chatgpt_plan_type" in payload:
+            creds["plan_type"] = payload["chatgpt_plan_type"]
 
         return creds
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2738,9 +2738,25 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
         auth = pool._accounts[index]
         try:
+            import json as _json
+            from pathlib import Path as _Path
+            from ..llm.codex_auth import _atomic_write_secure
+
             creds = auth._load()
             await auth._refresh(creds)
             creds = auth._load()
+
+            # Sync refreshed token back to canonical credentials file
+            path = _Path(bot.config.openai_codex.credentials_path)
+            if path.exists():
+                try:
+                    raw = _json.loads(path.read_text())
+                    if isinstance(raw, list) and index < len(raw):
+                        raw[index] = creds
+                        _atomic_write_secure(path, _json.dumps(raw, indent=2))
+                except Exception:
+                    pass
+
             return web.json_response({
                 "status": "refreshed",
                 "email": creds.get("email", "unknown"),

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2639,8 +2639,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 expires_at = creds.get("expires_at", 0)
                 accounts.append({
                     "index": i,
+                    "label": creds.get("label", ""),
                     "email": creds.get("email", payload.get("email", "unknown")),
-                    "account_id": creds.get("account_id", ""),
+                    "account_id": creds.get("account_id", payload.get("chatgpt_account_id", "")),
+                    "plan_type": creds.get("plan_type", payload.get("chatgpt_plan_type", "")),
                     "expires_at": expires_at,
                     "expired": _time.time() >= expires_at,
                     "rate_limited": auth.is_rate_limited(),
@@ -2719,6 +2721,85 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "restart_required": True,
             "message": "Credentials saved. Restart Odin to load into the active pool.",
         })
+
+    @routes.post("/api/codex/account/{index}/refresh")
+    async def codex_refresh_account(request: web.Request) -> web.Response:
+        try:
+            index = int(request.match_info["index"])
+        except ValueError:
+            return web.json_response({"error": "index must be an integer"}, status=400)
+
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool is None:
+            return web.json_response({"error": "codex not configured"}, status=503)
+        if index < 0 or index >= len(pool._accounts):
+            return web.json_response({"error": f"index {index} out of range"}, status=400)
+
+        auth = pool._accounts[index]
+        try:
+            creds = auth._load()
+            await auth._refresh(creds)
+            creds = auth._load()
+            return web.json_response({
+                "status": "refreshed",
+                "email": creds.get("email", "unknown"),
+                "expired": False,
+            })
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    @routes.put("/api/codex/account/{index}/label")
+    async def codex_set_label(request: web.Request) -> web.Response:
+        import json as _json
+        from pathlib import Path as _Path
+        from ..llm.codex_auth import _atomic_write_secure
+
+        try:
+            index = int(request.match_info["index"])
+        except ValueError:
+            return web.json_response({"error": "index must be an integer"}, status=400)
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON body"}, status=400)
+
+        label = body.get("label", "")
+        if not isinstance(label, str):
+            return web.json_response({"error": "label must be a string"}, status=400)
+
+        path = _Path(bot.config.openai_codex.credentials_path)
+        if not path.exists():
+            return web.json_response({"error": "no credentials file"}, status=404)
+
+        try:
+            raw = _json.loads(path.read_text())
+        except Exception:
+            return web.json_response({"error": "failed to read credentials"}, status=500)
+
+        if isinstance(raw, list):
+            if index < 0 or index >= len(raw):
+                return web.json_response({"error": f"index {index} out of range"}, status=400)
+            raw[index]["label"] = label
+        elif isinstance(raw, dict) and index == 0:
+            raw["label"] = label
+        else:
+            return web.json_response({"error": "invalid index"}, status=400)
+
+        _atomic_write_secure(path, _json.dumps(raw, indent=2))
+
+        # Also update the in-memory shadow file so status reflects immediately
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool and index < len(pool._accounts):
+            try:
+                creds = pool._accounts[index]._load()
+                creds["label"] = label
+                pool._accounts[index]._save(creds)
+            except Exception:
+                pass
+
+        return web.json_response({"status": "updated", "label": label})
 
     @routes.delete("/api/codex/account/{index}")
     async def codex_delete_account(request: web.Request) -> web.Response:

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2749,13 +2749,10 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             # Sync refreshed token back to canonical credentials file
             path = _Path(bot.config.openai_codex.credentials_path)
             if path.exists():
-                try:
-                    raw = _json.loads(path.read_text())
-                    if isinstance(raw, list) and index < len(raw):
-                        raw[index] = creds
-                        _atomic_write_secure(path, _json.dumps(raw, indent=2))
-                except Exception:
-                    pass
+                raw = _json.loads(path.read_text())
+                if isinstance(raw, list) and index < len(raw):
+                    raw[index] = creds
+                    _atomic_write_secure(path, _json.dumps(raw, indent=2))
 
             return web.json_response({
                 "status": "refreshed",

--- a/ui/js/pages/codex-auth.js
+++ b/ui/js/pages/codex-auth.js
@@ -44,8 +44,9 @@ export default {
             <thead>
               <tr>
                 <th>#</th>
+                <th>Label</th>
                 <th>Email</th>
-                <th>Account ID</th>
+                <th>Plan</th>
                 <th class="text-center">Status</th>
                 <th class="text-center">Active</th>
                 <th class="text-center">Actions</th>
@@ -54,8 +55,28 @@ export default {
             <tbody>
               <tr v-for="a in data.accounts" :key="a.index">
                 <td class="text-gray-400">{{ a.index + 1 }}</td>
+                <td>
+                  <span v-if="editingLabel !== a.index" class="text-gray-200 cursor-pointer hover:text-indigo-300"
+                        @click="startEditLabel(a.index, a.label)"
+                        :title="a.label ? 'Click to edit' : 'Click to add label'">
+                    {{ a.label || '—' }}
+                    <span class="text-gray-600 text-xs ml-1">&#9998;</span>
+                  </span>
+                  <span v-else class="flex items-center gap-1">
+                    <input v-model="labelValue" @keydown.enter="saveLabel(a.index)" @keydown.escape="editingLabel = null"
+                           class="bg-gray-900 border border-gray-600 rounded px-2 py-0.5 text-sm text-gray-300 w-32" />
+                    <button @click="saveLabel(a.index)" class="text-green-400 text-xs">Save</button>
+                    <button @click="editingLabel = null" class="text-gray-500 text-xs">Cancel</button>
+                  </span>
+                </td>
                 <td class="text-gray-200">{{ a.email || '—' }}</td>
-                <td class="font-mono text-xs text-gray-400">{{ a.account_id ? a.account_id.slice(0, 16) + '...' : '—' }}</td>
+                <td class="text-xs">
+                  <span v-if="a.plan_type" class="px-1.5 py-0.5 rounded"
+                        :class="a.plan_type === 'plus' ? 'bg-green-900 text-green-300' : a.plan_type === 'team' ? 'bg-blue-900 text-blue-300' : 'bg-gray-700 text-gray-300'">
+                    {{ a.plan_type }}
+                  </span>
+                  <span v-else class="text-gray-500">—</span>
+                </td>
                 <td class="text-center">
                   <span v-if="a.error" class="text-red-400 text-xs">Error</span>
                   <span v-else-if="a.expired" class="text-red-400 text-xs">Expired</span>
@@ -65,11 +86,15 @@ export default {
                 <td class="text-center">
                   <span v-if="a.is_current" class="text-xs px-1 rounded bg-indigo-900 text-indigo-300">Current</span>
                 </td>
-                <td class="text-center">
+                <td class="text-center text-xs space-x-2">
+                  <button @click="refreshAccount(a.index)" :disabled="refreshing === a.index"
+                          class="text-blue-400 hover:text-blue-300">
+                    {{ refreshing === a.index ? 'Refreshing...' : 'Refresh' }}
+                  </button>
                   <button v-if="a.expired || a.error" @click="startReauth(a.index)"
-                          class="text-indigo-400 hover:text-indigo-300 text-xs mr-2">Re-auth</button>
-                  <button @click="deleteAccount(a.index, a.email)"
-                          class="text-red-400 hover:text-red-300 text-xs">Delete</button>
+                          class="text-indigo-400 hover:text-indigo-300">Re-auth</button>
+                  <button @click="deleteAccount(a.index, a.label || a.email)"
+                          class="text-red-400 hover:text-red-300">Delete</button>
                 </td>
               </tr>
             </tbody>
@@ -130,12 +155,16 @@ export default {
     const error = ref('');
     const data = ref({ configured: false, accounts: [] });
     const toast = ref(null);
+    const refreshing = ref(null);
+    const editingLabel = ref(null);
+    const labelValue = ref('');
 
     const deviceState = ref(null);
     const deviceLoading = ref(false);
     const deviceInfo = ref(null);
     const deviceResult = ref(null);
     const deviceError = ref('');
+    const reauthIndex = ref(null);
     let pollController = null;
 
     let toastTimer = null;
@@ -157,6 +186,56 @@ export default {
       }
     }
 
+    async function refreshAccount(index) {
+      refreshing.value = index;
+      try {
+        await api.post(`/api/codex/account/${index}/refresh`);
+        showToast('Token refreshed');
+        await fetchStatus();
+      } catch (e) {
+        showToast(e.message || 'Refresh failed', 'error');
+      } finally {
+        refreshing.value = null;
+      }
+    }
+
+    function startEditLabel(index, current) {
+      editingLabel.value = index;
+      labelValue.value = current || '';
+      Vue.nextTick(() => {
+        const inputs = document.querySelectorAll('input.bg-gray-900');
+        if (inputs.length) inputs[inputs.length - 1].focus();
+      });
+    }
+
+    async function saveLabel(index) {
+      try {
+        await api.put(`/api/codex/account/${index}/label`, { label: labelValue.value });
+        showToast('Label updated');
+        editingLabel.value = null;
+        await fetchStatus();
+      } catch (e) {
+        showToast(e.message || 'Failed to save label', 'error');
+      }
+    }
+
+    async function deleteAccount(index, name) {
+      const label = name && name !== '—' ? name : `account #${index + 1}`;
+      if (!confirm(`Delete ${label}? Requires restart to apply.`)) return;
+      try {
+        await api.del(`/api/codex/account/${index}`);
+        showToast(`Deleted ${label}. Restart required.`);
+        await fetchStatus();
+      } catch (e) {
+        showToast(e.message || 'Failed to delete account', 'error');
+      }
+    }
+
+    function startReauth(index) {
+      reauthIndex.value = index;
+      startDeviceLogin();
+    }
+
     async function startDeviceLogin() {
       deviceLoading.value = true;
       try {
@@ -168,25 +247,6 @@ export default {
         showToast(e.message || 'Failed to request device code', 'error');
       } finally {
         deviceLoading.value = false;
-      }
-    }
-
-    const reauthIndex = ref(null);
-
-    function startReauth(index) {
-      reauthIndex.value = index;
-      startDeviceLogin();
-    }
-
-    async function deleteAccount(index, email) {
-      const label = email && email !== '—' ? email : `account #${index + 1}`;
-      if (!confirm(`Delete ${label}? Requires restart to apply.`)) return;
-      try {
-        await api.del(`/api/codex/account/${index}`);
-        showToast(`Deleted ${label}. Restart required.`);
-        fetchStatus();
-      } catch (e) {
-        showToast(e.message || 'Failed to delete account', 'error');
       }
     }
 
@@ -225,9 +285,11 @@ export default {
     });
 
     return {
-      loading, error, data, toast,
+      loading, error, data, toast, refreshing,
+      editingLabel, labelValue,
       deviceState, deviceLoading, deviceInfo, deviceResult, deviceError,
-      fetchStatus, startDeviceLogin, cancelDeviceLogin,
+      fetchStatus, refreshAccount, startEditLabel, saveLabel,
+      startDeviceLogin, cancelDeviceLogin,
       deleteAccount, startReauth,
     };
   },


### PR DESCRIPTION
## Summary
Three additions to the Codex Auth WebUI page:

### 1. Editable account labels
Click-to-edit label field per account. Persists in the credentials file and survives token refreshes. Lets you distinguish "Personal", "Work", "Friend's Business" when all accounts share the same email.

### 2. Plan type display
Extracts `chatgpt_plan_type` from the JWT (plus/team/enterprise) and shows it as a colored badge. Extracted during both token refresh and initial login.

### 3. Refresh button
Per-account token refresh button. Forces an immediate token refresh and updates the status display — no need to wait for Odin to use the token or restart.

### API
- `PUT /api/codex/account/{index}/label` — set account label
- `POST /api/codex/account/{index}/refresh` — force token refresh

## Test plan
- [ ] Click label cell → inline edit → save persists
- [ ] Refresh button updates expired token to active
- [ ] Plan type shows after refresh (plus/team badge)
- [ ] Labels survive token refresh cycles