### PR TITLE
fix: pool rotation on refresh failure + live management

### DIFF
--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -382,17 +382,33 @@ class CodexAuthPool:
         return self._accounts[self._current_index]
 
     async def get_access_token(self) -> str:
-        """Get a token from the current account, rotating if rate-limited."""
+        """Get a token from the current account, rotating on failure or rate-limit."""
         if not self._accounts:
             raise RuntimeError("No Codex credentials configured.")
         async with self._pool_lock:
-            for _ in range(len(self._accounts)):
+            errors = []
+            for attempt in range(len(self._accounts)):
                 auth = self._accounts[self._current_index]
-                if not auth.is_rate_limited():
+                if auth.is_rate_limited():
+                    self._rotate()
+                    continue
+                try:
                     return await auth.get_access_token()
-                self._rotate()
-            log.warning("All %d Codex accounts rate-limited, using current", len(self._accounts))
-            return await self._accounts[self._current_index].get_access_token()
+                except Exception as e:
+                    idx = self._current_index
+                    try:
+                        email = auth._load().get("email", f"account {idx}")
+                    except Exception:
+                        email = f"account {idx}"
+                    log.warning("Codex account %s failed: %s — rotating to next", email, e)
+                    errors.append((idx, str(e)))
+                    auth.mark_rate_limited()
+                    if len(self._accounts) > 1:
+                        self._rotate()
+            raise RuntimeError(
+                f"All {len(self._accounts)} Codex accounts failed: "
+                + "; ".join(f"#{i}: {err}" for i, err in errors)
+            )
 
     def get_account_id(self) -> str | None:
         if not self._accounts:
@@ -420,3 +436,22 @@ class CodexAuthPool:
 
     def _rotate(self) -> None:
         self._current_index = (self._current_index + 1) % len(self._accounts)
+
+    async def set_active(self, index: int) -> None:
+        """Switch the active account to the given index."""
+        if index < 0 or index >= len(self._accounts):
+            raise ValueError(f"index {index} out of range (0-{len(self._accounts)-1})")
+        async with self._pool_lock:
+            self._current_index = index
+            try:
+                email = self._accounts[index]._load().get("email", f"account {index}")
+            except Exception:
+                email = f"account {index}"
+            log.info("Active Codex account switched to %s (#%d)", email, index)
+
+    def reload(self) -> None:
+        """Reload the pool from the canonical credentials file."""
+        self._accounts.clear()
+        self._current_index = 0
+        self._init_accounts()
+        log.info("Codex auth pool reloaded: %d account(s)", len(self._accounts))

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2714,12 +2714,16 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             path.parent.mkdir(parents=True, exist_ok=True)
             _atomic_write_secure(path, _json.dumps(creds, indent=2))
 
+        # Auto-reload pool if available
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool:
+            pool.reload()
+
         return web.json_response({
             "status": "authenticated",
             "email": creds.get("email", "unknown"),
             "account_id": creds.get("account_id", ""),
-            "restart_required": True,
-            "message": "Credentials saved. Restart Odin to load into the active pool.",
         })
 
     @routes.post("/api/codex/account/{index}/refresh")
@@ -2761,6 +2765,35 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             })
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
+
+    @routes.post("/api/codex/account/{index}/activate")
+    async def codex_activate_account(request: web.Request) -> web.Response:
+        try:
+            index = int(request.match_info["index"])
+        except ValueError:
+            return web.json_response({"error": "index must be an integer"}, status=400)
+
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool is None:
+            return web.json_response({"error": "codex not configured"}, status=503)
+        try:
+            await pool.set_active(index)
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+        return web.json_response({"status": "activated", "active_index": index})
+
+    @routes.post("/api/codex/reload")
+    async def codex_reload(_request: web.Request) -> web.Response:
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool is None:
+            return web.json_response({"error": "codex not configured"}, status=503)
+        pool.reload()
+        return web.json_response({
+            "status": "reloaded",
+            "account_count": pool.account_count,
+        })
 
     @routes.put("/api/codex/account/{index}/label")
     async def codex_set_label(request: web.Request) -> web.Response:
@@ -2846,11 +2879,14 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         else:
             return web.json_response({"error": "invalid index"}, status=400)
 
+        pool = getattr(bot, "codex_client", None)
+        pool = getattr(pool, "auth", None) if pool else None
+        if pool:
+            pool.reload()
+
         return web.json_response({
             "status": "deleted",
             "email": email,
-            "restart_required": True,
-            "message": "Account removed. Restart Odin to apply.",
         })
 
     # ------------------------------------------------------------------

--- a/ui/js/pages/codex-auth.js
+++ b/ui/js/pages/codex-auth.js
@@ -87,6 +87,8 @@ export default {
                   <span v-if="a.is_current" class="text-xs px-1 rounded bg-indigo-900 text-indigo-300">Current</span>
                 </td>
                 <td class="text-center text-xs space-x-2">
+                  <button v-if="!a.is_current" @click="activateAccount(a.index)"
+                          class="text-green-400 hover:text-green-300">Activate</button>
                   <button @click="refreshAccount(a.index)" :disabled="refreshing === a.index"
                           class="text-blue-400 hover:text-blue-300">
                     {{ refreshing === a.index ? 'Refreshing...' : 'Refresh' }}
@@ -130,8 +132,7 @@ export default {
           </div>
 
           <div v-else-if="deviceState === 'success'" class="p-4 bg-green-900/30 rounded border border-green-800">
-            <p class="text-green-400 text-sm">Authenticated as {{ deviceResult.email }}.</p>
-            <p class="text-xs text-gray-400 mt-1">Restart Odin to load the new credentials into the active pool.</p>
+            <p class="text-green-400 text-sm">Authenticated as {{ deviceResult.email }}. Pool reloaded.</p>
             <button @click="deviceState = null" class="btn btn-ghost text-xs mt-2">Done</button>
           </div>
 
@@ -186,6 +187,16 @@ export default {
       }
     }
 
+    async function activateAccount(index) {
+      try {
+        await api.post(`/api/codex/account/${index}/activate`);
+        showToast('Active account switched');
+        await fetchStatus();
+      } catch (e) {
+        showToast(e.message || 'Failed to activate', 'error');
+      }
+    }
+
     async function refreshAccount(index) {
       refreshing.value = index;
       try {
@@ -221,10 +232,10 @@ export default {
 
     async function deleteAccount(index, name) {
       const label = name && name !== '—' ? name : `account #${index + 1}`;
-      if (!confirm(`Delete ${label}? Requires restart to apply.`)) return;
+      if (!confirm(`Delete ${label}?`)) return;
       try {
         await api.del(`/api/codex/account/${index}`);
-        showToast(`Deleted ${label}. Restart required.`);
+        showToast(`Deleted ${label}. Pool reloaded.`);
         await fetchStatus();
       } catch (e) {
         showToast(e.message || 'Failed to delete account', 'error');
@@ -288,7 +299,7 @@ export default {
       loading, error, data, toast, refreshing,
       editingLabel, labelValue,
       deviceState, deviceLoading, deviceInfo, deviceResult, deviceError,
-      fetchStatus, refreshAccount, startEditLabel, saveLabel,
+      fetchStatus, activateAccount, refreshAccount, startEditLabel, saveLabel,
       startDeviceLogin, cancelDeviceLogin,
       deleteAccount, startReauth,
     };


### PR DESCRIPTION
## Summary
Fixes the critical bug where Odin refuses to work when the primary OAuth token expires, even with 2 valid backup tokens available. Also eliminates the need to restart after auth changes.

### Bug fix: refresh failure rotation
`get_access_token()` now catches refresh failures (expired refresh token, network errors) and rotates to the next account instead of raising immediately. Marks the failed account as rate-limited, logs the failure, and tries the next one. Only raises if ALL accounts fail.

Before: token #0 refresh fails → RuntimeError → Odin refuses to respond
After: token #0 refresh fails → log warning → rotate to #1 → continue working

### Live pool management (no restart)
- `POST /api/codex/reload` — reinitializes pool from canonical file
- `POST /api/codex/account/{index}/activate` — switch active account live
- Device login and delete auto-reload the pool
- WebUI "Activate" button per account
- All restart messaging removed

### New CodexAuthPool methods
- `set_active(index)` — switch active account with pool lock
- `reload()` — clear and reinitialize from canonical credentials file

## Test plan
- [ ] Expire one token manually, verify Odin rotates to next and keeps working
- [ ] Click Activate on non-current account, verify it switches immediately
- [ ] Device login a new account, verify pool reloads without restart
- [ ] Delete an account, verify pool reloads without restart