### PR TITLE
feat: API access control for web-chat and API (v4)

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -420,6 +420,9 @@ class OdinBot(commands.Bot):
             overrides_path=config.permissions.overrides_path,
         )
 
+        from ..permissions.token_manager import ApiTokenManager
+        self.api_token_manager = ApiTokenManager("./data/api_tokens.json")
+
         self.tool_memory = ToolMemory("./data/tool_memory.json")
 
         # Wire optional services into skill manager for expanded skill context

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -522,6 +522,7 @@ class HealthServer:
             self._app, bot, api_token=self._web_config.api_token,
             web_config=self._web_config,
         )
+        self._app["ws_manager"] = self._ws_manager
         # Wire audit events to WebSocket for live dashboard/log updates
         ws_mgr = self._ws_manager
         bot.audit.set_event_callback(ws_mgr.broadcast_event)

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -168,8 +168,11 @@ def _make_auth_middleware(
             if token and hmac.compare_digest(bearer_value, token):
                 request._session_id = "admin-token"
                 return await handler(request)
-            # Check multi-token identities
-            identity = web_config.resolve_api_identity(bearer_value) if hasattr(web_config, "resolve_api_identity") else None
+            # Check dynamic token manager first, then static config tokens
+            tm = request.app.get("token_manager")
+            identity = tm.resolve(bearer_value) if tm else None
+            if identity is None and hasattr(web_config, "resolve_api_identity"):
+                identity = web_config.resolve_api_identity(bearer_value)
             if identity is not None:
                 request._session_id = identity.user_id
                 request._api_identity = identity
@@ -188,12 +191,14 @@ def _make_auth_middleware(
             if token and hmac.compare_digest(query_token, token):
                 request._session_id = "admin-token"
                 return await handler(request)
-            if hasattr(web_config, "resolve_api_identity"):
+            tm = request.app.get("token_manager")
+            identity = tm.resolve(query_token) if tm else None
+            if identity is None and hasattr(web_config, "resolve_api_identity"):
                 identity = web_config.resolve_api_identity(query_token)
-                if identity is not None:
-                    request._session_id = identity.user_id
-                    request._api_identity = identity
-                    return await handler(request)
+            if identity is not None:
+                request._session_id = identity.user_id
+                request._api_identity = identity
+                return await handler(request)
             if session_manager.validate(query_token):
                 request._session_id = query_token
                 session_identity = session_manager.get_identity(query_token)
@@ -500,8 +505,10 @@ class HealthServer:
         from ..web.api import setup_api
         from ..web.websocket import setup_websocket
         setup_api(self._app, bot)
+        self._app["token_manager"] = getattr(bot, "api_token_manager", None)
         self._ws_manager = setup_websocket(
             self._app, bot, api_token=self._web_config.api_token,
+            web_config=self._web_config,
         )
         # Wire audit events to WebSocket for live dashboard/log updates
         ws_mgr = self._ws_manager

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -155,7 +155,8 @@ def _make_auth_middleware(
             return await handler(request)
         # Skip auth if no token configured (dev mode)
         token = web_config.api_token
-        has_any_token = token or getattr(web_config, "api_tokens", None)
+        tm = request.app.get("token_manager")
+        has_any_token = token or getattr(web_config, "api_tokens", None) or (tm and tm.list_tokens())
         if not has_any_token:
             return await handler(request)
 

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -116,6 +116,17 @@ class SessionManager:
         self._identities.pop(sid, None)
         return self._sessions.pop(sid, None) is not None
 
+    def destroy_by_user_id(self, user_id: str) -> int:
+        """Destroy all sessions whose bound identity has the given user_id."""
+        to_remove = []
+        for sid, identity in self._identities.items():
+            if getattr(identity, "user_id", None) == user_id:
+                to_remove.append(sid)
+        for sid in to_remove:
+            self._sessions.pop(sid, None)
+            self._identities.pop(sid, None)
+        return len(to_remove)
+
     def cleanup(self) -> int:
         """Remove expired sessions. Returns count removed."""
         if self._timeout <= 0:

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -40,6 +40,7 @@ class HostAccessManager:
         self._users: dict[str, HostAccessEntry] = {}
         self._default_policy = HostAccessEntry()
         self._available_hosts: list[str] = available_hosts or []
+        self._transient_scopes: dict[str, list[str]] = {}
         self._load()
 
     def _load(self) -> None:
@@ -80,11 +81,24 @@ class HostAccessManager:
     def get_entry(self, user_id: str) -> HostAccessEntry:
         return self._users.get(user_id, self._default_policy)
 
+    def set_transient_scope(self, user_id: str, allowed_hosts: list[str]) -> None:
+        """Set a non-persisted host scope for API token enforcement."""
+        self._transient_scopes[user_id] = allowed_hosts
+
+    def clear_transient_scope(self, user_id: str) -> None:
+        """Remove a transient host scope."""
+        self._transient_scopes.pop(user_id, None)
+
     def get_allowed_hosts(self, user_id: str) -> list[str]:
         entry = self.get_entry(user_id)
         if entry.allowed_hosts is None:
-            return list(self._available_hosts)
-        return [h for h in entry.allowed_hosts if h in self._available_hosts]
+            base = list(self._available_hosts)
+        else:
+            base = [h for h in entry.allowed_hosts if h in self._available_hosts]
+        scope = self._transient_scopes.get(user_id)
+        if scope is not None:
+            base = [h for h in base if h in scope]
+        return base
 
     def get_default_host(self, user_id: str) -> str:
         entry = self.get_entry(user_id)
@@ -96,8 +110,13 @@ class HostAccessManager:
     def is_host_allowed(self, user_id: str, host: str) -> bool:
         entry = self.get_entry(user_id)
         if entry.allowed_hosts is None:
-            return host in self._available_hosts
-        return host in entry.allowed_hosts and host in self._available_hosts
+            allowed = host in self._available_hosts
+        else:
+            allowed = host in entry.allowed_hosts and host in self._available_hosts
+        scope = self._transient_scopes.get(user_id)
+        if scope is not None:
+            allowed = allowed and host in scope
+        return allowed
 
     def has_user_entry(self, user_id: str) -> bool:
         return user_id in self._users

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 from pathlib import Path
 
 from ..odin_log import get_logger
 
 log = get_logger("host_access")
+
+_request_host_scope: contextvars.ContextVar[list[str] | None] = contextvars.ContextVar("_request_host_scope", default=None)
 
 
 class HostAccessEntry:
@@ -40,7 +43,6 @@ class HostAccessManager:
         self._users: dict[str, HostAccessEntry] = {}
         self._default_policy = HostAccessEntry()
         self._available_hosts: list[str] = available_hosts or []
-        self._transient_scopes: dict[str, list[str]] = {}
         self._load()
 
     def _load(self) -> None:
@@ -81,13 +83,15 @@ class HostAccessManager:
     def get_entry(self, user_id: str) -> HostAccessEntry:
         return self._users.get(user_id, self._default_policy)
 
-    def set_transient_scope(self, user_id: str, allowed_hosts: list[str]) -> None:
-        """Set a non-persisted host scope for API token enforcement."""
-        self._transient_scopes[user_id] = allowed_hosts
+    @staticmethod
+    def set_request_host_scope(allowed_hosts: list[str]) -> contextvars.Token:
+        """Set a request-scoped host scope (concurrency-safe via contextvars)."""
+        return _request_host_scope.set(allowed_hosts)
 
-    def clear_transient_scope(self, user_id: str) -> None:
-        """Remove a transient host scope."""
-        self._transient_scopes.pop(user_id, None)
+    @staticmethod
+    def reset_request_host_scope(token: contextvars.Token) -> None:
+        """Reset the request-scoped host scope."""
+        _request_host_scope.reset(token)
 
     def get_allowed_hosts(self, user_id: str) -> list[str]:
         entry = self.get_entry(user_id)
@@ -95,7 +99,7 @@ class HostAccessManager:
             base = list(self._available_hosts)
         else:
             base = [h for h in entry.allowed_hosts if h in self._available_hosts]
-        scope = self._transient_scopes.get(user_id)
+        scope = _request_host_scope.get()
         if scope is not None:
             base = [h for h in base if h in scope]
         return base
@@ -113,7 +117,7 @@ class HostAccessManager:
             allowed = host in self._available_hosts
         else:
             allowed = host in entry.allowed_hosts and host in self._available_hosts
-        scope = self._transient_scopes.get(user_id)
+        scope = _request_host_scope.get()
         if scope is not None:
             allowed = allowed and host in scope
         return allowed

--- a/src/permissions/manager.py
+++ b/src/permissions/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 from pathlib import Path
 
@@ -9,6 +10,8 @@ from ..odin_log import get_logger
 log = get_logger("permissions")
 
 VALID_TIERS = ("admin", "user", "guest")
+
+_request_tier: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_tier", default=None)
 
 # Tools available to the "user" tier — read-only monitoring and search.
 # Everything else is admin-only.
@@ -40,7 +43,6 @@ class PermissionManager:
         self._default_tier = default_tier if default_tier in VALID_TIERS else "user"
         self._overrides_path = Path(overrides_path)
         self._overrides: dict[str, str] = {}
-        self._transient_tiers: dict[str, str] = {}
         self._lock = asyncio.Lock()
         self._load_overrides()
 
@@ -61,19 +63,21 @@ class PermissionManager:
         tmp.write_text(json.dumps(self._overrides, indent=2))
         tmp.replace(self._overrides_path)
 
-    def set_transient_tier(self, user_id: str, tier: str) -> None:
-        """Set a non-persisted tier for API/web-chat identity scoping."""
-        if tier in VALID_TIERS:
-            self._transient_tiers[user_id] = tier
+    @staticmethod
+    def set_request_tier(tier: str) -> contextvars.Token:
+        """Set a request-scoped tier override (concurrency-safe via contextvars)."""
+        return _request_tier.set(tier if tier in VALID_TIERS else None)
 
-    def clear_transient_tier(self, user_id: str) -> None:
-        """Remove a transient tier binding."""
-        self._transient_tiers.pop(user_id, None)
+    @staticmethod
+    def reset_request_tier(token: contextvars.Token) -> None:
+        """Reset the request-scoped tier override."""
+        _request_tier.reset(token)
 
     def get_tier(self, user_id: str) -> str:
-        """Get the permission tier for a user. Transient > overrides > config > default."""
-        if user_id in self._transient_tiers:
-            return self._transient_tiers[user_id]
+        """Get the permission tier. Request-scoped > overrides > config > default."""
+        req_tier = _request_tier.get()
+        if req_tier is not None:
+            return req_tier
         if user_id in self._overrides:
             return self._overrides[user_id]
         return self._config_tiers.get(user_id, self._default_tier)

--- a/src/permissions/manager.py
+++ b/src/permissions/manager.py
@@ -40,6 +40,7 @@ class PermissionManager:
         self._default_tier = default_tier if default_tier in VALID_TIERS else "user"
         self._overrides_path = Path(overrides_path)
         self._overrides: dict[str, str] = {}
+        self._transient_tiers: dict[str, str] = {}
         self._lock = asyncio.Lock()
         self._load_overrides()
 
@@ -60,8 +61,19 @@ class PermissionManager:
         tmp.write_text(json.dumps(self._overrides, indent=2))
         tmp.replace(self._overrides_path)
 
+    def set_transient_tier(self, user_id: str, tier: str) -> None:
+        """Set a non-persisted tier for API/web-chat identity scoping."""
+        if tier in VALID_TIERS:
+            self._transient_tiers[user_id] = tier
+
+    def clear_transient_tier(self, user_id: str) -> None:
+        """Remove a transient tier binding."""
+        self._transient_tiers.pop(user_id, None)
+
     def get_tier(self, user_id: str) -> str:
-        """Get the permission tier for a user. Runtime overrides take precedence."""
+        """Get the permission tier for a user. Transient > overrides > config > default."""
+        if user_id in self._transient_tiers:
+            return self._transient_tiers[user_id]
         if user_id in self._overrides:
             return self._overrides[user_id]
         return self._config_tiers.get(user_id, self._default_tier)

--- a/src/permissions/token_manager.py
+++ b/src/permissions/token_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import hmac
 import json
 import secrets
@@ -12,13 +13,26 @@ from ..odin_log import get_logger
 log = get_logger("token_manager")
 
 
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+class _StoredToken:
+    __slots__ = ("token_hash", "token_prefix", "identity")
+
+    def __init__(self, token_hash: str, token_prefix: str, identity: ApiTokenIdentity) -> None:
+        self.token_hash = token_hash
+        self.token_prefix = token_prefix
+        self.identity = identity
+
+
 class ApiTokenManager:
-    """Dynamic API token management with persistence and HMAC-safe lookup."""
+    """Dynamic API token management with hashed storage and HMAC-safe lookup."""
 
     def __init__(self, path: str = "./data/api_tokens.json") -> None:
         self._path = Path(path)
         self._lock = asyncio.Lock()
-        self._tokens: dict[str, ApiTokenIdentity] = {}
+        self._tokens: dict[str, _StoredToken] = {}
         self._load()
 
     def _load(self) -> None:
@@ -30,9 +44,21 @@ class ApiTokenManager:
                 return
             for entry in data:
                 try:
-                    identity = ApiTokenIdentity(**entry)
-                    if identity.user_id and identity.token:
-                        self._tokens[identity.user_id] = identity
+                    user_id = entry.get("user_id", "")
+                    token_hash = entry.get("token_hash", "")
+                    token_prefix = entry.get("token_prefix", "")
+                    if not user_id or not token_hash:
+                        continue
+                    identity = ApiTokenIdentity(
+                        token="",
+                        user_id=user_id,
+                        username=entry.get("username", "API"),
+                        tier=entry.get("tier", "admin"),
+                        label=entry.get("label", ""),
+                        allowed_tools=entry.get("allowed_tools", []),
+                        allowed_hosts=entry.get("allowed_hosts", []),
+                    )
+                    self._tokens[user_id] = _StoredToken(token_hash, token_prefix, identity)
                 except Exception as e:
                     log.warning("Skipping invalid token entry: %s", e)
         except (json.JSONDecodeError, OSError) as e:
@@ -40,32 +66,40 @@ class ApiTokenManager:
 
     def _save(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        data = [t.model_dump() for t in self._tokens.values()]
+        data = []
+        for st in self._tokens.values():
+            d = st.identity.model_dump()
+            del d["token"]
+            d["token_hash"] = st.token_hash
+            d["token_prefix"] = st.token_prefix
+            data.append(d)
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(data, indent=2))
         tmp.replace(self._path)
 
     def resolve(self, raw_token: str) -> ApiTokenIdentity | None:
-        """HMAC-safe lookup of a token. Returns identity or None."""
+        """HMAC-safe lookup by hashing the incoming token and comparing."""
         if not raw_token:
             return None
-        for identity in self._tokens.values():
-            if identity.token and hmac.compare_digest(identity.token, raw_token):
-                return identity
+        incoming_hash = _hash_token(raw_token)
+        for st in self._tokens.values():
+            if hmac.compare_digest(st.token_hash, incoming_hash):
+                return st.identity
         return None
 
     def list_tokens(self) -> list[dict]:
-        """Return all tokens with the token field masked."""
+        """Return all tokens with masked prefix for display."""
         result = []
-        for t in self._tokens.values():
-            d = t.model_dump()
-            d["token"] = d["token"][:8] + "..." if len(d["token"]) > 8 else "***"
+        for st in self._tokens.values():
+            d = st.identity.model_dump()
+            d["token"] = st.token_prefix + "..."
             d["source"] = "dynamic"
             result.append(d)
         return result
 
     def get(self, user_id: str) -> ApiTokenIdentity | None:
-        return self._tokens.get(user_id)
+        st = self._tokens.get(user_id)
+        return st.identity if st else None
 
     async def create_token(
         self,
@@ -76,13 +110,13 @@ class ApiTokenManager:
         allowed_tools: list[str] | None = None,
         allowed_hosts: list[str] | None = None,
     ) -> ApiTokenIdentity:
-        """Generate a new token. Returns the full identity including raw token."""
+        """Generate a new token. Returns identity with raw token (shown once)."""
         async with self._lock:
             if user_id in self._tokens:
                 raise ValueError(f"Token with user_id '{user_id}' already exists")
-            token = secrets.token_urlsafe(48)
+            raw_token = secrets.token_urlsafe(48)
             identity = ApiTokenIdentity(
-                token=token,
+                token=raw_token,
                 user_id=user_id,
                 username=username,
                 tier=tier,
@@ -90,7 +124,11 @@ class ApiTokenManager:
                 allowed_tools=allowed_tools or [],
                 allowed_hosts=allowed_hosts or [],
             )
-            self._tokens[user_id] = identity
+            self._tokens[user_id] = _StoredToken(
+                token_hash=_hash_token(raw_token),
+                token_prefix=raw_token[:8],
+                identity=ApiTokenIdentity(**{**identity.model_dump(), "token": ""}),
+            )
             self._save()
             log.info("Created API token for user_id=%s label=%s tier=%s", user_id, label, tier)
             return identity
@@ -98,26 +136,28 @@ class ApiTokenManager:
     async def update_token(self, user_id: str, **kwargs) -> ApiTokenIdentity | None:
         """Update fields on an existing token (not the token value itself)."""
         async with self._lock:
-            identity = self._tokens.get(user_id)
-            if identity is None:
+            st = self._tokens.get(user_id)
+            if st is None:
                 return None
             for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts"):
                 if field in kwargs:
-                    setattr(identity, field, kwargs[field])
+                    setattr(st.identity, field, kwargs[field])
             self._save()
             log.info("Updated API token for user_id=%s fields=%s", user_id, list(kwargs.keys()))
-            return identity
+            return st.identity
 
     async def regenerate_token(self, user_id: str) -> str | None:
-        """Generate a new token value for an existing identity. Returns raw token."""
+        """Generate a new token value. Returns raw token (shown once)."""
         async with self._lock:
-            identity = self._tokens.get(user_id)
-            if identity is None:
+            st = self._tokens.get(user_id)
+            if st is None:
                 return None
-            identity.token = secrets.token_urlsafe(48)
+            raw_token = secrets.token_urlsafe(48)
+            st.token_hash = _hash_token(raw_token)
+            st.token_prefix = raw_token[:8]
             self._save()
             log.info("Regenerated API token for user_id=%s", user_id)
-            return identity.token
+            return raw_token
 
     async def delete_token(self, user_id: str) -> bool:
         """Delete a token by user_id."""

--- a/src/permissions/token_manager.py
+++ b/src/permissions/token_manager.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import secrets
+from pathlib import Path
+
+from ..config.schema import ApiTokenIdentity
+from ..odin_log import get_logger
+
+log = get_logger("token_manager")
+
+
+class ApiTokenManager:
+    """Dynamic API token management with persistence and HMAC-safe lookup."""
+
+    def __init__(self, path: str = "./data/api_tokens.json") -> None:
+        self._path = Path(path)
+        self._lock = asyncio.Lock()
+        self._tokens: dict[str, ApiTokenIdentity] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+            if not isinstance(data, list):
+                return
+            for entry in data:
+                try:
+                    identity = ApiTokenIdentity(**entry)
+                    if identity.user_id and identity.token:
+                        self._tokens[identity.user_id] = identity
+                except Exception as e:
+                    log.warning("Skipping invalid token entry: %s", e)
+        except (json.JSONDecodeError, OSError) as e:
+            log.warning("Failed to load API tokens: %s", e)
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = [t.model_dump() for t in self._tokens.values()]
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._path)
+
+    def resolve(self, raw_token: str) -> ApiTokenIdentity | None:
+        """HMAC-safe lookup of a token. Returns identity or None."""
+        if not raw_token:
+            return None
+        for identity in self._tokens.values():
+            if identity.token and hmac.compare_digest(identity.token, raw_token):
+                return identity
+        return None
+
+    def list_tokens(self) -> list[dict]:
+        """Return all tokens with the token field masked."""
+        result = []
+        for t in self._tokens.values():
+            d = t.model_dump()
+            d["token"] = d["token"][:8] + "..." if len(d["token"]) > 8 else "***"
+            d["source"] = "dynamic"
+            result.append(d)
+        return result
+
+    def get(self, user_id: str) -> ApiTokenIdentity | None:
+        return self._tokens.get(user_id)
+
+    async def create_token(
+        self,
+        user_id: str,
+        username: str = "API",
+        tier: str = "admin",
+        label: str = "",
+        allowed_tools: list[str] | None = None,
+        allowed_hosts: list[str] | None = None,
+    ) -> ApiTokenIdentity:
+        """Generate a new token. Returns the full identity including raw token."""
+        async with self._lock:
+            if user_id in self._tokens:
+                raise ValueError(f"Token with user_id '{user_id}' already exists")
+            token = secrets.token_urlsafe(48)
+            identity = ApiTokenIdentity(
+                token=token,
+                user_id=user_id,
+                username=username,
+                tier=tier,
+                label=label,
+                allowed_tools=allowed_tools or [],
+                allowed_hosts=allowed_hosts or [],
+            )
+            self._tokens[user_id] = identity
+            self._save()
+            log.info("Created API token for user_id=%s label=%s tier=%s", user_id, label, tier)
+            return identity
+
+    async def update_token(self, user_id: str, **kwargs) -> ApiTokenIdentity | None:
+        """Update fields on an existing token (not the token value itself)."""
+        async with self._lock:
+            identity = self._tokens.get(user_id)
+            if identity is None:
+                return None
+            for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts"):
+                if field in kwargs:
+                    setattr(identity, field, kwargs[field])
+            self._save()
+            log.info("Updated API token for user_id=%s fields=%s", user_id, list(kwargs.keys()))
+            return identity
+
+    async def regenerate_token(self, user_id: str) -> str | None:
+        """Generate a new token value for an existing identity. Returns raw token."""
+        async with self._lock:
+            identity = self._tokens.get(user_id)
+            if identity is None:
+                return None
+            identity.token = secrets.token_urlsafe(48)
+            self._save()
+            log.info("Regenerated API token for user_id=%s", user_id)
+            return identity.token
+
+    async def delete_token(self, user_id: str) -> bool:
+        """Delete a token by user_id."""
+        async with self._lock:
+            if user_id in self._tokens:
+                del self._tokens[user_id]
+                self._save()
+                log.info("Deleted API token for user_id=%s", user_id)
+                return True
+        return False

--- a/src/permissions/token_manager.py
+++ b/src/permissions/token_manager.py
@@ -48,15 +48,28 @@ class ApiTokenManager:
                     token_hash = entry.get("token_hash", "")
                     token_prefix = entry.get("token_prefix", "")
                     if not user_id or not token_hash:
+                        log.warning("Skipping token entry: missing user_id or token_hash")
+                        continue
+                    tier = entry.get("tier", "admin")
+                    if tier not in ("admin", "user", "guest"):
+                        log.warning("Skipping token %s: invalid tier '%s'", user_id, tier)
+                        continue
+                    allowed_tools = entry.get("allowed_tools", [])
+                    if not isinstance(allowed_tools, list) or not all(isinstance(t, str) for t in allowed_tools):
+                        log.warning("Skipping token %s: allowed_tools must be a list of strings", user_id)
+                        continue
+                    allowed_hosts = entry.get("allowed_hosts", [])
+                    if not isinstance(allowed_hosts, list) or not all(isinstance(h, str) for h in allowed_hosts):
+                        log.warning("Skipping token %s: allowed_hosts must be a list of strings", user_id)
                         continue
                     identity = ApiTokenIdentity(
                         token="",
                         user_id=user_id,
-                        username=entry.get("username", "API"),
-                        tier=entry.get("tier", "admin"),
-                        label=entry.get("label", ""),
-                        allowed_tools=entry.get("allowed_tools", []),
-                        allowed_hosts=entry.get("allowed_hosts", []),
+                        username=str(entry.get("username", "API")),
+                        tier=tier,
+                        label=str(entry.get("label", "")),
+                        allowed_tools=allowed_tools,
+                        allowed_hosts=allowed_hosts,
                     )
                     self._tokens[user_id] = _StoredToken(token_hash, token_prefix, identity)
                 except Exception as e:

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -167,8 +167,11 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 })
             return web.json_response({"error": "no session manager"}, status=500)
 
-        # Check multi-token identities first
-        identity = bot.config.web.resolve_api_identity(token)
+        # Check dynamic token manager first, then static config tokens
+        tm = getattr(bot, "api_token_manager", None)
+        identity = tm.resolve(token) if tm else None
+        if identity is None:
+            identity = bot.config.web.resolve_api_identity(token)
         if identity is not None:
             sm = request.app.get("session_manager")
             if not sm:
@@ -190,7 +193,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not sm:
             return web.json_response({"error": "no session manager"}, status=500)
 
-        sid, timeout = sm.create()
+        from ..config.schema import ApiTokenIdentity
+        legacy_identity = ApiTokenIdentity(
+            token="", user_id="api-admin",
+            username="Admin", tier="admin", label="default",
+        )
+        sid, timeout = sm.create(identity=legacy_identity)
         return web.json_response({
             "session_id": sid,
             "timeout_seconds": timeout,
@@ -859,16 +867,21 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 {"error": f"content exceeds {MAX_CHAT_CONTENT_LEN} chars"}, status=400
             )
 
-        # Derive channel_id from the authenticated session to isolate web users.
-        # Ignore caller-supplied channel_id — identity must come from server side.
         session_id = getattr(request, "_session_id", None) or "web-anon"
         channel_id = f"web-{session_id[:16]}"
-        user_id = "web-user"
-        username = "WebUser"
+
+        identity = getattr(request, "_api_identity", None)
+        user_id = identity.user_id if identity else "web-user"
+        username = identity.username if identity else "WebUser"
+        tier = identity.tier if identity else None
+        token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
+        token_hosts = identity.allowed_hosts if identity and identity.allowed_hosts else None
 
         result = await process_web_chat(
             bot, content, channel_id,
             user_id=user_id, username=username,
+            allowed_tools=token_tools, tier=tier,
+            token_allowed_hosts=token_hosts,
         )
         status = 200 if not result["is_error"] else 502
         resp = {
@@ -909,15 +922,21 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if identity is None:
             auth_header = request.headers.get("Authorization", "")
             bearer_token = auth_header[7:] if auth_header.startswith("Bearer ") else ""
-            identity = bot.config.web.resolve_api_identity(bearer_token)
+            tm = getattr(bot, "api_token_manager", None)
+            identity = tm.resolve(bearer_token) if tm else None
+            if identity is None:
+                identity = bot.config.web.resolve_api_identity(bearer_token)
         user_id = identity.user_id if identity else "api-user"
         username = identity.username if identity else "API"
-        token_tools = identity.allowed_tools if identity is not None else None
+        token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
+        tier = identity.tier if identity else None
+        token_hosts = identity.allowed_hosts if identity and identity.allowed_hosts else None
 
         result = await process_web_chat(
             bot, content, channel_id,
             user_id=user_id, username=username,
-            allowed_tools=token_tools,
+            allowed_tools=token_tools, tier=tier,
+            token_allowed_hosts=token_hosts,
         )
 
         bot.sessions.reset(channel_id)
@@ -2966,6 +2985,128 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response({"error": "default_host must be a string"}, status=400)
         await ham.set_default_policy(allowed_hosts, default_host)
         return web.json_response({"status": "updated"})
+
+    # ------------------------------------------------------------------
+    # API Token Management
+    # ------------------------------------------------------------------
+
+    def _require_admin(request: web.Request) -> web.Response | None:
+        identity = getattr(request, "_api_identity", None)
+        if identity and getattr(identity, "tier", "admin") != "admin":
+            return web.json_response({"error": "admin access required"}, status=403)
+        return None
+
+    @routes.get("/api/tokens")
+    async def list_api_tokens(request: web.Request) -> web.Response:
+        denied = _require_admin(request)
+        if denied:
+            return denied
+        tm = getattr(bot, "api_token_manager", None)
+        tokens = tm.list_tokens() if tm else []
+        for t in bot.config.web.api_tokens:
+            d = t.model_dump()
+            d["token"] = d["token"][:8] + "..." if len(d.get("token", "")) > 8 else "***"
+            d["source"] = "config"
+            tokens.append(d)
+        ham = getattr(bot, "host_access_manager", None)
+        available_hosts = ham.available_hosts if ham else []
+        return web.json_response({"tokens": tokens, "available_hosts": available_hosts})
+
+    @routes.post("/api/tokens")
+    async def create_api_token(request: web.Request) -> web.Response:
+        denied = _require_admin(request)
+        if denied:
+            return denied
+        tm = getattr(bot, "api_token_manager", None)
+        if not tm:
+            return web.json_response({"error": "token manager not available"}, status=503)
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        user_id = (data.get("user_id") or "").strip()
+        if not user_id:
+            return web.json_response({"error": "user_id is required"}, status=400)
+        import re as _re
+        if not _re.fullmatch(r"[a-zA-Z0-9_.-]{1,64}", user_id):
+            return web.json_response({"error": "user_id must be alphanumeric/dash/underscore, max 64 chars"}, status=400)
+        tier = data.get("tier", "admin")
+        if tier not in ("admin", "user", "guest"):
+            return web.json_response({"error": "tier must be admin, user, or guest"}, status=400)
+        try:
+            identity = await tm.create_token(
+                user_id=user_id,
+                username=data.get("username") or "API",
+                tier=tier,
+                label=data.get("label") or "",
+                allowed_tools=data.get("allowed_tools"),
+                allowed_hosts=data.get("allowed_hosts"),
+            )
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=409)
+        return web.json_response({
+            "user_id": identity.user_id,
+            "token": identity.token,
+            "username": identity.username,
+            "tier": identity.tier,
+            "label": identity.label,
+            "allowed_tools": identity.allowed_tools,
+            "allowed_hosts": identity.allowed_hosts,
+        }, status=201)
+
+    @routes.put("/api/tokens/{user_id}")
+    async def update_api_token(request: web.Request) -> web.Response:
+        denied = _require_admin(request)
+        if denied:
+            return denied
+        tm = getattr(bot, "api_token_manager", None)
+        if not tm:
+            return web.json_response({"error": "token manager not available"}, status=503)
+        uid = request.match_info["user_id"]
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        kwargs = {}
+        for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts"):
+            if field in data:
+                kwargs[field] = data[field]
+        if "tier" in kwargs and kwargs["tier"] not in ("admin", "user", "guest"):
+            return web.json_response({"error": "tier must be admin, user, or guest"}, status=400)
+        if not kwargs:
+            return web.json_response({"error": "no fields to update"}, status=400)
+        identity = await tm.update_token(uid, **kwargs)
+        if identity is None:
+            return web.json_response({"error": "token not found"}, status=404)
+        return web.json_response({"user_id": uid, "status": "updated"})
+
+    @routes.post("/api/tokens/{user_id}/regenerate")
+    async def regenerate_api_token(request: web.Request) -> web.Response:
+        denied = _require_admin(request)
+        if denied:
+            return denied
+        tm = getattr(bot, "api_token_manager", None)
+        if not tm:
+            return web.json_response({"error": "token manager not available"}, status=503)
+        uid = request.match_info["user_id"]
+        new_token = await tm.regenerate_token(uid)
+        if new_token is None:
+            return web.json_response({"error": "token not found"}, status=404)
+        return web.json_response({"user_id": uid, "token": new_token})
+
+    @routes.delete("/api/tokens/{user_id}")
+    async def delete_api_token(request: web.Request) -> web.Response:
+        denied = _require_admin(request)
+        if denied:
+            return denied
+        tm = getattr(bot, "api_token_manager", None)
+        if not tm:
+            return web.json_response({"error": "token manager not available"}, status=503)
+        uid = request.match_info["user_id"]
+        deleted = await tm.delete_token(uid)
+        if not deleted:
+            return web.json_response({"error": "token not found"}, status=404)
+        return web.json_response({"user_id": uid, "status": "deleted"})
 
     # ------------------------------------------------------------------
     # Recovery stats (observability)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -155,7 +155,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response({"error": "token is required"}, status=400)
 
         api_token = bot.config.web.api_token
-        has_any_token = api_token or bot.config.web.api_tokens
+        tm = getattr(bot, "api_token_manager", None)
+        has_any_token = api_token or bot.config.web.api_tokens or (tm and tm.list_tokens())
         if not has_any_token:
             # No auth configured — dev mode, issue session anyway
             sm = request.app.get("session_manager")
@@ -3033,14 +3034,26 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         tier = data.get("tier", "admin")
         if tier not in ("admin", "user", "guest"):
             return web.json_response({"error": "tier must be admin, user, or guest"}, status=400)
+        allowed_tools = data.get("allowed_tools") or []
+        allowed_hosts = data.get("allowed_hosts") or []
+        if not isinstance(allowed_tools, list) or not all(isinstance(t, str) for t in allowed_tools):
+            return web.json_response({"error": "allowed_tools must be a list of strings"}, status=400)
+        if not isinstance(allowed_hosts, list) or not all(isinstance(h, str) for h in allowed_hosts):
+            return web.json_response({"error": "allowed_hosts must be a list of strings"}, status=400)
+        ham = getattr(bot, "host_access_manager", None)
+        if allowed_hosts and ham:
+            valid_hosts = set(ham.available_hosts)
+            bad = [h for h in allowed_hosts if h not in valid_hosts]
+            if bad:
+                return web.json_response({"error": f"unknown hosts: {', '.join(bad)}"}, status=400)
         try:
             identity = await tm.create_token(
                 user_id=user_id,
                 username=data.get("username") or "API",
                 tier=tier,
                 label=data.get("label") or "",
-                allowed_tools=data.get("allowed_tools"),
-                allowed_hosts=data.get("allowed_hosts"),
+                allowed_tools=allowed_tools,
+                allowed_hosts=allowed_hosts,
             )
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=409)
@@ -3073,6 +3086,18 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 kwargs[field] = data[field]
         if "tier" in kwargs and kwargs["tier"] not in ("admin", "user", "guest"):
             return web.json_response({"error": "tier must be admin, user, or guest"}, status=400)
+        if "allowed_tools" in kwargs:
+            if not isinstance(kwargs["allowed_tools"], list) or not all(isinstance(t, str) for t in kwargs["allowed_tools"]):
+                return web.json_response({"error": "allowed_tools must be a list of strings"}, status=400)
+        if "allowed_hosts" in kwargs:
+            if not isinstance(kwargs["allowed_hosts"], list) or not all(isinstance(h, str) for h in kwargs["allowed_hosts"]):
+                return web.json_response({"error": "allowed_hosts must be a list of strings"}, status=400)
+            ham = getattr(bot, "host_access_manager", None)
+            if kwargs["allowed_hosts"] and ham:
+                valid_hosts = set(ham.available_hosts)
+                bad = [h for h in kwargs["allowed_hosts"] if h not in valid_hosts]
+                if bad:
+                    return web.json_response({"error": f"unknown hosts: {', '.join(bad)}"}, status=400)
         if not kwargs:
             return web.json_response({"error": "no fields to update"}, status=400)
         identity = await tm.update_token(uid, **kwargs)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3117,6 +3117,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         new_token = await tm.regenerate_token(uid)
         if new_token is None:
             return web.json_response({"error": "token not found"}, status=404)
+        sm = request.app.get("session_manager")
+        if sm:
+            sm.destroy_by_user_id(uid)
         return web.json_response({"user_id": uid, "token": new_token})
 
     @routes.delete("/api/tokens/{user_id}")
@@ -3131,6 +3134,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         deleted = await tm.delete_token(uid)
         if not deleted:
             return web.json_response({"error": "token not found"}, status=404)
+        sm = request.app.get("session_manager")
+        if sm:
+            sm.destroy_by_user_id(uid)
         return web.json_response({"user_id": uid, "status": "deleted"})
 
     # ------------------------------------------------------------------

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3120,6 +3120,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         sm = request.app.get("session_manager")
         if sm:
             sm.destroy_by_user_id(uid)
+        ws_mgr = request.app.get("ws_manager")
+        if ws_mgr:
+            await ws_mgr.close_by_user_id(uid)
         return web.json_response({"user_id": uid, "token": new_token})
 
     @routes.delete("/api/tokens/{user_id}")
@@ -3137,6 +3140,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         sm = request.app.get("session_manager")
         if sm:
             sm.destroy_by_user_id(uid)
+        ws_mgr = request.app.get("ws_manager")
+        if ws_mgr:
+            await ws_mgr.close_by_user_id(uid)
         return web.json_response({"user_id": uid, "status": "deleted"})
 
     # ------------------------------------------------------------------

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -152,6 +152,8 @@ async def process_web_chat(
     user_id: str = "web-user",
     username: str = "WebUser",
     allowed_tools: list[str] | None = None,
+    tier: str | None = None,
+    token_allowed_hosts: list[str] | None = None,
 ) -> dict:
     """Process a web chat message through the Codex tool loop.
 
@@ -160,6 +162,30 @@ async def process_web_chat(
       - tools_used: list[str] — tool names called during processing
       - is_error: bool — whether an error occurred
     """
+    perm_mgr = getattr(bot, "permissions", None)
+    ham = getattr(bot, "host_access_manager", None)
+    if tier and perm_mgr:
+        perm_mgr.set_transient_tier(user_id, tier)
+    if token_allowed_hosts and ham:
+        ham.set_transient_scope(user_id, token_allowed_hosts)
+
+    try:
+        return await _do_process_web_chat(bot, content, channel_id, user_id, username, allowed_tools)
+    finally:
+        if tier and perm_mgr:
+            perm_mgr.clear_transient_tier(user_id)
+        if token_allowed_hosts and ham:
+            ham.clear_transient_scope(user_id)
+
+
+async def _do_process_web_chat(
+    bot: OdinBot,
+    content: str,
+    channel_id: str,
+    user_id: str,
+    username: str,
+    allowed_tools: list[str] | None,
+) -> dict:
     msg = WebMessage(channel_id=channel_id, user_id=user_id, username=username, content=content,
                      allowed_tools=allowed_tools)
     web_channel = msg.channel  # type: _WebChannel

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -162,20 +162,19 @@ async def process_web_chat(
       - tools_used: list[str] — tool names called during processing
       - is_error: bool — whether an error occurred
     """
-    perm_mgr = getattr(bot, "permissions", None)
-    ham = getattr(bot, "host_access_manager", None)
-    if tier and perm_mgr:
-        perm_mgr.set_transient_tier(user_id, tier)
-    if token_allowed_hosts and ham:
-        ham.set_transient_scope(user_id, token_allowed_hosts)
+    from ..permissions.manager import PermissionManager
+    from ..permissions.host_access import HostAccessManager
+
+    tier_token = PermissionManager.set_request_tier(tier) if tier else None
+    host_token = HostAccessManager.set_request_host_scope(token_allowed_hosts) if token_allowed_hosts else None
 
     try:
         return await _do_process_web_chat(bot, content, channel_id, user_id, username, allowed_tools)
     finally:
-        if tier and perm_mgr:
-            perm_mgr.clear_transient_tier(user_id)
-        if token_allowed_hosts and ham:
-            ham.clear_transient_scope(user_id)
+        if tier_token is not None:
+            PermissionManager.reset_request_tier(tier_token)
+        if host_token is not None:
+            HostAccessManager.reset_request_host_scope(host_token)
 
 
 async def _do_process_web_chat(

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -74,17 +74,24 @@ class WebSocketManager:
     async def handle(self, request: web.Request) -> web.WebSocketResponse:
         """Handle a WebSocket connection at /api/ws."""
         identity = getattr(request, "_api_identity", None)
-        if self._api_token:
+        if self._api_token or self._web_config:
             token = request.query.get("token", "")
-            valid = hmac.compare_digest(token, self._api_token)
-            if not valid and self._session_manager:
+            valid = bool(identity)
+            if not valid and self._api_token and token:
+                valid = hmac.compare_digest(token, self._api_token)
+            if not valid and self._session_manager and token:
                 valid = self._session_manager.validate(token)
+            if not valid and token:
+                resolved = self._resolve_identity(token, request)
+                if resolved is not None:
+                    identity = resolved
+                    valid = True
             if not valid:
                 ws = web.WebSocketResponse()
                 await ws.prepare(request)
                 await ws.close(code=4001, message=b"unauthorized")
                 return ws
-            if identity is None:
+            if identity is None and token:
                 identity = self._resolve_identity(token, request)
 
         ws = web.WebSocketResponse(heartbeat=30.0)

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -53,13 +53,18 @@ class WebSocketManager:
     def client_count(self) -> int:
         return len(self._clients)
 
-    def _resolve_identity(self, token: str):
+    def _resolve_identity(self, token: str, request=None):
         """Resolve an ApiTokenIdentity from a raw token string."""
         if self._session_manager:
             if self._session_manager.validate(token):
                 identity = self._session_manager.get_identity(token)
                 if identity is not None:
                     return identity
+        tm = request.app.get("token_manager") if request else None
+        if tm:
+            identity = tm.resolve(token)
+            if identity is not None:
+                return identity
         if self._web_config and hasattr(self._web_config, "resolve_api_identity"):
             identity = self._web_config.resolve_api_identity(token)
             if identity is not None:
@@ -80,7 +85,7 @@ class WebSocketManager:
                 await ws.close(code=4001, message=b"unauthorized")
                 return ws
             if identity is None:
-                identity = self._resolve_identity(token)
+                identity = self._resolve_identity(token, request)
 
         ws = web.WebSocketResponse(heartbeat=30.0)
         await ws.prepare(request)

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -243,6 +243,25 @@ class WebSocketManager:
             self._event_subscribers.discard(ws)
             self._clients.discard(ws)
 
+    async def close_by_user_id(self, user_id: str) -> int:
+        """Close all WebSocket connections for a given user_id."""
+        to_close = []
+        for ws in list(self._clients):
+            identity = getattr(ws, "_odin_identity", None)
+            if identity and getattr(identity, "user_id", None) == user_id:
+                to_close.append(ws)
+        for ws in to_close:
+            try:
+                await ws.close(code=4002, message=b"token revoked")
+            except Exception:
+                pass
+            self._clients.discard(ws)
+            self._log_subscribers.discard(ws)
+            self._event_subscribers.discard(ws)
+        if to_close:
+            log.info("Closed %d WebSocket connection(s) for revoked user_id=%s", len(to_close), user_id)
+        return len(to_close)
+
     async def _tail_logs(self, ws: web.WebSocketResponse) -> None:
         """Tail the audit log file and stream new lines to a client."""
         log_path = Path("./data/audit.jsonl")

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -32,13 +32,19 @@ _LOG_TAIL_LINES = 50
 _LOG_POLL_INTERVAL = 1.0
 
 
+_WS_CHAT_RATE_LIMIT = 10
+_WS_CHAT_RATE_WINDOW = 60.0
+_WS_CHAT_TIMEOUT = 300.0
+
+
 class WebSocketManager:
     """Manages WebSocket connections and broadcasts events."""
 
-    def __init__(self, bot: OdinBot, *, api_token: str = "", session_manager=None) -> None:
+    def __init__(self, bot: OdinBot, *, api_token: str = "", session_manager=None, web_config=None) -> None:
         self._bot = bot
         self._api_token = api_token
         self._session_manager = session_manager
+        self._web_config = web_config
         self._clients: set[web.WebSocketResponse] = set()
         self._log_subscribers: set[web.WebSocketResponse] = set()
         self._event_subscribers: set[web.WebSocketResponse] = set()
@@ -47,9 +53,22 @@ class WebSocketManager:
     def client_count(self) -> int:
         return len(self._clients)
 
+    def _resolve_identity(self, token: str):
+        """Resolve an ApiTokenIdentity from a raw token string."""
+        if self._session_manager:
+            if self._session_manager.validate(token):
+                identity = self._session_manager.get_identity(token)
+                if identity is not None:
+                    return identity
+        if self._web_config and hasattr(self._web_config, "resolve_api_identity"):
+            identity = self._web_config.resolve_api_identity(token)
+            if identity is not None:
+                return identity
+        return None
+
     async def handle(self, request: web.Request) -> web.WebSocketResponse:
         """Handle a WebSocket connection at /api/ws."""
-        # Authenticate via query param token (if configured)
+        identity = getattr(request, "_api_identity", None)
         if self._api_token:
             token = request.query.get("token", "")
             valid = hmac.compare_digest(token, self._api_token)
@@ -60,11 +79,14 @@ class WebSocketManager:
                 await ws.prepare(request)
                 await ws.close(code=4001, message=b"unauthorized")
                 return ws
+            if identity is None:
+                identity = self._resolve_identity(token)
 
         ws = web.WebSocketResponse(heartbeat=30.0)
         await ws.prepare(request)
         self._clients.add(ws)
         ws._odin_session_id = getattr(request, "_session_id", None) or "ws-anon"
+        ws._odin_identity = identity
         log.info("WebSocket client connected (%d total)", len(self._clients))
 
         log_task: asyncio.Task | None = None
@@ -137,18 +159,40 @@ class WebSocketManager:
             })
             return
 
+        import time as _time
+        now = _time.monotonic()
+        window_start = getattr(ws, "_chat_window_start", None)
+        if window_start is None or not isinstance(window_start, (int, float)) or now - window_start > _WS_CHAT_RATE_WINDOW:
+            ws._chat_window_start = now
+            ws._chat_count = 0
+        chat_count = getattr(ws, "_chat_count", None)
+        ws._chat_count = (chat_count + 1) if isinstance(chat_count, int) else 1
+        if ws._chat_count > _WS_CHAT_RATE_LIMIT:
+            await ws.send_json({"type": "chat_error", "error": "rate limit exceeded (10/min)"})
+            return
+
         channel_id = (data.get("channel_id") or "").strip()
         if not channel_id:
             ws_session_id = getattr(ws, "_odin_session_id", "ws-anon")
             channel_id = f"ws-{ws_session_id[:16]}"
-        user_id = "web-user"
-        username = "WebUser"
 
-        log.info("WebSocket chat from %s: %s", username, content[:80])
+        identity = getattr(ws, "_odin_identity", None)
+        user_id = identity.user_id if identity else "web-user"
+        username = identity.username if identity else "WebUser"
+        tier = identity.tier if identity else None
+        allowed_tools = identity.allowed_tools if identity and identity.allowed_tools else None
+        token_hosts = identity.allowed_hosts if identity and identity.allowed_hosts else None
+
+        log.info("WebSocket chat from %s (tier=%s): %s", username, tier or "default", content[:80])
         try:
-            result = await process_web_chat(
-                self._bot, content, channel_id,
-                user_id=user_id, username=username,
+            result = await asyncio.wait_for(
+                process_web_chat(
+                    self._bot, content, channel_id,
+                    user_id=user_id, username=username,
+                    allowed_tools=allowed_tools, tier=tier,
+                    token_allowed_hosts=token_hosts,
+                ),
+                timeout=_WS_CHAT_TIMEOUT,
             )
             resp = {
                 "type": "chat_response",
@@ -160,6 +204,11 @@ class WebSocketManager:
             if files:
                 resp["files"] = files
             await ws.send_json(resp)
+        except asyncio.TimeoutError:
+            await ws.send_json({
+                "type": "chat_error",
+                "error": f"Request timed out after {int(_WS_CHAT_TIMEOUT)}s. The operation may still be running.",
+            })
         except Exception as e:
             log.error("WebSocket chat error: %s", e, exc_info=True)
             await ws.send_json({
@@ -226,11 +275,11 @@ class WebSocketManager:
 
 
 def setup_websocket(
-    app: web.Application, bot: OdinBot, *, api_token: str = "",
+    app: web.Application, bot: OdinBot, *, api_token: str = "", web_config=None,
 ) -> WebSocketManager:
     """Register the WebSocket endpoint and return the manager."""
     session_manager = app.get("session_manager")
-    manager = WebSocketManager(bot, api_token=api_token, session_manager=session_manager)
+    manager = WebSocketManager(bot, api_token=api_token, session_manager=session_manager, web_config=web_config)
     app.router.add_get("/api/ws", manager.handle)
     log.info("WebSocket endpoint registered at /api/ws")
     return manager

--- a/tests/test_execute_api.py
+++ b/tests/test_execute_api.py
@@ -214,6 +214,7 @@ class TestRealHandler:
         bot.config = MagicMock()
         bot.config.web.api_token = ""
         bot.config.web.resolve_api_identity.return_value = None
+        bot.api_token_manager = None
         mock_result = {
             "response": "ok",
             "tools_used": [],
@@ -241,6 +242,7 @@ class TestRealHandler:
         bot.config = MagicMock()
         bot.config.web.api_token = ""
         bot.config.web.resolve_api_identity.return_value = None
+        bot.api_token_manager = None
         mock_result = {
             "response": "done",
             "tools_used": [],

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -215,6 +215,83 @@ class TestSetupWebsocket:
 
 
 # ---------------------------------------------------------------------------
+# WebSocket revocation
+# ---------------------------------------------------------------------------
+
+class TestCloseByUserId:
+    @pytest.mark.asyncio
+    async def test_closes_matching_user_only(self):
+        bot = _make_bot()
+        mgr = WebSocketManager(bot, api_token="tok")
+        ws_target = _make_ws()
+        ws_target._odin_identity = MagicMock(user_id="ci-bot")
+        ws_other = _make_ws()
+        ws_other._odin_identity = MagicMock(user_id="admin")
+        ws_none = _make_ws()
+        ws_none._odin_identity = None
+        mgr._clients = {ws_target, ws_other, ws_none}
+        mgr._log_subscribers = {ws_target, ws_other}
+        mgr._event_subscribers = {ws_target}
+
+        closed = await mgr.close_by_user_id("ci-bot")
+
+        assert closed == 1
+        ws_target.close.assert_awaited_once()
+        ws_other.close.assert_not_awaited()
+        ws_none.close.assert_not_awaited()
+        assert ws_target not in mgr._clients
+        assert ws_target not in mgr._log_subscribers
+        assert ws_target not in mgr._event_subscribers
+        assert ws_other in mgr._clients
+        assert ws_none in mgr._clients
+
+    @pytest.mark.asyncio
+    async def test_closes_multiple_connections_same_user(self):
+        bot = _make_bot()
+        mgr = WebSocketManager(bot, api_token="tok")
+        ws1 = _make_ws()
+        ws1._odin_identity = MagicMock(user_id="ci-bot")
+        ws2 = _make_ws()
+        ws2._odin_identity = MagicMock(user_id="ci-bot")
+        mgr._clients = {ws1, ws2}
+
+        closed = await mgr.close_by_user_id("ci-bot")
+
+        assert closed == 2
+        ws1.close.assert_awaited_once()
+        ws2.close.assert_awaited_once()
+        assert len(mgr._clients) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_zero(self):
+        bot = _make_bot()
+        mgr = WebSocketManager(bot, api_token="tok")
+        ws = _make_ws()
+        ws._odin_identity = MagicMock(user_id="admin")
+        mgr._clients = {ws}
+
+        closed = await mgr.close_by_user_id("nonexistent")
+
+        assert closed == 0
+        ws.close.assert_not_awaited()
+        assert ws in mgr._clients
+
+    @pytest.mark.asyncio
+    async def test_close_exception_does_not_propagate(self):
+        bot = _make_bot()
+        mgr = WebSocketManager(bot, api_token="tok")
+        ws = _make_ws()
+        ws._odin_identity = MagicMock(user_id="ci-bot")
+        ws.close = AsyncMock(side_effect=ConnectionError("already closed"))
+        mgr._clients = {ws}
+
+        closed = await mgr.close_by_user_id("ci-bot")
+
+        assert closed == 1
+        assert ws not in mgr._clients
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 

--- a/ui/js/pages/api-tokens.js
+++ b/ui/js/pages/api-tokens.js
@@ -1,0 +1,375 @@
+import { api } from '../api.js';
+
+const { ref, computed, onMounted, nextTick } = Vue;
+
+export default {
+  template: `
+    <div class="p-6 page-fade-in">
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold">API Tokens</h1>
+        <button @click="fetchData" class="btn btn-ghost text-xs" :disabled="loading">
+          {{ loading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+      <p class="text-xs text-gray-500 mb-6">
+        Manage API tokens for programmatic access, orchestrators, and web-chat identity.
+        Each token has its own user identity, permission tier, and host access scope.
+      </p>
+
+      <div v-if="loading && !tokens" class="space-y-2">
+        <div v-for="n in 3" :key="n" class="skeleton skeleton-row"></div>
+      </div>
+      <div v-else-if="error" class="hm-card border-red-900 error-state">
+        <p class="text-red-400">{{ error }}</p>
+        <button @click="fetchData" class="btn btn-ghost text-xs">Retry</button>
+      </div>
+
+      <div v-else class="space-y-6">
+        <!-- New token created banner -->
+        <div v-if="newToken" class="hm-card border-green-800 bg-green-950/30">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm font-semibold text-green-400">Token Created</span>
+            <button @click="newToken = null" class="text-gray-500 hover:text-gray-300 text-xs">Dismiss</button>
+          </div>
+          <p class="text-xs text-gray-400 mb-2">Copy this token now. It will not be shown again.</p>
+          <div class="flex items-center gap-2">
+            <code class="bg-gray-900 px-3 py-1.5 rounded text-sm text-green-300 flex-1 overflow-x-auto">{{ newToken }}</code>
+            <button @click="copyToken" class="btn btn-primary text-xs">Copy</button>
+          </div>
+        </div>
+
+        <!-- Create token form -->
+        <div class="hm-card">
+          <div class="flex items-center justify-between mb-3">
+            <h2 class="text-sm font-semibold text-gray-300">Create Token</h2>
+            <button @click="showCreate = !showCreate" class="btn btn-ghost text-xs">
+              {{ showCreate ? 'Cancel' : '+ New Token' }}
+            </button>
+          </div>
+          <div v-if="showCreate" class="space-y-3">
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">User ID (unique identifier)</label>
+                <input v-model="createForm.user_id" class="hm-input w-full text-sm"
+                       placeholder="e.g. orchestrator-1" />
+              </div>
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">Display Name</label>
+                <input v-model="createForm.username" class="hm-input w-full text-sm"
+                       placeholder="e.g. Task Orchestrator" />
+              </div>
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">Permission Tier</label>
+                <select v-model="createForm.tier" class="hm-input w-full text-sm">
+                  <option value="admin">admin — full tool access</option>
+                  <option value="user">user — read-only tools</option>
+                  <option value="guest">guest — chat only, no tools</option>
+                </select>
+              </div>
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">Label (description)</label>
+                <input v-model="createForm.label" class="hm-input w-full text-sm"
+                       placeholder="e.g. CI/CD pipeline" />
+              </div>
+            </div>
+            <div>
+              <label class="text-xs text-gray-500 block mb-1">Allowed Hosts (leave unchecked for host access default policy)</label>
+              <div class="flex flex-wrap gap-3">
+                <label v-for="host in availableHosts" :key="'ch-'+host"
+                       class="flex items-center gap-2 text-sm">
+                  <input type="checkbox" :checked="createForm.allowed_hosts.includes(host)"
+                         @change="toggleCreateHost(host, $event.target.checked)"
+                         class="rounded border-gray-600 bg-gray-800" />
+                  <span class="text-gray-300">{{ host }}</span>
+                </label>
+              </div>
+            </div>
+            <div>
+              <label class="text-xs text-gray-500 block mb-1">Allowed Tools (comma-separated, leave empty for tier default)</label>
+              <input v-model="createForm.allowed_tools_str" class="hm-input w-full text-sm"
+                     placeholder="e.g. run_command, web_search, fetch_url" />
+            </div>
+            <div class="flex justify-end">
+              <button @click="createToken" class="btn btn-primary text-sm" :disabled="!createForm.user_id.trim() || creating">
+                {{ creating ? 'Creating...' : 'Create Token' }}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Token list -->
+        <div class="hm-card">
+          <h2 class="text-sm font-semibold text-gray-300 mb-3">Active Tokens</h2>
+          <div v-if="!tokens || tokens.length === 0" class="text-xs text-gray-500 py-4 text-center">
+            No API tokens configured.
+          </div>
+          <div v-else class="overflow-x-auto">
+            <table class="hm-table w-full text-sm">
+              <thead>
+                <tr>
+                  <th class="text-left">User ID</th>
+                  <th class="text-left">Label</th>
+                  <th class="text-left">Tier</th>
+                  <th class="text-left">Hosts</th>
+                  <th class="text-left">Tools</th>
+                  <th class="text-left">Source</th>
+                  <th class="text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="t in tokens" :key="t.user_id">
+                  <td class="font-mono text-xs text-gray-300">{{ t.user_id }}</td>
+                  <td class="text-gray-400">{{ t.label || '—' }}</td>
+                  <td>
+                    <span :class="tierBadge(t.tier)">{{ t.tier }}</span>
+                  </td>
+                  <td class="text-gray-400 text-xs">
+                    {{ t.allowed_hosts && t.allowed_hosts.length ? t.allowed_hosts.join(', ') : 'default policy' }}
+                  </td>
+                  <td class="text-gray-400 text-xs">
+                    {{ t.allowed_tools && t.allowed_tools.length ? t.allowed_tools.length + ' tools' : 'tier default' }}
+                  </td>
+                  <td>
+                    <span class="text-xs px-1.5 py-0.5 rounded"
+                          :class="t.source === 'config' ? 'bg-gray-700 text-gray-400' : 'bg-blue-900/50 text-blue-400'">
+                      {{ t.source === 'config' ? 'config.yml' : 'dynamic' }}
+                    </span>
+                  </td>
+                  <td class="text-right space-x-2" v-if="t.source !== 'config'">
+                    <button @click="startEdit(t)" class="text-blue-400 hover:text-blue-300 text-xs">Edit</button>
+                    <button @click="confirmRegenerate(t)" class="text-yellow-400 hover:text-yellow-300 text-xs">Regen</button>
+                    <button @click="confirmDelete(t)" class="text-red-400 hover:text-red-300 text-xs">Delete</button>
+                  </td>
+                  <td class="text-right text-xs text-gray-600" v-else>read-only</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Edit modal -->
+        <div v-if="editing" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50" @click.self="editing = null">
+          <div class="hm-card w-full max-w-lg mx-4">
+            <h3 class="text-sm font-semibold text-gray-300 mb-4">Edit Token: {{ editing.user_id }}</h3>
+            <div class="space-y-3">
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="text-xs text-gray-500 block mb-1">Display Name</label>
+                  <input v-model="editForm.username" class="hm-input w-full text-sm" />
+                </div>
+                <div>
+                  <label class="text-xs text-gray-500 block mb-1">Tier</label>
+                  <select v-model="editForm.tier" class="hm-input w-full text-sm">
+                    <option value="admin">admin</option>
+                    <option value="user">user</option>
+                    <option value="guest">guest</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">Label</label>
+                <input v-model="editForm.label" class="hm-input w-full text-sm" />
+              </div>
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">Allowed Hosts</label>
+                <div class="flex flex-wrap gap-3">
+                  <label v-for="host in availableHosts" :key="'eh-'+host"
+                         class="flex items-center gap-2 text-sm">
+                    <input type="checkbox" :checked="editForm.allowed_hosts.includes(host)"
+                           @change="toggleEditHost(host, $event.target.checked)"
+                           class="rounded border-gray-600 bg-gray-800" />
+                    <span class="text-gray-300">{{ host }}</span>
+                  </label>
+                </div>
+              </div>
+              <div>
+                <label class="text-xs text-gray-500 block mb-1">Allowed Tools (comma-separated, empty for tier default)</label>
+                <input v-model="editForm.allowed_tools_str" class="hm-input w-full text-sm" />
+              </div>
+              <div class="flex justify-end gap-2 pt-2">
+                <button @click="editing = null" class="btn btn-ghost text-sm">Cancel</button>
+                <button @click="saveEdit" class="btn btn-primary text-sm" :disabled="saving">
+                  {{ saving ? 'Saving...' : 'Save' }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Toast -->
+      <div v-if="toast" class="fixed bottom-4 right-4 px-4 py-2 rounded shadow-lg text-sm z-50 transition-opacity"
+           :class="toast.ok ? 'bg-green-900 text-green-200' : 'bg-red-900 text-red-200'">
+        {{ toast.msg }}
+      </div>
+    </div>
+  `,
+  setup() {
+    const loading = ref(true);
+    const error = ref('');
+    const tokens = ref(null);
+    const availableHosts = ref([]);
+    const showCreate = ref(false);
+    const creating = ref(false);
+    const newToken = ref(null);
+    const editing = ref(null);
+    const saving = ref(false);
+    const toast = ref(null);
+
+    const createForm = ref({
+      user_id: '', username: '', tier: 'admin', label: '',
+      allowed_hosts: [], allowed_tools_str: '',
+    });
+
+    const editForm = ref({
+      username: '', tier: 'admin', label: '',
+      allowed_hosts: [], allowed_tools_str: '',
+    });
+
+    function showToast(msg, ok = true) {
+      toast.value = { msg, ok };
+      setTimeout(() => { toast.value = null; }, 3000);
+    }
+
+    function tierBadge(tier) {
+      if (tier === 'admin') return 'text-xs px-1.5 py-0.5 rounded bg-red-900/50 text-red-400';
+      if (tier === 'user') return 'text-xs px-1.5 py-0.5 rounded bg-blue-900/50 text-blue-400';
+      return 'text-xs px-1.5 py-0.5 rounded bg-gray-700 text-gray-400';
+    }
+
+    async function fetchData() {
+      loading.value = true;
+      error.value = '';
+      try {
+        const data = await api.get('/api/tokens');
+        tokens.value = data.tokens || [];
+        availableHosts.value = data.available_hosts || [];
+      } catch (e) {
+        error.value = e.message || 'Failed to load tokens';
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function parseTools(str) {
+      if (!str || !str.trim()) return [];
+      return str.split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    function toggleCreateHost(host, checked) {
+      const h = createForm.value.allowed_hosts;
+      if (checked && !h.includes(host)) h.push(host);
+      if (!checked) {
+        const i = h.indexOf(host);
+        if (i >= 0) h.splice(i, 1);
+      }
+    }
+
+    function toggleEditHost(host, checked) {
+      const h = editForm.value.allowed_hosts;
+      if (checked && !h.includes(host)) h.push(host);
+      if (!checked) {
+        const i = h.indexOf(host);
+        if (i >= 0) h.splice(i, 1);
+      }
+    }
+
+    async function createToken() {
+      creating.value = true;
+      try {
+        const tools = parseTools(createForm.value.allowed_tools_str);
+        const data = await api.post('/api/tokens', {
+          user_id: createForm.value.user_id.trim(),
+          username: createForm.value.username.trim() || 'API',
+          tier: createForm.value.tier,
+          label: createForm.value.label.trim(),
+          allowed_tools: tools.length ? tools : [],
+          allowed_hosts: createForm.value.allowed_hosts.length ? createForm.value.allowed_hosts : [],
+        });
+        newToken.value = data.token;
+        createForm.value = { user_id: '', username: '', tier: 'admin', label: '', allowed_hosts: [], allowed_tools_str: '' };
+        showCreate.value = false;
+        showToast('Token created');
+        await fetchData();
+      } catch (e) {
+        showToast(e.data?.error || e.message || 'Failed to create token', false);
+      } finally {
+        creating.value = false;
+      }
+    }
+
+    function startEdit(t) {
+      editing.value = t;
+      editForm.value = {
+        username: t.username || '',
+        tier: t.tier || 'admin',
+        label: t.label || '',
+        allowed_hosts: [...(t.allowed_hosts || [])],
+        allowed_tools_str: (t.allowed_tools || []).join(', '),
+      };
+    }
+
+    async function saveEdit() {
+      if (!editing.value) return;
+      saving.value = true;
+      try {
+        const tools = parseTools(editForm.value.allowed_tools_str);
+        await api.put('/api/tokens/' + encodeURIComponent(editing.value.user_id), {
+          username: editForm.value.username,
+          tier: editForm.value.tier,
+          label: editForm.value.label,
+          allowed_tools: tools,
+          allowed_hosts: editForm.value.allowed_hosts,
+        });
+        editing.value = null;
+        showToast('Token updated');
+        await fetchData();
+      } catch (e) {
+        showToast(e.data?.error || e.message || 'Failed to update', false);
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    async function confirmRegenerate(t) {
+      if (!confirm('Regenerate token for ' + t.user_id + '? The old token will stop working immediately.')) return;
+      try {
+        const data = await api.post('/api/tokens/' + encodeURIComponent(t.user_id) + '/regenerate');
+        newToken.value = data.token;
+        showToast('Token regenerated');
+      } catch (e) {
+        showToast(e.data?.error || e.message || 'Failed to regenerate', false);
+      }
+    }
+
+    async function confirmDelete(t) {
+      if (!confirm('Delete token for ' + t.user_id + '? This cannot be undone.')) return;
+      try {
+        await api.del('/api/tokens/' + encodeURIComponent(t.user_id));
+        showToast('Token deleted');
+        await fetchData();
+      } catch (e) {
+        showToast(e.data?.error || e.message || 'Failed to delete', false);
+      }
+    }
+
+    async function copyToken() {
+      if (!newToken.value) return;
+      try {
+        await navigator.clipboard.writeText(newToken.value);
+        showToast('Copied to clipboard');
+      } catch {
+        showToast('Copy failed — select and copy manually', false);
+      }
+    }
+
+    onMounted(fetchData);
+
+    return {
+      loading, error, tokens, availableHosts, showCreate, creating,
+      newToken, editing, saving, toast, createForm, editForm,
+      fetchData, tierBadge, toggleCreateHost, toggleEditHost,
+      createToken, startEdit, saveEdit, confirmRegenerate, confirmDelete, copyToken,
+    };
+  },
+};

--- a/ui/js/pages/system.js
+++ b/ui/js/pages/system.js
@@ -5,6 +5,7 @@ import LogsPage from './logs.js';
 import ConfigPage from './config.js';
 import DiscordConfigPage from './discord-config.js';
 import HostAccessPage from './host-access.js';
+import ApiTokensPage from './api-tokens.js';
 import CodexAuthPage from './codex-auth.js';
 import InternalsPage from './internals.js';
 import UpdatePage from './update.js';
@@ -19,6 +20,7 @@ export default {
       { id: 'config', label: 'Config', component: ConfigPage },
       { id: 'discord', label: 'Discord', component: DiscordConfigPage },
       { id: 'host-access', label: 'Host Access', component: HostAccessPage },
+      { id: 'api-tokens', label: 'API Tokens', component: ApiTokensPage },
       { id: 'codex', label: 'Codex Auth', component: CodexAuthPage },
       { id: 'internals', label: 'Internals', component: InternalsPage },
       { id: 'update', label: 'Update', component: UpdatePage },


### PR DESCRIPTION
## Summary

Replaces #85. Adds WebSocket connection revocation — the last blocking finding.

**Round 3 fix:**
- `WebSocketManager.close_by_user_id()` closes all live WebSocket connections for a revoked user_id (code 4002, "token revoked")
- Called from both token delete and regenerate endpoints alongside `SessionManager.destroy_by_user_id()`
- All three access paths now fully revoked: HTTP sessions, WebSocket connections, raw bearer tokens

**Full change set across 4 commits:**
1. Identity propagation, tier enforcement, host scoping, token manager, CRUD endpoints, WebUI page, rate limiting, timeout
2. Concurrency-safe contextvars, token hashing, auth detection, input validation
3. WS dynamic token auth, session revocation, loader validation
4. WebSocket connection revocation

## Test plan
- [ ] Connect WebSocket with dynamic token, delete token, verify WS is closed with code 4002
- [ ] Regenerate token, verify existing WS connections closed
- [ ] All 65 relevant tests pass