### PR TITLE
fix: token allowed_hosts authoritative when no host_access entry

### DIFF
--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -108,9 +108,15 @@ class HostAccessManager:
         return base
 
     def get_default_host(self, user_id: str) -> str:
+        scope = _request_host_scope.get()
+        has_own_entry = user_id in self._users
+        if scope is not None and not has_own_entry:
+            valid = [h for h in scope if h in self._available_hosts]
+            return valid[0] if valid else ""
         entry = self.get_entry(user_id)
         if entry.default_host and entry.default_host in self._available_hosts:
-            return entry.default_host
+            if scope is None or entry.default_host in scope:
+                return entry.default_host
         allowed = self.get_allowed_hosts(user_id)
         return allowed[0] if allowed else ""
 

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -94,12 +94,15 @@ class HostAccessManager:
         _request_host_scope.reset(token)
 
     def get_allowed_hosts(self, user_id: str) -> list[str]:
+        scope = _request_host_scope.get()
+        has_own_entry = user_id in self._users
+        if scope is not None and not has_own_entry:
+            return [h for h in scope if h in self._available_hosts]
         entry = self.get_entry(user_id)
         if entry.allowed_hosts is None:
             base = list(self._available_hosts)
         else:
             base = [h for h in entry.allowed_hosts if h in self._available_hosts]
-        scope = _request_host_scope.get()
         if scope is not None:
             base = [h for h in base if h in scope]
         return base
@@ -112,12 +115,15 @@ class HostAccessManager:
         return allowed[0] if allowed else ""
 
     def is_host_allowed(self, user_id: str, host: str) -> bool:
+        scope = _request_host_scope.get()
+        has_own_entry = user_id in self._users
+        if scope is not None and not has_own_entry:
+            return host in scope and host in self._available_hosts
         entry = self.get_entry(user_id)
         if entry.allowed_hosts is None:
             allowed = host in self._available_hosts
         else:
             allowed = host in entry.allowed_hosts and host in self._available_hosts
-        scope = _request_host_scope.get()
         if scope is not None:
             allowed = allowed and host in scope
         return allowed


### PR DESCRIPTION
## Summary

Bug fix for v3.27.0 identity-scoped sessions. When a token has `allowed_hosts` configured but the user_id has no explicit entry in `host_access.json`, the token's hosts should be the effective set — not intersected with `default_policy`.

**The bug**: Admin token configured with all hosts still got restricted to `playground` (the default policy) because the intersection of `token_hosts ∩ default_policy` narrowed it.

**The fix**: If a request-scoped host scope is set AND the user_id has no explicit host_access entry, use the scope directly as the authoritative host list. If the user HAS an explicit entry, intersection still applies (token scope narrows the entry).

## Test plan
- [ ] API call with Admin token (all hosts configured) can run commands on localhost
- [ ] Token with subset of hosts is restricted to those hosts only
- [ ] User with explicit host_access entry + token scope = intersection still works