### PR TITLE
fix: empty token allowed_hosts means deny-all

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -349,7 +349,7 @@ class ApiTokenIdentity(BaseModel):
     username: str = "API"
     tier: str = "admin"
     allowed_tools: list[str] = Field(default_factory=list)
-    allowed_hosts: list[str] = Field(default_factory=list)
+    allowed_hosts: list[str] | None = None
     label: str = ""
 
 

--- a/src/permissions/token_manager.py
+++ b/src/permissions/token_manager.py
@@ -58,9 +58,13 @@ class ApiTokenManager:
                     if not isinstance(allowed_tools, list) or not all(isinstance(t, str) for t in allowed_tools):
                         log.warning("Skipping token %s: allowed_tools must be a list of strings", user_id)
                         continue
-                    allowed_hosts = entry.get("allowed_hosts", [])
-                    if not isinstance(allowed_hosts, list) or not all(isinstance(h, str) for h in allowed_hosts):
-                        log.warning("Skipping token %s: allowed_hosts must be a list of strings", user_id)
+                    raw_hosts = entry.get("allowed_hosts")
+                    if raw_hosts is None:
+                        allowed_hosts = None
+                    elif isinstance(raw_hosts, list) and all(isinstance(h, str) for h in raw_hosts):
+                        allowed_hosts = raw_hosts
+                    else:
+                        log.warning("Skipping token %s: allowed_hosts must be a list of strings or null", user_id)
                         continue
                     identity = ApiTokenIdentity(
                         token="",
@@ -135,7 +139,7 @@ class ApiTokenManager:
                 tier=tier,
                 label=label,
                 allowed_tools=allowed_tools or [],
-                allowed_hosts=allowed_hosts or [],
+                allowed_hosts=allowed_hosts,
             )
             self._tokens[user_id] = _StoredToken(
                 token_hash=_hash_token(raw_token),

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -881,7 +881,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         username = identity.username if identity else "WebUser"
         tier = identity.tier if identity else None
         token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
-        token_hosts = identity.allowed_hosts if identity and identity.allowed_hosts else None
+        token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
 
         result = await process_web_chat(
             bot, content, channel_id,
@@ -936,7 +936,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         username = identity.username if identity else "API"
         token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         tier = identity.tier if identity else None
-        token_hosts = identity.allowed_hosts if identity and identity.allowed_hosts else None
+        token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
 
         result = await process_web_chat(
             bot, content, channel_id,

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3078,11 +3078,15 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if tier not in ("admin", "user", "guest"):
             return web.json_response({"error": "tier must be admin, user, or guest"}, status=400)
         allowed_tools = data.get("allowed_tools") or []
-        allowed_hosts = data.get("allowed_hosts") or []
+        raw_hosts = data.get("allowed_hosts")
+        if raw_hosts is None:
+            allowed_hosts = None
+        elif isinstance(raw_hosts, list) and all(isinstance(h, str) for h in raw_hosts):
+            allowed_hosts = raw_hosts
+        else:
+            return web.json_response({"error": "allowed_hosts must be a list of strings or null"}, status=400)
         if not isinstance(allowed_tools, list) or not all(isinstance(t, str) for t in allowed_tools):
             return web.json_response({"error": "allowed_tools must be a list of strings"}, status=400)
-        if not isinstance(allowed_hosts, list) or not all(isinstance(h, str) for h in allowed_hosts):
-            return web.json_response({"error": "allowed_hosts must be a list of strings"}, status=400)
         ham = getattr(bot, "host_access_manager", None)
         if allowed_hosts and ham:
             valid_hosts = set(ham.available_hosts)
@@ -3133,8 +3137,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             if not isinstance(kwargs["allowed_tools"], list) or not all(isinstance(t, str) for t in kwargs["allowed_tools"]):
                 return web.json_response({"error": "allowed_tools must be a list of strings"}, status=400)
         if "allowed_hosts" in kwargs:
-            if not isinstance(kwargs["allowed_hosts"], list) or not all(isinstance(h, str) for h in kwargs["allowed_hosts"]):
-                return web.json_response({"error": "allowed_hosts must be a list of strings"}, status=400)
+            if kwargs["allowed_hosts"] is not None:
+                if not isinstance(kwargs["allowed_hosts"], list) or not all(isinstance(h, str) for h in kwargs["allowed_hosts"]):
+                    return web.json_response({"error": "allowed_hosts must be a list of strings or null"}, status=400)
             ham = getattr(bot, "host_access_manager", None)
             if kwargs["allowed_hosts"] and ham:
                 valid_hosts = set(ham.available_hosts)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -173,7 +173,7 @@ async def process_web_chat(
     from ..permissions.host_access import HostAccessManager
 
     tier_token = PermissionManager.set_request_tier(tier) if tier else None
-    host_token = HostAccessManager.set_request_host_scope(token_allowed_hosts) if token_allowed_hosts else None
+    host_token = HostAccessManager.set_request_host_scope(token_allowed_hosts) if token_allowed_hosts is not None else None
 
     if not hasattr(bot, "_web_channel_locks"):
         bot._web_channel_locks = {}

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -189,7 +189,7 @@ class WebSocketManager:
         username = identity.username if identity else "WebUser"
         tier = identity.tier if identity else None
         allowed_tools = identity.allowed_tools if identity and identity.allowed_tools else None
-        token_hosts = identity.allowed_hosts if identity and identity.allowed_hosts else None
+        token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
 
         log.info("WebSocket chat from %s (tier=%s): %s", username, tier or "default", content[:80])
         try:

--- a/ui/js/pages/api-tokens.js
+++ b/ui/js/pages/api-tokens.js
@@ -73,8 +73,13 @@ export default {
               </div>
             </div>
             <div>
-              <label class="text-xs text-gray-500 block mb-1">Allowed Hosts (leave unchecked for host access default policy)</label>
-              <div class="flex flex-wrap gap-3">
+              <label class="text-xs text-gray-500 block mb-1">Host Access</label>
+              <select v-model="createForm.host_mode" class="hm-input w-full text-sm mb-2">
+                <option value="default">Use default host policy</option>
+                <option value="select">Restrict to selected hosts</option>
+                <option value="none">No host access (chat only)</option>
+              </select>
+              <div v-if="createForm.host_mode === 'select'" class="flex flex-wrap gap-3">
                 <label v-for="host in availableHosts" :key="'ch-'+host"
                        class="flex items-center gap-2 text-sm">
                   <input type="checkbox" :checked="createForm.allowed_hosts.includes(host)"
@@ -124,7 +129,7 @@ export default {
                     <span :class="tierBadge(t.tier)">{{ t.tier }}</span>
                   </td>
                   <td class="text-gray-400 text-xs">
-                    {{ t.allowed_hosts && t.allowed_hosts.length ? t.allowed_hosts.join(', ') : 'default policy' }}
+                    {{ t.allowed_hosts === null || t.allowed_hosts === undefined ? 'default policy' : t.allowed_hosts.length === 0 ? 'no host access' : t.allowed_hosts.join(', ') }}
                   </td>
                   <td class="text-gray-400 text-xs">
                     {{ t.allowed_tools && t.allowed_tools.length ? t.allowed_tools.length + ' tools' : 'tier default' }}
@@ -171,8 +176,13 @@ export default {
                 <input v-model="editForm.label" class="hm-input w-full text-sm" />
               </div>
               <div>
-                <label class="text-xs text-gray-500 block mb-1">Allowed Hosts</label>
-                <div class="flex flex-wrap gap-3">
+                <label class="text-xs text-gray-500 block mb-1">Host Access</label>
+                <select v-model="editForm.host_mode" class="hm-input w-full text-sm mb-2">
+                  <option value="default">Use default host policy</option>
+                  <option value="select">Restrict to selected hosts</option>
+                  <option value="none">No host access (chat only)</option>
+                </select>
+                <div v-if="editForm.host_mode === 'select'" class="flex flex-wrap gap-3">
                   <label v-for="host in availableHosts" :key="'eh-'+host"
                          class="flex items-center gap-2 text-sm">
                     <input type="checkbox" :checked="editForm.allowed_hosts.includes(host)"
@@ -218,12 +228,12 @@ export default {
 
     const createForm = ref({
       user_id: '', username: '', tier: 'admin', label: '',
-      allowed_hosts: [], allowed_tools_str: '',
+      host_mode: 'default', allowed_hosts: [], allowed_tools_str: '',
     });
 
     const editForm = ref({
       username: '', tier: 'admin', label: '',
-      allowed_hosts: [], allowed_tools_str: '',
+      host_mode: 'default', allowed_hosts: [], allowed_tools_str: '',
     });
 
     function showToast(msg, ok = true) {
@@ -278,16 +288,19 @@ export default {
       creating.value = true;
       try {
         const tools = parseTools(createForm.value.allowed_tools_str);
-        const data = await api.post('/api/tokens', {
+        const mode = createForm.value.host_mode;
+        const hostPayload = mode === 'none' ? [] : mode === 'select' ? createForm.value.allowed_hosts : null;
+        const body = {
           user_id: createForm.value.user_id.trim(),
           username: createForm.value.username.trim() || 'API',
           tier: createForm.value.tier,
           label: createForm.value.label.trim(),
           allowed_tools: tools.length ? tools : [],
-          allowed_hosts: createForm.value.allowed_hosts.length ? createForm.value.allowed_hosts : [],
-        });
+        };
+        if (hostPayload !== null) body.allowed_hosts = hostPayload;
+        const data = await api.post('/api/tokens', body);
         newToken.value = data.token;
-        createForm.value = { user_id: '', username: '', tier: 'admin', label: '', allowed_hosts: [], allowed_tools_str: '' };
+        createForm.value = { user_id: '', username: '', tier: 'admin', label: '', host_mode: 'default', allowed_hosts: [], allowed_tools_str: '' };
         showCreate.value = false;
         showToast('Token created');
         await fetchData();
@@ -300,11 +313,17 @@ export default {
 
     function startEdit(t) {
       editing.value = t;
+      const hosts = t.allowed_hosts;
+      let mode = 'default';
+      if (hosts === null || hosts === undefined) mode = 'default';
+      else if (Array.isArray(hosts) && hosts.length === 0) mode = 'none';
+      else if (Array.isArray(hosts)) mode = 'select';
       editForm.value = {
         username: t.username || '',
         tier: t.tier || 'admin',
         label: t.label || '',
-        allowed_hosts: [...(t.allowed_hosts || [])],
+        host_mode: mode,
+        allowed_hosts: Array.isArray(hosts) ? [...hosts] : [],
         allowed_tools_str: (t.allowed_tools || []).join(', '),
       };
     }
@@ -314,13 +333,17 @@ export default {
       saving.value = true;
       try {
         const tools = parseTools(editForm.value.allowed_tools_str);
-        await api.put('/api/tokens/' + encodeURIComponent(editing.value.user_id), {
+        const mode = editForm.value.host_mode;
+        const body = {
           username: editForm.value.username,
           tier: editForm.value.tier,
           label: editForm.value.label,
           allowed_tools: tools,
-          allowed_hosts: editForm.value.allowed_hosts,
-        });
+        };
+        if (mode === 'none') body.allowed_hosts = [];
+        else if (mode === 'select') body.allowed_hosts = editForm.value.allowed_hosts;
+        else body.allowed_hosts = null;
+        await api.put('/api/tokens/' + encodeURIComponent(editing.value.user_id), body);
         editing.value = null;
         showToast('Token updated');
         await fetchData();


### PR DESCRIPTION
## Summary

Fixes the edge case Odin flagged: empty `allowed_hosts: []` on a token was collapsed to `None` by falsy checks, making it mean "defer to default policy" instead of "deny all hosts".

**Before**: Token with no hosts checked → `[]` → falsy → `None` → no scope → default_policy applies
**After**: Token with no hosts checked → `[]` → preserved as `[]` → scope set → deny all hosts

Callers now use `isinstance(list)` instead of truthiness. `process_web_chat` checks `is not None`.

Discord users unaffected — they never go through the token scope path.

## Test plan
- [ ] Token with no hosts → cannot access any host (deny all)
- [ ] Token with hosts configured → only those hosts
- [ ] No token / legacy token → default_policy applies (unchanged)
- [ ] Discord users → host_access.json controls (unchanged)