### PR TITLE
fix: don't leak a per-channel lock for ephemeral /api/execute channels

### DIFF
--- a/src/web/api.py
+++ b/src/web/api.py
@@ -943,6 +943,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             user_id=user_id, username=username,
             allowed_tools=token_tools, tier=tier,
             token_allowed_hosts=token_hosts,
+            persist_channel_lock=False,  # ephemeral per-request channel — no lock to cache or leak
         )
 
         bot.sessions.reset(channel_id)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -161,8 +161,18 @@ async def process_web_chat(
     allowed_tools: list[str] | None = None,
     tier: str | None = None,
     token_allowed_hosts: list[str] | None = None,
+    persist_channel_lock: bool = True,
 ) -> dict:
     """Process a web chat message through the Codex tool loop.
+
+    persist_channel_lock: when True (default), concurrent calls sharing this
+        channel_id are serialized via a per-channel asyncio.Lock cached in
+        bot._web_channel_locks. Used by /api/chat and the WebSocket chat, where
+        channel_id == user_id and a user's overlapping requests must run one at
+        a time. Set False for single-use/ephemeral channels — e.g.
+        /api/execute's per-request UUID channels — which no other caller can
+        share: caching a lock there is pointless and leaks one permanent dict
+        entry per request, since the channel is reset and never reused.
 
     Returns dict with:
       - response: str — the LLM response text
@@ -175,12 +185,14 @@ async def process_web_chat(
     tier_token = PermissionManager.set_request_tier(tier) if tier else None
     host_token = HostAccessManager.set_request_host_scope(token_allowed_hosts) if token_allowed_hosts is not None else None
 
-    if not hasattr(bot, "_web_channel_locks"):
-        bot._web_channel_locks = {}
-    lock = bot._web_channel_locks.setdefault(channel_id, asyncio.Lock())
-
     try:
-        async with lock:
+        if persist_channel_lock:
+            if not hasattr(bot, "_web_channel_locks"):
+                bot._web_channel_locks = {}
+            lock = bot._web_channel_locks.setdefault(channel_id, asyncio.Lock())
+            async with lock:
+                return await _do_process_web_chat(bot, content, channel_id, user_id, username, allowed_tools)
+        else:
             return await _do_process_web_chat(bot, content, channel_id, user_id, username, allowed_tools)
     finally:
         if tier_token is not None:

--- a/tests/test_execute_api.py
+++ b/tests/test_execute_api.py
@@ -263,6 +263,31 @@ class TestRealHandler:
                 channel_id = bot.sessions.reset.call_args[0][0]
                 assert channel_id.startswith("api-")
 
+    @pytest.mark.asyncio
+    async def test_execute_opts_out_of_channel_lock(self):
+        """/api/execute must pass persist_channel_lock=False so it does not
+        cache (and leak) a per-request lock in bot._web_channel_locks."""
+        bot = _make_bot()
+        bot.config = MagicMock()
+        bot.config.web.api_token = ""
+        bot.config.web.resolve_api_identity.return_value = None
+        bot.api_token_manager = None
+        mock_result = {
+            "response": "ok",
+            "tools_used": [],
+            "is_error": False,
+            "files": [],
+        }
+        with patch("src.web.api.process_web_chat", new_callable=AsyncMock, return_value=mock_result):
+            from src.web.api import setup_api
+            app = web.Application()
+            setup_api(app, bot)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/api/execute", json={"prompt": "test"})
+                assert resp.status == 200
+                from src.web.api import process_web_chat
+                assert process_web_chat.call_args.kwargs["persist_channel_lock"] is False
+
 
 class TestCLIScript:
     def test_script_exists(self):

--- a/tests/test_web_chat.py
+++ b/tests/test_web_chat.py
@@ -269,7 +269,8 @@ class TestProcessWebChat:
         bot._process_with_tools = AsyncMock(side_effect=RuntimeError("boom"))
         result = await process_web_chat(bot, "hello", "ch-1")
         assert result["is_error"] is True
-        assert "Error processing" in result["response"]
+        # User-facing error is intentionally generic (no internal details leaked)
+        assert "Something went wrong" in result["response"]
         bot.sessions.remove_last_message.assert_called_once()
 
     @pytest.mark.asyncio
@@ -278,6 +279,28 @@ class TestProcessWebChat:
         result = await process_web_chat(bot, "make image", "ch-1")
         assert "files" in result
         assert isinstance(result["files"], list)
+
+    @pytest.mark.asyncio
+    async def test_single_use_channel_does_not_register_lock(self):
+        """persist_channel_lock=False (e.g. /api/execute) must not cache a
+        per-channel lock; otherwise each ephemeral UUID channel leaks one
+        permanent entry in bot._web_channel_locks."""
+        bot = self._make_bot()
+        bot._web_channel_locks = {}  # real dict so growth is observable
+        for i in range(5):
+            await process_web_chat(bot, "hi", f"api-{i}", persist_channel_lock=False)
+        assert bot._web_channel_locks == {}
+
+    @pytest.mark.asyncio
+    async def test_stateful_channel_registers_one_lock_per_channel(self):
+        """The default path (/api/chat, WebSocket) still caches exactly one
+        lock per channel_id so a user's overlapping requests serialize."""
+        bot = self._make_bot()
+        bot._web_channel_locks = {}
+        await process_web_chat(bot, "hi", "user-1")
+        await process_web_chat(bot, "again", "user-1")
+        assert set(bot._web_channel_locks) == {"user-1"}
+        assert isinstance(bot._web_channel_locks["user-1"], asyncio.Lock)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes an unbounded (slow) memory leak in `process_web_chat`'s per-channel lock cache, using the approach you recommended when I flagged it.

`process_web_chat` lazily caches one `asyncio.Lock` per `channel_id` in `bot._web_channel_locks` (`src/web/chat.py`) and never prunes it. That's fine for `/api/chat` and the WebSocket chat, where `channel_id == user_id` (bounded by distinct users). But `/api/execute` mints a fresh `api-<uuid>` channel per request and resets the session afterward (`src/web/api.py`) — so **every execute call left a permanent lock entry**, growing `_web_channel_locks` without bound for the life of the process.

## Fix

- Add `persist_channel_lock: bool = True` to `process_web_chat`.
- `/api/execute` passes `persist_channel_lock=False`. A single-use UUID channel can't be shared by a concurrent caller, so the lock provides no serialization there — skipping it avoids caching a lock that's never reused and never freed.
- `/api/chat` and the WebSocket chat path keep the default (lock retained — serialization still matters when `channel_id == user_id`).

This is your preferred option from our discussion: an explicit flag over a side-channel set, and no lock deletion that could race a waiter.

## Tests

- `test_single_use_channel_does_not_register_lock` — repeated `persist_channel_lock=False` calls leave `_web_channel_locks` empty.
- `test_stateful_channel_registers_one_lock_per_channel` — default path still caches exactly one lock per `channel_id`.
- `test_execute_opts_out_of_channel_lock` — verifies `/api/execute` wiring passes `False`.

## Notes

- Also fixes a **pre-existing** stale assertion in `test_exception_handling` (asserted `"Error processing"`; the code returns the intentionally-generic `"Something went wrong processing your message…"`). Unrelated to the leak, but it was red on `master` and I was already in the file.
- The full suite has **25 pre-existing failures** unrelated to this change (`test_terraform_ops`, `test_output_streamer`, `test_http_probe_ops`, `test_attachments`) — confirmed identical on a clean `master` worktree. This branch: **5469 passed**, and it removes the one `test_exception_handling` failure.
