### PR TITLE
feat: per-API-token default_host

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -350,6 +350,7 @@ class ApiTokenIdentity(BaseModel):
     tier: str = "admin"
     allowed_tools: list[str] = Field(default_factory=list)
     allowed_hosts: list[str] | None = None
+    default_host: str = ""
     label: str = ""
 
 

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -120,7 +120,8 @@ class HostAccessManager:
         scope = _request_host_scope.get()
         request_default = _request_default_host.get()
         if request_default and request_default in self._available_hosts:
-            if scope is None or request_default in scope:
+            effective = self.get_allowed_hosts(user_id)
+            if request_default in effective:
                 return request_default
         has_own_entry = user_id in self._users
         if scope is not None and not has_own_entry:

--- a/src/permissions/host_access.py
+++ b/src/permissions/host_access.py
@@ -10,6 +10,7 @@ from ..odin_log import get_logger
 log = get_logger("host_access")
 
 _request_host_scope: contextvars.ContextVar[list[str] | None] = contextvars.ContextVar("_request_host_scope", default=None)
+_request_default_host: contextvars.ContextVar[str] = contextvars.ContextVar("_request_default_host", default="")
 
 
 class HostAccessEntry:
@@ -93,6 +94,14 @@ class HostAccessManager:
         """Reset the request-scoped host scope."""
         _request_host_scope.reset(token)
 
+    @staticmethod
+    def set_request_default_host(default_host: str) -> contextvars.Token:
+        return _request_default_host.set(default_host or "")
+
+    @staticmethod
+    def reset_request_default_host(token: contextvars.Token) -> None:
+        _request_default_host.reset(token)
+
     def get_allowed_hosts(self, user_id: str) -> list[str]:
         scope = _request_host_scope.get()
         has_own_entry = user_id in self._users
@@ -109,6 +118,10 @@ class HostAccessManager:
 
     def get_default_host(self, user_id: str) -> str:
         scope = _request_host_scope.get()
+        request_default = _request_default_host.get()
+        if request_default and request_default in self._available_hosts:
+            if scope is None or request_default in scope:
+                return request_default
         has_own_entry = user_id in self._users
         if scope is not None and not has_own_entry:
             valid = [h for h in scope if h in self._available_hosts]

--- a/src/permissions/token_manager.py
+++ b/src/permissions/token_manager.py
@@ -66,6 +66,7 @@ class ApiTokenManager:
                     else:
                         log.warning("Skipping token %s: allowed_hosts must be a list of strings or null", user_id)
                         continue
+                    default_host = str(entry.get("default_host", ""))
                     identity = ApiTokenIdentity(
                         token="",
                         user_id=user_id,
@@ -74,6 +75,7 @@ class ApiTokenManager:
                         label=str(entry.get("label", "")),
                         allowed_tools=allowed_tools,
                         allowed_hosts=allowed_hosts,
+                        default_host=default_host,
                     )
                     self._tokens[user_id] = _StoredToken(token_hash, token_prefix, identity)
                 except Exception as e:
@@ -126,6 +128,7 @@ class ApiTokenManager:
         label: str = "",
         allowed_tools: list[str] | None = None,
         allowed_hosts: list[str] | None = None,
+        default_host: str = "",
     ) -> ApiTokenIdentity:
         """Generate a new token. Returns identity with raw token (shown once)."""
         async with self._lock:
@@ -140,6 +143,7 @@ class ApiTokenManager:
                 label=label,
                 allowed_tools=allowed_tools or [],
                 allowed_hosts=allowed_hosts,
+                default_host=default_host,
             )
             self._tokens[user_id] = _StoredToken(
                 token_hash=_hash_token(raw_token),
@@ -156,7 +160,7 @@ class ApiTokenManager:
             st = self._tokens.get(user_id)
             if st is None:
                 return None
-            for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts"):
+            for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts", "default_host"):
                 if field in kwargs:
                     setattr(st.identity, field, kwargs[field])
             self._save()

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -894,7 +894,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         tier = identity.tier if identity else None
         token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
-        token_default_host = identity.default_host if identity else ""
+        token_default_host = getattr(identity, "default_host", "") if identity else ""
 
         # Optional caller-supplied session id for multi-request chat continuity.
         # Omitted -> historical behavior (one history per identity). Supplied -> validated
@@ -974,7 +974,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         tier = identity.tier if identity else None
         token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
-        token_default_host = identity.default_host if identity else ""
+        token_default_host = getattr(identity, "default_host", "") if identity else ""
 
         result = await process_web_chat(
             bot, content, channel_id,

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -894,6 +894,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         tier = identity.tier if identity else None
         token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
+        token_default_host = identity.default_host if identity else ""
 
         # Optional caller-supplied session id for multi-request chat continuity.
         # Omitted -> historical behavior (one history per identity). Supplied -> validated
@@ -916,6 +917,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             user_id=user_id, username=username,
             allowed_tools=token_tools, tier=tier,
             token_allowed_hosts=token_hosts,
+            token_default_host=token_default_host,
         )
 
         # Scoped-session locks are cached like the default per-identity lock. We do NOT
@@ -972,12 +974,14 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         token_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         tier = identity.tier if identity else None
         token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
+        token_default_host = identity.default_host if identity else ""
 
         result = await process_web_chat(
             bot, content, channel_id,
             user_id=user_id, username=username,
             allowed_tools=token_tools, tier=tier,
             token_allowed_hosts=token_hosts,
+            token_default_host=token_default_host,
             persist_channel_lock=False,  # ephemeral per-request channel — no lock to cache or leak
         )
 
@@ -3130,6 +3134,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             bad = [h for h in allowed_hosts if h not in valid_hosts]
             if bad:
                 return web.json_response({"error": f"unknown hosts: {', '.join(bad)}"}, status=400)
+        default_host = str(data.get("default_host") or "").strip()
+        if default_host:
+            if ham and default_host not in ham.available_hosts:
+                return web.json_response({"error": f"unknown default_host: {default_host}"}, status=400)
+            if isinstance(allowed_hosts, list) and default_host not in allowed_hosts:
+                return web.json_response({"error": "default_host must be in allowed_hosts"}, status=400)
         try:
             identity = await tm.create_token(
                 user_id=user_id,
@@ -3138,6 +3148,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 label=data.get("label") or "",
                 allowed_tools=allowed_tools,
                 allowed_hosts=allowed_hosts,
+                default_host=default_host,
             )
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=409)
@@ -3149,6 +3160,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "label": identity.label,
             "allowed_tools": identity.allowed_tools,
             "allowed_hosts": identity.allowed_hosts,
+            "default_host": identity.default_host,
         }, status=201)
 
     @routes.put("/api/tokens/{user_id}")
@@ -3165,7 +3177,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         kwargs = {}
-        for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts"):
+        for field in ("username", "tier", "label", "allowed_tools", "allowed_hosts", "default_host"):
             if field in data:
                 kwargs[field] = data[field]
         if "tier" in kwargs and kwargs["tier"] not in ("admin", "user", "guest"):
@@ -3183,6 +3195,19 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 bad = [h for h in kwargs["allowed_hosts"] if h not in valid_hosts]
                 if bad:
                     return web.json_response({"error": f"unknown hosts: {', '.join(bad)}"}, status=400)
+        if "default_host" in kwargs:
+            dh = str(kwargs["default_host"] or "").strip()
+            kwargs["default_host"] = dh
+            if dh:
+                ham = getattr(bot, "host_access_manager", None)
+                if ham and dh not in ham.available_hosts:
+                    return web.json_response({"error": f"unknown default_host: {dh}"}, status=400)
+                ah = kwargs.get("allowed_hosts")
+                if ah is None:
+                    existing = tm.get(uid)
+                    ah = existing.allowed_hosts if existing else None
+                if isinstance(ah, list) and dh not in ah:
+                    return web.json_response({"error": "default_host must be in allowed_hosts"}, status=400)
         if not kwargs:
             return web.json_response({"error": "no fields to update"}, status=400)
         identity = await tm.update_token(uid, **kwargs)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -161,6 +161,7 @@ async def process_web_chat(
     allowed_tools: list[str] | None = None,
     tier: str | None = None,
     token_allowed_hosts: list[str] | None = None,
+    token_default_host: str = "",
     persist_channel_lock: bool = True,
 ) -> dict:
     """Process a web chat message through the Codex tool loop.
@@ -184,6 +185,7 @@ async def process_web_chat(
 
     tier_token = PermissionManager.set_request_tier(tier) if tier else None
     host_token = HostAccessManager.set_request_host_scope(token_allowed_hosts) if token_allowed_hosts is not None else None
+    default_host_token = HostAccessManager.set_request_default_host(token_default_host) if token_default_host else None
 
     try:
         if persist_channel_lock:
@@ -199,6 +201,8 @@ async def process_web_chat(
             PermissionManager.reset_request_tier(tier_token)
         if host_token is not None:
             HostAccessManager.reset_request_host_scope(host_token)
+        if default_host_token is not None:
+            HostAccessManager.reset_request_default_host(default_host_token)
 
 
 async def _do_process_web_chat(

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -190,7 +190,7 @@ class WebSocketManager:
         tier = identity.tier if identity else None
         allowed_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
-        token_default_host = identity.default_host if identity else ""
+        token_default_host = getattr(identity, "default_host", "") if identity else ""
 
         log.info("WebSocket chat from %s (tier=%s): %s", username, tier or "default", content[:80])
         try:

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -190,6 +190,7 @@ class WebSocketManager:
         tier = identity.tier if identity else None
         allowed_tools = identity.allowed_tools if identity and identity.allowed_tools else None
         token_hosts = identity.allowed_hosts if identity and isinstance(getattr(identity, "allowed_hosts", None), list) else None
+        token_default_host = identity.default_host if identity else ""
 
         log.info("WebSocket chat from %s (tier=%s): %s", username, tier or "default", content[:80])
         try:
@@ -199,6 +200,7 @@ class WebSocketManager:
                     user_id=user_id, username=username,
                     allowed_tools=allowed_tools, tier=tier,
                     token_allowed_hosts=token_hosts,
+                    token_default_host=token_default_host,
                 ),
                 timeout=_WS_CHAT_TIMEOUT,
             )

--- a/ui/js/pages/api-tokens.js
+++ b/ui/js/pages/api-tokens.js
@@ -90,6 +90,17 @@ export default {
               </div>
             </div>
             <div>
+              <label class="text-xs text-gray-500 block mb-1">Default Host</label>
+              <select v-model="createForm.default_host" class="hm-input w-full text-sm"
+                      :disabled="createForm.host_mode === 'none'">
+                <option value="">Use host policy default</option>
+                <option v-for="host in createDefaultHostOptions" :key="'cdh-'+host" :value="host">
+                  {{ host }}
+                </option>
+              </select>
+              <p class="text-xs text-gray-500 mt-1">Used when API requests don't specify a host.</p>
+            </div>
+            <div>
               <label class="text-xs text-gray-500 block mb-1">Allowed Tools (comma-separated, leave empty for tier default)</label>
               <input v-model="createForm.allowed_tools_str" class="hm-input w-full text-sm"
                      placeholder="e.g. run_command, web_search, fetch_url" />
@@ -116,6 +127,7 @@ export default {
                   <th class="text-left">Label</th>
                   <th class="text-left">Tier</th>
                   <th class="text-left">Hosts</th>
+                  <th class="text-left">Default</th>
                   <th class="text-left">Tools</th>
                   <th class="text-left">Source</th>
                   <th class="text-right">Actions</th>
@@ -130,6 +142,9 @@ export default {
                   </td>
                   <td class="text-gray-400 text-xs">
                     {{ t.allowed_hosts === null || t.allowed_hosts === undefined ? 'default policy' : t.allowed_hosts.length === 0 ? 'no host access' : t.allowed_hosts.join(', ') }}
+                  </td>
+                  <td class="text-gray-400 text-xs font-mono">
+                    {{ t.default_host || 'policy' }}
                   </td>
                   <td class="text-gray-400 text-xs">
                     {{ t.allowed_tools && t.allowed_tools.length ? t.allowed_tools.length + ' tools' : 'tier default' }}
@@ -193,6 +208,16 @@ export default {
                 </div>
               </div>
               <div>
+                <label class="text-xs text-gray-500 block mb-1">Default Host</label>
+                <select v-model="editForm.default_host" class="hm-input w-full text-sm"
+                        :disabled="editForm.host_mode === 'none'">
+                  <option value="">Use host policy default</option>
+                  <option v-for="host in editDefaultHostOptions" :key="'edh-'+host" :value="host">
+                    {{ host }}
+                  </option>
+                </select>
+              </div>
+              <div>
                 <label class="text-xs text-gray-500 block mb-1">Allowed Tools (comma-separated, empty for tier default)</label>
                 <input v-model="editForm.allowed_tools_str" class="hm-input w-full text-sm" />
               </div>
@@ -228,12 +253,24 @@ export default {
 
     const createForm = ref({
       user_id: '', username: '', tier: 'admin', label: '',
-      host_mode: 'default', allowed_hosts: [], allowed_tools_str: '',
+      host_mode: 'default', allowed_hosts: [], default_host: '', allowed_tools_str: '',
     });
 
     const editForm = ref({
       username: '', tier: 'admin', label: '',
-      host_mode: 'default', allowed_hosts: [], allowed_tools_str: '',
+      host_mode: 'default', allowed_hosts: [], default_host: '', allowed_tools_str: '',
+    });
+
+    const createDefaultHostOptions = computed(() => {
+      if (createForm.value.host_mode === 'select') return createForm.value.allowed_hosts;
+      if (createForm.value.host_mode === 'none') return [];
+      return availableHosts.value;
+    });
+
+    const editDefaultHostOptions = computed(() => {
+      if (editForm.value.host_mode === 'select') return editForm.value.allowed_hosts;
+      if (editForm.value.host_mode === 'none') return [];
+      return availableHosts.value;
     });
 
     function showToast(msg, ok = true) {
@@ -298,9 +335,10 @@ export default {
           allowed_tools: tools.length ? tools : [],
         };
         if (hostPayload !== null) body.allowed_hosts = hostPayload;
+        body.default_host = createForm.value.default_host || '';
         const data = await api.post('/api/tokens', body);
         newToken.value = data.token;
-        createForm.value = { user_id: '', username: '', tier: 'admin', label: '', host_mode: 'default', allowed_hosts: [], allowed_tools_str: '' };
+        createForm.value = { user_id: '', username: '', tier: 'admin', label: '', host_mode: 'default', allowed_hosts: [], default_host: '', allowed_tools_str: '' };
         showCreate.value = false;
         showToast('Token created');
         await fetchData();
@@ -324,6 +362,7 @@ export default {
         label: t.label || '',
         host_mode: mode,
         allowed_hosts: Array.isArray(hosts) ? [...hosts] : [],
+        default_host: t.default_host || '',
         allowed_tools_str: (t.allowed_tools || []).join(', '),
       };
     }
@@ -343,6 +382,7 @@ export default {
         if (mode === 'none') body.allowed_hosts = [];
         else if (mode === 'select') body.allowed_hosts = editForm.value.allowed_hosts;
         else body.allowed_hosts = null;
+        body.default_host = editForm.value.default_host || '';
         await api.put('/api/tokens/' + encodeURIComponent(editing.value.user_id), body);
         editing.value = null;
         showToast('Token updated');
@@ -391,6 +431,7 @@ export default {
     return {
       loading, error, tokens, availableHosts, showCreate, creating,
       newToken, editing, saving, toast, createForm, editForm,
+      createDefaultHostOptions, editDefaultHostOptions,
       fetchData, tierBadge, toggleCreateHost, toggleEditHost,
       createToken, startEdit, saveEdit, confirmRegenerate, confirmDelete, copyToken,
     };


### PR DESCRIPTION
## Summary
API tokens can now specify a `default_host` that applies to all requests authenticated with that key.

**Problem**: Norns dispatched work to Odin instances via API, but with no default host set, commands ran on the first alphabetical host (Uncraftbar — a friend's PC) instead of localhost.

**Fix**: `default_host` field on `ApiTokenIdentity`, injected as a request-scoped contextvar so `ToolExecutor._resolve_default_host()` picks it up without threading arguments through every tool call.

**Changes**:
- `ApiTokenIdentity.default_host` field
- `ApiTokenManager` create/update/load support
- `_request_default_host` contextvar in `HostAccessManager`
- `get_default_host()` checks request default first (if valid and allowed)
- `process_web_chat()` accepts `token_default_host`
- `/api/chat`, `/api/execute`, WebSocket all pass it through
- Token API routes validate against available/allowed hosts
- WebUI: Default Host dropdown in create/edit, column in token table

**Precedence**: explicit tool host > token default_host > user policy default > first allowed host > first configured host