### PR TITLE
feat: live Codex auth reload — no restart required

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -412,45 +412,6 @@ class OdinBot(commands.Bot):
 
         self.scheduler = Scheduler(data_path="./data/schedules.json")
 
-    def _wire_codex_callbacks(self) -> None:
-        """Attach Codex-backed compaction and reflection callbacks."""
-        async def _codex_compaction(messages: list[dict], system: str) -> str:
-            if not self.codex_client:
-                raise RuntimeError("Codex client not configured")
-            return await self.codex_client.chat(messages=messages, system=system, max_tokens=300)
-
-        async def _codex_reflection(messages: list[dict], system: str) -> str:
-            if not self.codex_client:
-                raise RuntimeError("Codex client not configured")
-            return await self.codex_client.chat(messages=messages, system=system, max_tokens=500)
-
-        self.sessions.set_compaction_fn(_codex_compaction)
-        self.reflector.set_text_fn(_codex_reflection)
-
-    async def reload_codex_auth(self) -> dict:
-        """Reload Codex credentials and create the client if it was missing at boot."""
-        if not self.config.openai_codex.enabled:
-            self.codex_client = None
-            return {"configured": False, "reason": "openai_codex disabled in config"}
-
-        if self.codex_client is not None:
-            auth = getattr(self.codex_client, "auth", None)
-            if isinstance(auth, CodexAuthPool):
-                count = await auth.reload_async()
-                return {"configured": True, "reloaded": True, "accounts": count}
-
-        auth = CodexAuthPool(self.config.openai_codex.credentials_path)
-        if not auth.is_configured():
-            return {"configured": False, "reason": "credentials file missing or empty"}
-
-        self.codex_client = CodexChatClient(
-            auth=auth,
-            model=self.config.openai_codex.model,
-            max_tokens=self.config.openai_codex.max_tokens,
-        )
-        self._wire_codex_callbacks()
-        log.info("Codex client created via live reload (model: %s)", self.config.openai_codex.model)
-        return {"configured": True, "created": True, "accounts": len(auth._accounts)}
         # Audit logger — HMAC chain signing is on iff config.audit.hmac_key is set
         _audit_key = config.audit.hmac_key if getattr(config, "audit", None) else ""
         self.audit = AuditLogger(path="./data/audit.jsonl", hmac_key=_audit_key)
@@ -629,6 +590,48 @@ class OdinBot(commands.Bot):
         self._register_commands()
         self._init_allowed_webhook_ids()
         self._log_startup_config()
+
+    # ---------- Live Codex reload -----------------------------------------
+
+    def _wire_codex_callbacks(self) -> None:
+        """Attach Codex-backed compaction and reflection callbacks."""
+        async def _codex_compaction(messages: list[dict], system: str) -> str:
+            if not self.codex_client:
+                raise RuntimeError("Codex client not configured")
+            return await self.codex_client.chat(messages=messages, system=system, max_tokens=300)
+
+        async def _codex_reflection(messages: list[dict], system: str) -> str:
+            if not self.codex_client:
+                raise RuntimeError("Codex client not configured")
+            return await self.codex_client.chat(messages=messages, system=system, max_tokens=500)
+
+        self.sessions.set_compaction_fn(_codex_compaction)
+        self.reflector.set_text_fn(_codex_reflection)
+
+    async def reload_codex_auth(self) -> dict:
+        """Reload Codex credentials and create the client if it was missing at boot."""
+        if not self.config.openai_codex.enabled:
+            self.codex_client = None
+            return {"configured": False, "reason": "openai_codex disabled in config"}
+
+        if self.codex_client is not None:
+            auth = getattr(self.codex_client, "auth", None)
+            if isinstance(auth, CodexAuthPool):
+                count = await auth.reload_async()
+                return {"configured": True, "reloaded": True, "accounts": count}
+
+        auth = CodexAuthPool(self.config.openai_codex.credentials_path)
+        if not auth.is_configured():
+            return {"configured": False, "reason": "credentials file missing or empty"}
+
+        self.codex_client = CodexChatClient(
+            auth=auth,
+            model=self.config.openai_codex.model,
+            max_tokens=self.config.openai_codex.max_tokens,
+        )
+        self._wire_codex_callbacks()
+        log.info("Codex client created via live reload (model: %s)", self.config.openai_codex.model)
+        return {"configured": True, "created": True, "accounts": len(auth._accounts)}
 
     # ---------- Live aliases expected by the health checker / web UI -------
     # These forward to the Heimdall-style internal names. Keeping them as

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -411,6 +411,46 @@ class OdinBot(commands.Bot):
                 log.warning("Codex enabled in config but no credentials found. Run scripts/codex_login.py")
 
         self.scheduler = Scheduler(data_path="./data/schedules.json")
+
+    def _wire_codex_callbacks(self) -> None:
+        """Attach Codex-backed compaction and reflection callbacks."""
+        async def _codex_compaction(messages: list[dict], system: str) -> str:
+            if not self.codex_client:
+                raise RuntimeError("Codex client not configured")
+            return await self.codex_client.chat(messages=messages, system=system, max_tokens=300)
+
+        async def _codex_reflection(messages: list[dict], system: str) -> str:
+            if not self.codex_client:
+                raise RuntimeError("Codex client not configured")
+            return await self.codex_client.chat(messages=messages, system=system, max_tokens=500)
+
+        self.sessions.set_compaction_fn(_codex_compaction)
+        self.reflector.set_text_fn(_codex_reflection)
+
+    async def reload_codex_auth(self) -> dict:
+        """Reload Codex credentials and create the client if it was missing at boot."""
+        if not self.config.openai_codex.enabled:
+            self.codex_client = None
+            return {"configured": False, "reason": "openai_codex disabled in config"}
+
+        if self.codex_client is not None:
+            auth = getattr(self.codex_client, "auth", None)
+            if isinstance(auth, CodexAuthPool):
+                count = await auth.reload_async()
+                return {"configured": True, "reloaded": True, "accounts": count}
+
+        auth = CodexAuthPool(self.config.openai_codex.credentials_path)
+        if not auth.is_configured():
+            return {"configured": False, "reason": "credentials file missing or empty"}
+
+        self.codex_client = CodexChatClient(
+            auth=auth,
+            model=self.config.openai_codex.model,
+            max_tokens=self.config.openai_codex.max_tokens,
+        )
+        self._wire_codex_callbacks()
+        log.info("Codex client created via live reload (model: %s)", self.config.openai_codex.model)
+        return {"configured": True, "created": True, "accounts": len(auth._accounts)}
         # Audit logger — HMAC chain signing is on iff config.audit.hmac_key is set
         _audit_key = config.audit.hmac_key if getattr(config, "audit", None) else ""
         self.audit = AuditLogger(path="./data/audit.jsonl", hmac_key=_audit_key)

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -450,8 +450,17 @@ class CodexAuthPool:
             log.info("Active Codex account switched to %s (#%d)", email, index)
 
     def reload(self) -> None:
-        """Reload the pool from the canonical credentials file."""
+        """Reload the pool from the canonical credentials file (sync compat)."""
         self._accounts.clear()
         self._current_index = 0
         self._init_accounts()
         log.info("Codex auth pool reloaded: %d account(s)", len(self._accounts))
+
+    async def reload_async(self) -> int:
+        """Reload under lock to avoid racing in-flight token operations."""
+        async with self._pool_lock:
+            self._accounts.clear()
+            self._init_accounts()
+            self._current_index = min(self._current_index, max(len(self._accounts) - 1, 0))
+            log.info("Codex auth pool reloaded (async): %d account(s)", len(self._accounts))
+            return len(self._accounts)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2818,11 +2818,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             path.parent.mkdir(parents=True, exist_ok=True)
             _atomic_write_secure(path, _json.dumps(creds, indent=2))
 
-        # Auto-reload pool if available
-        pool = getattr(bot, "codex_client", None)
-        pool = getattr(pool, "auth", None) if pool else None
-        if pool:
-            pool.reload()
+        await bot.reload_codex_auth()
 
         return web.json_response({
             "status": "authenticated",
@@ -2889,15 +2885,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/codex/reload")
     async def codex_reload(_request: web.Request) -> web.Response:
-        pool = getattr(bot, "codex_client", None)
-        pool = getattr(pool, "auth", None) if pool else None
-        if pool is None:
-            return web.json_response({"error": "codex not configured"}, status=503)
-        pool.reload()
-        return web.json_response({
-            "status": "reloaded",
-            "account_count": pool.account_count,
-        })
+        result = await bot.reload_codex_auth()
+        status = 200 if result.get("configured") else 503
+        return web.json_response(result, status=status)
 
     @routes.put("/api/codex/account/{index}/label")
     async def codex_set_label(request: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary
After authenticating Codex via the WebUI device-code flow, the bot now picks up credentials live without a restart.

**Problem**: If Odin booted without Codex credentials, `codex_client` was `None`. Saving credentials via the WebUI didn't create the client — users had to restart the bot.

**Fix**: `bot.reload_codex_auth()` handles both cases:
- Existing client: reloads the auth pool under lock
- Missing client: creates `CodexChatClient` + wires compaction/reflection callbacks

**Changes**:
- `CodexAuthPool.reload_async()` — locked reload to avoid racing in-flight token operations
- `OdinBot.reload_codex_auth()` — creates or reloads the Codex client
- `OdinBot._wire_codex_callbacks()` — extracted from init for reuse
- `POST /api/codex/reload` — calls bot method (creates client if missing, not just 503)
- Device-poll handler calls `reload_codex_auth()` after saving credentials