### PR TITLE
Fix web chat Discord status task leak

### DIFF
--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -232,9 +232,13 @@ async def _do_process_web_chat(
         sp = await bot._inject_tool_hints(sp, content, user_id)
         history = await bot.sessions.get_task_history(channel_id, max_messages=20)
 
-        response, _already_sent, is_error, tools_used, handoff = (
-            await bot._process_with_tools(msg, history, system_prompt_override=sp)
-        )
+        try:
+            response, _already_sent, is_error, tools_used, handoff = (
+                await bot._process_with_tools(msg, history, system_prompt_override=sp)
+            )
+        finally:
+            await bot._set_status(None, task_end=True)
+
         response = _scrub(response)
 
         if not is_error:

--- a/tests/test_web_chat.py
+++ b/tests/test_web_chat.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import io
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -221,6 +221,7 @@ class TestProcessWebChat:
 
         bot._build_system_prompt = MagicMock(return_value="system prompt")
         bot._inject_tool_hints = AsyncMock(return_value="system prompt")
+        bot._set_status = AsyncMock()
         bot._process_with_tools = AsyncMock(return_value=(
             response,
             False,  # already_sent
@@ -272,6 +273,21 @@ class TestProcessWebChat:
         # User-facing error is intentionally generic (no internal details leaked)
         assert "Something went wrong" in result["response"]
         bot.sessions.remove_last_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_web_chat_ends_status_after_tool_processing_success(self):
+        bot = self._make_bot(response="done")
+        result = await process_web_chat(bot, "hello", "ch-1")
+        assert result["is_error"] is False
+        bot._set_status.assert_awaited_once_with(None, task_end=True)
+
+    @pytest.mark.asyncio
+    async def test_web_chat_ends_status_when_tool_processing_raises(self):
+        bot = self._make_bot()
+        bot._process_with_tools = AsyncMock(side_effect=RuntimeError("boom"))
+        result = await process_web_chat(bot, "hello", "ch-1")
+        assert result["is_error"] is True
+        bot._set_status.assert_awaited_once_with(None, task_end=True)
 
     @pytest.mark.asyncio
     async def test_files_returned(self):


### PR DESCRIPTION
## Summary
- end the Discord presence task counter after web chat/API `_process_with_tools()` calls finish
- add regression coverage for success and exception paths through `process_web_chat()`

## Feedback on root cause
Claudia's analysis is correct. `_process_with_tools()` calls `_set_status("Working...", task_start=True)`, which increments `_active_tasks`. Discord messages later balance that in the Discord `on_message` path, but web/API calls return through `src/web/chat.py` and never hit the Discord handler's task-end call. Wrapping the web `_process_with_tools()` invocation in `try/finally` is the right fix because it balances the counter on both successful responses and raised exceptions.

## Tests
- `./.venv/bin/python -m pytest tests/test_web_chat.py -q` ✅ 30 passed
- `./.venv/bin/python -m pytest tests/ -x -q` ⚠️ currently fails on unrelated existing `tests/test_http_probe_ops.py::TestHandleHttpProbe::test_remote_probe_with_host` with `AttributeError: 'ToolExecutor' object has no attribute '_host_access'` after 1980 passed
