### PR TITLE
Increase web chat content limit for orchestrated prompts

### DIFF
--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -23,7 +23,7 @@ log = get_logger("web.chat")
 _msg_id_counter = itertools.count(int(time.time() * 1000))
 
 # Max content length for a single chat message
-MAX_CHAT_CONTENT_LEN = 4000
+MAX_CHAT_CONTENT_LEN = 32000
 
 
 class _NoOpContextManager:


### PR DESCRIPTION
## Summary
- increase `MAX_CHAT_CONTENT_LEN` from 4,000 to 32,000 characters for web chat/API requests
- preserves the existing validation path while allowing orchestrated Norns prompts with goal metadata, dependencies, and step context to pass through

## Validation
- `python3 -m py_compile src/web/chat.py`

## Notes
I agree with the root cause: the current 4k limit is appropriate for manual Discord-ish chat, but Norns' `/api/chat` integration sends structured orchestration context around the instruction. Rejecting that at the web boundary with HTTP 400 kills review/verify steps before the LLM ever sees them.
