### PR TITLE
fix: hardcode Kimi base_url — not user-configurable

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,10 +29,8 @@ ollama:
 kimi:
   enabled: false
   api_key: ""  # Moonshot AI API key from platform.kimi.ai
-  base_url: https://api.moonshot.ai/v1
   model: kimi-k2.6
   max_tokens: 4096
-  timeout: 300
 
 # Which LLM backend to use: "codex", "ollama", or "kimi"
 llm_provider:

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -309,17 +309,9 @@ class KimiConfig(BaseModel):
 
     enabled: bool = False
     api_key: str = ""
-    base_url: str = "https://api.moonshot.ai/v1"
     model: str = "kimi-k2.6"
     max_tokens: int = 4096
     timeout: int = 300
-
-    @field_validator("base_url")
-    @classmethod
-    def _validate_url(cls, v):
-        if not v.startswith(("http://", "https://")):
-            raise ValueError("base_url must start with http:// or https://")
-        return v
 
     @field_validator("max_tokens")
     @classmethod

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -415,7 +415,6 @@ class OdinBot(commands.Bot):
         if kimi_cfg and kimi_cfg.enabled and kimi_cfg.api_key:
             self.kimi_client = KimiClient(
                 api_key=kimi_cfg.api_key,
-                base_url=kimi_cfg.base_url,
                 model=kimi_cfg.model,
                 max_tokens=kimi_cfg.max_tokens,
                 timeout=kimi_cfg.timeout,
@@ -728,7 +727,6 @@ class OdinBot(commands.Bot):
         old = self.kimi_client
         self.kimi_client = KimiClient(
             api_key=kimi_cfg.api_key,
-            base_url=kimi_cfg.base_url,
             model=kimi_cfg.model,
             max_tokens=kimi_cfg.max_tokens,
             timeout=kimi_cfg.timeout,

--- a/src/llm/kimi.py
+++ b/src/llm/kimi.py
@@ -35,7 +35,6 @@ class KimiClient(LLMProvider):
     def __init__(
         self,
         api_key: str,
-        base_url: str = KIMI_API_URL,
         model: str = "kimi-k2.6",
         max_tokens: int = 4096,
         timeout: int = 300,
@@ -44,7 +43,7 @@ class KimiClient(LLMProvider):
         retry_max_delay: float = DEFAULT_MAX_DELAY,
     ) -> None:
         self.api_key = api_key
-        self.base_url = base_url.rstrip("/")
+        self.base_url = KIMI_API_URL
         self.model = model
         self.max_tokens = max_tokens
         self.timeout = timeout

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3053,7 +3053,6 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 "configured": bot.kimi_client is not None,
                 "enabled": kimi_cfg.enabled if kimi_cfg else False,
                 "model": kimi_cfg.model if kimi_cfg else "",
-                "base_url": kimi_cfg.base_url if kimi_cfg else "",
                 "max_tokens": kimi_cfg.max_tokens if kimi_cfg else 4096,
                 "has_api_key": kimi_has_key,
             },

--- a/tests/test_kimi_client.py
+++ b/tests/test_kimi_client.py
@@ -192,6 +192,9 @@ class TestProperties:
         assert stats["model"] == "kimi-k2.6"
         assert "api.moonshot.ai" in stats["base_url"]
 
+    def test_base_url_hardcoded(self, client):
+        assert client.base_url == "https://api.moonshot.ai/v1"
+
 
 class TestKimiConfig:
     def test_defaults(self):
@@ -199,12 +202,7 @@ class TestKimiConfig:
         cfg = KimiConfig()
         assert cfg.enabled is False
         assert cfg.model == "kimi-k2.6"
-        assert "moonshot" in cfg.base_url
-
-    def test_invalid_url(self):
-        from src.config.schema import KimiConfig
-        with pytest.raises(ValueError, match="http"):
-            KimiConfig(base_url="ftp://bad")
+        assert not hasattr(cfg, "base_url")
 
     def test_empty_model(self):
         from src.config.schema import KimiConfig

--- a/tests/test_llm_security.py
+++ b/tests/test_llm_security.py
@@ -46,10 +46,10 @@ class TestOllamaURLValidation:
 
 
 class TestKimiConfig:
-    def test_base_url_hardcoded(self):
+    def test_no_base_url_in_config(self):
         from src.config.schema import KimiConfig
         cfg = KimiConfig(enabled=True, api_key="sk-test")
-        assert "moonshot" in cfg.base_url
+        assert not hasattr(cfg, "base_url")
 
     def test_empty_model_rejected(self):
         from src.config.schema import KimiConfig

--- a/ui/js/pages/llm-config.js
+++ b/ui/js/pages/llm-config.js
@@ -420,7 +420,6 @@ export default {
         if (data.kimi) {
           kimiForm.value.enabled = data.kimi.enabled;
           kimiForm.value.model = data.kimi.model || '';
-          kimiForm.value.base_url = data.kimi.base_url || '';
           kimiForm.value.max_tokens = data.kimi.max_tokens || 4096;
         }
       } catch (e) {


### PR DESCRIPTION
## Summary
- Kimi API has a single endpoint (api.moonshot.ai/v1), same as Codex — not something users should configure
- Removed `base_url` from KimiConfig, KimiClient constructor, API endpoints, WebUI form, and default config.yml
- Endpoint hardcoded as `KIMI_API_URL` constant in `src/llm/kimi.py`

## Test plan
- [ ] 297 tests passing
- [ ] Kimi client uses hardcoded URL
- [ ] config.yml ships without kimi.base_url
- [ ] WebUI Kimi section has no base_url field