### PR TITLE
fix: idempotent vec0 re-indexing (session_vec startup error)

### DIFF
--- a/src/knowledge/store.py
+++ b/src/knowledge/store.py
@@ -281,8 +281,13 @@ class KnowledgeStore:
                     self._fts.index_knowledge_chunk(chunk_id, chunk, source, i)
                 if vectors[i] is not None:
                     vec_bytes = serialize_vector(vectors[i])
+                    # vec0 tables don't honor INSERT OR REPLACE (same issue as
+                    # session_vec) — delete-then-insert keeps re-ingest idempotent.
                     self._conn.execute(
-                        "INSERT OR REPLACE INTO knowledge_vec (chunk_id, embedding) VALUES (?, ?)",
+                        "DELETE FROM knowledge_vec WHERE chunk_id = ?", (chunk_id,)
+                    )
+                    self._conn.execute(
+                        "INSERT INTO knowledge_vec (chunk_id, embedding) VALUES (?, ?)",
                         (chunk_id, vec_bytes),
                     )
                 indexed += 1

--- a/src/search/vectorstore.py
+++ b/src/search/vectorstore.py
@@ -133,8 +133,15 @@ class SessionVectorStore:
             self._fts.index_session(doc_id, doc_text, channel_id, last_active)
         if vector is not None:
             vec_bytes = serialize_vector(vector)
+            # vec0 virtual tables do NOT honor INSERT OR REPLACE conflict
+            # resolution: re-inserting an existing doc_id raises "UNIQUE
+            # constraint failed on session_vec primary key" instead of replacing.
+            # Delete-then-insert makes re-indexing idempotent. (The backfill
+            # existence check is keyed on session_archives, so a doc_id present
+            # only in session_vec would otherwise error on every startup.)
+            self._conn.execute("DELETE FROM session_vec WHERE doc_id = ?", (doc_id,))
             self._conn.execute(
-                "INSERT OR REPLACE INTO session_vec (doc_id, embedding) VALUES (?, ?)",
+                "INSERT INTO session_vec (doc_id, embedding) VALUES (?, ?)",
                 (doc_id, vec_bytes),
             )
         self._conn.commit()

--- a/tests/test_session_vec_reindex.py
+++ b/tests/test_session_vec_reindex.py
@@ -1,0 +1,53 @@
+"""Regression test: re-indexing a session must be idempotent.
+
+sqlite-vec ``vec0`` virtual tables do NOT honor ``INSERT OR REPLACE`` conflict
+resolution — re-inserting an existing primary key raises "UNIQUE constraint
+failed" instead of replacing. The startup archive backfill keys its
+"already-indexed" check on ``session_archives``, so a doc_id present only in
+``session_vec`` was re-indexed and errored on every startup. The fix is
+delete-then-insert in the vec write path.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.search.vectorstore import VECTOR_DIM, SessionVectorStore
+
+
+def test_session_vec_reindex_is_idempotent(tmp_path):
+    store = SessionVectorStore(str(tmp_path / "sessions.db"))
+    if not store._has_vec:
+        pytest.skip("sqlite-vec not available")
+
+    doc_id = "ch1_1700000000"
+    # First index.
+    store._write_session_sync(doc_id, "hello world", "ch1", 1000.0, 3, [0.1] * VECTOR_DIM)
+    # Re-index the SAME doc_id with a different vector + metadata. Before the fix
+    # this raised "UNIQUE constraint failed on session_vec primary key".
+    store._write_session_sync(doc_id, "hello world updated", "ch1", 2000.0, 5, [0.9] * VECTOR_DIM)
+
+    # Exactly one vec row for the doc_id (replaced, not duplicated).
+    (vec_count,) = store._conn.execute(
+        "SELECT COUNT(*) FROM session_vec WHERE doc_id = ?", (doc_id,)
+    ).fetchone()
+    assert vec_count == 1
+
+    # Metadata was updated to the second write.
+    (msg_count,) = store._conn.execute(
+        "SELECT message_count FROM session_archives WHERE doc_id = ?", (doc_id,)
+    ).fetchone()
+    assert msg_count == 5
+
+    store.close() if hasattr(store, "close") else store._conn.close()
+
+
+def test_session_vec_write_without_vector_is_safe(tmp_path):
+    """A None vector (embed failure) must still write metadata without touching vec."""
+    store = SessionVectorStore(str(tmp_path / "sessions.db"))
+    doc_id = "ch2_1700000001"
+    store._write_session_sync(doc_id, "no embedding", "ch2", 1000.0, 2, None)
+    (msg_count,) = store._conn.execute(
+        "SELECT message_count FROM session_archives WHERE doc_id = ?", (doc_id,)
+    ).fetchone()
+    assert msg_count == 2
+    store._conn.close()


### PR DESCRIPTION
**Fixes the startup error** `Session index failed for api-...: UNIQUE constraint failed on session_vec primary key` (seen during the v3.28.2 deploy).

### Root cause (empirically verified)
sqlite-vec `vec0` virtual tables do **not** honor `INSERT OR REPLACE` conflict resolution — re-inserting an existing primary key raises `UNIQUE constraint failed` instead of replacing. Repro:
```
INSERT OR REPLACE INTO <vec0> (doc_id, ...) VALUES ('s1', ...)  # 2nd time -> OperationalError: UNIQUE constraint failed
DELETE FROM <vec0> WHERE doc_id='s1'; INSERT ...                # works
```
The startup `backfill()` keys its already-indexed check on `session_archives` (`_get_indexed_ids_sync`), **not** `session_vec`. So a doc_id present in `session_vec` but not `session_archives` gets re-indexed and the vec write throws — every startup.

### Fix
Delete-then-insert in both vec write paths:
- `vectorstore.py` `_write_session_sync` (session_vec) — the reported bug
- `store.py` `ingest` (knowledge_vec) — identical latent bug

Plus a regression test (`test_session_vec_reindex.py`) that re-indexes the same session and asserts no error + single row.

### Status
**Do not merge yet** — opened for review/discussion; @Calmingstorm wants to merge/deploy on return. Full suite unchanged (no new failures; +2 tests). 

### Open question for discussion
The deeper inconsistency is that backfill's existence check (session_archives) diverges from FTS (`has_session`) and vec — worth reconciling the three stores' membership later, but the idempotent write fixes the crash robustly regardless.