### PR TITLE
fix: rotate Codex accounts on 401/invalidated token (not just 429)

### DIFF
--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -15,6 +15,11 @@ from ..odin_log import get_logger
 
 log = get_logger("codex_auth")
 
+# A 401/invalidated-token account can't recover until the user re-auths, so the
+# pool sets it aside for this long (vs the 60s rate-limit window) before retrying
+# it — avoids thrashing a known-bad account, while still recovering on its own.
+AUTH_FAILED_BACKOFF_SECONDS = 600
+
 
 def _atomic_write_secure(path: Path, content: str) -> None:
     """Write content to a file atomically with 0600 permissions."""
@@ -149,6 +154,11 @@ class CodexAuth:
         async with self._refresh_lock:
             self._credentials = None
 
+    async def mark_current_auth_failed(self) -> bool:
+        """Single-account auth has nothing to rotate to — returns False so the
+        caller surfaces the 401 (this account must be re-authed)."""
+        return False
+
     async def _refresh(self, creds: dict) -> None:
         """Refresh the access token using the refresh token."""
         refresh_token = creds.get("refresh_token")
@@ -207,9 +217,9 @@ class CodexAuth:
         self._save(new_creds)
         log.info("Codex tokens refreshed successfully")
 
-    def mark_rate_limited(self) -> None:
-        """Mark this credential set as rate-limited."""
-        self._rate_limited_until = time.time() + 60  # Back off 60s minimum
+    def mark_rate_limited(self, seconds: float = 60) -> None:
+        """Mark this credential set as unavailable for ``seconds`` (default 60s)."""
+        self._rate_limited_until = time.time() + seconds
 
     def is_rate_limited(self) -> bool:
         return time.time() < getattr(self, "_rate_limited_until", 0)
@@ -461,6 +471,34 @@ class CodexAuthPool:
         # invalidate_current() takes the inner account's own refresh lock;
         # call it outside the pool lock to keep lock ordering simple.
         await current.invalidate_current()
+
+    async def mark_current_auth_failed(self) -> bool:
+        """Mark the current account as auth-failed (401/invalidated) and rotate.
+
+        Distinct from rate-limit rotation: an invalidated token won't recover
+        until re-auth, so set the account aside for a longer window
+        (AUTH_FAILED_BACKOFF_SECONDS) rather than retrying it every minute, then
+        rotate to the next account. Returns True if it rotated to a *different*
+        account, False if this is the only one (caller should surface the error).
+        """
+        if not self._accounts:
+            return False
+        async with self._pool_lock:
+            current = self._accounts[self._current_index]
+            current.mark_rate_limited(AUTH_FAILED_BACKOFF_SECONDS)
+            try:
+                email = current._load().get("email", f"account {self._current_index}")
+            except Exception:
+                email = f"account {self._current_index}"
+            if len(self._accounts) > 1:
+                self._rotate()
+                log.warning(
+                    "Codex %s auth failed (401/invalidated), skipped to account %d/%d",
+                    email, self._current_index + 1, len(self._accounts),
+                )
+                return True
+            log.warning("Codex %s auth failed (401), only account — cannot rotate", email)
+            return False
 
     def _rotate(self) -> None:
         self._current_index = (self._current_index + 1) % len(self._accounts)

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -434,15 +434,42 @@ class CodexChatClient:
 
                     error_body = (await resp.read()).decode("utf-8", errors="replace")
 
-                    if resp.status == 401 and attempt == 0:
-                        log.warning("Codex auth expired, forcing token refresh...")
-                        await self.auth.invalidate_current()
-                        new_token = await self.auth.get_access_token()
-                        headers["Authorization"] = f"Bearer {new_token}"
-                        account_id = self.auth.get_account_id()
-                        if account_id:
-                            headers["ChatGPT-Account-Id"] = account_id
-                        continue
+                    if resp.status == 401:
+                        body_l = error_body.lower()
+                        invalidated = (
+                            "token_invalidated" in body_l
+                            or "invalidated" in body_l
+                            or "sign in again" in body_l
+                        )
+                        # Likely-stale cached bearer (generic 401, first try):
+                        # clear + refresh and retry the SAME account once.
+                        if attempt == 0 and not invalidated:
+                            log.warning("Codex auth 401, forcing token refresh...")
+                            await self.auth.invalidate_current()
+                            new_token = await self.auth.get_access_token()
+                            headers["Authorization"] = f"Bearer {new_token}"
+                            account_id = self.auth.get_account_id()
+                            if account_id:
+                                headers["ChatGPT-Account-Id"] = account_id
+                            continue
+                        # Invalidated, or a 401 that survived the refresh: this
+                        # account can't authenticate. Skip it and rotate to the
+                        # next account — only on this error, never routine traffic.
+                        rotated = False
+                        if hasattr(self.auth, "mark_current_auth_failed"):
+                            rotated = await self.auth.mark_current_auth_failed()
+                        if rotated and attempt < self.max_retries - 1:
+                            log.warning("Codex 401: skipped failed account, retrying on next...")
+                            new_token = await self.auth.get_access_token()
+                            headers["Authorization"] = f"Bearer {new_token}"
+                            account_id = self.auth.get_account_id()
+                            if account_id:
+                                headers["ChatGPT-Account-Id"] = account_id
+                            continue
+                        self.breaker.record_failure()
+                        raise RuntimeError(
+                            f"Codex 401 (auth failed, no healthy account): {error_body[:200]}"
+                        )
 
                     if resp.status == 429:
                         if hasattr(self.auth, "mark_current_limited"):
@@ -665,15 +692,42 @@ class CodexChatClient:
 
                     error_body = (await resp.read()).decode("utf-8", errors="replace")
 
-                    if resp.status == 401 and attempt == 0:
-                        log.warning("Codex auth expired, forcing token refresh...")
-                        await self.auth.invalidate_current()
-                        new_token = await self.auth.get_access_token()
-                        headers["Authorization"] = f"Bearer {new_token}"
-                        account_id = self.auth.get_account_id()
-                        if account_id:
-                            headers["ChatGPT-Account-Id"] = account_id
-                        continue
+                    if resp.status == 401:
+                        body_l = error_body.lower()
+                        invalidated = (
+                            "token_invalidated" in body_l
+                            or "invalidated" in body_l
+                            or "sign in again" in body_l
+                        )
+                        # Likely-stale cached bearer (generic 401, first try):
+                        # clear + refresh and retry the SAME account once.
+                        if attempt == 0 and not invalidated:
+                            log.warning("Codex auth 401, forcing token refresh...")
+                            await self.auth.invalidate_current()
+                            new_token = await self.auth.get_access_token()
+                            headers["Authorization"] = f"Bearer {new_token}"
+                            account_id = self.auth.get_account_id()
+                            if account_id:
+                                headers["ChatGPT-Account-Id"] = account_id
+                            continue
+                        # Invalidated, or a 401 that survived the refresh: this
+                        # account can't authenticate. Skip it and rotate to the
+                        # next account — only on this error, never routine traffic.
+                        rotated = False
+                        if hasattr(self.auth, "mark_current_auth_failed"):
+                            rotated = await self.auth.mark_current_auth_failed()
+                        if rotated and attempt < self.max_retries - 1:
+                            log.warning("Codex 401: skipped failed account, retrying on next...")
+                            new_token = await self.auth.get_access_token()
+                            headers["Authorization"] = f"Bearer {new_token}"
+                            account_id = self.auth.get_account_id()
+                            if account_id:
+                                headers["ChatGPT-Account-Id"] = account_id
+                            continue
+                        self.breaker.record_failure()
+                        raise RuntimeError(
+                            f"Codex 401 (auth failed, no healthy account): {error_body[:200]}"
+                        )
 
                     if resp.status == 429:
                         if hasattr(self.auth, "mark_current_limited"):

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -451,6 +451,8 @@ class CodexChatClient:
                             account_id = self.auth.get_account_id()
                             if account_id:
                                 headers["ChatGPT-Account-Id"] = account_id
+                            else:
+                                headers.pop("ChatGPT-Account-Id", None)
                             continue
                         # Invalidated, or a 401 that survived the refresh: this
                         # account can't authenticate. Skip it and rotate to the
@@ -465,6 +467,8 @@ class CodexChatClient:
                             account_id = self.auth.get_account_id()
                             if account_id:
                                 headers["ChatGPT-Account-Id"] = account_id
+                            else:
+                                headers.pop("ChatGPT-Account-Id", None)
                             continue
                         self.breaker.record_failure()
                         raise RuntimeError(
@@ -709,6 +713,8 @@ class CodexChatClient:
                             account_id = self.auth.get_account_id()
                             if account_id:
                                 headers["ChatGPT-Account-Id"] = account_id
+                            else:
+                                headers.pop("ChatGPT-Account-Id", None)
                             continue
                         # Invalidated, or a 401 that survived the refresh: this
                         # account can't authenticate. Skip it and rotate to the
@@ -723,6 +729,8 @@ class CodexChatClient:
                             account_id = self.auth.get_account_id()
                             if account_id:
                                 headers["ChatGPT-Account-Id"] = account_id
+                            else:
+                                headers.pop("ChatGPT-Account-Id", None)
                             continue
                         self.breaker.record_failure()
                         raise RuntimeError(

--- a/tests/test_codex_auth_rotation.py
+++ b/tests/test_codex_auth_rotation.py
@@ -1,0 +1,66 @@
+"""Tests for 401/invalidated-token account rotation in CodexAuthPool.
+
+The pool rotates on rate-limits (429) via mark_current_limited. These tests
+cover the new event-driven rotation on auth failure (401/invalidated token):
+skip the failed account to the next healthy one, set the bad account aside with
+a longer backoff (so it isn't thrashed), and surface the error only when there
+is no other account.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from src.llm.codex_auth import AUTH_FAILED_BACKOFF_SECONDS, CodexAuth, CodexAuthPool
+
+
+def _pool(n: int) -> CodexAuthPool:
+    pool = CodexAuthPool.__new__(CodexAuthPool)
+    pool._accounts = []
+    for i in range(n):
+        acct = MagicMock(spec=CodexAuth)
+        acct._load.return_value = {"email": f"acct{i}@example.com"}
+        pool._accounts.append(acct)
+    pool._current_index = 0
+    pool._pool_lock = asyncio.Lock()
+    return pool
+
+
+async def test_auth_failed_rotates_to_next_account():
+    pool = _pool(3)
+    rotated = await pool.mark_current_auth_failed()
+    assert rotated is True
+    assert pool._current_index == 1  # skipped to the next account
+    # The failed account was set aside with the long auth-failed backoff
+    # (NOT the 60s rate-limit window) so it isn't retried constantly.
+    pool._accounts[0].mark_rate_limited.assert_called_once_with(AUTH_FAILED_BACKOFF_SECONDS)
+    # Healthy accounts are untouched.
+    pool._accounts[1].mark_rate_limited.assert_not_called()
+
+
+async def test_auth_failed_single_account_surfaces_error():
+    pool = _pool(1)
+    rotated = await pool.mark_current_auth_failed()
+    assert rotated is False  # nothing to rotate to -> caller raises
+    assert pool._current_index == 0
+    pool._accounts[0].mark_rate_limited.assert_called_once_with(AUTH_FAILED_BACKOFF_SECONDS)
+
+
+async def test_auth_failed_empty_pool_is_safe():
+    pool = _pool(0)
+    assert await pool.mark_current_auth_failed() is False
+
+
+async def test_single_codexauth_cannot_rotate():
+    auth = CodexAuth.__new__(CodexAuth)
+    assert await auth.mark_current_auth_failed() is False
+
+
+def test_mark_rate_limited_accepts_custom_window():
+    auth = CodexAuth.__new__(CodexAuth)
+    auth.mark_rate_limited(AUTH_FAILED_BACKOFF_SECONDS)
+    assert auth.is_rate_limited() is True
+    # Default still works (backward compatible).
+    auth2 = CodexAuth.__new__(CodexAuth)
+    auth2.mark_rate_limited()
+    assert auth2.is_rate_limited() is True


### PR DESCRIPTION
### Problem
The pool rotates on **429** (`mark_current_limited` → rotate), but a **401 `token_invalidated`** only triggered `invalidate_current()` (clear + refresh) gated to `attempt==0`, with **no rotation**. An account whose token is revoked server-side ("Please try signing in again") can't be refreshed, so it dead-ended and surfaced the error instead of failing over — observed live when one of 3 accounts got invalidated.

### Fix (event-driven, no routine rotation)
- On a 401 that is explicitly `invalidated`/"sign in again", or that **survives a refresh**: mark the account auth-failed and **skip to the next account**.
- The bad account is set aside for a longer window (`AUTH_FAILED_BACKOFF_SECONDS=600`) instead of the 60s rate-limit retry — so it isn't thrashed every minute (per AT: don't constantly rotate; only skip on error).
- Generic first-time 401 still does the cheap refresh-and-retry on the same account.
- Single account / no pool: surfaces the error as before (genuine re-auth needed).
- Both stream-loop 401 sites updated; `mark_rate_limited` gains an optional window; new `CodexAuthPool.mark_current_auth_failed()`.

### Tests
`tests/test_codex_auth_rotation.py` — rotates multi-account, surfaces single-account, custom backoff window. LLM suite green, no new ruff.

**Status: review only — do not merge.** Awaiting AT's go + Odin review.