### PR TITLE
Memory systems overhaul: learned-context integrity + session continuity

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,9 @@ sessions:
   # Archives are kept indefinitely; pruned oldest-first only past these caps
   archive_max_bytes: 2147483648
   archive_max_files: 10000
+  # Max estimated tokens of session history per LLM request (per-channel
+  # overrides: context_budget_overrides: {"<channel_id>": 131072})
+  context_token_budget: 64000
 
 tools:
   enabled: true
@@ -85,6 +88,7 @@ learning:
   enabled: true
   max_entries: 150
   consolidation_target: 120
+  injection_token_budget: 4000
 
 search:
   enabled: true

--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,11 @@ sessions:
   max_history: 50
   max_age_hours: 24
   persist_directory: ./data/sessions
+  token_budget: 256000
+  adaptive_compaction: true
+  # Archives are kept indefinitely; pruned oldest-first only past these caps
+  archive_max_bytes: 2147483648
+  archive_max_files: 10000
 
 tools:
   enabled: true
@@ -78,8 +83,8 @@ webhook:
 
 learning:
   enabled: true
-  max_entries: 30
-  consolidation_target: 20
+  max_entries: 150
+  consolidation_target: 120
 
 search:
   enabled: true

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -36,6 +36,10 @@ class SessionsConfig(BaseModel):
     # only past these caps (restore-on-demand depends on archives surviving).
     archive_max_bytes: int = 2 * 1024**3
     archive_max_files: int = 10_000
+    # Max estimated tokens of session history sent per LLM request; hot
+    # channels can run larger windows via per-channel overrides.
+    context_token_budget: int = 64_000
+    context_budget_overrides: dict[str, int] = {}
 
 
 class ToolHost(BaseModel):
@@ -350,6 +354,9 @@ class LearningConfig(BaseModel):
     enabled: bool = True
     max_entries: int = 150
     consolidation_target: int = 120
+    # Learned Context injection budget (tokens). When the scoped corpus fits,
+    # ALL of it is injected; relevance gating engages only beyond this.
+    injection_token_budget: int = 4000
 
 
 class SearchConfig(BaseModel):

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -32,6 +32,10 @@ class SessionsConfig(BaseModel):
     persist_directory: str = "./data/sessions"
     token_budget: int = 256_000
     adaptive_compaction: bool = True
+    # Session archives are retained indefinitely by default; pruned oldest-first
+    # only past these caps (restore-on-demand depends on archives surviving).
+    archive_max_bytes: int = 2 * 1024**3
+    archive_max_files: int = 10_000
 
 
 class ToolHost(BaseModel):
@@ -344,8 +348,8 @@ class WebhookConfig(BaseModel):
 
 class LearningConfig(BaseModel):
     enabled: bool = True
-    max_entries: int = 30
-    consolidation_target: int = 20
+    max_entries: int = 150
+    consolidation_target: int = 120
 
 
 class SearchConfig(BaseModel):

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -1492,14 +1492,11 @@ class OdinBot(commands.Bot):
     async def _operational_reflection(
         self, user_request: str, tools_used: list[str],
         response: str, is_error: bool, user_id: str | None,
-        channel_id: str | None = None,
+        tool_details: list[dict] | None = None,
     ) -> None:
         """Fire-and-forget post-operation reflection — selective, with real
         tool inputs/results from the operation instead of bare tool names."""
         try:
-            tool_details = (
-                self._last_op_details.pop(channel_id, None) if channel_id else None
-            )
             if not tool_details:
                 tool_details = [{"tool": t} for t in tools_used[:20]]
             if not self._should_reflect_on_operation(
@@ -2440,9 +2437,13 @@ class OdinBot(commands.Bot):
         # failures. Must run for both the success and error paths (previously this
         # was nested under the success branch, so is_error was never observed).
         if tools_used:
+            # Pop synchronously inside the channel-locked request body so a
+            # fast follow-up request can never swap details under the
+            # fire-and-forget reflection task.
+            op_details = self._last_op_details.pop(channel_id, None)
             fire_and_forget(self._operational_reflection(
                 content, tools_used, response, is_error, user_id,
-                channel_id=channel_id,
+                tool_details=op_details,
             ), name="operational_reflection")
 
         if voice_callback:

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2269,15 +2269,12 @@ class OdinBot(commands.Bot):
                 _sp = self._build_system_prompt(channel=message.channel, user_id=user_id, query=content)
                 _sp = await self._inject_tool_hints(_sp, content, user_id)
                 log.info("Routing to Codex with tools")
-                # Detect topic change before fetching history
-                topic_info = self.sessions.detect_topic_change(channel_id, content)
                 # Use abbreviated history to reduce poisoning from stale responses
                 # (get_task_history handles compaction internally)
                 # Pass current message content for relevance scoring —
                 # older messages unrelated to the current query are dropped
                 task_history = await self.sessions.get_task_history(
                     channel_id, max_messages=40, current_query=content,
-                    topic_change=topic_info["is_topic_change"],
                 )
                 if image_blocks and task_history and task_history[-1]["role"] == "user":
                     last = task_history[-1]
@@ -2290,7 +2287,6 @@ class OdinBot(commands.Bot):
                 try:
                     response, already_sent, is_error, tools_used, handoff = await self._process_with_tools(
                         message, task_history, system_prompt_override=_sp,
-                        topic_change=topic_info["is_topic_change"],
                     )
                 except asyncio.TimeoutError as codex_err:
                     log.warning("Codex tool loop timed out: %s", codex_err)
@@ -2535,7 +2531,6 @@ class OdinBot(commands.Bot):
         message: discord.Message,
         history: list[dict],
         system_prompt_override: str | None = None,
-        topic_change: bool = False,
     ) -> tuple[str, bool, bool, list[str], bool]:
         """Process a message with Codex tool loop.
 
@@ -2579,7 +2574,6 @@ class OdinBot(commands.Bot):
             message_id=message.id,
             channel_description=channel_ctx,
             has_history=len(messages) > 1,
-            topic_change=topic_change,
             from_another_bot=is_bot_message,
         )
         if len(messages) > 1:

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -247,6 +247,10 @@ class OdinBot(commands.Bot):
         # Recent tool executions for conversational context (injected into system prompt)
         # Per-channel: {channel_id: [(timestamp, entry_text), ...]}
         self._recent_actions: dict[str, list[tuple[float, str]]] = {}
+        # Per-channel tool input/result details from the most recent tool
+        # loop — consumed by post-operation reflection so it learns from
+        # what actually happened, not just tool names.
+        self._last_op_details: dict[str, list[dict]] = {}
         self._recent_actions_max = 10
         self._recent_actions_expiry = 3600  # seconds (1 hour)
         # Background task tracking
@@ -1460,13 +1464,50 @@ class OdinBot(commands.Bot):
         finally:
             self._llm_active_requests -= 1
 
+    # Successful operations below this tool count are routine — reflection
+    # is reserved for failures, corrections, explicit asks, and substantive work.
+    _REFLECT_MIN_TOOLS = 5
+    _REFLECT_CORRECTION_MARKERS = (
+        "remember this", "remember that", "that's wrong", "thats wrong",
+        "that is wrong", "not what i asked", "you should have", "incorrect,",
+        "no, ", "actually,",
+    )
+
+    def _should_reflect_on_operation(
+        self, user_request: str, tools_used: list[str],
+        is_error: bool, tool_details: list[dict],
+    ) -> bool:
+        """Reflection triggers: failure, mid-operation tool errors (recovery),
+        user corrections, explicit remember-this, or substantive operations.
+        Routine successes (ls/git-status class) skip reflection entirely."""
+        if is_error:
+            return True
+        if any(d.get("error") for d in tool_details):
+            return True
+        req = user_request.lower()
+        if any(marker in req for marker in self._REFLECT_CORRECTION_MARKERS):
+            return True
+        return len(tools_used) >= self._REFLECT_MIN_TOOLS
+
     async def _operational_reflection(
         self, user_request: str, tools_used: list[str],
         response: str, is_error: bool, user_id: str | None,
+        channel_id: str | None = None,
     ) -> None:
-        """Fire-and-forget post-operation reflection."""
+        """Fire-and-forget post-operation reflection — selective, with real
+        tool inputs/results from the operation instead of bare tool names."""
         try:
-            tool_details = [{"tool": t} for t in tools_used[:20]]
+            tool_details = self._last_op_details.pop(channel_id, None) if channel_id else None
+            if not tool_details:
+                tool_details = [{"tool": t} for t in tools_used[:20]]
+            if not self._should_reflect_on_operation(
+                user_request, tools_used, is_error, tool_details,
+            ):
+                log.debug(
+                    "Skipping reflection for routine operation (%d tools, no errors)",
+                    len(tools_used),
+                )
+                return
             await self.reflector.reflect_on_operation(
                 user_request=user_request,
                 tools_used=tools_used,
@@ -2395,6 +2436,7 @@ class OdinBot(commands.Bot):
         if tools_used:
             fire_and_forget(self._operational_reflection(
                 content, tools_used, response, is_error, user_id,
+                channel_id=channel_id,
             ), name="operational_reflection")
 
         if voice_callback:
@@ -2627,6 +2669,7 @@ class OdinBot(commands.Bot):
 
         # Per-turn trajectory accumulator — populated each iteration, saved at end.
         from ..trajectories.saver import TrajectoryTurn, ToolIteration
+        _op_tool_details: list[dict] = []
         _trajectory = TrajectoryTurn(
             message_id=str(getattr(message, "id", "")),
             channel_id=str(getattr(message.channel, "id", "")),
@@ -3242,6 +3285,21 @@ class OdinBot(commands.Bot):
                     *[_run_tool_with_timeout(b) for b in tool_calls],
                 )
             messages.append({"role": "user", "content": list(tool_results)})
+
+            # Pair calls with results for post-operation reflection. Stashed
+            # per iteration so every loop exit path leaves the latest state.
+            _results_by_id = {
+                r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)
+            }
+            for _tc in tool_calls:
+                _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
+                _op_tool_details.append({
+                    "tool": _tc.name,
+                    "input": _tc.input,
+                    "result": _rcontent[:300],
+                    "error": _rcontent.lstrip().lower().startswith(("error", "[error", "failed", "traceback")),
+                })
+            self._last_op_details[str(message.channel.id)] = _op_tool_details
 
             if _cancel.is_set():
                 return _stopped("after_tools")

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -877,7 +877,7 @@ class OdinBot(commands.Bot):
         """Learned Context for the prompt — query-aware relevance selection.
 
         File parsing is mtime-cached inside the reflector, so calling per
-        message is cheap; selection math is microseconds over <=150 entries.
+        message is cheap; selection is fast over <=150 entries.
         """
         if not hasattr(self, "reflector"):
             return ""
@@ -1497,7 +1497,9 @@ class OdinBot(commands.Bot):
         """Fire-and-forget post-operation reflection — selective, with real
         tool inputs/results from the operation instead of bare tool names."""
         try:
-            tool_details = self._last_op_details.pop(channel_id, None) if channel_id else None
+            tool_details = (
+                self._last_op_details.pop(channel_id, None) if channel_id else None
+            )
             if not tool_details:
                 tool_details = [{"tool": t} for t in tools_used[:20]]
             if not self._should_reflect_on_operation(
@@ -2278,7 +2280,9 @@ class OdinBot(commands.Bot):
                         }
                     log.info("Attached %d image(s) to message for Claude vision", len(image_blocks))
                 if self.llm_client:
-                    chat_prompt = self._build_chat_system_prompt(channel=message.channel, user_id=user_id, query=content)
+                    chat_prompt = self._build_chat_system_prompt(
+                        channel=message.channel, user_id=user_id, query=content,
+                    )
                     try:
                         response = await self.llm_client.chat(
                             messages=history,
@@ -2339,7 +2343,9 @@ class OdinBot(commands.Bot):
                 if handoff and self.llm_client and not is_error:
                     log.info("Skill handoff to Codex for response")
                     _skill_response = response  # Save before overwriting
-                    chat_prompt = self._build_chat_system_prompt(channel=message.channel, user_id=user_id, query=content)
+                    chat_prompt = self._build_chat_system_prompt(
+                        channel=message.channel, user_id=user_id, query=content,
+                    )
                     # Fetch full history for handoff (compaction already ran in get_task_history)
                     history = self.sessions.get_history(channel_id)
                     codex_messages = list(history) + [
@@ -3297,7 +3303,8 @@ class OdinBot(commands.Bot):
                     "tool": _tc.name,
                     "input": _tc.input,
                     "result": _rcontent[:300],
-                    "error": _rcontent.lstrip().lower().startswith(("error", "[error", "failed", "traceback")),
+                    "error": _rcontent.lstrip().lower().startswith(
+                        ("error", "[error", "failed", "traceback")),
                 })
             self._last_op_details[str(message.channel.id)] = _op_tool_details
 

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -327,6 +327,10 @@ class OdinBot(commands.Bot):
             reflector=self.reflector,
             vector_store=self._vector_store,
             embedder=self._embedder,
+            token_budget=config.sessions.token_budget,
+            adaptive_compaction=config.sessions.adaptive_compaction,
+            archive_max_bytes=config.sessions.archive_max_bytes,
+            archive_max_files=config.sessions.archive_max_files,
         )
         self.sessions.load()
 

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -268,8 +268,6 @@ class OdinBot(commands.Bot):
         self._memory_cache: dict[str | None, tuple[float, dict[str, str]]] = {}
         self._memory_cache_ttl: float = 60.0  # seconds
         # TTL cache for reflector prompt section (avoids file I/O per message)
-        self._reflector_cache: dict[str | None, tuple[float, str]] = {}
-        self._reflector_cache_ttl: float = 60.0  # seconds
         # Throttled cache cleanup
         self._last_cache_cleanup: float = 0.0
         self._cache_cleanup_interval: float = 300.0  # every 5 minutes
@@ -281,6 +279,7 @@ class OdinBot(commands.Bot):
             learned_path="./data/learned.json",
             max_entries=config.learning.max_entries,
             consolidation_target=config.learning.consolidation_target,
+            injection_token_budget=config.learning.injection_token_budget,
             enabled=config.learning.enabled,
         )
 
@@ -331,6 +330,8 @@ class OdinBot(commands.Bot):
             adaptive_compaction=config.sessions.adaptive_compaction,
             archive_max_bytes=config.sessions.archive_max_bytes,
             archive_max_files=config.sessions.archive_max_files,
+            context_token_budget=config.sessions.context_token_budget,
+            context_budget_overrides=config.sessions.context_budget_overrides,
         )
         self.sessions.load()
 
@@ -868,24 +869,23 @@ class OdinBot(commands.Bot):
         self._memory_cache[user_id] = (now, memory)
         return memory
 
-    def _get_cached_reflector(self, user_id: str | None) -> str:
-        """Return cached reflector prompt section with TTL to avoid file I/O per message."""
+    def _get_reflector_section(self, user_id: str | None, query: str | None = None) -> str:
+        """Learned Context for the prompt — query-aware relevance selection.
+
+        File parsing is mtime-cached inside the reflector, so calling per
+        message is cheap; selection math is microseconds over <=150 entries.
+        """
         if not hasattr(self, "reflector"):
             return ""
-        now = time.time()
-        cached = self._reflector_cache.get(user_id)
-        if cached and now - cached[0] < self._reflector_cache_ttl:
-            return cached[1]
-        learned = self.reflector.get_prompt_section(user_id=user_id)
-        self._reflector_cache[user_id] = (now, learned)
-        return learned
+        return self.reflector.get_prompt_section(user_id=user_id, query=query)
 
     def _invalidate_prompt_caches(self) -> None:
         """Invalidate all prompt-related caches. Called on config/context reload."""
         self._cached_hosts = None
         self._cached_skills_text = None
         self._memory_cache.clear()
-        self._reflector_cache.clear()
+        if hasattr(self, "reflector"):
+            self.reflector.invalidate_cache()
 
     def _invoke_skill_missing_required(self, name: str, payload: dict) -> list[str]:
         """Return required input fields the payload omits, or [] if complete.
@@ -1016,8 +1016,9 @@ class OdinBot(commands.Bot):
             memory_text = "\n".join(f"- **{k}**: {v}" for k, v in memory.items())
             prompt += f"\n\n## Persistent Memory\n{memory_text}"
 
-        # Inject learned context from cross-conversation reflection (per-user filtered)
-        learned = self._get_cached_reflector(user_id)
+        # Inject learned context from cross-conversation reflection
+        # (per-user filtered, relevance-ranked against the current query)
+        learned = self._get_reflector_section(user_id, query)
         if learned:
             prompt += f"\n\n{learned}"
 
@@ -1080,6 +1081,7 @@ class OdinBot(commands.Bot):
     def _build_chat_system_prompt(
         self, channel: discord.abc.GuildChannel | None = None,
         user_id: str | None = None,
+        query: str | None = None,
     ) -> str:
         """Build a lightweight system prompt for chat-routed messages.
 
@@ -1114,8 +1116,8 @@ class OdinBot(commands.Bot):
             memory_text = "\n".join(f"- **{k}**: {v}" for k, v in memory.items())
             prompt += f"\n\n## Persistent Memory\n{memory_text}"
 
-        # Inject learned context (per-user filtered, personality from past conversations)
-        learned = self._get_cached_reflector(user_id)
+        # Inject learned context (per-user filtered, relevance-ranked)
+        learned = self._get_reflector_section(user_id, query)
         if learned:
             prompt += f"\n\n{learned}"
 
@@ -1169,11 +1171,6 @@ class OdinBot(commands.Bot):
         ttl = getattr(self, "_memory_cache_ttl", 60.0)
         self._memory_cache = {
             k: v for k, v in getattr(self, "_memory_cache", {}).items()
-            if now - v[0] < ttl
-        }
-        ttl = getattr(self, "_reflector_cache_ttl", 60.0)
-        self._reflector_cache = {
-            k: v for k, v in getattr(self, "_reflector_cache", {}).items()
             if now - v[0] < ttl
         }
 
@@ -2240,7 +2237,7 @@ class OdinBot(commands.Bot):
                         }
                     log.info("Attached %d image(s) to message for Claude vision", len(image_blocks))
                 if self.llm_client:
-                    chat_prompt = self._build_chat_system_prompt(channel=message.channel, user_id=user_id)
+                    chat_prompt = self._build_chat_system_prompt(channel=message.channel, user_id=user_id, query=content)
                     try:
                         response = await self.llm_client.chat(
                             messages=history,
@@ -2274,7 +2271,7 @@ class OdinBot(commands.Bot):
                 # Pass current message content for relevance scoring —
                 # older messages unrelated to the current query are dropped
                 task_history = await self.sessions.get_task_history(
-                    channel_id, max_messages=40, current_query=content,
+                    channel_id, max_messages=160, current_query=content,
                 )
                 if image_blocks and task_history and task_history[-1]["role"] == "user":
                     last = task_history[-1]
@@ -2301,7 +2298,7 @@ class OdinBot(commands.Bot):
                 if handoff and self.llm_client and not is_error:
                     log.info("Skill handoff to Codex for response")
                     _skill_response = response  # Save before overwriting
-                    chat_prompt = self._build_chat_system_prompt(channel=message.channel, user_id=user_id)
+                    chat_prompt = self._build_chat_system_prompt(channel=message.channel, user_id=user_id, query=content)
                     # Fetch full history for handoff (compaction already ran in get_task_history)
                     history = self.sessions.get_history(channel_id)
                     codex_messages = list(history) + [

--- a/src/discord/tool_loop_helpers.py
+++ b/src/discord/tool_loop_helpers.py
@@ -25,7 +25,6 @@ def build_request_preamble(
     message_id: Any,
     channel_description: str,
     has_history: bool,
-    topic_change: bool = False,
     from_another_bot: bool = False,
 ) -> dict:
     """Build the developer-role separator message that delimits the current
@@ -57,13 +56,6 @@ def build_request_preamble(
         "being referenced — do not sweep through history re-executing everything. "
         "Evaluate tools fresh. Do not repeat prior refusals."
     )
-    if topic_change:
-        sep_text += (
-            "\n\nTOPIC CHANGE DETECTED. The user has switched to a new subject. "
-            "History above is from a DIFFERENT topic — do NOT carry over "
-            "assumptions, hosts, files, or context from the previous topic. "
-            "Treat this as a fresh request."
-        )
     if from_another_bot:
         sep_text += (
             "\n\nIMPORTANT: This message is from ANOTHER BOT. "

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -175,7 +175,11 @@ class ConversationReflector:
 
     def _save(self, data: dict) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps(data, indent=2))
+        # Atomic temp+replace — a crash mid-write must never corrupt the
+        # learned store (the whole point of this subsystem is integrity).
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._path)
 
     def get_all_entries(self) -> list[dict]:
         return self._load().get("entries", [])

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -36,7 +36,8 @@ _CATEGORY_EXPIRY_DAYS: dict[str, int] = {"operational": 180, "fact": 180}
 
 _REFLECTION_HEADER = """\
 Extract clear, explicit lessons from this conversation. Return a JSON array.
-Each element: {"key": "snake_case_id", "category": "correction|preference|operational|fact", "content": "ONE lesson, max 700 chars", "topic": "short-project-or-area-slug", "tags": ["optional", "keywords"]}
+Each element: {"key": "snake_case_id", "category": "correction|preference|operational|fact",
+"content": "ONE lesson, max 700 chars", "topic": "short-project-or-area-slug", "tags": ["optional"]}
 Rules:
 - Max 5 insights per reflection
 - ONE lesson per entry — never combine unrelated lessons into a single entry
@@ -341,7 +342,7 @@ class ConversationReflector:
         """Record injection usage in memory; persisted opportunistically by
         the next locked write (merge/consolidation). last_used_at only feeds
         the 180-day staleness window, so eventual persistence is fine."""
-        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        now = datetime.now(UTC).isoformat(timespec="seconds")
         for e in entries:
             self._use_stamps[e.get("key", "")] = now
 
@@ -673,14 +674,19 @@ class ConversationReflector:
         prompt = (
             _CONSOLIDATION_HEADER + str(target)
             + " or fewer.\nSTRICT RULES:\n"
-            "- Merge ONLY entries that cover the same topic/key/meaning (true duplicates or updates of the same fact).\n"
-            "- NEVER combine unrelated lessons into one entry to reduce the count — one lesson per entry.\n"
+            "- Merge ONLY entries that cover the same topic/key/meaning "
+            "(true duplicates or updates of the same fact).\n"
+            "- NEVER combine unrelated lessons into one entry to reduce "
+            "the count — one lesson per entry.\n"
             "- Prefer DROPPING stale or low-value entries over merging unrelated ones.\n"
-            "- If the target cannot be reached without merging unrelated topics, return more entries than the target instead.\n"
+            "- If the target cannot be reached without merging unrelated "
+            "topics, return more entries than the target instead.\n"
             f"- Keep each content under {_SOFT_CONTENT_CHARS} characters.\n"
-            "- Preserve key, user_id, topic, tags, and confidence fields exactly as-is (null if absent).\n"
+            "- Preserve key, user_id, topic, tags, and confidence fields "
+            "exactly as-is (null if absent).\n"
             " Return a JSON array with the same schema:"
-            ' [{"key": ..., "category": ..., "content": ..., "user_id": ..., "topic": ..., "tags": ..., "confidence": ...}]'
+            ' [{"key": ..., "category": ..., "content": ..., "user_id": ...,'
+            ' "topic": ..., "tags": ..., "confidence": ...}]'
             "\n\nEntries:\n" + entries_text
         )
 

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -310,6 +310,33 @@ class ConversationReflector:
         lines = [fmt(e) for e in selected]
         return "## Learned Context\n" + "\n".join(lines)
 
+    _REFLECTION_CONTEXT_TOP_K = 30
+
+    @staticmethod
+    def _relevant_existing_text(entries: list[dict], context_text: str) -> str:
+        """Render the existing entries most relevant to *context_text* for a
+        reflection prompt. Embedding the whole corpus made every reflection
+        pay for (and be biased by) all stored knowledge; the model only
+        needs nearby entries to reuse keys and avoid duplicates."""
+        if not entries:
+            return "(none)"
+        if len(entries) > ConversationReflector._REFLECTION_CONTEXT_TOP_K:
+            from ..relevance import rank as relevance_rank
+            ranked = relevance_rank(
+                context_text, entries,
+                lambda e: " ".join([
+                    e.get("content", ""), e.get("topic", ""),
+                    " ".join(e.get("tags", [])), e.get("key", ""),
+                ]),
+                top_k=ConversationReflector._REFLECTION_CONTEXT_TOP_K,
+            )
+            chosen = {id(e) for e in ranked}
+            entries = [e for e in entries if id(e) in chosen]
+        return "\n".join(
+            f"- [{e['category']}] {e['key']}: {e['content']}"
+            for e in entries
+        )
+
     def _note_used(self, entries: list[dict]) -> None:
         """Record injection usage in memory; persisted opportunistically by
         the next locked write (merge/consolidation). last_used_at only feeds
@@ -369,10 +396,7 @@ class ConversationReflector:
         )
 
         existing = self._load().get("entries", [])
-        existing_text = "\n".join(
-            f"- [{e['category']}] {e['key']}: {e['content']}"
-            for e in existing
-        ) if existing else "(none)"
+        existing_text = self._relevant_existing_text(existing, operation_summary)
 
         prompt = (
             "Review this completed operation and extract ONLY durable operational "
@@ -481,10 +505,7 @@ class ConversationReflector:
             data = await asyncio.to_thread(self._load)
             existing = data.get("entries", [])
 
-            existing_text = "\n".join(
-                f"- [{e['category']}] {e['key']}: {e['content']}"
-                for e in existing
-            ) if existing else "(none)"
+            existing_text = self._relevant_existing_text(existing, conversation)
 
             # When multiple users participated, instruct the LLM to attribute entries
             user_hint = ""

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -17,13 +17,29 @@ TextFn = Callable[[list[dict], str], Awaitable[str]]
 
 log = get_logger("learning")
 
-_MAX_CONTENT_CHARS = 800
+# Content length policy. The soft limit is prompt guidance to the LLM; the
+# hard limit is enforced at storage time — but never as a silent chop.
+# Oversized content is clipped at a sentence boundary, suffixed with
+# _TRUNCATION_MARKER, and flagged damaged=True so it can be resummarized
+# rather than degrading further through future consolidation cycles.
+_SOFT_CONTENT_CHARS = 700
+_HARD_CONTENT_CHARS = 1000
+_TRUNCATION_MARKER = " [truncated: needs resummary]"
+_SENTENCE_TERMINATORS = (".", "!", "?", "…", '"', "'", ")", "]", "`")
+
+_LEARNED_SCHEMA_VERSION = 2
+
+# Category-aware expiry: corrections and preferences never auto-expire
+# (removed only via supersession); operational/fact entries go stale when
+# neither used nor updated within the window.
+_CATEGORY_EXPIRY_DAYS: dict[str, int] = {"operational": 180, "fact": 180}
 
 _REFLECTION_HEADER = """\
 Extract clear, explicit lessons from this conversation. Return a JSON array.
-Each element: {"key": "snake_case_id", "category": "correction|preference|operational|fact", "content": "max 800 chars"}
+Each element: {"key": "snake_case_id", "category": "correction|preference|operational|fact", "content": "ONE lesson, max 700 chars", "topic": "short-project-or-area-slug", "tags": ["optional", "keywords"]}
 Rules:
 - Max 5 insights per reflection
+- ONE lesson per entry — never combine unrelated lessons into a single entry
 - Reuse existing keys when updating a known fact
 - Return [] if nothing worth learning
 - Categories: correction (user corrected the bot), preference (how user likes things done), operational (system/infra knowledge), fact (general truth)
@@ -36,6 +52,49 @@ Anti-hallucination rules:
 
 _CONSOLIDATION_HEADER = """\
 Consolidate these learned entries to """
+
+
+def _clip_content(entry: dict) -> dict:
+    """Enforce the hard content limit without silent data loss.
+
+    Content over _HARD_CONTENT_CHARS is clipped at the latest sentence
+    boundary, suffixed with an explicit marker, and the entry is flagged
+    damaged=True so consolidation leaves it alone until resummarized.
+    """
+    content = entry.get("content", "")
+    if len(content) <= _HARD_CONTENT_CHARS:
+        return entry
+    limit = _HARD_CONTENT_CHARS - len(_TRUNCATION_MARKER)
+    clipped = content[:limit]
+    boundary = -1
+    for term in _SENTENCE_TERMINATORS:
+        boundary = max(boundary, clipped.rfind(term))
+    if boundary > limit // 2:
+        clipped = clipped[: boundary + 1]
+    else:
+        last_space = clipped.rfind(" ")
+        if last_space > 0:
+            clipped = clipped[:last_space]
+    entry["content"] = clipped.rstrip() + _TRUNCATION_MARKER
+    entry["damaged"] = True
+    log.warning(
+        "Learned entry %r exceeded %d chars; clipped at sentence boundary and flagged damaged",
+        entry.get("key"), _HARD_CONTENT_CHARS,
+    )
+    return entry
+
+
+def _looks_chopped(content: str) -> bool:
+    """Heuristic for legacy entries damaged by the old silent [:800] chop."""
+    stripped = content.rstrip()
+    if len(stripped) < 780:
+        return False
+    return not stripped.endswith(_SENTENCE_TERMINATORS)
+
+
+def _default_confidence(category: str) -> str:
+    """Explicit user signals are high-confidence; inferred lessons are medium."""
+    return "high" if category in ("correction", "preference") else "medium"
 
 
 class ConversationReflector:
@@ -68,10 +127,46 @@ class ConversationReflector:
     def _load(self) -> dict:
         if self._path.exists():
             try:
-                return json.loads(self._path.read_text())
+                data = json.loads(self._path.read_text())
+                return self._migrate(data)
             except (json.JSONDecodeError, OSError) as e:
                 log.error("Failed to load learned.json: %s", e)
-        return {"version": 1, "last_reflection": None, "entries": []}
+        return {
+            "version": _LEARNED_SCHEMA_VERSION,
+            "last_reflection": None,
+            "entries": [],
+        }
+
+    def _migrate(self, data: dict) -> dict:
+        """One-time v1→v2 migration: flag legacy chop damage, backfill metadata.
+
+        Idempotent — guarded by the stored schema version. Entries silently
+        truncated by the old [:800] policy are detected heuristically (long
+        content not ending at a sentence boundary), marked damaged, and given
+        an explicit truncation marker so the loss is visible and they are
+        excluded from further consolidation until resummarized.
+        """
+        if data.get("version", 1) >= _LEARNED_SCHEMA_VERSION:
+            return data
+        damaged_count = 0
+        for entry in data.get("entries", []):
+            content = entry.get("content", "")
+            if not entry.get("damaged") and _looks_chopped(content):
+                entry["content"] = content.rstrip() + _TRUNCATION_MARKER
+                entry["damaged"] = True
+                damaged_count += 1
+            entry.setdefault("confidence", _default_confidence(entry.get("category", "")))
+            entry.setdefault("source", {"created_by": "legacy"})
+        data["version"] = _LEARNED_SCHEMA_VERSION
+        try:
+            self._save(data)
+        except OSError as e:
+            log.error("Failed to persist learned.json migration: %s", e)
+        log.info(
+            "Migrated learned.json to schema v%d (%d entries, %d flagged damaged)",
+            _LEARNED_SCHEMA_VERSION, len(data.get("entries", [])), damaged_count,
+        )
+        return data
 
     def _save(self, data: dict) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -196,7 +291,9 @@ class ConversationReflector:
             "- Generic knowledge the bot already has\n\n"
             "Return a JSON array. Each entry: {\"key\": \"snake_case_id\", "
             "\"category\": \"correction|operational|preference\", "
-            "\"content\": \"concise lesson\"}\n"
+            "\"content\": \"ONE concise lesson, max 700 chars\", "
+            "\"topic\": \"short-project-or-area-slug\", \"tags\": [\"optional\"]}\n"
+            "ONE lesson per entry — never combine unrelated lessons.\n"
             "Return [] if nothing worth remembering.\n\n"
             "Currently known:\n" + existing_text + "\n\n"
             "Operation:\n" + operation_summary
@@ -215,6 +312,7 @@ class ConversationReflector:
 
             single_user = user_ids[0] if len(user_ids) == 1 else None
             for entry in new_entries:
+                entry.setdefault("source", {"created_by": "operation"})
                 if entry["category"] in ("preference", "correction") and single_user:
                     if "user_id" not in entry:
                         entry["user_id"] = single_user
@@ -344,6 +442,7 @@ class ConversationReflector:
             effective_ids = user_ids or []
             single_user = effective_ids[0] if len(effective_ids) == 1 else None
             for entry in new_entries:
+                entry.setdefault("source", {"created_by": "reflection"})
                 if entry["category"] in ("preference", "correction"):
                     if single_user and "user_id" not in entry:
                         entry["user_id"] = single_user
@@ -370,89 +469,148 @@ class ConversationReflector:
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         by_key = {e["key"]: e for e in existing}
         for entry in new_entries:
-            entry["content"] = entry["content"][:_MAX_CONTENT_CHARS]
+            _clip_content(entry)
+            entry.setdefault("confidence", _default_confidence(entry.get("category", "")))
+            # A new entry may explicitly supersede older ones — remove them,
+            # keeping the list on the new entry for provenance.
+            for superseded_key in entry.get("supersedes", []):
+                if superseded_key in by_key and superseded_key != entry["key"]:
+                    by_key.pop(superseded_key)
+                    log.info(
+                        "Learned entry %r superseded by %r", superseded_key, entry["key"],
+                    )
             if entry["key"] in by_key:
-                by_key[entry["key"]]["content"] = entry["content"]
-                by_key[entry["key"]]["category"] = entry["category"]
-                by_key[entry["key"]]["updated_at"] = now
-                if "user_id" in entry:
-                    by_key[entry["key"]]["user_id"] = entry["user_id"]
+                current = by_key[entry["key"]]
+                current["content"] = entry["content"]
+                current["category"] = entry["category"]
+                current["updated_at"] = now
+                # Fresh full-length content repairs a previously damaged entry
+                if entry.get("damaged"):
+                    current["damaged"] = True
+                else:
+                    current.pop("damaged", None)
+                for field in ("user_id", "topic", "tags", "confidence", "source", "supersedes"):
+                    if field in entry:
+                        current[field] = entry[field]
             else:
                 entry["created_at"] = now
                 entry["updated_at"] = now
                 by_key[entry["key"]] = entry
         return list(by_key.values())
 
-    _MAX_ENTRY_AGE_DAYS = 90
+    def _expire_entries(self, entries: list[dict]) -> list[dict]:
+        """Category-aware expiry.
+
+        Corrections and preferences never auto-expire (only supersession
+        removes them). Operational and fact entries go stale when neither
+        used nor updated within their _CATEGORY_EXPIRY_DAYS window.
+        """
+        now = datetime.now(timezone.utc)
+        kept = []
+        expired = 0
+        for e in entries:
+            days = _CATEGORY_EXPIRY_DAYS.get(e.get("category", ""))
+            if days is None:
+                kept.append(e)
+                continue
+            ref = e.get("last_used_at") or e.get("updated_at") or e.get("created_at")
+            if not ref:
+                kept.append(e)
+                continue
+            try:
+                ref_dt = datetime.fromisoformat(ref)
+            except ValueError:
+                kept.append(e)
+                continue
+            if now - ref_dt <= timedelta(days=days):
+                kept.append(e)
+            else:
+                expired += 1
+        if expired:
+            log.info("Reflector: expired %d stale operational/fact entries", expired)
+        return kept
 
     async def _consolidate(self, entries: list[dict]) -> list[dict]:
-        """Ask the LLM to merge entries down to the consolidation target."""
-        now = datetime.now(timezone.utc)
-        cutoff = now - timedelta(days=self._MAX_ENTRY_AGE_DAYS)
-        before = len(entries)
-        entries = [
-            e for e in entries
-            if not e.get("created_at") or datetime.fromisoformat(e["created_at"]) > cutoff
-        ]
-        if len(entries) < before:
-            log.info("Reflector: expired %d entries older than %d days", before - len(entries), self._MAX_ENTRY_AGE_DAYS)
+        """Ask the LLM to merge same-topic duplicates down to the target.
+
+        Damaged entries are passed through unmerged — consolidating already
+        clipped text compounds the damage. Unrelated topics are never packed
+        together to hit the target count; dropping low-value entries is the
+        sanctioned way to shrink.
+        """
+        entries = self._expire_entries(entries)
         if not entries:
             return []
-        entries_text = json.dumps(entries, indent=2)
+
+        damaged = [e for e in entries if e.get("damaged")]
+        candidates = [e for e in entries if not e.get("damaged")]
+        if not candidates:
+            return damaged
+
+        target = max(1, self._consolidation_target - len(damaged))
+        entries_text = json.dumps(candidates, indent=2)
         prompt = (
-            _CONSOLIDATION_HEADER + str(self._consolidation_target)
-            + ' or fewer. Merge duplicates, drop stale or low-value items.'
-            ' Return a JSON array with the same schema:'
-            ' [{"key": ..., "category": ..., "content": ..., "user_id": ...}]'
-            ' Preserve the user_id field exactly as-is for each entry (null if absent).'
+            _CONSOLIDATION_HEADER + str(target)
+            + " or fewer.\nSTRICT RULES:\n"
+            "- Merge ONLY entries that cover the same topic/key/meaning (true duplicates or updates of the same fact).\n"
+            "- NEVER combine unrelated lessons into one entry to reduce the count — one lesson per entry.\n"
+            "- Prefer DROPPING stale or low-value entries over merging unrelated ones.\n"
+            "- If the target cannot be reached without merging unrelated topics, return more entries than the target instead.\n"
+            f"- Keep each content under {_SOFT_CONTENT_CHARS} characters.\n"
+            "- Preserve key, user_id, topic, tags, and confidence fields exactly as-is (null if absent).\n"
+            " Return a JSON array with the same schema:"
+            ' [{"key": ..., "category": ..., "content": ..., "user_id": ..., "topic": ..., "tags": ..., "confidence": ...}]'
             "\n\nEntries:\n" + entries_text
         )
 
         system_instruction = "You consolidate learned entries. Return only valid JSON array."
 
+        def _fallback() -> list[dict]:
+            candidates.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+            return candidates[:target] + damaged
+
         try:
             if not self._text_fn:
                 log.warning("No text completion backend configured for consolidation")
-                entries.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
-                return entries[: self._consolidation_target]
+                return _fallback()
             raw_text = await self._text_fn(
                 [{"role": "user", "content": prompt}],
                 system_instruction,
             )
         except Exception as e:
             log.error("Consolidation API call failed: %s", e)
-            # Fallback: just keep the most recently updated entries
-            entries.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
-            return entries[: self._consolidation_target]
+            return _fallback()
 
         raw = raw_text.strip()
         consolidated = self._parse_entries(raw)
         if not consolidated:
             log.warning("Consolidation returned no entries, keeping originals trimmed")
-            entries.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
-            return entries[: self._consolidation_target]
+            return _fallback()
 
-        # Preserve timestamps from originals where possible
-        orig_by_key = {e["key"]: e for e in entries}
+        # Preserve timestamps and metadata from originals where possible
+        orig_by_key = {e["key"]: e for e in candidates}
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         for entry in consolidated:
-            entry["content"] = entry["content"][:_MAX_CONTENT_CHARS]
+            _clip_content(entry)
             if entry["key"] in orig_by_key:
                 orig = orig_by_key[entry["key"]]
                 entry["created_at"] = orig.get("created_at", now)
                 entry["updated_at"] = now
-                # Preserve user_id from original if consolidation dropped it
-                if "user_id" not in entry and "user_id" in orig:
-                    entry["user_id"] = orig["user_id"]
+                # Consolidation must not invent or upgrade metadata it dropped
+                for field in ("user_id", "topic", "tags", "confidence", "source", "last_used_at"):
+                    if field not in entry and field in orig:
+                        entry[field] = orig[field]
             else:
                 entry["created_at"] = now
                 entry["updated_at"] = now
+                entry.setdefault("confidence", _default_confidence(entry.get("category", "")))
+                entry.setdefault("source", {"created_by": "consolidation"})
 
         log.info(
-            "Consolidated %d entries down to %d",
-            len(entries), len(consolidated),
+            "Consolidated %d entries down to %d (+%d damaged passed through)",
+            len(candidates), len(consolidated), len(damaged),
         )
-        return consolidated
+        return consolidated + damaged
 
     @staticmethod
     def _parse_entries(raw: str) -> list[dict]:
@@ -505,5 +663,13 @@ class ConversationReflector:
                 }
                 if item.get("user_id"):
                     entry["user_id"] = str(item["user_id"])
+                if item.get("topic"):
+                    entry["topic"] = str(item["topic"])
+                if isinstance(item.get("tags"), list):
+                    entry["tags"] = [str(t) for t in item["tags"] if t][:8]
+                if item.get("confidence") in ("high", "medium", "low"):
+                    entry["confidence"] = item["confidence"]
+                if isinstance(item.get("supersedes"), list):
+                    entry["supersedes"] = [str(k) for k in item["supersedes"] if k]
                 valid.append(entry)
         return valid

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -104,16 +104,20 @@ class ConversationReflector:
         self,
         learned_path: str,
         *,
-        max_entries: int = 30,
-        consolidation_target: int = 20,
+        max_entries: int = 150,
+        consolidation_target: int = 120,
+        injection_token_budget: int = 4000,
         enabled: bool = True,
     ) -> None:
         self._path = Path(learned_path)
         self._lock = asyncio.Lock()
         self._max_entries = max_entries
         self._consolidation_target = consolidation_target
+        self._injection_token_budget = injection_token_budget
         self._enabled = enabled
         self._text_fn: TextFn | None = None
+        self._injection_cache: tuple[float, dict] | None = None
+        self._use_stamps: dict[str, str] = {}
 
     def set_text_fn(self, fn: TextFn) -> None:
         """Register an async callable for LLM text generation.
@@ -206,14 +210,51 @@ class ConversationReflector:
                 return e
         return None
 
-    def get_prompt_section(self, user_id: str | None = None) -> str:
+    # Injection selection caps, applied only when the corpus exceeds the
+    # token budget. Corrections and the requester's preferences are pinned;
+    # operational/fact entries compete on relevance to the current query.
+    _PIN_CORRECTIONS_CAP = 30
+    _PIN_PREFERENCES_CAP = 25
+    _OPERATIONAL_TOP_K = 12
+    _FACTS_TOP_K = 5
+
+    def _read_for_injection(self) -> dict:
+        """mtime-cached read for the hot injection path.
+
+        Write paths always use _load() directly for fresh data; this cache
+        only avoids re-parsing the file on every message.
+        """
+        try:
+            mtime = self._path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        cached = getattr(self, "_injection_cache", None)
+        if cached and cached[0] == mtime:
+            return cached[1]
+        data = self._load()
+        self._injection_cache = (mtime, data)
+        return data
+
+    def invalidate_cache(self) -> None:
+        self._injection_cache = None
+
+    def get_prompt_section(
+        self, user_id: str | None = None, query: str | None = None,
+    ) -> str:
         """Format learned entries for injection into the system prompt.
 
-        If *user_id* is provided, includes global entries (no user_id) plus
-        entries tagged for that specific user.  Entries tagged for *other*
-        users are excluded.
+        Scope: global entries plus entries tagged for *user_id*; other
+        users' entries are excluded.
+
+        Selection: when the whole scoped corpus fits the injection token
+        budget, ALL of it is included — relevance gating only engages when
+        the corpus outgrows the budget. Gated selection pins corrections
+        and the requester's preferences, then fills with the operational
+        and fact entries most relevant to *query*.
         """
-        data = self._load()
+        from ..relevance import rank as relevance_rank
+
+        data = self._read_for_injection()
         entries = data.get("entries", [])
         if not entries:
             return ""
@@ -229,8 +270,63 @@ class ConversationReflector:
             # else: entry belongs to another user — skip
         if not filtered:
             return ""
-        lines = [f"- [{e['category']}] {e['content']}" for e in filtered]
+
+        def fmt(e: dict) -> str:
+            return f"- [{e['category']}] {e['content']}"
+
+        total_tokens = sum(len(fmt(e)) for e in filtered) // 4
+        if total_tokens <= self._injection_token_budget or not query:
+            selected = filtered
+        else:
+            def entry_text(e: dict) -> str:
+                return " ".join([
+                    e.get("content", ""), e.get("topic", ""),
+                    " ".join(e.get("tags", [])), e.get("key", ""),
+                ])
+
+            corrections = [e for e in filtered if e["category"] == "correction"]
+            corrections = corrections[-self._PIN_CORRECTIONS_CAP:]
+            preferences = [e for e in filtered if e["category"] == "preference"]
+            preferences = preferences[-self._PIN_PREFERENCES_CAP:]
+            operational = relevance_rank(
+                query,
+                [e for e in filtered if e["category"] == "operational"],
+                entry_text, top_k=self._OPERATIONAL_TOP_K,
+            )
+            facts = relevance_rank(
+                query,
+                [e for e in filtered if e["category"] == "fact"],
+                entry_text, top_k=self._FACTS_TOP_K,
+            )
+            # Preserve original corpus order for stable prompts
+            chosen = {id(e) for e in (*corrections, *preferences, *operational, *facts)}
+            selected = [e for e in filtered if id(e) in chosen]
+            log.debug(
+                "Learned injection gated: %d/%d entries selected",
+                len(selected), len(filtered),
+            )
+
+        self._note_used(selected)
+        lines = [fmt(e) for e in selected]
         return "## Learned Context\n" + "\n".join(lines)
+
+    def _note_used(self, entries: list[dict]) -> None:
+        """Record injection usage in memory; persisted opportunistically by
+        the next locked write (merge/consolidation). last_used_at only feeds
+        the 180-day staleness window, so eventual persistence is fine."""
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        for e in entries:
+            self._use_stamps[e.get("key", "")] = now
+
+    def _apply_use_stamps(self, entries: list[dict]) -> None:
+        """Fold pending in-memory usage stamps into entries (call under lock)."""
+        if not self._use_stamps:
+            return
+        for e in entries:
+            stamp = self._use_stamps.get(e.get("key", ""))
+            if stamp:
+                e["last_used_at"] = stamp
+        self._use_stamps.clear()
 
     async def reflect_on_operation(
         self,
@@ -320,12 +416,14 @@ class ConversationReflector:
             async with self._lock:
                 data = await asyncio.to_thread(self._load)
                 existing = data.get("entries", [])
+                self._apply_use_stamps(existing)
                 merged = self._merge_entries(existing, new_entries)
                 if len(merged) > self._max_entries:
                     merged = await self._consolidate(merged)
                 data["entries"] = merged
                 data["last_reflection"] = datetime.now(timezone.utc).isoformat()
                 await asyncio.to_thread(self._save, data)
+                self.invalidate_cache()
                 log.info("Operational reflection: %d new entries merged", len(new_entries))
         except Exception as e:
             log.error("Operational reflection failed: %s", e)
@@ -450,6 +548,7 @@ class ConversationReflector:
                     # If it didn't and we have multiple users, leave untagged (global)
                 # operational and fact entries stay global (no user_id)
 
+            self._apply_use_stamps(existing)
             merged = self._merge_entries(existing, new_entries)
 
             # Consolidate if over limit
@@ -459,6 +558,7 @@ class ConversationReflector:
             data["entries"] = merged
             data["last_reflection"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
             await asyncio.to_thread(self._save, data)
+            self.invalidate_cache()
             log.info(
                 "Reflection complete: %d new insights, %d total entries",
                 len(new_entries), len(merged),

--- a/src/relevance.py
+++ b/src/relevance.py
@@ -1,0 +1,65 @@
+"""Shared relevance scoring for memory surfaces.
+
+One ranking implementation used by both memory systems — learned-context
+injection (reflector) and session context assembly (messages, summary
+segments) — so selection behavior stays consistent and tunable in one
+place. Lexical token-overlap scoring with stop-word filtering; cheap
+enough to run inline on every request over a few hundred candidates.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# Common stop words to ignore when scoring relevance
+STOP_WORDS = frozenset({
+    "a", "an", "the", "is", "it", "in", "on", "to", "of", "and", "or",
+    "for", "that", "this", "with", "was", "are", "be", "has", "have",
+    "had", "do", "does", "did", "but", "not", "you", "i", "me", "my",
+    "we", "he", "she", "they", "what", "how", "can", "will", "just",
+    "so", "if", "no", "yes", "at", "by", "from", "up", "out", "as",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9_./:-]+")
+
+
+def tokenize(text: str) -> set[str]:
+    """Extract meaningful lowercase tokens from text, filtering stop words."""
+    return {t for t in _TOKEN_RE.findall(text.lower()) if t not in STOP_WORDS and len(t) > 1}
+
+
+def score(query: str, text: str) -> float:
+    """Score how relevant *text* is to *query* — 0.0 to 1.0.
+
+    Jaccard-like overlap: |intersection| / |query_tokens|.
+    """
+    query_tokens = tokenize(query)
+    if not query_tokens:
+        return 0.0
+    text_tokens = tokenize(text)
+    if not text_tokens:
+        return 0.0
+    return len(query_tokens & text_tokens) / len(query_tokens)
+
+
+def rank(
+    query: str,
+    items: Iterable[T],
+    text_fn: Callable[[T], str],
+    *,
+    top_k: int,
+    floor: float = 0.0,
+) -> list[T]:
+    """Return up to *top_k* items most relevant to *query*, best first.
+
+    Items scoring below *floor* are excluded entirely. Ties keep the
+    original iteration order (stable sort), so callers can pre-order by
+    recency to break ties in favor of newer items.
+    """
+    scored = [(score(query, text_fn(item)), idx, item) for idx, item in enumerate(items)]
+    kept = [(s, idx, item) for s, idx, item in scored if s >= floor]
+    kept.sort(key=lambda x: (-x[0], x[1]))
+    return [item for _, _, item in kept[:top_k]]

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from ..llm.cost_tracker import estimate_tokens
 from ..odin_log import get_logger
-from ..relevance import rank as relevance_rank, score as relevance_score, tokenize as _tokenize
+from ..relevance import rank as relevance_rank, score as relevance_score
 if TYPE_CHECKING:
     from ..learning.reflector import ConversationReflector
     from ..search.embedder import LocalEmbedder
@@ -255,7 +255,9 @@ def apply_token_budget(
     protected_count = 0
     for m in older:
         text = _content_text(m)
-        if any(text.startswith(p) for p in _PROTECTED_PREFIXES) or text == "Understood, I have context from our previous conversation.":  # legacy pair tolerated in flight
+        # ("Understood…" tolerates the legacy summary pair while in flight)
+        if (any(text.startswith(p) for p in _PROTECTED_PREFIXES)
+                or text == "Understood, I have context from our previous conversation."):
             protected_count += 1
         else:
             break
@@ -792,7 +794,10 @@ class SessionManager:
                         meta[field_name] = [p.strip() for p in raw.split(sep) if p.strip()][:12]
         return meta
 
-    def _append_segment(self, session: Session, summary_text: str, source_messages: list[Message], *, fallback: bool = False) -> dict:
+    def _append_segment(
+        self, session: Session, summary_text: str,
+        source_messages: list[Message], *, fallback: bool = False,
+    ) -> dict:
         """Build a summary segment with provenance and append it to the session."""
         summary_text = self._clip_segment_text(summary_text.strip())
         participants = sorted({m.user_id for m in source_messages if m.user_id})
@@ -873,7 +878,8 @@ class SessionManager:
             "Summarize the following conversation slice into a context segment.\n\n"
             "FORMAT:\n"
             "Line 1: [Topics: comma-separated topic tags, e.g. nginx, dns, server-a]\n"
-            "Line 2: [Entities: comma-separated identifiers — file paths, PR numbers, SHAs, hosts, services]\n"
+            "Line 2: [Entities: comma-separated identifiers — file paths, "
+            "PR numbers, SHAs, hosts, services]\n"
             "Line 3: [Decisions: semicolon-separated decisions made, or none]\n"
             "Line 4: [Open: semicolon-separated unresolved threads, or none]\n"
             "Line 5+: Bullet points of key facts.\n\n"

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -360,6 +360,10 @@ class SessionManager:
         self.archive_max_files = archive_max_files
         self.context_token_budget = context_token_budget
         self.context_budget_overrides = context_budget_overrides or {}
+        # Reset tombstones: channel -> epoch. Archives at or before the
+        # epoch are never restored — reset/purge means GONE, not "back on
+        # the next message". Persisted so restarts honor resets too.
+        self._reset_epochs: dict[str, float] = self._load_reset_epochs()
         self._sessions: dict[str, Session] = {}
         self._dirty: set[str] = set()
         self._reflector = reflector
@@ -407,12 +411,15 @@ class SessionManager:
         archive_dir = self.persist_dir / "archive"
         if not archive_dir.exists():
             return None
+        reset_epoch = self._reset_epochs.get(channel_id, 0.0)
         candidates: list[tuple[float, Path]] = []
         for path in archive_dir.glob(f"{channel_id}_*.json"):
             try:
                 ts = float(path.stem.rsplit("_", 1)[1])
             except (ValueError, IndexError):
                 ts = path.stat().st_mtime
+            if ts <= reset_epoch:
+                continue  # reset/purged context stays gone
             candidates.append((ts, path))
         if not candidates:
             return None
@@ -504,21 +511,32 @@ class SessionManager:
             parts.append(f"{header}\n{text}")
         return "\n\n".join(parts)
 
+    @classmethod
+    def _summary_context_message(
+        cls, session: Session, query: str | None = None,
+    ) -> dict | None:
+        """The single source of the prior-context block — a developer-role
+        read-only message, never fake user/assistant dialogue."""
+        context_summary = cls._render_context_summary(session, query=query)
+        if not context_summary:
+            return None
+        sanitized = _sanitize_summary(context_summary)
+        return {
+            "role": "developer",
+            "content": (
+                "[SESSION_CONTEXT_READ_ONLY]\n"
+                "Summaries of earlier completed conversation (context, not pending work):\n"
+                f"{sanitized}"
+            ),
+        }
+
     def get_history(self, channel_id: str) -> list[dict[str, str]]:
         session = self.get_or_create(channel_id)
         messages = [{"role": m.role, "content": m.content} for m in session.messages]
 
-        # Prepend prior-context summary (legacy string and/or segments)
-        context_summary = self._render_context_summary(session)
-        if context_summary:
-            messages.insert(0, {
-                "role": "user",
-                "content": f"[Previous conversation summary: {context_summary}]",
-            })
-            messages.insert(1, {
-                "role": "assistant",
-                "content": "Understood, I have context from our previous conversation.",
-            })
+        context_msg = self._summary_context_message(session)
+        if context_msg:
+            messages.insert(0, context_msg)
 
         return messages
 
@@ -649,17 +667,9 @@ class SessionManager:
         # Prepend prior-context summaries as a read-only developer block —
         # NOT as fake user/assistant dialogue, which polluted the transcript
         # with turns nobody actually said.
-        context_summary = self._render_context_summary(session, query=current_query)
-        if context_summary:
-            sanitized = _sanitize_summary(context_summary)
-            messages.insert(0, {
-                "role": "developer",
-                "content": (
-                    "[SESSION_CONTEXT_READ_ONLY]\n"
-                    "Summaries of earlier completed conversation (context, not pending work):\n"
-                    f"{sanitized}"
-                ),
-            })
+        context_msg = self._summary_context_message(session, query=current_query)
+        if context_msg:
+            messages.insert(0, context_msg)
 
         # Mark ALL history (including summaries) as read-only — must be first
         if len(messages) > 1:
@@ -986,9 +996,42 @@ class SessionManager:
             session.channel_id, len(discarded),
         )
 
-    def reset(self, channel_id: str) -> None:
+    def _epochs_path(self) -> Path:
+        return self.persist_dir / "reset_epochs.json"
+
+    def _load_reset_epochs(self) -> dict[str, float]:
+        try:
+            path = self._epochs_path()
+            if path.exists():
+                raw = json.loads(path.read_text())
+                return {str(k): float(v) for k, v in raw.items()}
+        except Exception as e:
+            log.warning("Failed to load reset epochs: %s", e)
+        return {}
+
+    def _save_reset_epochs(self) -> None:
+        try:
+            path = self._epochs_path()
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._reset_epochs))
+            tmp.replace(path)
+        except Exception as e:
+            log.warning("Failed to persist reset epochs: %s", e)
+
+    def _tombstone(self, channel_id: str) -> None:
+        """Drop the live session AND block archive restoration up to now."""
         self._sessions.pop(channel_id, None)
-        log.info("Session reset for channel %s", channel_id)
+        session_file = self.persist_dir / f"{channel_id}.json"
+        try:
+            session_file.unlink(missing_ok=True)
+        except OSError as e:
+            log.warning("Could not remove session file for %s: %s", channel_id, e)
+        self._reset_epochs[channel_id] = time.time()
+
+    def reset(self, channel_id: str) -> None:
+        self._tombstone(channel_id)
+        self._save_reset_epochs()
+        log.info("Session reset for channel %s (archives tombstoned)", channel_id)
 
     def count(self) -> int:
         return len(self._sessions)
@@ -1008,17 +1051,32 @@ class SessionManager:
     def reset_many(self, channel_ids: list[str]) -> int:
         removed = 0
         for cid in channel_ids:
-            if self._sessions.pop(cid, None) is not None:
+            existed = cid in self._sessions
+            self._tombstone(cid)
+            if existed:
                 removed += 1
+        if channel_ids:
+            self._save_reset_epochs()
         if removed:
-            log.info("Bulk reset %d sessions", removed)
+            log.info("Bulk reset %d sessions (archives tombstoned)", removed)
         return removed
 
     def clear_all(self) -> int:
         count = len(self._sessions)
-        self._sessions.clear()
+        # Tombstone every channel known from memory, live files, or archives —
+        # clear-all means nothing comes back from any of them.
+        known = set(self._sessions)
+        known.update(p.stem for p in self.persist_dir.glob("*.json")
+                     if p.name != "reset_epochs.json")
+        archive_dir = self.persist_dir / "archive"
+        if archive_dir.exists():
+            known.update(p.stem.rsplit("_", 1)[0] for p in archive_dir.glob("*_*.json"))
+        for cid in known:
+            self._tombstone(cid)
+        if known:
+            self._save_reset_epochs()
         if count:
-            log.info("Cleared all %d sessions", count)
+            log.info("Cleared all %d sessions (%d channels tombstoned)", count, len(known))
         return count
 
     def prune(self) -> int:
@@ -1383,6 +1441,8 @@ class SessionManager:
 
     def load(self) -> None:
         for path in self.persist_dir.glob("*.json"):
+            if path.name == "reset_epochs.json":
+                continue
             try:
                 data = json.loads(path.read_text())
                 self._sessions[data["channel_id"]] = self._session_from_dict(data)

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from ..llm.cost_tracker import estimate_tokens
 from ..odin_log import get_logger
+from ..relevance import rank as relevance_rank, score as relevance_score, tokenize as _tokenize
 if TYPE_CHECKING:
     from ..learning.reflector import ConversationReflector
     from ..search.embedder import LocalEmbedder
@@ -47,9 +48,9 @@ MAX_STORED_SEGMENTS = 100     # per-session cap on stored segments (oldest dropp
 KEEP_TAIL_MIN = 20            # always retain at least this many raw recent messages
 
 # Relevance scoring constants
-RELEVANCE_KEEP_RECENT = 5  # always include the most recent N messages
-RELEVANCE_MIN_SCORE = 0.10  # minimum overlap score to include an older message
-RELEVANCE_MAX_OLDER = 10  # max older messages to include beyond recent window
+RELEVANCE_KEEP_RECENT = 12  # always include the most recent N messages
+RELEVANCE_MIN_SCORE = 0.08  # minimum overlap score to include an older message
+RELEVANCE_MAX_OLDER = 40  # max older messages to include beyond recent window
 
 # Tool output summarization constants. These cap what the bot REMEMBERS of
 # its own responses after an operation ends (the user always sees the full
@@ -60,29 +61,13 @@ TOOL_SUMMARY_THRESHOLD = 10  # summarize when this many tool calls occurred
 TOOL_SUMMARY_MAX_CHARS = 2000  # max chars for summarized tool response in history
 CHAT_RESPONSE_MAX_CHARS = 4000  # max chars for text-only (no-tool) response in history
 
-# Context budget constants
-CONTEXT_TOKEN_BUDGET = 16000  # max estimated tokens for history sent to LLM
-BUDGET_KEEP_RECENT = 5  # always keep the most recent N messages regardless of budget
+# Context budget constants. The send budget is configurable
+# (sessions.context_token_budget, per-channel overrides) — this is the default.
+CONTEXT_TOKEN_BUDGET = 64_000  # max estimated tokens for history sent to LLM
+BUDGET_KEEP_RECENT = 12  # always keep the most recent N messages regardless of budget
 
 # Session token budget — auto-compact when a session's estimated tokens exceed this
 DEFAULT_SESSION_TOKEN_BUDGET = 256_000
-
-# Common stop words to ignore when scoring relevance
-_STOP_WORDS = frozenset({
-    "a", "an", "the", "is", "it", "in", "on", "to", "of", "and", "or",
-    "for", "that", "this", "with", "was", "are", "be", "has", "have",
-    "had", "do", "does", "did", "but", "not", "you", "i", "me", "my",
-    "we", "he", "she", "they", "what", "how", "can", "will", "just",
-    "so", "if", "no", "yes", "at", "by", "from", "up", "out", "as",
-})
-
-_TOKEN_RE = re.compile(r"[a-z0-9_./:-]+")
-
-
-def _tokenize(text: str) -> set[str]:
-    """Extract meaningful lowercase tokens from text, filtering stop words."""
-    return {t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOP_WORDS and len(t) > 1}
-
 
 _IMPERATIVE_RE = re.compile(
     r"^(?:run|execute|restart|deploy|check|install|update|delete|create|stop|start|kill|push|merge|build)\s+",
@@ -155,19 +140,12 @@ def adaptive_keep_ratio(rate: float) -> float:
 
 
 def score_relevance(query: str, message_content: str) -> float:
-    """Score how relevant a message is to the current query.
+    """Score how relevant a message is to the current query (0.0-1.0).
 
-    Returns a float between 0.0 and 1.0 based on keyword overlap.
-    Uses Jaccard-like scoring: |intersection| / |query_tokens|.
+    Thin alias over the shared relevance module so all memory surfaces
+    rank with one implementation.
     """
-    query_tokens = _tokenize(query)
-    if not query_tokens:
-        return 0.0
-    msg_tokens = _tokenize(message_content)
-    if not msg_tokens:
-        return 0.0
-    overlap = query_tokens & msg_tokens
-    return len(overlap) / len(query_tokens)
+    return relevance_score(query, message_content)
 
 
 def summarize_tool_response(
@@ -238,7 +216,7 @@ def summarize_tool_response(
 
 
 _SUMMARY_PREFIX = "[Previous conversation summary:"
-_PROTECTED_PREFIXES = ("[HISTORY_READ_ONLY]", "[COMPLETED SUMMARY]", _SUMMARY_PREFIX)
+_PROTECTED_PREFIXES = ("[HISTORY_READ_ONLY]", "[SESSION_CONTEXT_READ_ONLY]", _SUMMARY_PREFIX)
 
 
 def _content_text(m: dict) -> str:
@@ -277,7 +255,7 @@ def apply_token_budget(
     protected_count = 0
     for m in older:
         text = _content_text(m)
-        if any(text.startswith(p) for p in _PROTECTED_PREFIXES) or text == "Understood, I have context from our previous conversation.":
+        if any(text.startswith(p) for p in _PROTECTED_PREFIXES) or text == "Understood, I have context from our previous conversation.":  # legacy pair tolerated in flight
             protected_count += 1
         else:
             break
@@ -367,6 +345,8 @@ class SessionManager:
         adaptive_compaction: bool = True,
         archive_max_bytes: int = 2 * 1024**3,
         archive_max_files: int = 10_000,
+        context_token_budget: int = CONTEXT_TOKEN_BUDGET,
+        context_budget_overrides: dict[str, int] | None = None,
     ) -> None:
         self.max_history = max_history
         self.max_age_seconds = max_age_hours * 3600
@@ -376,6 +356,8 @@ class SessionManager:
         self.adaptive_compaction = adaptive_compaction
         self.archive_max_bytes = archive_max_bytes
         self.archive_max_files = archive_max_files
+        self.context_token_budget = context_token_budget
+        self.context_budget_overrides = context_budget_overrides or {}
         self._sessions: dict[str, Session] = {}
         self._dirty: set[str] = set()
         self._reflector = reflector
@@ -476,13 +458,38 @@ class SessionManager:
         return False
 
     @staticmethod
-    def _render_context_summary(session: Session, max_segments: int = 5) -> str:
-        """Render prior-context text from the legacy summary and/or the most
-        recent summary segments (chronological), for prompt injection."""
+    def _render_context_summary(
+        session: Session, query: str | None = None, max_segments: int = 5,
+    ) -> str:
+        """Render prior-context text from the legacy summary and/or summary
+        segments for prompt injection.
+
+        The newest segment is always included (it is the immediate past);
+        when a *query* is given, the remaining slots go to the most relevant
+        older segments instead of simple recency. Rendering stays
+        chronological regardless of how segments were selected.
+        """
         parts: list[str] = []
         if session.summary:
             parts.append(session.summary)
-        for seg in session.summary_segments[-max_segments:]:
+        segments = session.summary_segments
+        if not query or len(segments) <= max_segments:
+            selected = segments[-max_segments:]
+        else:
+            newest = segments[-1]
+            older = segments[:-1]
+            ranked = relevance_rank(
+                query, list(reversed(older)),
+                lambda s: " ".join([
+                    s.get("summary", ""),
+                    " ".join(s.get("topics", [])),
+                    " ".join(s.get("entities", [])),
+                ]),
+                top_k=max_segments - 1,
+            )
+            chosen = {id(s) for s in ranked}
+            selected = [s for s in older if id(s) in chosen] + [newest]
+        for seg in selected:
             text = seg.get("summary", "")
             if not text:
                 continue
@@ -637,20 +644,22 @@ class SessionManager:
 
         messages = [{"role": m.role, "content": m.content} for m in filtered]
 
-        # Prepend prior-context summary if available
-        context_summary = self._render_context_summary(session)
+        # Prepend prior-context summaries as a read-only developer block —
+        # NOT as fake user/assistant dialogue, which polluted the transcript
+        # with turns nobody actually said.
+        context_summary = self._render_context_summary(session, query=current_query)
         if context_summary:
             sanitized = _sanitize_summary(context_summary)
             messages.insert(0, {
-                "role": "user",
-                "content": f"[COMPLETED SUMMARY] {sanitized}",
-            })
-            messages.insert(1, {
-                "role": "assistant",
-                "content": "Understood, I have context from our previous conversation.",
+                "role": "developer",
+                "content": (
+                    "[SESSION_CONTEXT_READ_ONLY]\n"
+                    "Summaries of earlier completed conversation (context, not pending work):\n"
+                    f"{sanitized}"
+                ),
             })
 
-        # Mark ALL history (including summary) as read-only — must be first
+        # Mark ALL history (including summaries) as read-only — must be first
         if len(messages) > 1:
             messages.insert(0, {
                 "role": "developer",
@@ -661,8 +670,11 @@ class SessionManager:
                 ),
             })
 
-        # Enforce token budget — drop oldest first, keep recent BUDGET_KEEP_RECENT
-        messages, budget_dropped = apply_token_budget(messages)
+        # Enforce the send budget — drop oldest first, keep recent
+        # BUDGET_KEEP_RECENT. Per-channel overrides allow hot ops channels
+        # to run with a larger window than the default.
+        budget = self.context_budget_overrides.get(channel_id, self.context_token_budget)
+        messages, budget_dropped = apply_token_budget(messages, budget=budget)
         if budget_dropped > 0:
             log.info(
                 "Token budget: dropped %d message(s) for channel %s",

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -5,6 +5,7 @@ import copy
 import json
 import re
 import time
+from datetime import datetime
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
@@ -22,26 +23,28 @@ if TYPE_CHECKING:
 CompactionFn = Callable[[list[dict], str], Awaitable[str]]
 
 log = get_logger("sessions")
-COMPACTION_THRESHOLD = 40  # compact when history exceeds this
-CONTINUITY_MAX_AGE = 48 * 3600  # carry forward summaries from archives < 48 hours old
-COMPACTION_MAX_CHARS = 800  # target max chars per compacted summary block
+COMPACTION_THRESHOLD = 100  # compact when history exceeds this many messages
+COMPACTION_MAX_CHARS = 2000  # default target chars per summary segment
 
 # Adaptive compaction — thresholds scale with channel message rate
 ACTIVITY_LOW = 5.0       # msgs/hr below this = low activity
 ACTIVITY_HIGH = 20.0     # msgs/hr above this = high activity
-ADAPTIVE_THRESHOLD_LOW = 60   # low-activity channels compact later
-ADAPTIVE_THRESHOLD_HIGH = 25  # high-activity channels compact sooner
-ADAPTIVE_SUMMARY_LOW = 1200   # low-activity channels get richer summaries
-ADAPTIVE_SUMMARY_HIGH = 500   # high-activity channels get tighter summaries
+ADAPTIVE_THRESHOLD_LOW = 120  # low-activity channels compact later
+ADAPTIVE_THRESHOLD_HIGH = 80  # high-activity channels compact sooner
+ADAPTIVE_SUMMARY_LOW = 2500   # low-activity channels get richer segments
+ADAPTIVE_SUMMARY_HIGH = 1500  # high-activity channels get tighter segments
 ADAPTIVE_KEEP_LOW = 0.60      # low-activity channels keep more after compaction
 ADAPTIVE_KEEP_HIGH = 0.35     # high-activity channels keep less
 ADAPTIVE_KEEP_DEFAULT = 0.50  # normal activity keep ratio
 ACTIVITY_WINDOW = 3600        # measure activity over last hour of messages
 
-# Topic change detection constants
-TOPIC_CHANGE_SCORE_THRESHOLD = 0.05  # below this overlap = topic change
-TOPIC_CHANGE_TIME_GAP = 300  # 5 minutes in seconds
-TOPIC_CHANGE_RECENT_WINDOW = 5  # check overlap against this many recent messages
+# Rolling summary segments
+SEGMENT_HARD_CHARS = 4000     # absolute segment size — clipped WITH marker, never silently
+SEGMENT_TRUNCATION_MARKER = "\n[segment truncated: source messages exceeded budget]"
+SEGMENT_IDLE_GAP_SECONDS = 6 * 3600  # idle gap that closes a conversation segment
+SEGMENT_MIN_MESSAGES = 15     # minimum messages before a gap-triggered segment closes
+MAX_STORED_SEGMENTS = 100     # per-session cap on stored segments (oldest dropped)
+KEEP_TAIL_MIN = 20            # always retain at least this many raw recent messages
 
 # Relevance scoring constants
 RELEVANCE_KEEP_RECENT = 5  # always include the most recent N messages
@@ -314,11 +317,15 @@ class Message:
     user_id: str | None = None
 
 
-def _estimate_session_tokens(messages: list[Message], summary: str) -> int:
-    """Estimate total token count for a session's messages and summary."""
+def _estimate_session_tokens(
+    messages: list[Message], summary: str, segments: list | None = None,
+) -> int:
+    """Estimate total token count for a session's messages, summary and segments."""
     total = 0
     if summary:
         total += estimate_tokens(summary)
+    for seg in segments or []:
+        total += estimate_tokens(seg.get("summary", ""))
     for m in messages:
         total += estimate_tokens(m.content if isinstance(m.content, str) else str(m.content))
     return total
@@ -344,7 +351,7 @@ class Session:
     @property
     def estimated_tokens(self) -> int:
         """Current estimated token count for this session's full content."""
-        return _estimate_session_tokens(self.messages, self.summary)
+        return _estimate_session_tokens(self.messages, self.summary, self.summary_segments)
 
 
 class SessionManager:
@@ -396,36 +403,48 @@ class SessionManager:
 
     def get_or_create(self, channel_id: str) -> Session:
         if channel_id not in self._sessions:
-            session = Session(channel_id=channel_id)
-            summary = self._find_recent_summary(channel_id)
-            if summary:
-                session.summary = f"[Continuing from previous conversation] {summary}"
-                log.info("Carried forward summary for channel %s", channel_id)
+            session = self._restore_from_archive(channel_id)
+            if session is None:
+                session = Session(channel_id=channel_id)
             self._sessions[channel_id] = session
             self._dirty.add(channel_id)
         session = self._sessions[channel_id]
         session.last_active = time.time()
         return session
 
-    def _find_recent_summary(self, channel_id: str) -> str:
-        """Find the most recent archived summary for a channel within the continuity window."""
+    def _restore_from_archive(self, channel_id: str) -> Session | None:
+        """Rehydrate the most recent archived session for this channel, any age.
+
+        Continuity no longer depends on wall-clock survival: a pruned session
+        comes back in full (messages + summary segments) the moment the
+        channel is active again. Compaction and relevance selection — not
+        restoration — decide what actually reaches the prompt.
+        """
         archive_dir = self.persist_dir / "archive"
         if not archive_dir.exists():
-            return ""
-        now = time.time()
-        best_summary = ""
-        best_time = 0.0
+            return None
+        candidates: list[tuple[float, Path]] = []
         for path in archive_dir.glob(f"{channel_id}_*.json"):
             try:
-                data = json.loads(path.read_text())
-                last_active = data.get("last_active", 0)
-                summary = data.get("summary", "")
-                if summary and now - last_active < CONTINUITY_MAX_AGE and last_active > best_time:
-                    best_summary = summary
-                    best_time = last_active
-            except Exception:
-                continue
-        return best_summary
+                ts = float(path.stem.rsplit("_", 1)[1])
+            except (ValueError, IndexError):
+                ts = path.stat().st_mtime
+            candidates.append((ts, path))
+        if not candidates:
+            return None
+        candidates.sort()
+        _, latest = candidates[-1]
+        try:
+            data = json.loads(latest.read_text())
+            session = self._session_from_dict(data)
+        except Exception as e:
+            log.error("Failed to restore archive %s: %s", latest, e)
+            return None
+        log.info(
+            "Restored session for channel %s from archive %s (%d messages, %d segments)",
+            channel_id, latest.name, len(session.messages), len(session.summary_segments),
+        )
+        return session
 
     def add_message(
         self, channel_id: str, role: str, content: str,
@@ -456,15 +475,36 @@ class SessionManager:
             return True
         return False
 
+    @staticmethod
+    def _render_context_summary(session: Session, max_segments: int = 5) -> str:
+        """Render prior-context text from the legacy summary and/or the most
+        recent summary segments (chronological), for prompt injection."""
+        parts: list[str] = []
+        if session.summary:
+            parts.append(session.summary)
+        for seg in session.summary_segments[-max_segments:]:
+            text = seg.get("summary", "")
+            if not text:
+                continue
+            try:
+                start = datetime.fromtimestamp(seg.get("start_ts", 0)).strftime("%b %d %H:%M")
+                end = datetime.fromtimestamp(seg.get("end_ts", 0)).strftime("%b %d %H:%M")
+                header = f"[Segment {start} – {end}]"
+            except (OSError, OverflowError, ValueError):
+                header = "[Segment]"
+            parts.append(f"{header}\n{text}")
+        return "\n\n".join(parts)
+
     def get_history(self, channel_id: str) -> list[dict[str, str]]:
         session = self.get_or_create(channel_id)
         messages = [{"role": m.role, "content": m.content} for m in session.messages]
 
-        # Prepend summary if we have one
-        if session.summary:
+        # Prepend prior-context summary (legacy string and/or segments)
+        context_summary = self._render_context_summary(session)
+        if context_summary:
             messages.insert(0, {
                 "role": "user",
-                "content": f"[Previous conversation summary: {session.summary}]",
+                "content": f"[Previous conversation summary: {context_summary}]",
             })
             messages.insert(1, {
                 "role": "assistant",
@@ -491,13 +531,36 @@ class SessionManager:
         }
 
     def _needs_compaction(self, session: Session) -> bool:
-        """Check if a session needs compaction (message count or token budget)."""
+        """Check if a session needs compaction.
+
+        Triggers: message count over the (adaptive) threshold, estimated
+        tokens over the session budget, or a closed conversation segment —
+        an idle gap of SEGMENT_IDLE_GAP_SECONDS with enough material before
+        it to be worth summarizing.
+        """
         params = self._get_compaction_params(session)
         if len(session.messages) > params["threshold"]:
             return True
         if session.estimated_tokens > self.token_budget:
             return True
+        if self._find_idle_split(session.messages) is not None:
+            return True
         return False
+
+    @staticmethod
+    def _find_idle_split(messages: list[Message]) -> int | None:
+        """Find the index that closes a conversation segment at an idle gap.
+
+        Returns the index of the first message AFTER the most recent idle
+        gap longer than SEGMENT_IDLE_GAP_SECONDS, provided at least
+        SEGMENT_MIN_MESSAGES precede the gap (so trivial exchanges don't
+        churn segments). Returns None when no qualifying gap exists.
+        """
+        for i in range(len(messages) - 1, 0, -1):
+            gap = messages[i].timestamp - messages[i - 1].timestamp
+            if gap > SEGMENT_IDLE_GAP_SECONDS and i >= SEGMENT_MIN_MESSAGES:
+                return i
+        return None
 
     async def get_history_with_compaction(
         self, channel_id: str,
@@ -517,72 +580,9 @@ class SessionManager:
 
         return self.get_history(channel_id)
 
-    def detect_topic_change(
-        self, channel_id: str, current_query: str,
-    ) -> dict:
-        """Detect whether the current query represents a topic change.
-
-        Returns a dict with:
-        - ``is_topic_change``: whether a topic change was detected
-        - ``time_gap``: seconds since last message (0 if no history)
-        - ``has_time_gap``: whether the time gap exceeds TOPIC_CHANGE_TIME_GAP
-        - ``max_overlap``: highest relevance score against recent messages
-
-        A topic change is detected when the keyword overlap between the current
-        query and recent history messages is below TOPIC_CHANGE_SCORE_THRESHOLD.
-        A time gap >5 min combined with low overlap strengthens the signal.
-        """
-        session = self._sessions.get(channel_id)
-        if not session or not session.messages:
-            return {
-                "is_topic_change": False,
-                "time_gap": 0.0,
-                "has_time_gap": False,
-                "max_overlap": 0.0,
-            }
-
-        # Time gap from last message
-        last_msg = session.messages[-1]
-        time_gap = time.time() - last_msg.timestamp
-
-        # Score overlap against recent messages
-        recent = session.messages[-TOPIC_CHANGE_RECENT_WINDOW:]
-        scores = []
-        for msg in recent:
-            content = msg.content if isinstance(msg.content, str) else str(msg.content)
-            s = score_relevance(current_query, content)
-            scores.append(s)
-
-        max_overlap = max(scores) if scores else 0.0
-        has_time_gap = time_gap > TOPIC_CHANGE_TIME_GAP
-
-        # Topic change: low overlap with all recent messages AND a time gap.
-        # Both conditions required — prevents false triggers on casual follow-ups
-        # like "thanks" or "what about X" that have low keyword overlap but are
-        # clearly part of the same conversation.
-        is_topic_change = (
-            max_overlap < TOPIC_CHANGE_SCORE_THRESHOLD
-            and has_time_gap
-            and len(recent) >= 2
-        )
-
-        if is_topic_change:
-            log.info(
-                "Topic change detected for channel %s (max_overlap=%.3f, time_gap=%.0fs)",
-                channel_id, max_overlap, time_gap,
-            )
-
-        return {
-            "is_topic_change": is_topic_change,
-            "time_gap": time_gap,
-            "has_time_gap": has_time_gap,
-            "max_overlap": max_overlap,
-        }
-
     async def get_task_history(
         self, channel_id: str, max_messages: int = 10,
         current_query: str | None = None,
-        topic_change: bool = False,
     ) -> list[dict[str, str]]:
         """Get abbreviated history for the tool-calling path.
 
@@ -594,11 +594,6 @@ class SessionManager:
         recent ``RELEVANCE_KEEP_RECENT``) are scored for keyword relevance
         and only the most relevant ones are included.  This prevents stale
         context from unrelated earlier conversations from bleeding in.
-
-        When *topic_change* is True, the history window is reduced to only
-        the most recent message (the current one) — previous context is
-        mostly irrelevant for a new topic.  The summary is still included
-        for broad continuity.
         """
         session = self.get_or_create(channel_id)
 
@@ -606,18 +601,10 @@ class SessionManager:
         if self._needs_compaction(session):
             await self._compact(session)
 
-        # On topic change, shrink to just the most recent message
-        if topic_change:
-            candidate_msgs = session.messages[-1:] if session.messages else []
-            log.info(
-                "Topic change: reduced history to %d message(s) for channel %s",
-                len(candidate_msgs), channel_id,
-            )
-        else:
-            # Take only the most recent messages as the candidate pool
-            candidate_msgs = session.messages[-max_messages:]
+        # Take only the most recent messages as the candidate pool
+        candidate_msgs = session.messages[-max_messages:]
 
-        if current_query and not topic_change and len(candidate_msgs) > RELEVANCE_KEEP_RECENT:
+        if current_query and len(candidate_msgs) > RELEVANCE_KEEP_RECENT:
             # Always include the most recent messages unconditionally
             recent = candidate_msgs[-RELEVANCE_KEEP_RECENT:]
             older = candidate_msgs[:-RELEVANCE_KEEP_RECENT]
@@ -650,9 +637,10 @@ class SessionManager:
 
         messages = [{"role": m.role, "content": m.content} for m in filtered]
 
-        # Prepend summary if available
-        if session.summary:
-            sanitized = _sanitize_summary(session.summary)
+        # Prepend prior-context summary if available
+        context_summary = self._render_context_summary(session)
+        if context_summary:
+            sanitized = _sanitize_summary(context_summary)
             messages.insert(0, {
                 "role": "user",
                 "content": f"[COMPLETED SUMMARY] {sanitized}",
@@ -733,58 +721,150 @@ class SessionManager:
             }
         return result
 
-    async def _compact(self, session: Session) -> None:
-        """Summarize older messages and keep only recent ones.
+    def _split_for_compaction(self, session: Session) -> tuple[list[Message], list[Message]]:
+        """Decide which messages close into a segment vs stay as raw tail.
 
-        When adaptive compaction is enabled, the keep count and summary char
-        budget scale with channel activity — busy channels compact more
-        aggressively to prevent context bloat.
+        An idle gap takes priority — it is a natural conversation boundary,
+        so everything before the gap becomes the segment and everything
+        after stays raw. Otherwise the adaptive keep-ratio applies, floored
+        at KEEP_TAIL_MIN and capped at max_history so technical threads keep
+        a substantial raw tail.
         """
-        params = self._get_compaction_params(session)
-        keep_ratio = params["keep_ratio"]
-        summary_chars = params["summary_chars"]
+        idle_split = self._find_idle_split(session.messages)
+        if idle_split is not None:
+            return session.messages[:idle_split], session.messages[idle_split:]
 
-        keep_count = max(2, round(len(session.messages) * keep_ratio))
-        # Clamp to at most max_history // 2 (original behaviour ceiling)
-        keep_count = min(keep_count, self.max_history // 2)
+        params = self._get_compaction_params(session)
+        keep_count = max(KEEP_TAIL_MIN, round(len(session.messages) * params["keep_ratio"]))
+        keep_count = min(keep_count, self.max_history)
         # When token budget triggers compaction with fewer messages than
         # keep_count, reduce keep_count so there's actually something to compact
         if len(session.messages) <= keep_count and len(session.messages) > 2:
             keep_count = max(2, len(session.messages) // 2)
-        to_summarize = session.messages[:-keep_count] if keep_count < len(session.messages) else []
-        to_keep = session.messages[-keep_count:]
+        if keep_count >= len(session.messages):
+            return [], session.messages
+        return session.messages[:-keep_count], session.messages[-keep_count:]
 
+    @staticmethod
+    def _clip_segment_text(text: str) -> str:
+        """Enforce the hard segment size at a line boundary, with an explicit
+        marker — stored summaries are never silently chopped."""
+        if len(text) <= SEGMENT_HARD_CHARS:
+            return text
+        limit = SEGMENT_HARD_CHARS - len(SEGMENT_TRUNCATION_MARKER)
+        clipped = text[:limit]
+        last_newline = clipped.rfind("\n")
+        if last_newline > limit // 2:
+            clipped = clipped[:last_newline]
+        return clipped.rstrip() + SEGMENT_TRUNCATION_MARKER
+
+    @staticmethod
+    def _parse_segment_metadata(summary_text: str) -> dict:
+        """Best-effort extraction of the structured header lines the
+        compaction prompt requests. The raw summary is kept regardless."""
+        meta: dict = {"topics": [], "entities": [], "decisions": [], "open_threads": []}
+        patterns = {
+            "topics": re.compile(r"^\[Topics:\s*(.*?)\]\s*$", re.IGNORECASE),
+            "entities": re.compile(r"^\[Entities:\s*(.*?)\]\s*$", re.IGNORECASE),
+            "decisions": re.compile(r"^\[Decisions:\s*(.*?)\]\s*$", re.IGNORECASE),
+            "open_threads": re.compile(r"^\[Open:\s*(.*?)\]\s*$", re.IGNORECASE),
+        }
+        for line in summary_text.splitlines()[:6]:
+            line = line.strip()
+            for field_name, pattern in patterns.items():
+                m = pattern.match(line)
+                if m:
+                    raw = m.group(1).strip()
+                    if raw and raw.lower() != "none":
+                        sep = ";" if field_name in ("decisions", "open_threads") else ","
+                        meta[field_name] = [p.strip() for p in raw.split(sep) if p.strip()][:12]
+        return meta
+
+    def _append_segment(self, session: Session, summary_text: str, source_messages: list[Message], *, fallback: bool = False) -> dict:
+        """Build a summary segment with provenance and append it to the session."""
+        summary_text = self._clip_segment_text(summary_text.strip())
+        participants = sorted({m.user_id for m in source_messages if m.user_id})
+        start_ts = source_messages[0].timestamp if source_messages else time.time()
+        end_ts = source_messages[-1].timestamp if source_messages else time.time()
+        segment = {
+            "id": f"seg_{int(end_ts)}_{len(session.summary_segments)}",
+            "start_ts": start_ts,
+            "end_ts": end_ts,
+            "participants": participants,
+            "summary": summary_text,
+            "source_count": len(source_messages),
+            "created_at": time.time(),
+            **self._parse_segment_metadata(summary_text),
+        }
+        if fallback:
+            segment["fallback"] = True
+        session.summary_segments.append(segment)
+        if len(session.summary_segments) > MAX_STORED_SEGMENTS:
+            dropped = len(session.summary_segments) - MAX_STORED_SEGMENTS
+            session.summary_segments = session.summary_segments[-MAX_STORED_SEGMENTS:]
+            log.info(
+                "Dropped %d oldest summary segment(s) for channel %s (cap %d)",
+                dropped, session.channel_id, MAX_STORED_SEGMENTS,
+            )
+        return segment
+
+    def _fold_legacy_summary(self, session: Session) -> None:
+        """Convert a pre-segment summary string into the first stored segment."""
+        if not session.summary:
+            return
+        legacy = {
+            "id": "seg_legacy",
+            "start_ts": session.created_at,
+            "end_ts": session.last_active,
+            "participants": [],
+            "summary": session.summary,
+            "source_count": 0,
+            "created_at": time.time(),
+            "legacy": True,
+            **self._parse_segment_metadata(session.summary),
+        }
+        session.summary_segments.insert(0, legacy)
+        session.summary = ""
+        log.info("Folded legacy summary into segment for channel %s", session.channel_id)
+
+    async def _compact(self, session: Session) -> None:
+        """Close older messages into a rolling summary segment.
+
+        Each compaction produces a NEW segment (older segments are kept,
+        never re-merged into one paragraph), preserving sequence, decisions,
+        and identifiers across long-running channels. A substantial raw tail
+        always survives — see _split_for_compaction.
+        """
+        to_summarize, to_keep = self._split_for_compaction(session)
         if not to_summarize:
             return
 
+        params = self._get_compaction_params(session)
+        summary_chars = params["summary_chars"]
         if params["activity_rate"] > 0:
             log.info(
                 "Adaptive compaction for %s: rate=%.1f msg/hr, threshold=%d, "
-                "keep=%d/%d, summary_budget=%d chars",
+                "keep=%d/%d, segment_budget=%d chars",
                 session.channel_id, params["activity_rate"],
-                params["threshold"], keep_count, len(session.messages),
+                params["threshold"], len(to_keep), len(session.messages),
                 summary_chars,
             )
 
-        # Build conversation text for summarization
-        convo_text = "\n".join(
-            f"{m.role}: {m.content[:500]}" for m in to_summarize
-        )
-
-        # If there's an existing summary, include it so the LLM merges
-        # everything into one concise summary instead of concatenating
-        if session.summary:
-            convo_text = (
-                f"[Previous summary]: {session.summary[:1000]}\n\n"
-                f"[New messages to incorporate]:\n{convo_text}"
-            )
+        # Build conversation text for summarization, attributing speakers
+        convo_lines = []
+        for m in to_summarize:
+            speaker = f"{m.role}[{m.user_id}]" if m.user_id else m.role
+            convo_lines.append(f"{speaker}: {m.content[:500]}")
+        convo_text = "\n".join(convo_lines)
 
         system_instruction = (
-            "Summarize the following conversation into a concise context summary. "
-            "If a previous summary is provided, merge it with the new messages.\n\n"
+            "Summarize the following conversation slice into a context segment.\n\n"
             "FORMAT:\n"
             "Line 1: [Topics: comma-separated topic tags, e.g. nginx, dns, server-a]\n"
-            "Line 2+: Bullet points of key facts.\n\n"
+            "Line 2: [Entities: comma-separated identifiers — file paths, PR numbers, SHAs, hosts, services]\n"
+            "Line 3: [Decisions: semicolon-separated decisions made, or none]\n"
+            "Line 4: [Open: semicolon-separated unresolved threads, or none]\n"
+            "Line 5+: Bullet points of key facts.\n\n"
             "RULES:\n"
             "1. PRESERVE VERBATIM: Hostnames, IPs, UUIDs, file paths, container names, "
             "service names, port numbers, usernames. Never paraphrase identifiers.\n"
@@ -794,12 +874,13 @@ class SessionManager:
             "3. PRESERVE: Error messages, failures, retries, and their outcomes — "
             "these are critical for debugging. Summarize them as: what failed, why, "
             "and whether it was resolved.\n"
-            "4. OMIT: Intermediate tool iteration details (keep only final outcomes), "
-            "conversational filler, greetings, acknowledgments, "
-            "'I can\\'t' or 'unable to' statements without useful context.\n"
-            "5. OMIT: Any data not confirmed by actual tool results.\n"
-            f"6. Keep the ENTIRE summary under {summary_chars} characters.\n"
-            "7. Each bullet: WHAT happened → OUTCOME (host/path/service if applicable)."
+            "4. PRESERVE: WHO said or decided what — attribute by the speaker tags "
+            "given (e.g. user[1234]), especially with multiple participants.\n"
+            "5. OMIT: Intermediate tool iteration details (keep only final outcomes), "
+            "conversational filler, greetings, acknowledgments.\n"
+            "6. OMIT: Any data not confirmed by actual tool results.\n"
+            f"7. Keep the ENTIRE segment under {summary_chars} characters.\n"
+            "8. Each bullet: WHAT happened → OUTCOME (host/path/service if applicable)."
         )
 
         try:
@@ -809,37 +890,18 @@ class SessionManager:
                 [{"role": "user", "content": convo_text}],
                 system_instruction,
             )
-            summary_text = summary_text.strip()
 
-            # Enforce max summary length — truncate at last complete line
-            if len(summary_text) > summary_chars:
-                truncated = summary_text[:summary_chars]
-                last_newline = truncated.rfind("\n")
-                if last_newline > 0:
-                    truncated = truncated[:last_newline]
-                else:
-                    # No newline — fall back to last space to avoid mid-word cut
-                    last_space = truncated.rfind(" ")
-                    if last_space > 0:
-                        truncated = truncated[:last_space]
-                summary_text = truncated.rstrip()
-                log.info(
-                    "Compaction summary truncated to %d chars for channel %s",
-                    len(summary_text), session.channel_id,
-                )
-
-            session.summary = summary_text
+            self._fold_legacy_summary(session)
+            segment = self._append_segment(session, summary_text, to_summarize)
 
             # Trigger reflection on discarded messages before replacing
             discarded = list(to_summarize)
-            summary_snapshot = session.summary
-
             session.messages = to_keep
             self._dirty.add(session.channel_id)
             log.info(
-                "Compacted %d messages into summary for channel %s",
-                len(to_summarize),
-                session.channel_id,
+                "Compacted %d messages into segment %s for channel %s (%d segments total)",
+                len(discarded), segment["id"], session.channel_id,
+                len(session.summary_segments),
             )
 
             if self._reflector and len(discarded) >= 5:
@@ -849,7 +911,7 @@ class SessionManager:
                 ))
                 task = asyncio.create_task(
                     self._safe_reflect_compacted(
-                        discarded, summary_snapshot,
+                        discarded, segment["summary"],
                         user_ids=participant_ids,
                     )
                 )
@@ -862,10 +924,9 @@ class SessionManager:
     def _fallback_compact(self, session) -> None:
         """Deterministic local compaction when LLM summarization fails.
 
-        Instead of blindly truncating and losing context, build a simple
-        extractive summary from the discarded messages: who spoke, what
-        tools were used, and the first line of each message. Preserves
-        existing summary and appends the new extract.
+        Builds an extractive segment from the discarded messages — who
+        spoke, what tools were used, first lines — clearly marked as a
+        fallback so it can be distinguished from LLM-quality segments.
         """
         keep = self.max_history
         if len(session.messages) <= keep:
@@ -890,23 +951,21 @@ class SessionManager:
                     tools_mentioned.add(marker.rstrip("_"))
                     break
 
-        parts = []
-        if session.summary:
-            parts.append(session.summary)
-        parts.append(f"[compaction fallback: {len(discarded)} messages trimmed]")
+        parts = [f"[compaction fallback: {len(discarded)} messages trimmed]"]
         if user_ids:
             parts.append(f"Participants: {', '.join(sorted(user_ids))}")
         if tools_mentioned:
             parts.append(f"Tools used: {', '.join(sorted(tools_mentioned))}")
         if snippets:
-            sample = snippets[:5]
+            sample = snippets[:8]
             parts.append("Recent topics: " + " | ".join(sample))
 
-        session.summary = "\n".join(parts)[-1200:]
+        self._fold_legacy_summary(session)
+        self._append_segment(session, "\n".join(parts), discarded, fallback=True)
         self._dirty.add(session.channel_id)
         log.warning(
-            "Fallback compaction for %s: trimmed %d messages, built extractive summary (%d chars)",
-            session.channel_id, len(discarded), len(session.summary),
+            "Fallback compaction for %s: trimmed %d messages into extractive segment",
+            session.channel_id, len(discarded),
         )
 
     def reset(self, channel_id: str) -> None:
@@ -1128,6 +1187,17 @@ class SessionManager:
                         "timestamp": session.last_active,
                         "channel_id": session.channel_id,
                     })
+            for seg in session.summary_segments:
+                seg_text = seg.get("summary", "")
+                if seg_text and query_lower in seg_text.lower():
+                    ts = seg.get("end_ts", session.last_active)
+                    if _ts_ok(ts):
+                        results.append({
+                            "type": "summary",
+                            "content": seg_text[:500],
+                            "timestamp": ts,
+                            "channel_id": session.channel_id,
+                        })
             for msg in reversed(session.messages):
                 if user_id and msg.user_id != user_id:
                     continue

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -48,10 +48,14 @@ RELEVANCE_KEEP_RECENT = 5  # always include the most recent N messages
 RELEVANCE_MIN_SCORE = 0.10  # minimum overlap score to include an older message
 RELEVANCE_MAX_OLDER = 10  # max older messages to include beyond recent window
 
-# Tool output summarization constants
+# Tool output summarization constants. These cap what the bot REMEMBERS of
+# its own responses after an operation ends (the user always sees the full
+# response on Discord). Raised from 500/1500 — the old caps meant a long
+# investigation survived in history as a half-KB stub, forcing tools to
+# rediscover results on follow-up requests.
 TOOL_SUMMARY_THRESHOLD = 10  # summarize when this many tool calls occurred
-TOOL_SUMMARY_MAX_CHARS = 500  # max chars for summarized tool response in history
-CHAT_RESPONSE_MAX_CHARS = 1500  # max chars for text-only (no-tool) response in history
+TOOL_SUMMARY_MAX_CHARS = 2000  # max chars for summarized tool response in history
+CHAT_RESPONSE_MAX_CHARS = 4000  # max chars for text-only (no-tool) response in history
 
 # Context budget constants
 CONTEXT_TOKEN_BUDGET = 16000  # max estimated tokens for history sent to LLM
@@ -320,14 +324,22 @@ def _estimate_session_tokens(messages: list[Message], summary: str) -> int:
     return total
 
 
+SESSION_SCHEMA_VERSION = 2
+
+
 @dataclass(slots=True)
 class Session:
     channel_id: str
     messages: list[Message] = field(default_factory=list)
     created_at: float = field(default_factory=time.time)
     last_active: float = field(default_factory=time.time)
-    summary: str = ""  # compacted summary of older messages
+    summary: str = ""  # legacy single-summary; folded into segments on first compaction
     last_user_id: str | None = None  # Discord user ID of most recent human message
+    # Rolling summary segments (schema v2): list of dicts with summary text
+    # plus metadata (time range, participants, topics, entities, decisions,
+    # open_threads, validation, source message provenance).
+    summary_segments: list = field(default_factory=list)
+    schema_version: int = SESSION_SCHEMA_VERSION
 
     @property
     def estimated_tokens(self) -> int:
@@ -346,6 +358,8 @@ class SessionManager:
         embedder: LocalEmbedder | None = None,
         token_budget: int = DEFAULT_SESSION_TOKEN_BUDGET,
         adaptive_compaction: bool = True,
+        archive_max_bytes: int = 2 * 1024**3,
+        archive_max_files: int = 10_000,
     ) -> None:
         self.max_history = max_history
         self.max_age_seconds = max_age_hours * 3600
@@ -353,6 +367,8 @@ class SessionManager:
         self.persist_dir.mkdir(parents=True, exist_ok=True)
         self.token_budget = token_budget
         self.adaptive_compaction = adaptive_compaction
+        self.archive_max_bytes = archive_max_bytes
+        self.archive_max_files = archive_max_files
         self._sessions: dict[str, Session] = {}
         self._dirty: set[str] = set()
         self._reflector = reflector
@@ -947,9 +963,6 @@ class SessionManager:
             log.info("Pruned and archived %d expired sessions", len(expired))
         return len(expired)
 
-    ARCHIVE_MAX_AGE_SECONDS = 7 * 86400  # 7 days
-    ARCHIVE_MAX_FILES = 500
-
     def _archive_session(self, channel_id: str) -> None:
         """Save a session to the archive before pruning."""
         session = self._sessions.get(channel_id)
@@ -984,25 +997,30 @@ class SessionManager:
             task.add_done_callback(self._indexing_tasks.discard)
 
     def _prune_old_archives(self, archive_dir: Path) -> None:
-        """Remove archives older than ARCHIVE_MAX_AGE_SECONDS and enforce ARCHIVE_MAX_FILES."""
+        """Enforce size/count caps on the archive directory.
+
+        Archives are knowledge, not garbage: there is deliberately NO
+        time-based deletion (restore-on-demand depends on old archives
+        surviving). Oldest files are removed only when the directory
+        exceeds the configured byte or file-count caps.
+        """
         try:
-            now = time.time()
             files = sorted(archive_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
             pruned = 0
-            for f in files:
-                age = now - f.stat().st_mtime
-                if age > self.ARCHIVE_MAX_AGE_SECONDS:
-                    f.unlink()
-                    pruned += 1
-            remaining = list(archive_dir.glob("*.json"))
-            if len(remaining) > self.ARCHIVE_MAX_FILES:
-                by_mtime = sorted(remaining, key=lambda p: p.stat().st_mtime)
-                excess = len(remaining) - self.ARCHIVE_MAX_FILES
-                for f in by_mtime[:excess]:
-                    f.unlink()
-                    pruned += 1
+            total_bytes = sum(f.stat().st_size for f in files)
+            while files and (
+                total_bytes > self.archive_max_bytes
+                or len(files) > self.archive_max_files
+            ):
+                oldest = files.pop(0)
+                total_bytes -= oldest.stat().st_size
+                oldest.unlink()
+                pruned += 1
             if pruned:
-                log.info("Pruned %d old archive(s) from %s", pruned, archive_dir)
+                log.info(
+                    "Pruned %d oldest archive(s) from %s (caps: %d bytes / %d files)",
+                    pruned, archive_dir, self.archive_max_bytes, self.archive_max_files,
+                )
         except Exception as e:
             log.warning("Archive pruning failed: %s", e)
 
@@ -1259,18 +1277,26 @@ class SessionManager:
             tmp.replace(path)
         self._dirty.clear()
 
+    @staticmethod
+    def _session_from_dict(data: dict) -> Session:
+        """Build a Session from persisted JSON, accepting v1 files (no
+        schema_version / summary_segments) transparently."""
+        messages = [Message(**m) for m in data.get("messages", [])]
+        return Session(
+            channel_id=data["channel_id"],
+            messages=messages,
+            created_at=data.get("created_at", time.time()),
+            last_active=data.get("last_active", time.time()),
+            summary=data.get("summary", ""),
+            last_user_id=data.get("last_user_id"),
+            summary_segments=data.get("summary_segments", []),
+            schema_version=SESSION_SCHEMA_VERSION,
+        )
+
     def load(self) -> None:
         for path in self.persist_dir.glob("*.json"):
             try:
                 data = json.loads(path.read_text())
-                messages = [Message(**m) for m in data.get("messages", [])]
-                self._sessions[data["channel_id"]] = Session(
-                    channel_id=data["channel_id"],
-                    messages=messages,
-                    created_at=data.get("created_at", time.time()),
-                    last_active=data.get("last_active", time.time()),
-                    summary=data.get("summary", ""),
-                    last_user_id=data.get("last_user_id"),
-                )
+                self._sessions[data["channel_id"]] = self._session_from_dict(data)
             except Exception as e:
                 log.error("Failed to load session from %s: %s", path, e)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -230,7 +230,9 @@ async def _do_process_web_chat(
     try:
         sp = bot._build_system_prompt(channel=None, user_id=user_id, query=content)
         sp = await bot._inject_tool_hints(sp, content, user_id)
-        history = await bot.sessions.get_task_history(channel_id, max_messages=20)
+        history = await bot.sessions.get_task_history(
+            channel_id, max_messages=160, current_query=content,
+        )
 
         try:
             response, _already_sent, is_error, tools_used, handoff = (

--- a/tests/test_adaptive_compaction.py
+++ b/tests/test_adaptive_compaction.py
@@ -312,9 +312,9 @@ class TestNeedsCompactionAdaptive:
 
     def test_above_adaptive_threshold_high_activity(self, tmp_path):
         mgr = _make_manager(tmp_path, adaptive_compaction=True)
-        # High activity → threshold = 25, so 30 messages should trigger
+        # High activity → threshold = ADAPTIVE_THRESHOLD_HIGH (80), so 85 should trigger
         now = time.time()
-        msgs = _make_timed_messages(30, interval_seconds=30, start=now - 900)
+        msgs = _make_timed_messages(85, interval_seconds=30, start=now - 2550)
         session = _make_session(messages=msgs)
         assert mgr._needs_compaction(session)
 
@@ -364,9 +364,13 @@ class TestCompactAdaptive:
         session = _make_session(messages=msgs)
         mgr._sessions["ch1"] = session
         await mgr._compact(session)
-        # High activity: keep_ratio ~0.35 → keep ~18, compact ~32
-        assert len(session.messages) < 25
-        assert session.summary == "compacted summary"
+        # High activity: keep_ratio ~0.35 → 18, floored at KEEP_TAIL_MIN (20)
+        assert len(session.messages) == 20
+        # Compaction now produces a segment, not a single summary string
+        assert session.summary == ""
+        assert len(session.summary_segments) == 1
+        assert session.summary_segments[0]["summary"] == "compacted summary"
+        assert session.summary_segments[0]["source_count"] == 30
 
     async def test_low_activity_keeps_more(self, mgr_adaptive):
         mgr, fn = mgr_adaptive
@@ -375,8 +379,8 @@ class TestCompactAdaptive:
         session = _make_session(messages=msgs)
         mgr._sessions["ch1"] = session
         await mgr._compact(session)
-        # Low activity: keep_ratio ~0.60, clamped to max_history//2 = 25
-        assert len(session.messages) == 25
+        # Low activity: keep_ratio ~0.60 → 30 (clamp is now max_history, not //2)
+        assert len(session.messages) == 30
 
     async def test_adaptive_disabled_uses_fixed_keep(self, mgr_fixed):
         mgr, fn = mgr_fixed
@@ -384,7 +388,7 @@ class TestCompactAdaptive:
         session = _make_session(messages=msgs)
         mgr._sessions["ch1"] = session
         await mgr._compact(session)
-        # Fixed mode: max_history // 2 = 25
+        # Fixed mode: default keep_ratio 0.50 → 25
         assert len(session.messages) == 25
 
     async def test_summary_chars_scales_with_activity(self, mgr_adaptive):
@@ -400,17 +404,20 @@ class TestCompactAdaptive:
         system_instruction = call_args[0][1]
         assert f"under {ADAPTIVE_SUMMARY_HIGH}" in system_instruction or "under 5" in system_instruction
 
-    async def test_summary_truncation_uses_adaptive_budget(self, mgr_adaptive):
+    async def test_oversized_segment_clipped_with_marker(self, mgr_adaptive):
+        from src.sessions.manager import SEGMENT_HARD_CHARS, SEGMENT_TRUNCATION_MARKER
         mgr, fn = mgr_adaptive
-        # Return a long summary that needs truncation
-        fn.return_value = "x " * 1000
+        # Return a summary exceeding the hard segment cap
+        fn.return_value = "line of segment text\n" * 400
         now = time.time()
-        # High activity → summary budget ~500 chars
         msgs = _make_timed_messages(50, interval_seconds=30, start=now - 1500)
         session = _make_session(messages=msgs)
         mgr._sessions["ch1"] = session
         await mgr._compact(session)
-        assert len(session.summary) <= ADAPTIVE_SUMMARY_HIGH
+        seg = session.summary_segments[0]
+        assert len(seg["summary"]) <= SEGMENT_HARD_CHARS
+        # Never silently chopped — the clip is marked
+        assert seg["summary"].endswith(SEGMENT_TRUNCATION_MARKER)
 
     async def test_compaction_fn_failure_fallback(self, mgr_adaptive):
         mgr, fn = mgr_adaptive
@@ -427,18 +434,18 @@ class TestCompactAdaptive:
     async def test_compaction_via_get_history_with_compaction(self, mgr_adaptive):
         mgr, fn = mgr_adaptive
         now = time.time()
-        # High activity: 30 msgs at 30s intervals → rate > 20
-        msgs = _make_timed_messages(30, interval_seconds=30, start=now - 900)
+        # High activity: 85 msgs at 30s intervals → rate > 20, threshold 80
+        msgs = _make_timed_messages(85, interval_seconds=30, start=now - 2550)
         session = _make_session(channel_id="ch2", messages=msgs)
         mgr._sessions["ch2"] = session
         history = await mgr.get_history_with_compaction("ch2")
-        # Should have compacted (threshold ~25) since we have 30 msgs
+        # Should have compacted (threshold 80) since we have 85 msgs
         assert fn.called
 
     async def test_compaction_via_get_task_history(self, mgr_adaptive):
         mgr, fn = mgr_adaptive
         now = time.time()
-        msgs = _make_timed_messages(30, interval_seconds=30, start=now - 900)
+        msgs = _make_timed_messages(85, interval_seconds=30, start=now - 2550)
         session = _make_session(channel_id="ch3", messages=msgs)
         mgr._sessions["ch3"] = session
         history = await mgr.get_task_history("ch3")
@@ -655,10 +662,13 @@ class TestEdgeCases:
         session = _make_session(messages=msgs, summary="old summary context")
         mgr._sessions["ch1"] = session
         await mgr._compact(session)
-        assert session.summary == "new summary"
-        # Verify the previous summary was included in the compaction input
-        call_args = compaction_fn.call_args[0][0]
-        assert "old summary" in call_args[0]["content"]
+        # Legacy summary is folded into the FIRST segment; the new compaction
+        # output becomes the second. The single-summary field is retired.
+        assert session.summary == ""
+        assert len(session.summary_segments) == 2
+        assert session.summary_segments[0]["summary"] == "old summary context"
+        assert session.summary_segments[0].get("legacy") is True
+        assert session.summary_segments[1]["summary"] == "new summary"
 
     async def test_manager_constructor_default_adaptive(self, tmp_path):
         mgr = SessionManager(
@@ -686,10 +696,10 @@ class TestEdgeCases:
         fn = AsyncMock(return_value="compacted")
         mgr.set_compaction_fn(fn)
         now = time.time()
-        # 30 messages at high rate → threshold ~25 → should compact
-        msgs = _make_timed_messages(30, interval_seconds=30, start=now - 900)
+        # 85 messages at high rate → threshold 80 → should compact
+        msgs = _make_timed_messages(85, interval_seconds=30, start=now - 2550)
         session = _make_session(channel_id="ch1", messages=msgs)
         mgr._sessions["ch1"] = session
         await mgr.get_history_with_compaction("ch1")
         assert fn.called
-        assert session.summary == "compacted"
+        assert session.summary_segments[-1]["summary"] == "compacted"

--- a/tests/test_history_replay.py
+++ b/tests/test_history_replay.py
@@ -78,7 +78,9 @@ class TestHistoryReadOnlyMarker:
         mgr.add_message("ch1", "user", "what happened earlier?")
 
         messages = await mgr.get_task_history("ch1")
-        summary_msgs = [m for m in messages if "COMPLETED SUMMARY" in m.get("content", "")]
+        summary_msgs = [m for m in messages if "SESSION_CONTEXT_READ_ONLY" in m.get("content", "")]
+        # Summaries are a developer-scoped block now, not fake user dialogue
+        assert all(m["role"] == "developer" for m in summary_msgs)
         assert any("[completed]" in m["content"] for m in summary_msgs)
 
     @pytest.mark.asyncio
@@ -102,7 +104,7 @@ class TestHistoryReadOnlyMarker:
             content = m.get("content", "")
             if "HISTORY_READ_ONLY" in content:
                 marker_idx = i
-            if "COMPLETED SUMMARY" in content:
+            if "SESSION_CONTEXT_READ_ONLY" in content:
                 summary_idx = i
         assert marker_idx is not None, "HISTORY_READ_ONLY marker missing"
         assert summary_idx is not None, "Summary missing"

--- a/tests/test_learned_overhaul.py
+++ b/tests/test_learned_overhaul.py
@@ -1,0 +1,298 @@
+"""Tests for the learned-context overhaul (memory systems PR).
+
+Invariants under test:
+- stored content is NEVER silently truncated — oversized text is clipped
+  at a sentence boundary, explicitly marked, and flagged damaged
+- the v1→v2 migration detects legacy chop damage and is idempotent
+- consolidation passes damaged entries through unmerged
+- category-aware expiry: corrections/preferences never auto-expire
+- supersession removes superseded keys
+- injection: include-all-when-fits, pinned corrections/preferences when
+  gated, user-scope isolation, last_used_at stamping via locked writes
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.learning.reflector import (
+    _HARD_CONTENT_CHARS,
+    _LEARNED_SCHEMA_VERSION,
+    _TRUNCATION_MARKER,
+    ConversationReflector,
+    _clip_content,
+    _looks_chopped,
+)
+
+
+def _entry(key, category="operational", content="a lesson.", **kw):
+    e = {"key": key, "category": category, "content": content}
+    e.update(kw)
+    return e
+
+
+def _write_store(path, entries, version=_LEARNED_SCHEMA_VERSION):
+    path.write_text(json.dumps({
+        "version": version, "last_reflection": None, "entries": entries,
+    }))
+
+
+class TestClipContent:
+    def test_short_content_untouched(self):
+        e = _entry("k", content="short lesson.")
+        assert _clip_content(e)["content"] == "short lesson."
+        assert "damaged" not in e
+
+    def test_oversized_clipped_with_marker_and_flag(self):
+        text = ("A useful sentence. " * 100).strip()  # ~1900 chars
+        e = _entry("k", content=text)
+        _clip_content(e)
+        assert len(e["content"]) <= _HARD_CONTENT_CHARS
+        assert e["content"].endswith(_TRUNCATION_MARKER)
+        assert e["damaged"] is True
+        # Clip landed on a sentence boundary, not mid-word
+        body = e["content"][: -len(_TRUNCATION_MARKER)]
+        assert body.rstrip().endswith(".")
+
+
+class TestLooksChopped:
+    def test_long_mid_sentence_is_chopped(self):
+        assert _looks_chopped("x" * 790 + " For job-search r")
+
+    def test_long_complete_sentence_is_not(self):
+        assert not _looks_chopped("x" * 790 + " This ends properly.")
+
+    def test_short_content_is_not(self):
+        assert not _looks_chopped("short fragment without punct")
+
+
+class TestMigration:
+    def test_v1_chopped_entries_flagged(self, tmp_path):
+        path = tmp_path / "learned.json"
+        chopped = "y" * 795 + " and then it just"
+        clean = "z" * 700 + " but this one ends fine."
+        _write_store(path, [
+            _entry("damaged_one", content=chopped),
+            _entry("clean_one", content=clean),
+        ], version=1)
+
+        r = ConversationReflector(str(path))
+        data = r._load()
+        assert data["version"] == _LEARNED_SCHEMA_VERSION
+        by_key = {e["key"]: e for e in data["entries"]}
+        assert by_key["damaged_one"]["damaged"] is True
+        assert by_key["damaged_one"]["content"].endswith(_TRUNCATION_MARKER)
+        # Damage marking appends, never removes surviving text
+        assert chopped in by_key["damaged_one"]["content"]
+        assert "damaged" not in by_key["clean_one"]
+
+    def test_migration_backfills_confidence_and_source(self, tmp_path):
+        path = tmp_path / "learned.json"
+        _write_store(path, [
+            _entry("c", category="correction"),
+            _entry("o", category="operational"),
+        ], version=1)
+        data = ConversationReflector(str(path))._load()
+        by_key = {e["key"]: e for e in data["entries"]}
+        assert by_key["c"]["confidence"] == "high"
+        assert by_key["o"]["confidence"] == "medium"
+        assert by_key["o"]["source"] == {"created_by": "legacy"}
+
+    def test_migration_idempotent(self, tmp_path):
+        path = tmp_path / "learned.json"
+        _write_store(path, [_entry("k", content="v" * 800)], version=1)
+        r = ConversationReflector(str(path))
+        r._load()
+        first = path.read_text()
+        r._load()
+        assert path.read_text() == first
+
+
+class TestMergeEntries:
+    def test_supersession_removes_old_keys(self):
+        existing = [_entry("old_rule"), _entry("unrelated")]
+        new = [_entry("new_rule", supersedes=["old_rule"])]
+        merged = ConversationReflector._merge_entries(existing, new)
+        keys = {e["key"] for e in merged}
+        assert keys == {"unrelated", "new_rule"}
+
+    def test_clean_update_repairs_damaged_entry(self):
+        existing = [_entry("k", content="old chopped", damaged=True)]
+        new = [_entry("k", content="fresh complete lesson.")]
+        merged = ConversationReflector._merge_entries(existing, new)
+        assert merged[0]["content"] == "fresh complete lesson."
+        assert "damaged" not in merged[0]
+
+    def test_oversized_new_entry_never_silently_chopped(self):
+        new = [_entry("big", content="A point. " * 200)]
+        merged = ConversationReflector._merge_entries([], new)
+        assert merged[0]["content"].endswith(_TRUNCATION_MARKER)
+        assert merged[0]["damaged"] is True
+
+
+class TestCategoryExpiry:
+    def _aged(self, key, category, days):
+        ts = (datetime.now(UTC) - timedelta(days=days)).isoformat(timespec="seconds")
+        return _entry(key, category=category, created_at=ts, updated_at=ts)
+
+    def test_corrections_and_preferences_never_expire(self, tmp_path):
+        r = ConversationReflector(str(tmp_path / "l.json"))
+        entries = [
+            self._aged("c", "correction", 400),
+            self._aged("p", "preference", 400),
+        ]
+        assert len(r._expire_entries(entries)) == 2
+
+    def test_stale_operational_expires(self, tmp_path):
+        r = ConversationReflector(str(tmp_path / "l.json"))
+        entries = [self._aged("o", "operational", 200)]
+        assert r._expire_entries(entries) == []
+
+    def test_recently_used_operational_survives(self, tmp_path):
+        r = ConversationReflector(str(tmp_path / "l.json"))
+        e = self._aged("o", "operational", 200)
+        e["last_used_at"] = datetime.now(UTC).isoformat(timespec="seconds")
+        assert len(r._expire_entries([e])) == 1
+
+
+class TestConsolidationDamagePassThrough:
+    @pytest.mark.asyncio
+    async def test_damaged_entries_bypass_the_llm(self, tmp_path):
+        r = ConversationReflector(str(tmp_path / "l.json"), consolidation_target=2)
+        seen_prompts = []
+
+        async def fake_text_fn(messages, system):
+            seen_prompts.append(messages[0]["content"])
+            return json.dumps([_entry("merged", content="merged lesson.")])
+
+        r.set_text_fn(fake_text_fn)
+        now = datetime.now(UTC).isoformat(timespec="seconds")
+        entries = [
+            _entry("a", content="lesson a.", created_at=now, updated_at=now),
+            _entry("b", content="lesson b.", created_at=now, updated_at=now),
+            _entry("hurt", content="chopped tex" + _TRUNCATION_MARKER,
+                   damaged=True, created_at=now, updated_at=now),
+        ]
+        result = await r._consolidate(entries)
+        keys = {e["key"] for e in result}
+        assert "hurt" in keys  # passed through unmerged
+        assert "hurt" not in seen_prompts[0]  # never sent to the LLM
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back_without_data_loss(self, tmp_path):
+        r = ConversationReflector(str(tmp_path / "l.json"), consolidation_target=5)
+
+        async def broken(messages, system):
+            raise RuntimeError("api down")
+
+        r.set_text_fn(broken)
+        now = datetime.now(UTC).isoformat(timespec="seconds")
+        entries = [
+            _entry(f"k{i}", content=f"lesson {i}.", created_at=now, updated_at=now)
+            for i in range(3)
+        ]
+        result = await r._consolidate(entries)
+        assert len(result) == 3
+
+
+class TestInjection:
+    def _store(self, tmp_path, entries):
+        path = tmp_path / "learned.json"
+        _write_store(path, entries)
+        return path
+
+    def test_include_all_when_corpus_fits(self, tmp_path):
+        path = self._store(tmp_path, [
+            _entry(f"k{i}", content=f"lesson number {i}.") for i in range(10)
+        ])
+        r = ConversationReflector(str(path), injection_token_budget=4000)
+        section = r.get_prompt_section(query="completely unrelated query text")
+        assert section.count("- [") == 10
+
+    def test_gating_pins_corrections_and_preferences(self, tmp_path):
+        entries = [
+            _entry("corr", category="correction", content="never do the bad thing."),
+            _entry("pref", category="preference", content="user likes terse output.",
+                   user_id="42"),
+        ]
+        entries += [
+            _entry(f"op{i}", content=f"operational detail about {topic}.")
+            for i, topic in enumerate(
+                ["minecraft", "genealogy", "eve", "wow", "ffxi", "nginx",
+                 "dns", "grafana", "loki", "docker", "incus", "pihole",
+                 "ansible", "tailscale", "plex", "gitea"]
+            )
+        ]
+        path = self._store(tmp_path, entries)
+        r = ConversationReflector(str(path), injection_token_budget=50)  # force gating
+        section = r.get_prompt_section(user_id="42", query="fix the nginx config")
+        assert "never do the bad thing." in section
+        assert "user likes terse output." in section
+        assert "operational detail about nginx." in section
+
+    def test_other_users_entries_never_leak(self, tmp_path):
+        path = self._store(tmp_path, [
+            _entry("mine", category="preference", content="my pref.", user_id="42"),
+            _entry("theirs", category="preference", content="their secret pref.", user_id="99"),
+            _entry("global", content="global lesson."),
+        ])
+        r = ConversationReflector(str(path))
+        section = r.get_prompt_section(user_id="42", query="anything")
+        assert "my pref." in section
+        assert "their secret pref." not in section
+        assert "global lesson." in section
+
+    def test_no_query_includes_all_in_scope(self, tmp_path):
+        path = self._store(tmp_path, [
+            _entry(f"k{i}", content="x" * 600 + ".") for i in range(40)
+        ])
+        r = ConversationReflector(str(path), injection_token_budget=100)
+        # Without a query there is nothing to rank against — include all
+        section = r.get_prompt_section(query=None)
+        assert section.count("- [") == 40
+
+    @pytest.mark.asyncio
+    async def test_use_stamps_persist_via_locked_write(self, tmp_path):
+        path = self._store(tmp_path, [_entry("used_one", content="a lesson.")])
+        r = ConversationReflector(str(path))
+        r.get_prompt_section(query="a lesson")
+        assert r._use_stamps  # recorded in memory
+
+        async def fake_text_fn(messages, system):
+            return json.dumps([_entry("new_one", content="another lesson.")])
+
+        r.set_text_fn(fake_text_fn)
+        await r.reflect_on_operation(
+            user_request="do something substantial",
+            tools_used=["run_command"] * 6,
+            tool_details=[{"tool": "run_command"}],
+            final_response="done",
+        )
+        data = json.loads(path.read_text())
+        by_key = {e["key"]: e for e in data["entries"]}
+        assert "last_used_at" in by_key["used_one"]
+        assert not r._use_stamps
+
+    def test_mtime_cache_invalidation(self, tmp_path):
+        path = self._store(tmp_path, [_entry("k1", content="first.")])
+        r = ConversationReflector(str(path))
+        assert "first." in r.get_prompt_section()
+        # External write (e.g. WebUI edit) must be picked up via mtime
+        import os
+        import time as _time
+        _write_store(path, [_entry("k2", content="second.")])
+        os.utime(path, (_time.time() + 5, _time.time() + 5))
+        section = r.get_prompt_section()
+        assert "second." in section and "first." not in section
+
+
+class TestTopicChangeRemoved:
+    def test_session_manager_has_no_detector(self):
+        from src.sessions.manager import SessionManager
+        assert not hasattr(SessionManager, "detect_topic_change")
+
+    def test_no_topic_change_constants(self):
+        import src.sessions.manager as m
+        assert not any(name.startswith("TOPIC_CHANGE") for name in dir(m))

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -1,0 +1,61 @@
+"""Tests for the shared relevance module and its prompt-assembly consumers."""
+from __future__ import annotations
+
+import pytest
+
+from src.relevance import rank, score, tokenize
+
+
+class TestTokenize:
+    def test_filters_stop_words_and_short_tokens(self):
+        assert tokenize("the cat is on a mat") == {"cat", "mat"}
+
+    def test_keeps_identifiers(self):
+        tokens = tokenize("check /opt/odin/config.yml on host-1")
+        assert "/opt/odin/config.yml" in tokens
+        assert "host-1" in tokens
+
+
+class TestScore:
+    def test_full_overlap(self):
+        assert score("nginx restart", "restart nginx now") == 1.0
+
+    def test_no_overlap(self):
+        assert score("nginx restart", "minecraft mods") == 0.0
+
+    def test_empty_query(self):
+        assert score("", "anything") == 0.0
+
+
+class TestRank:
+    def test_top_k_and_floor(self):
+        items = ["nginx config reload", "dns zone update", "totally unrelated words"]
+        result = rank("nginx config", items, lambda s: s, top_k=2, floor=0.4)
+        assert result == ["nginx config reload"]
+
+    def test_stable_order_for_ties(self):
+        items = ["b unrelated", "a unrelated"]
+        result = rank("xyz", items, lambda s: s, top_k=2, floor=0.0)
+        assert result == ["b unrelated", "a unrelated"]  # original order kept
+
+
+class TestPerChannelBudgetOverride:
+    @pytest.mark.asyncio
+    async def test_override_applies_to_channel(self, tmp_path):
+        from src.sessions.manager import SessionManager
+
+        mgr = SessionManager(
+            max_history=200, max_age_hours=24, persist_dir=str(tmp_path),
+            context_token_budget=100,
+            context_budget_overrides={"hot-channel": 1_000_000},
+        )
+        for ch in ("hot-channel", "cold-channel"):
+            for i in range(30):
+                mgr.add_message(ch, "user", f"{ch} message {i} " + "filler words " * 40)
+
+        hot = await mgr.get_task_history("hot-channel", max_messages=160)
+        cold = await mgr.get_task_history("cold-channel", max_messages=160)
+        # The hot channel keeps everything; the 100-token default forces
+        # the cold channel down to its protected recent tail.
+        assert len(hot) > len(cold)
+        assert len(hot) >= 30

--- a/tests/test_session_restore.py
+++ b/tests/test_session_restore.py
@@ -251,3 +251,121 @@ class TestSegmentClip:
 
     def test_short_text_untouched(self):
         assert SessionManager._clip_segment_text("short") == "short"
+
+
+class TestResetTombstones:
+    """Odin's PR #103 review blocker: reset/purge must not be undone by
+    restore-on-demand pulling the abandoned context back from the archive."""
+
+    def test_reset_blocks_archive_restoration(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=8, age_hours=2)
+        mgr.prune()  # archived
+        mgr.reset("ch1")
+        session = mgr.get_or_create("ch1")
+        assert session.messages == []
+
+    def test_reset_deletes_live_file(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=4)
+        mgr.save()
+        assert (tmp_path / "ch1.json").exists()
+        mgr.reset("ch1")
+        assert not (tmp_path / "ch1.json").exists()
+
+    def test_tombstone_survives_restart(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=8, age_hours=2)
+        mgr.prune()
+        mgr.reset("ch1")
+        # Fresh manager over the same persist dir (process restart)
+        mgr2 = _make_manager(tmp_path)
+        mgr2.load()
+        session = mgr2.get_or_create("ch1")
+        assert session.messages == []
+
+    def test_new_conversation_after_reset_archives_and_restores(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=8, age_hours=4)
+        mgr.prune()
+        mgr.reset("ch1")
+        # Model reality: the reset happened 3h ago, the NEW conversation 2h
+        # ago (post-reset activity always postdates the reset epoch).
+        mgr._reset_epochs["ch1"] = time.time() - 3 * 3600
+        mgr._save_reset_epochs()
+        for i in range(4):
+            mgr.add_message("ch1", "user", f"post-reset {i}")
+        mgr.get("ch1").last_active = time.time() - 2 * 3600
+        mgr.prune()  # …new conversation gets archived…
+        restored = mgr.get_or_create("ch1")
+        # …and IS restorable (only pre-reset context stays gone)
+        assert [m.content for m in restored.messages] == [
+            "post-reset 0", "post-reset 1", "post-reset 2", "post-reset 3",
+        ]
+        # The original pre-reset 8-message archive must NOT be the restored one
+        assert all("post-reset" in m.content for m in restored.messages)
+
+    def test_clear_all_tombstones_archived_channels(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "live-ch", count=4)
+        _fill_session(mgr, "archived-ch", count=6, age_hours=2)
+        mgr.prune()  # archived-ch leaves live state
+        assert mgr.clear_all() == 1
+        assert mgr.get_or_create("live-ch").messages == []
+        assert mgr.get_or_create("archived-ch").messages == []
+
+    def test_reset_many_tombstones(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "a", count=6, age_hours=2)
+        _fill_session(mgr, "b", count=6, age_hours=2)
+        mgr.prune()
+        mgr.get_or_create("a")  # restore both
+        mgr.get_or_create("b")
+        assert mgr.reset_many(["a", "b"]) == 2
+        assert mgr.get_or_create("a").messages == []
+        assert mgr.get_or_create("b").messages == []
+
+
+class TestGetHistoryContextBlock:
+    """Odin's PR #103 review blocker: the full-history path also must not
+    fabricate user/assistant dialogue for summaries."""
+
+    def test_get_history_uses_developer_block(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        session = mgr.get_or_create("ch1")
+        session.summary = "deploy completed on host-1"
+        mgr.add_message("ch1", "user", "hello")
+
+        messages = mgr.get_history("ch1")
+        assert messages[0]["role"] == "developer"
+        assert "[SESSION_CONTEXT_READ_ONLY]" in messages[0]["content"]
+        assert "deploy completed on host-1" in messages[0]["content"]
+        # The fabricated pair is gone everywhere
+        assert not any(
+            m["content"] == "Understood, I have context from our previous conversation."
+            for m in messages
+        )
+
+    def test_get_history_includes_segments(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        session = mgr.get_or_create("ch1")
+        session.summary_segments.append({
+            "id": "s1", "summary": "segment about nginx", "start_ts": 1.0,
+            "end_ts": 2.0, "participants": [], "source_count": 5,
+            "created_at": 3.0, "topics": [], "entities": [],
+            "decisions": [], "open_threads": [],
+        })
+        mgr.add_message("ch1", "user", "hi")
+        messages = mgr.get_history("ch1")
+        assert "segment about nginx" in messages[0]["content"]
+
+
+class TestLearnedAtomicSave:
+    def test_no_tmp_residue_and_valid_json(self, tmp_path):
+        from src.learning.reflector import ConversationReflector
+        path = tmp_path / "learned.json"
+        r = ConversationReflector(str(path))
+        r._save({"version": 2, "last_reflection": None, "entries": []})
+        assert path.exists()
+        assert not path.with_suffix(".tmp").exists()
+        json.loads(path.read_text())

--- a/tests/test_session_restore.py
+++ b/tests/test_session_restore.py
@@ -15,7 +15,6 @@ import time
 import pytest
 
 from src.sessions.manager import (
-    KEEP_TAIL_MIN,
     SEGMENT_HARD_CHARS,
     SEGMENT_IDLE_GAP_SECONDS,
     SEGMENT_MIN_MESSAGES,
@@ -227,10 +226,12 @@ class TestIdleSplit:
         base_ts = time.time() - SEGMENT_IDLE_GAP_SECONDS * 2
         session = Session(channel_id="ch1")
         for i in range(20):
-            session.messages.append(Message(role="user", content=f"old {i}", timestamp=base_ts + i * 60))
+            session.messages.append(
+                Message(role="user", content=f"old {i}", timestamp=base_ts + i * 60))
         # New conversation after a long gap
         for i in range(3):
-            session.messages.append(Message(role="user", content=f"new {i}", timestamp=time.time() + i))
+            session.messages.append(
+                Message(role="user", content=f"new {i}", timestamp=time.time() + i))
         mgr._sessions["ch1"] = session
 
         assert mgr._needs_compaction(session)

--- a/tests/test_session_restore.py
+++ b/tests/test_session_restore.py
@@ -1,0 +1,252 @@
+"""Tests for session archive restore-on-demand and rolling summary segments.
+
+Covers the memory-overhaul guarantees:
+- pruned sessions come back in full from the archive, regardless of age
+- archives are never deleted by time, only by size/count caps
+- idle gaps close conversation segments at the natural boundary
+- v1 session files (no schema_version / summary_segments) load transparently
+- segment text is never silently chopped
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from src.sessions.manager import (
+    KEEP_TAIL_MIN,
+    SEGMENT_HARD_CHARS,
+    SEGMENT_IDLE_GAP_SECONDS,
+    SEGMENT_MIN_MESSAGES,
+    SEGMENT_TRUNCATION_MARKER,
+    SESSION_SCHEMA_VERSION,
+    Message,
+    Session,
+    SessionManager,
+)
+
+
+def _make_manager(tmp_path, **kw) -> SessionManager:
+    defaults = dict(
+        max_history=50,
+        max_age_hours=1,
+        persist_dir=str(tmp_path),
+        adaptive_compaction=False,
+    )
+    defaults.update(kw)
+    return SessionManager(**defaults)
+
+
+def _fill_session(mgr, channel_id: str, count: int = 10, age_hours: float = 0.0):
+    for i in range(count):
+        mgr.add_message(channel_id, "user" if i % 2 == 0 else "assistant",
+                        f"message {i}", user_id="42" if i % 2 == 0 else None)
+    session = mgr.get(channel_id)
+    if age_hours:
+        session.last_active = time.time() - age_hours * 3600
+        for m in session.messages:
+            m.timestamp = session.last_active
+    return session
+
+
+class TestRestoreOnDemand:
+    def test_pruned_session_restores_in_full(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=12, age_hours=2)  # past 1h TTL
+        assert mgr.prune() == 1
+        assert not mgr.exists("ch1")
+
+        restored = mgr.get_or_create("ch1")
+        assert len(restored.messages) == 12
+        assert restored.messages[0].content == "message 0"
+        assert restored.messages[0].user_id == "42"
+
+    def test_restore_ignores_archive_age(self, tmp_path):
+        """The old 48h continuity window is gone — any-age archives restore."""
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=6, age_hours=2)
+        mgr.prune()
+        # Make the archive look 30 days old
+        archive_dir = tmp_path / "archive"
+        old = next(archive_dir.glob("ch1_*.json"))
+        month_ago = time.time() - 30 * 86400
+        data = json.loads(old.read_text())
+        data["last_active"] = month_ago
+        renamed = archive_dir / f"ch1_{int(month_ago)}.json"
+        renamed.write_text(json.dumps(data))
+        old.unlink()
+
+        restored = mgr.get_or_create("ch1")
+        assert len(restored.messages) == 6
+
+    def test_restore_picks_latest_archive(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        for ts, marker in ((1000, "older"), (2000, "newer")):
+            data = {
+                "channel_id": "ch1",
+                "messages": [{"role": "user", "content": marker, "timestamp": ts, "user_id": None}],
+                "created_at": ts,
+                "last_active": ts,
+                "summary": "",
+                "last_user_id": None,
+            }
+            (archive_dir / f"ch1_{ts}.json").write_text(json.dumps(data))
+
+        restored = mgr.get_or_create("ch1")
+        assert restored.messages[0].content == "newer"
+
+    def test_segments_survive_prune_restore_cycle(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        session = _fill_session(mgr, "ch1", count=6, age_hours=2)
+        session.summary_segments.append({
+            "id": "seg_1", "summary": "earlier work on the scheduler",
+            "start_ts": 1.0, "end_ts": 2.0, "participants": ["42"],
+            "source_count": 30, "created_at": 3.0,
+            "topics": ["scheduler"], "entities": [], "decisions": [], "open_threads": [],
+        })
+        mgr.prune()
+        restored = mgr.get_or_create("ch1")
+        assert len(restored.summary_segments) == 1
+        assert restored.summary_segments[0]["summary"] == "earlier work on the scheduler"
+
+    def test_fresh_channel_without_archive_starts_empty(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        session = mgr.get_or_create("brand-new")
+        assert session.messages == []
+        assert session.summary_segments == []
+
+    def test_corrupt_archive_falls_back_to_fresh(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        (archive_dir / "ch1_1000.json").write_text("{not json")
+        session = mgr.get_or_create("ch1")
+        assert session.messages == []
+
+
+class TestV1SchemaLoad:
+    def test_v1_session_file_loads(self, tmp_path):
+        """Old persisted sessions (no schema_version/summary_segments) load."""
+        data = {
+            "channel_id": "legacy",
+            "messages": [{"role": "user", "content": "old", "timestamp": 1.0, "user_id": "7"}],
+            "created_at": 1.0,
+            "last_active": time.time(),
+            "summary": "old style summary",
+            "last_user_id": "7",
+        }
+        (tmp_path / "legacy.json").write_text(json.dumps(data))
+        mgr = _make_manager(tmp_path)
+        mgr.load()
+        session = mgr.get("legacy")
+        assert session is not None
+        assert session.summary == "old style summary"
+        assert session.summary_segments == []
+        assert session.schema_version == SESSION_SCHEMA_VERSION
+
+    def test_saved_session_includes_v2_fields(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _fill_session(mgr, "ch1", count=2)
+        mgr.save()
+        data = json.loads((tmp_path / "ch1.json").read_text())
+        assert data["schema_version"] == SESSION_SCHEMA_VERSION
+        assert data["summary_segments"] == []
+
+
+class TestArchiveRetention:
+    def test_no_time_based_deletion(self, tmp_path):
+        """Archives older than the old 7-day window must survive pruning."""
+        mgr = _make_manager(tmp_path)
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        import os
+        old_file = archive_dir / "ch9_100.json"
+        old_file.write_text("{}")
+        month_ago = time.time() - 30 * 86400
+        os.utime(old_file, (month_ago, month_ago))
+
+        mgr._prune_old_archives(archive_dir)
+        assert old_file.exists()
+
+    def test_file_count_cap_prunes_oldest(self, tmp_path):
+        import os
+        mgr = _make_manager(tmp_path, archive_max_files=3)
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        for i in range(5):
+            f = archive_dir / f"ch{i}_100.json"
+            f.write_text("{}")
+            os.utime(f, (1000 + i, 1000 + i))
+        mgr._prune_old_archives(archive_dir)
+        remaining = sorted(p.name for p in archive_dir.glob("*.json"))
+        assert remaining == ["ch2_100.json", "ch3_100.json", "ch4_100.json"]
+
+    def test_byte_cap_prunes_oldest(self, tmp_path):
+        import os
+        mgr = _make_manager(tmp_path, archive_max_bytes=250)
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        for i in range(3):
+            f = archive_dir / f"ch{i}_100.json"
+            f.write_text("x" * 100)
+            os.utime(f, (1000 + i, 1000 + i))
+        mgr._prune_old_archives(archive_dir)
+        remaining = sorted(p.name for p in archive_dir.glob("*.json"))
+        assert remaining == ["ch1_100.json", "ch2_100.json"]
+
+
+class TestIdleSplit:
+    def _timed(self, specs):
+        return [Message(role="user", content=f"m{i}", timestamp=ts)
+                for i, ts in enumerate(specs)]
+
+    def test_no_gap_no_split(self):
+        msgs = self._timed([1000 + i * 60 for i in range(30)])
+        assert SessionManager._find_idle_split(msgs) is None
+
+    def test_gap_after_enough_messages_splits(self):
+        base = [1000 + i * 60 for i in range(SEGMENT_MIN_MESSAGES)]
+        after_gap = base[-1] + SEGMENT_IDLE_GAP_SECONDS + 60
+        msgs = self._timed(base + [after_gap, after_gap + 60])
+        assert SessionManager._find_idle_split(msgs) == SEGMENT_MIN_MESSAGES
+
+    def test_gap_with_too_few_messages_does_not_split(self):
+        base = [1000 + i * 60 for i in range(SEGMENT_MIN_MESSAGES - 5)]
+        after_gap = base[-1] + SEGMENT_IDLE_GAP_SECONDS + 60
+        msgs = self._timed(base + [after_gap])
+        assert SessionManager._find_idle_split(msgs) is None
+
+    @pytest.mark.asyncio
+    async def test_idle_split_closes_segment_at_gap(self, tmp_path):
+        from unittest.mock import AsyncMock
+        mgr = _make_manager(tmp_path)
+        mgr.set_compaction_fn(AsyncMock(return_value="vacation-era summary"))
+        base_ts = time.time() - SEGMENT_IDLE_GAP_SECONDS * 2
+        session = Session(channel_id="ch1")
+        for i in range(20):
+            session.messages.append(Message(role="user", content=f"old {i}", timestamp=base_ts + i * 60))
+        # New conversation after a long gap
+        for i in range(3):
+            session.messages.append(Message(role="user", content=f"new {i}", timestamp=time.time() + i))
+        mgr._sessions["ch1"] = session
+
+        assert mgr._needs_compaction(session)
+        await mgr._compact(session)
+        # Everything before the gap became a segment; the new tail stays raw
+        assert [m.content for m in session.messages] == ["new 0", "new 1", "new 2"]
+        assert session.summary_segments[-1]["summary"] == "vacation-era summary"
+        assert session.summary_segments[-1]["source_count"] == 20
+
+
+class TestSegmentClip:
+    def test_clip_is_marked_never_silent(self):
+        long_text = "useful line\n" * 600
+        clipped = SessionManager._clip_segment_text(long_text)
+        assert len(clipped) <= SEGMENT_HARD_CHARS
+        assert clipped.endswith(SEGMENT_TRUNCATION_MARKER)
+
+    def test_short_text_untouched(self):
+        assert SessionManager._clip_segment_text("short") == "short"

--- a/tests/test_tool_loop_helpers.py
+++ b/tests/test_tool_loop_helpers.py
@@ -61,9 +61,12 @@ class TestBuildRequestPreamble:
         assert "Channel: #ops" in body
         assert "HISTORY ABOVE | REQUEST BELOW" in body
 
-    def test_topic_change_block(self):
-        p = build_request_preamble(**self._base_kwargs(), topic_change=True)
-        assert "TOPIC CHANGE DETECTED" in p["content"]
+    def test_topic_change_parameter_removed(self):
+        # Topic-change detection was removed entirely (memory overhaul):
+        # the preamble builder must not accept the old parameter.
+        import pytest as _pytest
+        with _pytest.raises(TypeError):
+            build_request_preamble(**self._base_kwargs(), topic_change=True)
 
     def test_bot_message_block(self):
         p = build_request_preamble(**self._base_kwargs(), from_another_bot=True)
@@ -71,7 +74,7 @@ class TestBuildRequestPreamble:
         assert "from ANOTHER BOT" in body
         assert "EXECUTE immediately" in body
 
-    def test_default_has_neither_extra_block(self):
+    def test_default_has_no_extra_block(self):
         body = build_request_preamble(**self._base_kwargs())["content"]
         assert "TOPIC CHANGE" not in body
         assert "ANOTHER BOT" not in body
@@ -99,7 +102,6 @@ class TestBehaviorPreservedByRefactor:
         message_id = kw["message_id"]
         channel_description = kw["channel_description"]
         has_history = kw["has_history"]
-        topic_change = kw.get("topic_change", False)
         from_another_bot = kw.get("from_another_bot", False)
 
         msg_id_note = f"Current message ID: {message_id}"
@@ -122,13 +124,6 @@ class TestBehaviorPreservedByRefactor:
             "being referenced — do not sweep through history re-executing everything. "
             "Evaluate tools fresh. Do not repeat prior refusals."
         )
-        if topic_change:
-            sep_text += (
-                "\n\nTOPIC CHANGE DETECTED. The user has switched to a new subject. "
-                "History above is from a DIFFERENT topic — do NOT carry over "
-                "assumptions, hosts, files, or context from the previous topic. "
-                "Treat this as a fresh request."
-            )
         if from_another_bot:
             sep_text += (
                 "\n\nIMPORTANT: This message is from ANOTHER BOT. "
@@ -154,16 +149,14 @@ class TestBehaviorPreservedByRefactor:
         base.update(override)
         return base
 
-    def test_all_four_combinations_match_reference(self):
+    def test_all_combinations_match_reference(self):
         for has_history in (True, False):
-            for topic_change in (True, False):
-                for from_another_bot in (True, False):
-                    kw = self._kwargs(
-                        has_history=has_history,
-                        topic_change=topic_change,
-                        from_another_bot=from_another_bot,
-                    )
-                    assert build_request_preamble(**kw) == self._reference_preamble(**kw), (
-                        f"mismatch at has_history={has_history} "
-                        f"topic_change={topic_change} from_another_bot={from_another_bot}"
-                    )
+            for from_another_bot in (True, False):
+                kw = self._kwargs(
+                    has_history=has_history,
+                    from_another_bot=from_another_bot,
+                )
+                assert build_request_preamble(**kw) == self._reference_preamble(**kw), (
+                    f"mismatch at has_history={has_history} "
+                    f"from_another_bot={from_another_bot}"
+                )


### PR DESCRIPTION
## Summary

Joint overhaul of the two memory subsystems, built from two investigation rounds reviewed with Odin (reflector/Learned Context + sessions). Five staged commits, each independently coherent and test-passing.

**Core invariant, applied everywhere: no stored memory is silently truncated.** If compressed, it is summarized; if clipped, it is marked; if too large, it is flagged for resummary.

## Stage 1 — schema v2 + stop data destruction
- Learned: the silent `[:800]` chop (both merge and consolidation paths) is gone — hard limit 1000 chars enforced as sentence-boundary clip + `[truncated: needs resummary]` marker + `damaged` flag. One-lesson-per-entry rule in all prompts; consolidation merges same-topic duplicates only and passes damaged entries through unmerged. New entry fields: topic, tags, confidence, source, last_used_at, supersedes. Category-aware expiry (corrections/preferences never auto-expire; operational/fact 180d from last use). v1→v2 migration flags legacy chop damage — verified on a live-data copy: 5 damaged flagged, 13 long-but-complete untouched, idempotent.
- Sessions: schema v2 (summary_segments), archive retention switched from time-based (7d) to size caps (2GB / 10k files). Storage caps raised: TOOL_SUMMARY_MAX_CHARS 500→2000, CHAT_RESPONSE_MAX_CHARS 1500→4000 — the bot remembers materially more of its own findings between operations.
- Plumbing fix: `sessions.token_budget` and `adaptive_compaction` config keys were silently ignored (never passed to SessionManager).

## Stage 2 — restore-on-demand + rolling segments
- A channel with no live session restores the latest archive in full — any age. The 48h continuity window is removed; vacations no longer reset context. Live TTL pruning remains as memory management only.
- Compaction emits rolling summary segments (1.5-2.5K target / 4K marked-clip max) with provenance: time range, participants, source counts, parsed topics/entities/decisions/open-threads. Segments are never re-merged into one paragraph. Legacy summary strings fold into the first segment automatically.
- Triggers: thresholds raised (40→100 fixed / 80-120 adaptive), token budget, plus idle-gap segmentation (>6h gap with ≥15 prior messages closes the segment at the natural boundary). Raw tail floored at 20 messages, clamped at max_history (was max_history//2).
- **Topic-change detection killed entirely** (AT decision). It was dead code — ran after add_message, so the query was always in its own comparison window (overlap pinned at 1.0, gap ~0; zero fires in 30 days of logs). Removed: detector, constants, parameter threading, the collapse-to-one-message path, and the preamble block.

## Stage 3 — relevance-gated prompt assembly
- New `src/relevance.py`: one lexical ranking implementation shared by learned injection, session message filtering, and segment selection.
- Learned injection: **include-all-when-fits** — when the scoped corpus fits `learning.injection_token_budget` (4000 ≈ today's full corpus) everything is injected; gating engages only as the corpus grows. Gated: corrections pinned (≤30) + requester preferences pinned (≤25) + operational top-12 / facts top-5 ranked against the query. Verified on live data: 3/3 corrections pinned, no cross-user preference leaks. `last_used_at` stamped in memory, persisted by the next locked write.
- Session send budget 16K→**64K** default (`sessions.context_token_budget`), 128K+ per-channel via `context_budget_overrides`. Candidates 40→160, keep-recent 5→12, relevant-older 10→40, floor 0.10→0.08.
- The fake user/assistant summary dialogue is replaced by a developer-role `[SESSION_CONTEXT_READ_ONLY]` block. Web chat gains parity (same window + relevance filtering as Discord).

## Stage 4 — selective reflection with real inputs
- Reflection fires only on: operation error, mid-operation tool errors, user-correction / remember-this markers, or substantive ops (≥5 tools). Routine ls/git-status successes skip it.
- `_process_with_tools` now stashes per-tool input + result excerpt + error heuristic each iteration; reflection consumes that instead of bare tool names. Reflection prompts embed only the ~30 most relevant existing entries instead of the whole corpus.

## Verification
- 5,604 passed / 29 failed on the full suite — the 29 are **byte-identical to the v3.28.5 baseline** on the same machine (environmental); zero new failures.
- 49 new tests (24 learned-overhaul, 8 relevance, 17 session-restore) covering every invariant above, including migration idempotency, damaged pass-through, scope no-leak, budget overrides, and topic-change removal regressions.
- Zero new ruff violations vs baseline under the project ruleset.
- Learned migration + injection gating exercised against a copy of the live `/opt/odin/data/learned.json`.

## Deploy notes (IMPORTANT)
1. The live `config.yml` is skip-worktree'd and contains explicit old values (`learning.max_entries: 30`, `consolidation_target: 20`, `sessions.max_age_hours: 168`). After merge, the live keys must be updated (150 / 120 / + new keys `injection_token_budget`, `context_token_budget`, `archive_max_bytes`, `archive_max_files`) or the capacity changes ship dormant.
2. First boot runs the learned.json v1→v2 migration automatically (idempotent, persisted in place). The 6h Gitea data backup covers rollback.
3. Session files upgrade shape lazily on save; archives accumulate from now on (size-capped) — no action needed.

## Out of scope (agreed)
Embedding-based topic-change rebuild (killed, not rebuilt), structured tool-trace artifact store, archive management UI, schedule run-history.