### PR TITLE
Observability bundle: context trace, failure classification, passive aggregates

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -90,6 +90,17 @@ learning:
   consolidation_target: 120
   injection_token_budget: 4000
 
+# Pure instrumentation — records prompt assembly + failure metadata,
+# never influences behavior. Safe to disable per piece.
+observability:
+  context_trace:
+    enabled: true
+    memory_key_mode: hash   # raw | hash | redacted
+    include_segment_ids: true
+    max_trace_bytes: 16384
+  audit_failure_classification: true
+  prompt_budget_accounting: true
+
 search:
   enabled: true
   search_db_path: ./data/search

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import aiofiles
 
+from ..observability.failure_classes import classify_failure
 from ..odin_log import get_logger
 from .signer import AuditSigner, verify_log
 
@@ -17,11 +18,15 @@ log = get_logger("audit")
 class AuditLogger:
     """Append-only JSON Lines audit log for tool executions."""
 
-    def __init__(self, path: str = "./data/audit.jsonl", *, hmac_key: str = "") -> None:
+    def __init__(
+        self, path: str = "./data/audit.jsonl", *,
+        hmac_key: str = "", classify_failures: bool = True,
+    ) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._event_callback: Callable | None = None
         self._signer: AuditSigner | None = AuditSigner(hmac_key) if hmac_key else None
+        self._classify_failures = classify_failures
 
     def set_event_callback(self, callback: Callable) -> None:
         """Set a callback to be invoked with each audit entry (for live WS events)."""
@@ -55,6 +60,10 @@ class AuditLogger:
             "execution_time_ms": execution_time_ms,
             "error": error,
         }
+        if error and self._classify_failures:
+            # Write-time heuristic classification (observability). The raw
+            # error string is classified here; aggregates never re-store it.
+            entry["failure"] = classify_failure(error)
         if diff:
             entry["diff"] = diff
         if risk_level:

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -598,6 +598,22 @@ class MCPServerConfig(BaseModel):
         return v
 
 
+class ContextTraceConfig(BaseModel):
+    enabled: bool = True
+    # raw | hash | redacted — how learned/memory keys appear in traces
+    memory_key_mode: Literal["raw", "hash", "redacted"] = "hash"
+    include_segment_ids: bool = True
+    max_trace_bytes: int = 16384
+
+
+class ObservabilityConfig(BaseModel):
+    """Pure instrumentation — records prompt assembly and failure metadata,
+    never influences behavior. Each piece has its own kill-switch."""
+    context_trace: ContextTraceConfig = ContextTraceConfig()
+    audit_failure_classification: bool = True
+    prompt_budget_accounting: bool = True
+
+
 class MCPConfig(BaseModel):
     enabled: bool = False
     servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
@@ -621,6 +637,7 @@ class Config(BaseModel):
     usage: UsageConfig = UsageConfig()
     webhook: WebhookConfig = WebhookConfig()
     learning: LearningConfig = LearningConfig()
+    observability: ObservabilityConfig = ObservabilityConfig()
     search: SearchConfig = SearchConfig()
     voice: VoiceConfig = VoiceConfig()
     monitoring: MonitoringConfig = MonitoringConfig()

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -444,7 +444,13 @@ class OdinBot(commands.Bot):
 
         # Audit logger — HMAC chain signing is on iff config.audit.hmac_key is set
         _audit_key = config.audit.hmac_key if getattr(config, "audit", None) else ""
-        self.audit = AuditLogger(path="./data/audit.jsonl", hmac_key=_audit_key)
+        self.audit = AuditLogger(
+            path="./data/audit.jsonl", hmac_key=_audit_key,
+            classify_failures=getattr(
+                getattr(config, "observability", None),
+                "audit_failure_classification", True,
+            ),
+        )
         if getattr(config, "audit", None) is not None and not _audit_key:
             log.warning(
                 "Audit HMAC signing is DISABLED (config.audit.hmac_key is empty): "
@@ -873,7 +879,29 @@ class OdinBot(commands.Bot):
         self._memory_cache[user_id] = (now, memory)
         return memory
 
-    def _get_reflector_section(self, user_id: str | None, query: str | None = None) -> str:
+    def _new_context_trace(self):
+        """Create a context-trace collector when observability is enabled.
+
+        Returns None when disabled — every consumer treats None as
+        "record nothing", leaving the request path byte-identical.
+        """
+        try:
+            obs = getattr(self.config, "observability", None)
+            ct = getattr(obs, "context_trace", None)
+            if ct is None or not ct.enabled:
+                return None
+            from ..observability import ContextTraceCollector
+            return ContextTraceCollector(
+                memory_key_mode=ct.memory_key_mode,
+                include_segment_ids=ct.include_segment_ids,
+                max_trace_bytes=ct.max_trace_bytes,
+            )
+        except Exception:  # noqa: BLE001 — tracing must never block a turn
+            return None
+
+    def _get_reflector_section(
+        self, user_id: str | None, query: str | None = None, trace=None,
+    ) -> str:
         """Learned Context for the prompt — query-aware relevance selection.
 
         File parsing is mtime-cached inside the reflector, so calling per
@@ -881,7 +909,9 @@ class OdinBot(commands.Bot):
         """
         if not hasattr(self, "reflector"):
             return ""
-        return self.reflector.get_prompt_section(user_id=user_id, query=query)
+        return self.reflector.get_prompt_section(
+            user_id=user_id, query=query, trace=trace,
+        )
 
     def _invalidate_prompt_caches(self) -> None:
         """Invalidate all prompt-related caches. Called on config/context reload."""
@@ -982,6 +1012,7 @@ class OdinBot(commands.Bot):
         self, channel: discord.abc.GuildChannel | None = None,
         user_id: str | None = None,
         query: str | None = None,
+        trace=None,
     ) -> str:
         voice_info = "Voice support is not enabled."
         if self.voice_manager:
@@ -1014,15 +1045,22 @@ class OdinBot(commands.Bot):
             personality_voice=p_cfg.custom_voice if p_cfg else "",
         )
 
+        if trace is not None:
+            trace.section("base", tokens=len(prompt) // 4)
+
         # Inject persistent memory into the system prompt (per-user + global)
         memory = self._get_cached_memory(user_id)
         if memory:
             memory_text = "\n".join(f"- **{k}**: {v}" for k, v in memory.items())
             prompt += f"\n\n## Persistent Memory\n{memory_text}"
+            if trace is not None:
+                trace.section("persistent_memory", tokens=len(memory_text) // 4,
+                              keys=len(memory))
 
         # Inject learned context from cross-conversation reflection
-        # (per-user filtered, relevance-ranked against the current query)
-        learned = self._get_reflector_section(user_id, query)
+        # (per-user filtered, relevance-ranked against the current query).
+        # The reflector records its own selection decisions on the trace.
+        learned = self._get_reflector_section(user_id, query, trace=trace)
         if learned:
             prompt += f"\n\n{learned}"
 
@@ -1030,6 +1068,8 @@ class OdinBot(commands.Bot):
         skills_text = self._get_cached_skills_text()
         if skills_text:
             prompt += f"\n\n## User-Created Skills\n{skills_text}"
+            if trace is not None:
+                trace.section("skills_list", tokens=len(skills_text) // 4)
 
         # Inject recent tool executions for this channel only
         if channel is not None:
@@ -1043,6 +1083,9 @@ class OdinBot(commands.Bot):
             if channel_actions:
                 actions_text = "\n".join(channel_actions[-10:])
                 prompt += f"\n\n## Recent Actions\n{actions_text}"
+                if trace is not None:
+                    trace.section("recent_actions", tokens=len(actions_text) // 4,
+                                  entries=len(channel_actions[-10:]))
 
         # Tool use pattern hints injected separately via _inject_tool_hints()
         # because format_hints is async (needs embedder).
@@ -1058,6 +1101,8 @@ class OdinBot(commands.Bot):
                 degradation_notes.append("LLM backend circuit breaker is recovering (half-open) — requests may be slow or fail.")
         if degradation_notes:
             prompt += "\n\n## System Health Warnings\n" + "\n".join(f"- {n}" for n in degradation_notes)
+            if trace is not None:
+                trace.section("health_warnings", tokens=20, notes=len(degradation_notes))
 
         return prompt
 
@@ -1520,12 +1565,14 @@ class OdinBot(commands.Bot):
 
     async def _save_turn_trajectory(
         self, trajectory, *, error: str = "", final_response: str = "",
-        tools_used: list[str] | None = None,
+        tools_used: list[str] | None = None, trace=None,
     ) -> None:
         """Persist the turn trajectory as JSONL. Non-fatal on error."""
         if self.trajectory_saver is None:
             return
         try:
+            if trace is not None:
+                trajectory.context_trace = trace.finalize()
             from datetime import datetime, timezone
             trajectory.timestamp = datetime.now(timezone.utc).isoformat()
             if error:
@@ -2305,16 +2352,33 @@ class OdinBot(commands.Bot):
                     )
                     self.sessions.remove_last_message(channel_id, "user")
                     return
-                _sp = self._build_system_prompt(channel=message.channel, user_id=user_id, query=content)
+                _trace = self._new_context_trace()
+                if _trace is not None:
+                    with _trace.phase("system_prompt"):
+                        _sp = self._build_system_prompt(
+                            channel=message.channel, user_id=user_id,
+                            query=content, trace=_trace,
+                        )
+                else:
+                    _sp = self._build_system_prompt(
+                        channel=message.channel, user_id=user_id, query=content,
+                    )
                 _sp = await self._inject_tool_hints(_sp, content, user_id)
                 log.info("Routing to Codex with tools")
                 # Use abbreviated history to reduce poisoning from stale responses
                 # (get_task_history handles compaction internally)
                 # Pass current message content for relevance scoring —
                 # older messages unrelated to the current query are dropped
-                task_history = await self.sessions.get_task_history(
-                    channel_id, max_messages=160, current_query=content,
-                )
+                if _trace is not None:
+                    with _trace.phase("history"):
+                        task_history = await self.sessions.get_task_history(
+                            channel_id, max_messages=160, current_query=content,
+                            trace=_trace,
+                        )
+                else:
+                    task_history = await self.sessions.get_task_history(
+                        channel_id, max_messages=160, current_query=content,
+                    )
                 if image_blocks and task_history and task_history[-1]["role"] == "user":
                     last = task_history[-1]
                     text = last["content"] if isinstance(last["content"], str) else str(last["content"])
@@ -2325,7 +2389,7 @@ class OdinBot(commands.Bot):
                     log.info("Attached %d image(s) to message for Claude vision", len(image_blocks))
                 try:
                     response, already_sent, is_error, tools_used, handoff = await self._process_with_tools(
-                        message, task_history, system_prompt_override=_sp,
+                        message, task_history, system_prompt_override=_sp, trace=_trace,
                     )
                 except asyncio.TimeoutError as codex_err:
                     log.warning("Codex tool loop timed out: %s", codex_err)
@@ -2577,6 +2641,7 @@ class OdinBot(commands.Bot):
         message: discord.Message,
         history: list[dict],
         system_prompt_override: str | None = None,
+        trace=None,
     ) -> tuple[str, bool, bool, list[str], bool]:
         """Process a message with Codex tool loop.
 
@@ -2676,6 +2741,12 @@ class OdinBot(commands.Bot):
 
         # Per-turn trajectory accumulator — populated each iteration, saved at end.
         from ..trajectories.saver import TrajectoryTurn, ToolIteration
+        if trace is not None:
+            provider_cfg = getattr(self.config, "llm_provider", None)
+            trace.provider(
+                name=getattr(provider_cfg, "active_provider", "codex") if provider_cfg else "codex",
+                model=getattr(self.llm_client, "model", "") or "",
+            )
         _op_tool_details: list[dict] = []
         _trajectory = TrajectoryTurn(
             message_id=str(getattr(message, "id", "")),
@@ -2758,13 +2829,13 @@ class OdinBot(commands.Bot):
                         user_id=user_id, channel_id=_channel_id, tools_used=tools_used_in_loop,
                     )
                 except Exception as retry_err:
-                    await self._save_turn_trajectory(_trajectory, error=str(retry_err))
+                    await self._save_turn_trajectory(_trajectory, error=str(retry_err), trace=trace)
                     _clear_active()
                     return f"LLM API error (circuit breaker recovery failed): {retry_err}", False, True, tools_used_in_loop, False
             except Exception as api_err:
                 err_msg = str(api_err) or f"{type(api_err).__name__} (no message)"
                 log.error("LLM API call failed: %s", err_msg, exc_info=True)
-                await self._save_turn_trajectory(_trajectory, error=err_msg)
+                await self._save_turn_trajectory(_trajectory, error=err_msg, trace=trace)
                 _clear_active()
                 return f"LLM API error: {err_msg}", False, True, tools_used_in_loop, False
             finally:
@@ -2793,7 +2864,7 @@ class OdinBot(commands.Bot):
             if stuck_tracker.check():
                 if stuck_tracker.warned:
                     log.warning("Stuck loop confirmed after warning — terminating tool loop")
-                    await self._save_turn_trajectory(_trajectory)
+                    await self._save_turn_trajectory(_trajectory, trace=trace)
                     await self._emit_lifecycle_event("loop.stuck", {
                         "channel_id": str(message.channel.id),
                         "iteration": iteration,
@@ -2940,6 +3011,7 @@ class OdinBot(commands.Bot):
                 _final = llm_resp.text or _EMPTY_RESPONSE_FALLBACK
                 await self._save_turn_trajectory(
                     _trajectory, final_response=_final, tools_used=tools_used_in_loop,
+                    trace=trace,
                 )
                 _clear_active()
                 return _final, False, False, tools_used_in_loop, False
@@ -3299,6 +3371,11 @@ class OdinBot(commands.Bot):
                 r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)
             }
             for _tc in tool_calls:
+                if trace is not None and _tc.id not in _results_by_id:
+                    trace.warning(
+                        "TOOL_RESULT_CONTINUATION_MISMATCH", "error",
+                        f"tool {_tc.name} call has no paired result",
+                    )
                 _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
                 _op_tool_details.append({
                     "tool": _tc.name,
@@ -3370,6 +3447,7 @@ class OdinBot(commands.Bot):
         )
         await self._save_turn_trajectory(
             _trajectory, final_response=_cap_msg, tools_used=tools_used_in_loop,
+            trace=trace,
         )
         return _cap_msg, False, True, tools_used_in_loop, False
 

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -245,6 +245,7 @@ class ConversationReflector:
 
     def get_prompt_section(
         self, user_id: str | None = None, query: str | None = None,
+        trace=None,
     ) -> str:
         """Format learned entries for injection into the system prompt.
 
@@ -279,9 +280,14 @@ class ConversationReflector:
         def fmt(e: dict) -> str:
             return f"- [{e['category']}] {e['content']}"
 
+        corrections_available = [
+            e["key"] for e in filtered if e["category"] == "correction"
+        ]
         total_tokens = sum(len(fmt(e)) for e in filtered) // 4
         if total_tokens <= self._injection_token_budget or not query:
             selected = filtered
+            selection_mode = "include_all"
+            gated_records: list[dict] = []
         else:
             def entry_text(e: dict) -> str:
                 return " ".join([
@@ -306,6 +312,16 @@ class ConversationReflector:
             # Preserve original corpus order for stable prompts
             chosen = {id(e) for e in (*corrections, *preferences, *operational, *facts)}
             selected = [e for e in filtered if id(e) in chosen]
+            selection_mode = "gated"
+            gated_records = []
+            if trace is not None:
+                pin_capped = {id(e) for e in filtered
+                              if e["category"] in ("correction", "preference")} - chosen
+                for e in filtered:
+                    if id(e) in chosen:
+                        continue
+                    reason = "pin_cap" if id(e) in pin_capped else "low_relevance"
+                    gated_records.append({"key": trace.key(e["key"]), "reason": reason})
             log.debug(
                 "Learned injection gated: %d/%d entries selected",
                 len(selected), len(filtered),
@@ -313,7 +329,21 @@ class ConversationReflector:
 
         self._note_used(selected)
         lines = [fmt(e) for e in selected]
-        return "## Learned Context\n" + "\n".join(lines)
+        section_text = "## Learned Context\n" + "\n".join(lines)
+        if trace is not None:
+            injected_correction_keys = [
+                e["key"] for e in selected if e["category"] == "correction"
+            ]
+            trace.learned(
+                available=len(filtered),
+                injected_keys=[trace.key(e["key"]) for e in selected],
+                pinned_available=[trace.key(k) for k in corrections_available],
+                pinned_injected=[trace.key(k) for k in injected_correction_keys],
+                gated_out=gated_records,
+                tokens=len(section_text) // 4,
+                mode=selection_mode,
+            )
+        return section_text
 
     _REFLECTION_CONTEXT_TOP_K = 30
 

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,0 +1,15 @@
+"""Observability: pure instrumentation of how Odin assembles context and
+why operations fail. Records decisions — never influences them.
+
+Design contract (PR #104):
+- Zero behavior impact: tracing is opt-in per call site via an optional
+  collector argument; absent collector means the code path is unchanged.
+- Never the outage: every recording operation is exception-guarded; a
+  broken trace logs a warning and the turn proceeds untouched.
+- Metadata only: section names, counts, token estimates, decision reasons,
+  hashed keys, opaque ids — never prompt or message content.
+"""
+from .context_trace import TRACE_SCHEMA_VERSION, ContextTraceCollector
+from .failure_classes import classify_failure
+
+__all__ = ["TRACE_SCHEMA_VERSION", "ContextTraceCollector", "classify_failure"]

--- a/src/observability/aggregates.py
+++ b/src/observability/aggregates.py
@@ -1,0 +1,211 @@
+"""Passive aggregation over recorded observability data.
+
+Reads trajectory context traces and audit failure classifications, computes
+windowed aggregates and drift candidates, and returns plain dicts for the
+API layer. No alert delivery here — exposure only; consumers (Grafana,
+future heartbeat) decide what to do with drift candidates.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from ..odin_log import get_logger
+
+log = get_logger("observability")
+
+# A section is a drift candidate when its average token cost moves by more
+# than BOTH thresholds vs the previous window (absolute floor avoids noise
+# on tiny sections; relative floor avoids flagging large stable sections).
+DRIFT_ABS_TOKENS = 300
+DRIFT_REL_FRACTION = 0.25
+
+_AUDIT_TAIL_BYTES = 4 * 1024 * 1024  # parse at most the last 4MB of audit log
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, round(pct / 100 * (len(ordered) - 1))))
+    return float(ordered[idx])
+
+
+def _iter_trajectory_turns(directory: Path, since: datetime, until: datetime):
+    """Yield parsed turns from date-partitioned JSONL files within range."""
+    day = since.date()
+    while day <= until.date():
+        path = directory / f"{day.isoformat()}.jsonl"
+        if path.exists():
+            try:
+                with path.open() as fh:
+                    for line in fh:
+                        try:
+                            turn = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        ts = turn.get("timestamp", "")
+                        try:
+                            turn_dt = datetime.fromisoformat(ts)
+                        except (ValueError, TypeError):
+                            continue
+                        if since <= turn_dt <= until:
+                            yield turn
+            except OSError as e:
+                log.warning("Could not read trajectory file %s: %s", path, e)
+        day += timedelta(days=1)
+
+
+def _window_section_stats(turns: list[dict]) -> tuple[dict, list[float], int]:
+    """Per-section average tokens + total-token samples for one window."""
+    section_tokens: dict[str, list[float]] = {}
+    totals: list[float] = []
+    traced = 0
+    for turn in turns:
+        trace = turn.get("context_trace")
+        if not isinstance(trace, dict):
+            continue
+        traced += 1
+        summary = trace.get("summary", {})
+        total = summary.get("system_tokens", 0) + summary.get("history_used_tokens", 0)
+        totals.append(float(total))
+        for section in trace.get("sections", []):
+            name = section.get("section", "?")
+            section_tokens.setdefault(name, []).append(float(section.get("tokens", 0)))
+        learned = trace.get("learned", {})
+        if learned:
+            section_tokens.setdefault("learned", []).append(float(learned.get("tokens", 0)))
+        history = trace.get("history", {})
+        if history:
+            section_tokens.setdefault("history", []).append(float(history.get("used", 0)))
+    by_section = {
+        name: round(sum(vals) / len(vals), 1)
+        for name, vals in section_tokens.items() if vals
+    }
+    return by_section, totals, traced
+
+
+def context_aggregates(trajectory_dir: str, window_hours: int = 24) -> dict:
+    """Windowed prompt-assembly aggregates + drift candidates vs the
+    previous window of the same length."""
+    directory = Path(trajectory_dir)
+    now = datetime.now(UTC)
+    window = timedelta(hours=window_hours)
+
+    current = list(_iter_trajectory_turns(directory, now - window, now))
+    previous = list(_iter_trajectory_turns(directory, now - 2 * window, now - window))
+
+    cur_sections, cur_totals, cur_traced = _window_section_stats(current)
+    prev_sections, _, prev_traced = _window_section_stats(previous)
+
+    by_section = {}
+    drift_candidates = []
+    for name, avg in sorted(cur_sections.items()):
+        prev_avg = prev_sections.get(name)
+        delta = round(avg - prev_avg, 1) if prev_avg is not None else None
+        by_section[name] = {"avg_tokens": avg, "delta_vs_prev_window": delta}
+        if (
+            delta is not None
+            and abs(delta) >= DRIFT_ABS_TOKENS
+            and prev_avg > 0
+            and abs(delta) / prev_avg >= DRIFT_REL_FRACTION
+        ):
+            drift_candidates.append({
+                "type": "section_growth" if delta > 0 else "section_shrink",
+                "section": name,
+                "delta_tokens": delta,
+                "window_hours": window_hours,
+            })
+
+    warnings_count = sum(
+        len((t.get("context_trace") or {}).get("warnings", []))
+        for t in current if isinstance(t.get("context_trace"), dict)
+    )
+
+    return {
+        "window_hours": window_hours,
+        "turns": len(current),
+        "turns_traced": cur_traced,
+        "previous_window_traced": prev_traced,
+        "prompt_tokens_avg": round(sum(cur_totals) / len(cur_totals), 1) if cur_totals else 0,
+        "prompt_tokens_p95": round(_percentile(cur_totals, 95), 1),
+        "by_section": by_section,
+        "trace_warnings": warnings_count,
+        "drift_candidates": drift_candidates,
+    }
+
+
+def _tail_lines(path: Path, max_bytes: int) -> list[str]:
+    size = path.stat().st_size
+    with path.open("rb") as fh:
+        if size > max_bytes:
+            fh.seek(size - max_bytes)
+            fh.readline()  # discard the partial first line
+        return fh.read().decode(errors="replace").splitlines()
+
+
+def failure_aggregates(audit_path: str, window_hours: int = 24) -> dict:
+    """Failure-class counts for the current vs previous window.
+
+    Only classification metadata is aggregated — raw error strings are
+    never surfaced here.
+    """
+    path = Path(audit_path)
+    if not path.exists():
+        return {"window_hours": window_hours, "classified": 0, "by_class": {}, "trends": []}
+
+    now = datetime.now(UTC)
+    window = timedelta(hours=window_hours)
+    current: dict[str, int] = {}
+    previous: dict[str, int] = {}
+    by_tool: dict[str, dict[str, int]] = {}
+    classified = 0
+
+    try:
+        lines = _tail_lines(path, _AUDIT_TAIL_BYTES)
+    except OSError as e:
+        log.warning("Could not read audit log: %s", e)
+        return {"window_hours": window_hours, "classified": 0, "by_class": {}, "trends": []}
+
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        failure = entry.get("failure")
+        if not isinstance(failure, dict):
+            continue
+        try:
+            ts = datetime.fromisoformat(entry.get("timestamp", ""))
+        except (ValueError, TypeError):
+            continue
+        cls = failure.get("class", "unknown")
+        if now - window <= ts <= now:
+            classified += 1
+            current[cls] = current.get(cls, 0) + 1
+            tool = entry.get("tool_name", "?")
+            by_tool.setdefault(cls, {})
+            by_tool[cls][tool] = by_tool[cls].get(tool, 0) + 1
+        elif now - 2 * window <= ts < now - window:
+            previous[cls] = previous.get(cls, 0) + 1
+
+    trends = []
+    for cls in sorted(set(current) | set(previous)):
+        cur_n, prev_n = current.get(cls, 0), previous.get(cls, 0)
+        if cur_n != prev_n:
+            trends.append({
+                "class": cls, "current": cur_n, "previous": prev_n,
+                "delta": cur_n - prev_n,
+            })
+
+    return {
+        "window_hours": window_hours,
+        "classified": classified,
+        "by_class": {
+            cls: {"count": n, "top_tools": dict(sorted(
+                by_tool.get(cls, {}).items(), key=lambda kv: -kv[1])[:5])}
+            for cls, n in sorted(current.items(), key=lambda kv: -kv[1])
+        },
+        "trends": trends,
+    }

--- a/src/observability/context_trace.py
+++ b/src/observability/context_trace.py
@@ -1,0 +1,299 @@
+"""Per-request context trace: what was assembled into the prompt, what was
+filtered out, and WHY — recorded as metadata only, attached to the turn's
+trajectory record.
+
+The collector is deliberately paranoid: every public method is wrapped so
+that an internal failure can never propagate into the request path.
+Observability must never become the outage.
+"""
+from __future__ import annotations
+
+import functools
+import hashlib
+import json
+import re
+import time
+
+from ..odin_log import get_logger
+
+log = get_logger("observability")
+
+TRACE_SCHEMA_VERSION = 1
+ASSEMBLY_VERSION = "prompt_assembler_v1"
+
+# Heuristic patterns for the privacy self-check. Intentionally coarse —
+# the goal is catching accidental key/token leakage into trace metadata,
+# not perfect secret detection.
+_SECRET_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{20,}"),
+    re.compile(r"gho_[A-Za-z0-9]{20,}"),
+    re.compile(r"AKIA[A-Z0-9]{12,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}"),  # JWT-ish
+)
+
+
+def _guarded(method):
+    """Recording must never raise into the request path."""
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as e:  # noqa: BLE001 — by design: swallow everything
+            self._internal_errors += 1
+            if self._internal_errors == 1:
+                log.warning("Context trace recording failed (non-fatal): %s", e)
+            return None
+    return wrapper
+
+
+class ContextTraceCollector:
+    """Accumulates prompt-assembly decision metadata for a single turn.
+
+    Pass an instance into the assembly functions (system prompt builder,
+    task history, learned injection); each records its decisions when a
+    collector is present and does nothing different when it is not.
+    Call :meth:`finalize` once to produce the JSON-safe trace dict.
+    """
+
+    def __init__(
+        self,
+        *,
+        memory_key_mode: str = "hash",
+        include_segment_ids: bool = True,
+        max_trace_bytes: int = 16384,
+    ) -> None:
+        self._memory_key_mode = memory_key_mode
+        self._include_segment_ids = include_segment_ids
+        self._max_trace_bytes = max_trace_bytes
+        self._internal_errors = 0
+        self._started = time.monotonic()
+        self._sections: list[dict] = []
+        self._history: dict = {}
+        self._learned: dict = {}
+        self._segments: list[dict] = []
+        self._warnings: list[dict] = []
+        self._timings: dict[str, float] = {}
+        self._provider: dict = {}
+        self._continuity_source: str | None = None
+        self._finalized: dict | None = None
+
+    # -- key/id privacy -----------------------------------------------------
+
+    def key(self, raw_key: str) -> str:
+        """Apply the configured memory-key privacy mode."""
+        try:
+            if self._memory_key_mode == "raw":
+                return str(raw_key)
+            if self._memory_key_mode == "redacted":
+                return "<redacted>"
+            digest = hashlib.sha256(str(raw_key).encode()).hexdigest()[:12]
+            return f"k_{digest}"
+        except Exception:  # noqa: BLE001
+            return "<key-error>"
+
+    def segment_id(self, raw_id: str) -> str:
+        return str(raw_id) if self._include_segment_ids else "<segment>"
+
+    # -- recording ------------------------------------------------------------
+
+    @_guarded
+    def section(self, name: str, *, tokens: int, **meta) -> None:
+        """Record one system-prompt section with its estimated token cost."""
+        entry = {"section": name, "tokens": int(tokens)}
+        for field_name, value in meta.items():
+            entry[field_name] = value
+        self._sections.append(entry)
+
+    @_guarded
+    def learned(
+        self,
+        *,
+        available: int,
+        injected_keys: list[str],
+        pinned_available: list[str],
+        pinned_injected: list[str],
+        gated_out: list[dict],
+        tokens: int,
+        mode: str,
+    ) -> None:
+        """Record the learned-context selection decision.
+
+        *mode* is ``include_all`` (corpus fit the budget) or ``gated``.
+        ``gated_out`` entries are ``{"key": ..., "reason": ...}`` dicts with
+        keys already passed through :meth:`key`.
+        """
+        self._learned = {
+            "available_count": int(available),
+            "injected_count": len(injected_keys),
+            "injected_keys": list(injected_keys),
+            "pinned_corrections_available": list(pinned_available),
+            "pinned_corrections_injected": list(pinned_injected),
+            "gated_out": list(gated_out),
+            "tokens": int(tokens),
+            "mode": mode,
+        }
+        missing = set(pinned_available) - set(pinned_injected)
+        if missing:
+            self.warning(
+                "PINNED_CORRECTION_NOT_INJECTED", "error",
+                f"{len(missing)} correction(s) available but not injected",
+            )
+
+    @_guarded
+    def history(
+        self,
+        *,
+        budget: int,
+        used: int,
+        candidates: int,
+        kept_recent: int,
+        kept_relevant: int,
+        dropped_relevance: int,
+        dropped_budget: int,
+    ) -> None:
+        self._history = {
+            "budget": int(budget),
+            "used": int(used),
+            "candidates": int(candidates),
+            "kept_recent": int(kept_recent),
+            "kept_relevant": int(kept_relevant),
+            "dropped_relevance": int(dropped_relevance),
+            "dropped_budget": int(dropped_budget),
+        }
+
+    @_guarded
+    def segment(
+        self, seg_id: str, *, decision: str, reason: str,
+        tokens: int = 0, source_type: str = "session",
+    ) -> None:
+        """Record one summary-segment decision: injected/skipped + reason."""
+        self._segments.append({
+            "id": self.segment_id(seg_id),
+            "decision": decision,
+            "reason": reason,
+            "tokens": int(tokens),
+            "source_type": source_type,
+        })
+
+    @_guarded
+    def continuity(self, source: str) -> None:
+        """Where this turn's session came from: live | archive_restore | fresh."""
+        self._continuity_source = source
+
+    @_guarded
+    def provider(self, *, name: str, model: str, message_format: str = "") -> None:
+        self._provider = {"name": name, "model": model}
+        if message_format:
+            self._provider["message_format"] = message_format
+
+    @_guarded
+    def warning(self, code: str, severity: str, detail: str) -> None:
+        """Record an invariant violation. Golden eval cases assert zero of these."""
+        self._warnings.append({
+            "code": code, "severity": severity, "detail": str(detail)[:200],
+        })
+
+    @_guarded
+    def timing(self, phase: str, ms: float) -> None:
+        self._timings[phase] = round(float(ms), 2)
+
+    class _PhaseTimer:
+        def __init__(self, collector: ContextTraceCollector, phase: str) -> None:
+            self._collector = collector
+            self._phase = phase
+            self._t0 = 0.0
+
+        def __enter__(self):
+            self._t0 = time.monotonic()
+            return self
+
+        def __exit__(self, *exc):
+            self._collector.timing(self._phase, (time.monotonic() - self._t0) * 1000)
+            return False
+
+    def phase(self, name: str) -> _PhaseTimer:
+        """Context manager recording wall-time for an assembly phase."""
+        return self._PhaseTimer(self, name)
+
+    # -- output -----------------------------------------------------------------
+
+    def _secret_scan(self, serialized: str) -> dict:
+        matches = 0
+        try:
+            for pattern in _SECRET_PATTERNS:
+                matches += len(pattern.findall(serialized))
+        except Exception:  # noqa: BLE001
+            return {"performed": False, "matches": -1}
+        if matches:
+            log.warning(
+                "Context trace privacy scan found %d secret-like token(s) in metadata",
+                matches,
+            )
+        return {"performed": True, "matches": matches}
+
+    def finalize(self) -> dict | None:
+        """Build the JSON-safe trace dict. Never raises; returns None only if
+        even the minimal fallback cannot be built."""
+        if self._finalized is not None:
+            return self._finalized
+        try:
+            duration_ms = round((time.monotonic() - self._started) * 1000, 2)
+            total_tokens = sum(s.get("tokens", 0) for s in self._sections)
+            trace = {
+                "schema_version": TRACE_SCHEMA_VERSION,
+                "assembly": {
+                    "version": ASSEMBLY_VERSION,
+                    "duration_ms": duration_ms,
+                    "phase_ms": dict(self._timings),
+                    "internal_errors": self._internal_errors,
+                },
+                "summary": {
+                    "system_tokens": total_tokens,
+                    "sections_count": len(self._sections),
+                    "history_used_tokens": self._history.get("used", 0),
+                    "history_candidates": self._history.get("candidates", 0),
+                    "learned_injected": self._learned.get("injected_count", 0),
+                    "pinned_corrections_injected": len(
+                        self._learned.get("pinned_corrections_injected", [])
+                    ),
+                    "dropped_budget": self._history.get("dropped_budget", 0),
+                    "warnings_count": len(self._warnings),
+                    "trace_truncated": False,
+                },
+                "sections": self._sections,
+                "history": self._history,
+                "learned": self._learned,
+                "segments": self._segments,
+                "continuity_source": self._continuity_source,
+                "provider": self._provider,
+                "warnings": self._warnings,
+            }
+            serialized = json.dumps(trace, default=str)
+            trace["privacy"] = {
+                "content_recorded": False,
+                "memory_key_mode": self._memory_key_mode,
+                "secret_scan": self._secret_scan(serialized),
+            }
+            # Enforce the size cap by shedding the bulkiest sublists —
+            # explicitly flagged, never silent.
+            if len(serialized) > self._max_trace_bytes:
+                for bulky in ("segments", "sections"):
+                    trace[bulky] = []
+                self._learned.pop("gated_out", None)
+                trace["summary"]["trace_truncated"] = True
+                trace["truncation_reason"] = "max_trace_bytes"
+            self._finalized = trace
+            return trace
+        except Exception as e:  # noqa: BLE001
+            log.warning("Context trace finalize failed (non-fatal): %s", e)
+            try:
+                self._finalized = {
+                    "schema_version": TRACE_SCHEMA_VERSION,
+                    "finalize_error": True,
+                    "internal_errors": self._internal_errors + 1,
+                }
+                return self._finalized
+            except Exception:  # noqa: BLE001
+                return None

--- a/src/observability/failure_classes.py
+++ b/src/observability/failure_classes.py
@@ -1,0 +1,169 @@
+"""Heuristic failure classification for audit entries.
+
+Classifies tool-execution error text into a stable taxonomy at write time —
+no LLM in the path, deterministic, rule-id'd so future reclassification can
+tell which heuristic generation produced a verdict. The raw error string is
+classified but never re-stored by the aggregate layer.
+
+Class order matters: the first matching rule wins, so specific classes
+(dependency_missing, quota, policy_blocked) precede broad ones (network,
+provider).
+"""
+from __future__ import annotations
+
+import re
+
+CLASSIFIER_SOURCE = "heuristic_v1"
+
+FAILURE_CLASSES = (
+    "cancelled",
+    "policy_blocked",
+    "auth",
+    "rate_limit",
+    "quota",
+    "dependency_missing",
+    "validation_failed",
+    "conflict",
+    "permission_denied",
+    "not_found",
+    "timeout",
+    "remote_state",
+    "network",
+    "bad_input",
+    "provider",
+    "unknown",
+)
+
+# (rule_id, class, subclass, compiled_pattern, confidence)
+_RULES: tuple[tuple[str, str, str, re.Pattern, float], ...] = (
+    # -- cancelled --------------------------------------------------------
+    ("cancel_explicit_v1", "cancelled", "explicit_cancel",
+     re.compile(
+         r"cancell?ed|keyboardinterrupt|task was destroyed|loop stopped|"
+         r"aborted by user",
+         re.I), 0.9),
+    # -- policy / RBAC ------------------------------------------------------
+    ("policy_rbac_v1", "policy_blocked", "rbac_denied",
+     re.compile(
+         r"rbac|not permitted|denied by polic|governor blocked|"
+         r"blocked by governor|tool .* is restricted|permission tier",
+         re.I), 0.9),
+    # -- auth ----------------------------------------------------------------
+    ("auth_401_v1", "auth", "unauthorized",
+     re.compile(
+         r"\b401\b|unauthorized|invalid[ _]token|token.{0,20}(expired|"
+         r"invalidated)|authentication failed|sign in again|"
+         r"invalid credentials|oauth",
+         re.I), 0.88),
+    # -- rate limit / quota --------------------------------------------------
+    ("rate_429_v1", "rate_limit", "http_429",
+     re.compile(r"\b429\b|rate.?limit|too many requests|slow down", re.I), 0.9),
+    ("quota_v1", "quota", "quota_exhausted",
+     re.compile(
+         r"quota|insufficient[ _]credits|out of credits|usage limit reached|"
+         r"billing",
+         re.I), 0.85),
+    # -- dependency ---------------------------------------------------------
+    ("dep_missing_v1", "dependency_missing", "missing_component",
+     re.compile(
+         r"command not found|no module named|modulenotfounderror|"
+         r"not installed|no such (binary|executable)|"
+         r"executable file not found|importerror",
+         re.I), 0.9),
+    # -- validation (post-change check failed, structurally fine) ------------
+    ("validation_v1", "validation_failed", "post_change_validation",
+     re.compile(
+         r"validate_action|validation failed|verification failed|"
+         r"post-?change check",
+         re.I), 0.85),
+    # -- conflict -------------------------------------------------------------
+    ("conflict_git_v1", "conflict", "vcs_or_lock",
+     re.compile(
+         r"merge conflict|\bCONFLICT\b|would be overwritten|lock(ed| held|"
+         r" contention)|stale.{0,12}branch|non-fast-forward|"
+         r"concurrent modification|resource busy",
+         re.I), 0.88),
+    # -- permission (filesystem/OS, not auth) ----------------------------------
+    ("perm_denied_v1", "permission_denied", "os_permission",
+     re.compile(
+         r"permission denied|eacces|read-?only file system|"
+         r"operation not permitted",
+         re.I), 0.88),
+    # -- not found -------------------------------------------------------------
+    ("notfound_v1", "not_found", "missing_target",
+     re.compile(
+         r"\b404\b|not found|no such (file|directory|host|container|table|"
+         r"column)|does not exist|unknown (host|channel|tool)",
+         re.I), 0.8),
+    # -- timeout ---------------------------------------------------------------
+    ("timeout_v1", "timeout", "operation_timeout",
+     re.compile(r"timed? ?out|timeouterror|deadline exceeded", re.I), 0.9),
+    # -- remote state (transport works, service is dead) ------------------------
+    ("remote_state_v1", "remote_state", "service_down",
+     re.compile(
+         r"daemon (is not|not) running|is the docker daemon running|"
+         r"service (is )?(inactive|dead|not active|failed)|"
+         r"connection refused.*sock|systemctl status|"
+         r"container .* (is not running|exited)",
+         re.I), 0.82),
+    # -- network ------------------------------------------------------------------
+    ("network_v1", "network", "transport",
+     re.compile(
+         r"econnrefused|econnreset|etimedout|ehostunreach|enetunreach|"
+         r"connection (refused|reset|aborted)|name or service not known|"
+         r"temporary failure in name resolution|no route to host|ssl|"
+         r"certificate|broken pipe|getaddrinfo",
+         re.I), 0.85),
+    # -- bad input -------------------------------------------------------------------
+    ("badinput_v1", "bad_input", "invalid_arguments",
+     re.compile(
+         r"invalid (argument|input|option|value|syntax)|jsondecodeerror|"
+         r"expecting value|unrecognized arguments|usage:|missing required|"
+         r"valueerror|typeerror",
+         re.I), 0.8),
+    # -- provider/upstream --------------------------------------------------------------
+    ("provider_5xx_v1", "provider", "upstream_error",
+     re.compile(
+         r"\b(500|502|503|504)\b|internal server error|bad gateway|"
+         r"service unavailable|upstream|model (error|overloaded)|codex|"
+         r"api error",
+         re.I), 0.75),
+)
+
+
+def classify_failure(error_text: str | None) -> dict:
+    """Classify an error string into the failure taxonomy.
+
+    Returns Odin's agreed structure::
+
+        {"class": ..., "subclass": ..., "confidence": ...,
+         "matched_rule": ..., "source": "heuristic_v1"}
+
+    Never raises; anything unmatchable is ``unknown`` at low confidence.
+    """
+    try:
+        text = str(error_text or "")
+        if not text.strip():
+            return {
+                "class": "unknown", "subclass": "empty_error",
+                "confidence": 0.3, "matched_rule": None,
+                "source": CLASSIFIER_SOURCE,
+            }
+        for rule_id, cls, subclass, pattern, confidence in _RULES:
+            if pattern.search(text):
+                return {
+                    "class": cls, "subclass": subclass,
+                    "confidence": confidence, "matched_rule": rule_id,
+                    "source": CLASSIFIER_SOURCE,
+                }
+        return {
+            "class": "unknown", "subclass": "no_rule_matched",
+            "confidence": 0.3, "matched_rule": None,
+            "source": CLASSIFIER_SOURCE,
+        }
+    except Exception:  # noqa: BLE001 — classification must never break audit writes
+        return {
+            "class": "unknown", "subclass": "classifier_error",
+            "confidence": 0.0, "matched_rule": None,
+            "source": CLASSIFIER_SOURCE,
+        }

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -364,6 +364,9 @@ class SessionManager:
         # epoch are never restored — reset/purge means GONE, not "back on
         # the next message". Persisted so restarts honor resets too.
         self._reset_epochs: dict[str, float] = self._load_reset_epochs()
+        # Observability metadata only: how each live session came to exist
+        # (fresh | archive_restore | loaded_live). Read by context tracing.
+        self._continuity_source: dict[str, str] = {}
         self._sessions: dict[str, Session] = {}
         self._dirty: set[str] = set()
         self._reflector = reflector
@@ -394,6 +397,9 @@ class SessionManager:
             session = self._restore_from_archive(channel_id)
             if session is None:
                 session = Session(channel_id=channel_id)
+                self._continuity_source[channel_id] = "fresh"
+            else:
+                self._continuity_source[channel_id] = "archive_restore"
             self._sessions[channel_id] = session
             self._dirty.add(channel_id)
         session = self._sessions[channel_id]
@@ -469,6 +475,7 @@ class SessionManager:
     @staticmethod
     def _render_context_summary(
         session: Session, query: str | None = None, max_segments: int = 5,
+        trace=None,
     ) -> str:
         """Render prior-context text from the legacy summary and/or summary
         segments for prompt injection.
@@ -484,6 +491,7 @@ class SessionManager:
         segments = session.summary_segments
         if not query or len(segments) <= max_segments:
             selected = segments[-max_segments:]
+            selection_reason = "recency"
         else:
             newest = segments[-1]
             older = segments[:-1]
@@ -498,6 +506,20 @@ class SessionManager:
             )
             chosen = {id(s) for s in ranked}
             selected = [s for s in older if id(s) in chosen] + [newest]
+            selection_reason = "semantic_match"
+        if trace is not None:
+            selected_ids = {id(s) for s in selected}
+            for seg in segments:
+                seg_tokens = len(seg.get("summary", "")) // 4
+                if id(seg) in selected_ids:
+                    reason = ("newest" if segments and seg is segments[-1]
+                              else selection_reason)
+                    trace.segment(seg.get("id", "?"), decision="injected",
+                                  reason=reason, tokens=seg_tokens)
+                else:
+                    trace.segment(seg.get("id", "?"), decision="skipped",
+                                  reason="low_relevance" if query else "older_than_window",
+                                  tokens=seg_tokens)
         for seg in selected:
             text = seg.get("summary", "")
             if not text:
@@ -513,11 +535,11 @@ class SessionManager:
 
     @classmethod
     def _summary_context_message(
-        cls, session: Session, query: str | None = None,
+        cls, session: Session, query: str | None = None, trace=None,
     ) -> dict | None:
         """The single source of the prior-context block — a developer-role
         read-only message, never fake user/assistant dialogue."""
-        context_summary = cls._render_context_summary(session, query=query)
+        context_summary = cls._render_context_summary(session, query=query, trace=trace)
         if not context_summary:
             return None
         sanitized = _sanitize_summary(context_summary)
@@ -610,6 +632,7 @@ class SessionManager:
     async def get_task_history(
         self, channel_id: str, max_messages: int = 10,
         current_query: str | None = None,
+        trace=None,
     ) -> list[dict[str, str]]:
         """Get abbreviated history for the tool-calling path.
 
@@ -659,15 +682,21 @@ class SessionManager:
             # Preserve original ordering among the kept older messages
             kept_set = {id(m) for _, m in relevant}
             filtered = [m for m in older if id(m) in kept_set] + list(recent)
+            kept_recent_n, kept_relevant_n = len(recent), len(relevant)
+            dropped_relevance_n = dropped if dropped > 0 else 0
         else:
             filtered = list(candidate_msgs)
+            kept_recent_n, kept_relevant_n = len(filtered), 0
+            dropped_relevance_n = 0
 
         messages = [{"role": m.role, "content": m.content} for m in filtered]
 
         # Prepend prior-context summaries as a read-only developer block —
         # NOT as fake user/assistant dialogue, which polluted the transcript
         # with turns nobody actually said.
-        context_msg = self._summary_context_message(session, query=current_query)
+        context_msg = self._summary_context_message(
+            session, query=current_query, trace=trace,
+        )
         if context_msg:
             messages.insert(0, context_msg)
 
@@ -692,6 +721,18 @@ class SessionManager:
                 "Token budget: dropped %d message(s) for channel %s",
                 budget_dropped, channel_id,
             )
+
+        if trace is not None:
+            trace.history(
+                budget=budget,
+                used=sum(estimate_tokens(_content_text(m)) for m in messages),
+                candidates=len(candidate_msgs),
+                kept_recent=kept_recent_n,
+                kept_relevant=kept_relevant_n,
+                dropped_relevance=dropped_relevance_n,
+                dropped_budget=budget_dropped,
+            )
+            trace.continuity(self._continuity_source.get(channel_id, "live"))
 
         return messages
 
@@ -1446,5 +1487,6 @@ class SessionManager:
             try:
                 data = json.loads(path.read_text())
                 self._sessions[data["channel_id"]] = self._session_from_dict(data)
+                self._continuity_source[data["channel_id"]] = "loaded_live"
             except Exception as e:
                 log.error("Failed to load session from %s: %s", path, e)

--- a/src/trajectories/saver.py
+++ b/src/trajectories/saver.py
@@ -58,6 +58,9 @@ class TrajectoryTurn:
     tools_used: list[str] = field(default_factory=list)
     is_error: bool = False
     handoff: bool = False
+    # Observability: prompt-assembly decision metadata (PR #104) — counters,
+    # reasons, hashed keys; never content. None when tracing is disabled.
+    context_trace: dict | None = None
 
     total_input_tokens: int = 0
     total_output_tokens: int = 0
@@ -119,6 +122,8 @@ class TrajectoryTurn:
             "total_duration_ms": self.total_duration_ms,
             "iteration_count": len(self.iterations),
         }
+        if self.context_trace is not None:
+            d["context_trace"] = self.context_trace
         return d
 
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -1329,6 +1329,37 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response({"error": "cost tracking not available"}, status=503)
         return web.json_response(tracker.get_summary())
 
+    # ------------------------------------------------------------------
+    # Observability aggregates — passive exposure only (no alert delivery)
+    # ------------------------------------------------------------------
+
+    def _obs_window(request: web.Request) -> int:
+        try:
+            return max(1, min(int(request.query.get("window", "24")), 24 * 14))
+        except ValueError:
+            return 24
+
+    @routes.get("/api/observability/context")
+    async def get_observability_context(request: web.Request) -> web.Response:
+        obs_cfg = getattr(bot.config, "observability", None)
+        if obs_cfg is not None and not obs_cfg.prompt_budget_accounting:
+            return web.json_response({"error": "prompt budget accounting disabled"}, status=503)
+        from ..observability.aggregates import context_aggregates
+        directory = getattr(bot.config.tools, "trajectory_path", "./data/trajectories")
+        data = await asyncio.to_thread(
+            context_aggregates, directory, _obs_window(request),
+        )
+        return web.json_response(data)
+
+    @routes.get("/api/observability/failures")
+    async def get_observability_failures(request: web.Request) -> web.Response:
+        from ..observability.aggregates import failure_aggregates
+        audit_path = getattr(bot.config.tools, "audit_log_path", "./data/audit.jsonl")
+        data = await asyncio.to_thread(
+            failure_aggregates, audit_path, _obs_window(request),
+        )
+        return web.json_response(data)
+
     @routes.get("/api/usage/totals")
     async def get_usage_totals(_request: web.Request) -> web.Response:
         tracker = getattr(bot, "cost_tracker", None)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -228,15 +228,20 @@ async def _do_process_web_chat(
         }
 
     try:
-        sp = bot._build_system_prompt(channel=None, user_id=user_id, query=content)
+        trace = bot._new_context_trace()
+        sp = bot._build_system_prompt(
+            channel=None, user_id=user_id, query=content, trace=trace,
+        )
         sp = await bot._inject_tool_hints(sp, content, user_id)
         history = await bot.sessions.get_task_history(
-            channel_id, max_messages=160, current_query=content,
+            channel_id, max_messages=160, current_query=content, trace=trace,
         )
 
         try:
             response, _already_sent, is_error, tools_used, handoff = (
-                await bot._process_with_tools(msg, history, system_prompt_override=sp)
+                await bot._process_with_tools(
+                    msg, history, system_prompt_override=sp, trace=trace,
+                )
             )
         finally:
             await bot._set_status(None, task_end=True)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,363 @@
+"""Tests for the observability bundle (context trace, failure classification,
+aggregates).
+
+The two contracts under test:
+1. ZERO BEHAVIOR IMPACT — assembly output is byte-identical with tracing
+   on, off, or broken.
+2. NEVER THE OUTAGE — a failing collector logs and records nothing, but
+   the request path proceeds untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.observability.context_trace import (
+    TRACE_SCHEMA_VERSION,
+    ContextTraceCollector,
+)
+from src.observability.failure_classes import FAILURE_CLASSES, classify_failure
+
+# ---------------------------------------------------------------------------
+# Collector
+# ---------------------------------------------------------------------------
+
+class TestCollector:
+    def test_finalize_shape(self):
+        c = ContextTraceCollector()
+        c.section("base", tokens=1000)
+        c.section("persistent_memory", tokens=200, keys=5)
+        c.history(budget=64000, used=900, candidates=20, kept_recent=12,
+                  kept_relevant=3, dropped_relevance=5, dropped_budget=0)
+        c.continuity("live")
+        c.provider(name="codex", model="gpt-5.5")
+        trace = c.finalize()
+        assert trace["schema_version"] == TRACE_SCHEMA_VERSION
+        assert trace["summary"]["system_tokens"] == 1200
+        assert trace["summary"]["sections_count"] == 2
+        assert trace["history"]["candidates"] == 20
+        assert trace["continuity_source"] == "live"
+        assert trace["provider"]["name"] == "codex"
+        assert trace["privacy"]["content_recorded"] is False
+        assert trace["privacy"]["secret_scan"]["performed"] is True
+
+    def test_finalize_idempotent(self):
+        c = ContextTraceCollector()
+        c.section("base", tokens=10)
+        assert c.finalize() is c.finalize()
+
+    def test_recording_never_raises(self):
+        c = ContextTraceCollector()
+        # Hostile inputs that would explode without guards
+        c.section(None, tokens="not-an-int")
+        c.history(budget="x", used=None, candidates=[], kept_recent={},
+                  kept_relevant=0, dropped_relevance=0, dropped_budget=0)
+        c.learned(available="?", injected_keys=None, pinned_available=None,
+                  pinned_injected=None, gated_out=None, tokens=None, mode=1)
+        trace = c.finalize()
+        assert trace is not None
+        assert trace["assembly"]["internal_errors"] >= 3
+
+    def test_key_modes(self):
+        raw = ContextTraceCollector(memory_key_mode="raw")
+        assert raw.key("my_secret_key_name") == "my_secret_key_name"
+        hashed = ContextTraceCollector(memory_key_mode="hash")
+        h = hashed.key("my_secret_key_name")
+        assert h.startswith("k_") and "secret" not in h
+        assert h == hashed.key("my_secret_key_name")  # stable
+        redacted = ContextTraceCollector(memory_key_mode="redacted")
+        assert redacted.key("my_secret_key_name") == "<redacted>"
+
+    def test_pinned_correction_warning(self):
+        c = ContextTraceCollector()
+        c.learned(available=5, injected_keys=["a"], pinned_available=["c1", "c2"],
+                  pinned_injected=["c1"], gated_out=[], tokens=100, mode="gated")
+        trace = c.finalize()
+        codes = [w["code"] for w in trace["warnings"]]
+        assert "PINNED_CORRECTION_NOT_INJECTED" in codes
+        assert trace["summary"]["warnings_count"] == 1
+
+    def test_size_cap_truncates_with_flag(self):
+        c = ContextTraceCollector(max_trace_bytes=500)
+        for i in range(100):
+            c.segment(f"seg_{i}", decision="skipped", reason="low_relevance", tokens=10)
+        trace = c.finalize()
+        assert trace["summary"]["trace_truncated"] is True
+        assert trace["truncation_reason"] == "max_trace_bytes"
+        assert trace["segments"] == []
+
+    def test_secret_scan_flags_leaks(self):
+        c = ContextTraceCollector(memory_key_mode="raw")
+        c.section("base", tokens=10, note="ghp_abcdefghijklmnopqrstuv012345")
+        trace = c.finalize()
+        assert trace["privacy"]["secret_scan"]["matches"] >= 1
+
+    def test_phase_timer_records(self):
+        c = ContextTraceCollector()
+        with c.phase("system_prompt"):
+            pass
+        trace = c.finalize()
+        assert "system_prompt" in trace["assembly"]["phase_ms"]
+
+
+# ---------------------------------------------------------------------------
+# Failure classification
+# ---------------------------------------------------------------------------
+
+class TestFailureClassification:
+    CASES = [
+        ("HTTP 401 Unauthorized: invalid_token", "auth"),
+        ("token has been invalidated, sign in again", "auth"),
+        ("HTTP 429 Too Many Requests", "rate_limit"),
+        ("insufficient_quota: you have run out of credits", "quota"),
+        ("bash: packwiz: command not found", "dependency_missing"),
+        ("ModuleNotFoundError: No module named 'aioresponses'", "dependency_missing"),
+        ("validate_action: post-change check failed on host server-1", "validation_failed"),
+        ("CONFLICT (content): Merge conflict in src/web/api.py", "conflict"),
+        ("error: Your local changes would be overwritten by merge", "conflict"),
+        ("PermissionError: [Errno 13] Permission denied: '/etc/shadow'", "permission_denied"),
+        ("HTTP 404: repository not found", "not_found"),
+        ("Tool 'run_command' timed out after 900s", "timeout"),
+        ("Cannot connect to the Docker daemon. Is the docker daemon running?", "remote_state"),
+        ("Unit odin.service is inactive (dead)", "remote_state"),
+        ("ConnectionResetError: [Errno 104] ECONNRESET", "network"),
+        ("Temporary failure in name resolution", "network"),
+        ("json.decoder.JSONDecodeError: Expecting value: line 1", "bad_input"),
+        ("usage: git push [<options>] — unrecognized arguments", "bad_input"),
+        ("HTTP 502 Bad Gateway from upstream", "provider"),
+        ("RBAC gate denied tool run_command for user 42", "policy_blocked"),
+        ("operation cancelled by user", "cancelled"),
+        ("complete gibberish nobody can classify §§§", "unknown"),
+        ("", "unknown"),
+        (None, "unknown"),
+    ]
+
+    @pytest.mark.parametrize("text,expected", CASES)
+    def test_classification_matrix(self, text, expected):
+        result = classify_failure(text)
+        assert result["class"] == expected, f"{text!r} → {result}"
+        assert result["class"] in FAILURE_CLASSES
+        assert result["source"] == "heuristic_v1"
+        assert 0.0 <= result["confidence"] <= 1.0
+
+    def test_structure_complete(self):
+        result = classify_failure("timed out")
+        assert set(result) == {"class", "subclass", "confidence", "matched_rule", "source"}
+
+
+# ---------------------------------------------------------------------------
+# Zero-behavior guarantee on the assembly paths
+# ---------------------------------------------------------------------------
+
+class _ExplodingCollector(ContextTraceCollector):
+    """Collector whose internal recording blows up — the guard decorator
+    must absorb every failure."""
+    def __init__(self):
+        super().__init__()
+        # Poison the storage the task-history path appends to
+        self._segments = None  # .append raises AttributeError
+
+
+def _make_session_manager(tmp_path):
+    from src.sessions.manager import SessionManager
+    mgr = SessionManager(max_history=50, max_age_hours=24, persist_dir=str(tmp_path))
+    for i in range(30):
+        mgr.add_message("ch1", "user" if i % 2 == 0 else "assistant",
+                        f"message about nginx number {i}", user_id="42" if i % 2 == 0 else None)
+    session = mgr.get("ch1")
+    session.summary_segments.append({
+        "id": "seg_a", "summary": "earlier nginx work", "start_ts": 1.0,
+        "end_ts": 2.0, "participants": [], "source_count": 10, "created_at": 3.0,
+        "topics": ["nginx"], "entities": [], "decisions": [], "open_threads": [],
+    })
+    return mgr
+
+
+class TestZeroBehavior:
+    @pytest.mark.asyncio
+    async def test_task_history_identical_with_and_without_trace(self, tmp_path):
+        mgr = _make_session_manager(tmp_path)
+        without = await mgr.get_task_history("ch1", max_messages=160, current_query="fix nginx")
+        trace = ContextTraceCollector()
+        with_trace = await mgr.get_task_history(
+            "ch1", max_messages=160, current_query="fix nginx", trace=trace,
+        )
+        assert with_trace == without
+        # And the trace actually recorded the decisions
+        final = trace.finalize()
+        assert final["history"]["candidates"] == 30
+        assert final["continuity_source"] in ("fresh", "live")
+        assert any(s["decision"] == "injected" for s in final["segments"])
+
+    @pytest.mark.asyncio
+    async def test_task_history_survives_exploding_collector(self, tmp_path):
+        mgr = _make_session_manager(tmp_path)
+        without = await mgr.get_task_history("ch1", max_messages=160, current_query="fix nginx")
+        broken = _ExplodingCollector()
+        with_broken = await mgr.get_task_history(
+            "ch1", max_messages=160, current_query="fix nginx", trace=broken,
+        )
+        assert with_broken == without
+        assert broken._internal_errors > 0
+
+    def test_learned_injection_identical_with_and_without_trace(self, tmp_path):
+        from src.learning.reflector import ConversationReflector
+        path = tmp_path / "learned.json"
+        entries = [
+            {"key": f"op{i}", "category": "operational",
+             "content": f"operational lesson about {t}."}
+            for i, t in enumerate(["nginx", "dns", "minecraft", "eve", "docker",
+                                   "grafana", "loki", "incus", "plex", "gitea"])
+        ]
+        entries.append({"key": "corr1", "category": "correction",
+                        "content": "never do the bad thing."})
+        path.write_text(json.dumps({"version": 2, "last_reflection": None,
+                                    "entries": entries}))
+        r = ConversationReflector(str(path), injection_token_budget=50)  # force gating
+        without = r.get_prompt_section(query="fix the nginx config")
+        trace = ContextTraceCollector()
+        with_trace = r.get_prompt_section(query="fix the nginx config", trace=trace)
+        assert with_trace == without
+        final = trace.finalize()
+        assert final["learned"]["mode"] == "gated"
+        assert final["learned"]["available_count"] == 11
+        # Correction pinned and recorded (hashed key)
+        assert len(final["learned"]["pinned_corrections_injected"]) == 1
+        assert final["learned"]["pinned_corrections_injected"][0].startswith("k_")
+        assert all(g["reason"] in ("low_relevance", "pin_cap")
+                   for g in final["learned"]["gated_out"])
+        assert final["warnings"] == []
+
+    def test_continuity_source_archive_restore(self, tmp_path):
+        mgr = _make_session_manager(tmp_path)
+        session = mgr.get("ch1")
+        # Ancient enough to prune, but a positive timestamp — an archive at
+        # ts=0 would collide with the default reset-epoch boundary, a state
+        # impossible in reality.
+        session.last_active = 1000.0
+        for m in session.messages:
+            m.timestamp = 999.0
+        mgr.prune()
+        mgr.get_or_create("ch1")  # restores
+        assert mgr._continuity_source["ch1"] == "archive_restore"
+
+
+# ---------------------------------------------------------------------------
+# Audit integration
+# ---------------------------------------------------------------------------
+
+class TestAuditClassification:
+    def _log(self, tmp_path, *, error, classify=True):
+        from src.audit.logger import AuditLogger
+        path = tmp_path / "audit.jsonl"
+        logger = AuditLogger(path=str(path), classify_failures=classify)
+        asyncio.get_event_loop().run_until_complete(logger.log_execution(
+            user_id="42", user_name="aaron", channel_id="ch1",
+            tool_name="run_command", tool_input={"command": "x"},
+            approved=True, result_summary="failed", execution_time_ms=10,
+            error=error,
+        ))
+        return json.loads(path.read_text().splitlines()[-1])
+
+    def test_error_entries_get_failure_class(self, tmp_path):
+        entry = self._log(tmp_path, error="Tool 'run_command' timed out after 900s")
+        assert entry["failure"]["class"] == "timeout"
+        assert entry["failure"]["matched_rule"] == "timeout_v1"
+
+    def test_success_entries_have_no_failure_field(self, tmp_path):
+        entry = self._log(tmp_path, error=None)
+        assert "failure" not in entry
+
+    def test_kill_switch_disables_classification(self, tmp_path):
+        entry = self._log(tmp_path, error="timed out", classify=False)
+        assert "failure" not in entry
+
+
+# ---------------------------------------------------------------------------
+# Aggregates
+# ---------------------------------------------------------------------------
+
+def _write_trajectory_day(directory, day, traces):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{day.isoformat()}.jsonl"
+    with path.open("a") as fh:
+        for hours_ago, trace in traces:
+            ts = datetime.combine(day, datetime.min.time(), tzinfo=UTC) + timedelta(hours=hours_ago)
+            fh.write(json.dumps({"timestamp": ts.isoformat(), "context_trace": trace}) + "\n")
+
+
+class TestAggregates:
+    def _trace(self, base_tokens):
+        return {
+            "schema_version": 1,
+            "summary": {"system_tokens": base_tokens, "history_used_tokens": 1000},
+            "sections": [{"section": "context_dir", "tokens": base_tokens}],
+            "history": {"used": 1000},
+            "learned": {"tokens": 200},
+            "warnings": [],
+        }
+
+    def test_drift_candidate_detected(self, tmp_path):
+        from src.observability.aggregates import context_aggregates
+        now = datetime.now(UTC)
+        # Previous window: small context_dir; current window: grown by 1500
+        for h in (30, 32, 34):  # 24-48h ago
+            _write_trajectory_day(tmp_path, (now - timedelta(hours=h)).date(),
+                                  [((now - timedelta(hours=h)).hour, self._trace(500))])
+        for h in (2, 4, 6):  # current window
+            _write_trajectory_day(tmp_path, (now - timedelta(hours=h)).date(),
+                                  [((now - timedelta(hours=h)).hour, self._trace(2000))])
+        agg = context_aggregates(str(tmp_path), window_hours=24)
+        assert agg["turns_traced"] == 3
+        sections = agg["by_section"]
+        assert sections["context_dir"]["avg_tokens"] == 2000
+        drift_sections = [d["section"] for d in agg["drift_candidates"]]
+        assert "context_dir" in drift_sections
+
+    def test_no_drift_when_stable(self, tmp_path):
+        from src.observability.aggregates import context_aggregates
+        now = datetime.now(UTC)
+        for h in (2, 30):
+            _write_trajectory_day(tmp_path, (now - timedelta(hours=h)).date(),
+                                  [((now - timedelta(hours=h)).hour, self._trace(1000))])
+        agg = context_aggregates(str(tmp_path), window_hours=24)
+        assert agg["drift_candidates"] == []
+
+    def test_failure_aggregates_window_and_trends(self, tmp_path):
+        from src.observability.aggregates import failure_aggregates
+        path = tmp_path / "audit.jsonl"
+        now = datetime.now(UTC)
+        rows = []
+        for hours_ago, cls in ((1, "timeout"), (2, "timeout"), (3, "network"),
+                               (30, "timeout")):
+            rows.append(json.dumps({
+                "timestamp": (now - timedelta(hours=hours_ago)).isoformat(),
+                "tool_name": "run_command",
+                "error": "raw error string that must not surface",
+                "failure": {"class": cls, "subclass": "x", "confidence": 0.9,
+                            "matched_rule": "r", "source": "heuristic_v1"},
+            }))
+        path.write_text("\n".join(rows) + "\n")
+        agg = failure_aggregates(str(path), window_hours=24)
+        assert agg["classified"] == 3
+        assert agg["by_class"]["timeout"]["count"] == 2
+        timeout_trend = next(t for t in agg["trends"] if t["class"] == "timeout")
+        assert timeout_trend == {"class": "timeout", "current": 2, "previous": 1, "delta": 1}
+        # Raw error strings never surface in aggregates
+        assert "raw error string" not in json.dumps(agg)
+
+
+# ---------------------------------------------------------------------------
+# Trajectory serialization
+# ---------------------------------------------------------------------------
+
+class TestTrajectorySerialization:
+    def test_to_dict_includes_trace_when_set(self):
+        from src.trajectories.saver import TrajectoryTurn
+        turn = TrajectoryTurn(message_id="m1")
+        assert "context_trace" not in turn.to_dict()
+        turn.context_trace = {"schema_version": 1}
+        assert turn.to_dict()["context_trace"] == {"schema_version": 1}

--- a/ui/js/pages/audit.js
+++ b/ui/js/pages/audit.js
@@ -99,7 +99,8 @@ export default {
               </td>
               <td>
                 <span v-if="e.error" class="badge badge-danger">error</span>
-                <span v-else class="badge badge-success">ok</span>
+                <span v-if="e.failure && e.failure.class" class="badge badge-warning" :title="e.failure.subclass">{{ e.failure.class }}</span>
+                <span v-if="!e.error" class="badge badge-success">ok</span>
               </td>
             </tr>
           </tbody>

--- a/ui/js/pages/traces.js
+++ b/ui/js/pages/traces.js
@@ -376,6 +376,51 @@ export default {
                 <div class="text-gray-400 text-xs mb-1">Final Response</div>
                 <pre class="p-2 rounded bg-gray-900 text-xs text-gray-300 font-mono max-h-40 overflow-y-auto whitespace-pre-wrap break-words">{{ truncateBlock(entries[expandedIdx].final_response, 5000) }}</pre>
               </div>
+
+              <!-- Context trace (observability): what the prompt assembler did -->
+              <div v-if="entries[expandedIdx].context_trace" class="mt-3">
+                <div class="text-gray-400 text-xs mb-1">Context Assembly</div>
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-2">
+                  <div class="p-2 rounded bg-gray-900 text-xs">
+                    <span class="text-gray-500 block">System tokens</span>
+                    <span class="font-semibold">{{ formatTokens(entries[expandedIdx].context_trace.summary?.system_tokens) }}</span>
+                  </div>
+                  <div class="p-2 rounded bg-gray-900 text-xs">
+                    <span class="text-gray-500 block">History tokens</span>
+                    <span class="font-semibold">{{ formatTokens(entries[expandedIdx].context_trace.summary?.history_used_tokens) }}</span>
+                  </div>
+                  <div class="p-2 rounded bg-gray-900 text-xs">
+                    <span class="text-gray-500 block">Learned injected</span>
+                    <span class="font-semibold">{{ entries[expandedIdx].context_trace.summary?.learned_injected ?? '—' }}
+                      <span class="text-gray-500">({{ entries[expandedIdx].context_trace.learned?.mode || '?' }})</span>
+                    </span>
+                  </div>
+                  <div class="p-2 rounded bg-gray-900 text-xs">
+                    <span class="text-gray-500 block">Continuity</span>
+                    <span class="font-semibold">{{ entries[expandedIdx].context_trace.continuity_source || '—' }}</span>
+                  </div>
+                </div>
+                <table v-if="(entries[expandedIdx].context_trace.sections || []).length" class="hm-table text-xs mb-2">
+                  <thead><tr><th>Section</th><th class="text-right">Tokens</th></tr></thead>
+                  <tbody>
+                    <tr v-for="s in entries[expandedIdx].context_trace.sections" :key="s.section">
+                      <td class="font-mono">{{ s.section }}</td>
+                      <td class="text-right">{{ formatTokens(s.tokens) }}</td>
+                    </tr>
+                    <tr v-if="entries[expandedIdx].context_trace.history?.used">
+                      <td class="font-mono">history ({{ entries[expandedIdx].context_trace.history.kept_recent }} recent + {{ entries[expandedIdx].context_trace.history.kept_relevant }} relevant of {{ entries[expandedIdx].context_trace.history.candidates }})</td>
+                      <td class="text-right">{{ formatTokens(entries[expandedIdx].context_trace.history.used) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div v-if="(entries[expandedIdx].context_trace.warnings || []).length" class="mt-1">
+                  <span v-for="w in entries[expandedIdx].context_trace.warnings" :key="w.code"
+                        class="badge badge-danger mr-1" :title="w.detail">{{ w.code }}</span>
+                </div>
+                <div v-if="entries[expandedIdx].context_trace.summary?.trace_truncated" class="text-xs text-amber-400 mt-1">
+                  trace truncated ({{ entries[expandedIdx].context_trace.truncation_reason }})
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Pure instrumentation of how Odin assembles context and why operations fail — **records decisions, never influences them**. Designed in consult with Odin (decision reasons over counters, key privacy modes, passive-only drift exposure, never-the-outage guarantees); selected by AT specifically because it has zero behavior impact while making future tuning evidence-based.

## The two contracts, made executable

1. **Zero behavior impact** — tracing rides an optional collector parameter; when absent (every path with `observability.context_trace.enabled: false`), code paths are byte-identical. Tests assert `get_task_history` and learned injection produce identical output with tracing on, off, and **broken** (an exploding collector is absorbed by the guard layer with errors counted).
2. **Never the outage** — every recording method is exception-guarded, `finalize()` never raises, oversized traces truncate with an explicit flag, and a failing trace logs a warning while the turn proceeds untouched.

## What gets recorded (metadata only — never content)

- **Context trace** per turn, attached to the trajectory record: section token costs (base/memory/learned/skills/recent-actions/health), learned selection decisions (include-all vs gated, pinned correction keys, per-entry gated-out reasons), history assembly stats (candidates / kept-recent / kept-relevant / dropped-by-relevance / dropped-by-budget), summary-segment decisions with reasons, session continuity source (fresh / archive_restore / loaded_live / live), active provider, tool-call↔result continuation mismatch warnings, assembly phase timings, invariant warnings (`PINNED_CORRECTION_NOT_INJECTED`), and a privacy block with secret-scan results. Keys pass through configurable `raw/hash/redacted` modes (hash default). `schema_version` + assembly version from day one.
- **Failure classification** at audit write time: 16-class heuristic taxonomy (including Odin's additions: `validation_failed`, `dependency_missing`, `conflict`, `quota`, `cancelled`, `policy_blocked`, `remote_state`) with rule ids + confidence. No LLM in the path. Kill-switch wired.
- **Passive aggregates**: `GET /api/observability/context` (per-section averages, p95, vs-previous-window deltas, **drift candidates**) and `/api/observability/failures` (class counts, trends, top tools). Raw error strings never surface in aggregates. **No alert delivery** — deliberately deferred per the consult.

## Surfaces

WebUI: Context Assembly panel in the expanded trace view (summary cards, section table, warning badges, truncation notice) and a failure-class chip on audit rows.

## Found in passing

`TrajectoryTurn.to_dict()` is a field whitelist — the new `context_trace` field had to be added there explicitly or it would silently never persist.

## Verification

- 44 new tests: hostile-input guards, key modes, size cap, secret scan, 24-string classification matrix, zero-behavior assertions, continuity tracking, audit kill-switch, aggregate math incl. drift detection and no-raw-error-leakage.
- Full suite: 5,657 passed / 29 failed — **identical environmental set to the v3.29.0 baseline, zero new failures**. Zero new ruff violations vs baseline.

## Deploy notes

Live `config.yml` is skip-worktree'd; the new `observability:` block is optional (schema defaults apply when absent), so deploy works without config edits — adding the block to live config is recommended for explicit control. Traces add a few hundred bytes–16KB per turn to daily trajectory files.

## Deferred (by design)

Alert delivery wiring, offline LLM reclassifier for `unknown` failures, the behavioral eval harness that consumes these traces (next round), autonomous-loop path instrumentation.