### PR TITLE
Complete trajectory coverage and prompt-input observability

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -89,6 +89,10 @@ learning:
   max_entries: 150
   consolidation_target: 120
   injection_token_budget: 4000
+  # Loop reflection: dedup/cooldown so repeated identical failures teach once
+  loop_reflection_enabled: true
+  loop_reflection_cooldown_hours: 12.0
+  loop_reflection_max_per_hour: 10
 
 # Pure instrumentation — records prompt assembly + failure metadata,
 # never influences behavior. Safe to disable per piece.
@@ -100,6 +104,15 @@ observability:
     max_trace_bytes: 16384
   audit_failure_classification: true
   prompt_budget_accounting: true
+  # Record the user request on trajectory turns (capped + secret-scrubbed)
+  trajectory_user_content: true
+  max_user_content_chars: 4000
+  # Trajectory + context-trace coverage for autonomous loop iterations
+  loop_trace: true
+
+# Kill-switch for "## Tool Use Patterns" prompt hints (pending eval verdict)
+tool_memory:
+  inject_hints: true
 
 search:
   enabled: true

--- a/config.yml
+++ b/config.yml
@@ -109,6 +109,8 @@ observability:
   max_user_content_chars: 4000
   # Trajectory + context-trace coverage for autonomous loop iterations
   loop_trace: true
+  # Storage cap per tool result persisted into trajectory iterations
+  max_tool_result_chars: 2000
 
 # Kill-switch for "## Tool Use Patterns" prompt hints (pending eval verdict)
 tool_memory:

--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -41,8 +41,9 @@ class LoopAgentRecord:
 class LoopAgentBridge:
     """Bridges LoopManager and AgentManager for agent-aware loops."""
 
-    def __init__(self, agent_manager: object) -> None:
+    def __init__(self, agent_manager: object, trajectory_saver: object | None = None) -> None:
         self._agent_manager = agent_manager
+        self._trajectory_saver = trajectory_saver
         # loop_id → list of LoopAgentRecords
         self._loop_agents: dict[str, list[LoopAgentRecord]] = {}
 
@@ -122,6 +123,7 @@ class LoopAgentBridge:
                 tools=tools,
                 system_prompt=system_prompt,
                 tool_timeouts=tool_timeouts,
+                trajectory_saver=self._trajectory_saver,
             )
 
             if not agent_id.startswith("Error"):

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import aiofiles
 
+from ..observability.correlation import get_turn
 from ..observability.failure_classes import classify_failure
 from ..odin_log import get_logger
 from .signer import AuditSigner, verify_log
@@ -64,6 +65,11 @@ class AuditLogger:
             # Write-time heuristic classification (observability). The raw
             # error string is classified here; aggregates never re-store it.
             entry["failure"] = classify_failure(error)
+        turn = get_turn()
+        if turn:
+            # Correlation: join audit entries to the trajectory turn (and
+            # loop iteration) they belong to. Metadata only.
+            entry["turn"] = turn
         if diff:
             entry["diff"] = diff
         if risk_level:

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -622,6 +622,9 @@ class ObservabilityConfig(BaseModel):
     max_user_content_chars: int = 4000
     # Trajectory + context trace coverage for autonomous loop iterations
     loop_trace: bool = True
+    # Storage cap per tool result persisted into trajectory iterations
+    # (model-facing content is separately capped at 12000)
+    max_tool_result_chars: int = 2000
 
 
 class ToolMemoryConfig(BaseModel):

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -357,6 +357,11 @@ class LearningConfig(BaseModel):
     # Learned Context injection budget (tokens). When the scoped corpus fits,
     # ALL of it is injected; relevance gating engages only beyond this.
     injection_token_budget: int = 4000
+    # Reflection on autonomous loop iterations — gated by signature dedup so
+    # a loop failing identically all night produces ONE lesson, not sixty.
+    loop_reflection_enabled: bool = True
+    loop_reflection_cooldown_hours: float = 12.0
+    loop_reflection_max_per_hour: int = 10
 
 
 class SearchConfig(BaseModel):
@@ -612,6 +617,17 @@ class ObservabilityConfig(BaseModel):
     context_trace: ContextTraceConfig = ContextTraceConfig()
     audit_failure_classification: bool = True
     prompt_budget_accounting: bool = True
+    # Record the user request on trajectory turns (capped + secret-scrubbed)
+    trajectory_user_content: bool = True
+    max_user_content_chars: int = 4000
+    # Trajectory + context trace coverage for autonomous loop iterations
+    loop_trace: bool = True
+
+
+class ToolMemoryConfig(BaseModel):
+    # Kill-switch for "## Tool Use Patterns" prompt hints — pending an
+    # eval-harness A/B verdict on whether they help, hurt, or neither.
+    inject_hints: bool = True
 
 
 class MCPConfig(BaseModel):
@@ -638,6 +654,7 @@ class Config(BaseModel):
     webhook: WebhookConfig = WebhookConfig()
     learning: LearningConfig = LearningConfig()
     observability: ObservabilityConfig = ObservabilityConfig()
+    tool_memory: ToolMemoryConfig = ToolMemoryConfig()
     search: SearchConfig = SearchConfig()
     voice: VoiceConfig = VoiceConfig()
     monitoring: MonitoringConfig = MonitoringConfig()

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -2827,7 +2827,10 @@ class OdinBot(commands.Bot):
         stuck_tracker = self.stuck_loop_tracker_cls()
 
         # Per-turn trajectory accumulator — populated each iteration, saved at end.
-        from ..trajectories.saver import TrajectoryTurn, ToolIteration
+        from ..trajectories.saver import TrajectoryTurn, ToolIteration, stored_tool_results
+        _result_store_cap = int(getattr(
+            getattr(self.config, "observability", None), "max_tool_result_chars", 2000,
+        ) or 2000)
         if trace is not None:
             provider_cfg = getattr(self.config, "llm_provider", None)
             trace.provider(
@@ -2844,8 +2847,9 @@ class OdinBot(commands.Bot):
             source=str(_turn_ctx.get("source") or getattr(message, "_odin_source", "discord")),
         )
         self._record_user_content(_trajectory, getattr(message, "content", "") or "")
-        # No explicit reset — each message/loop handler runs in its own
-        # asyncio task, so the context var dies with the task.
+        # No explicit reset — each message handler runs in its own asyncio
+        # task, so the context var dies with the task. (The loop manager
+        # resets its own stamp explicitly around each iteration callback.)
         set_turn(
             turn_id=_trajectory.message_id or None,
             source=_trajectory.source,
@@ -3483,6 +3487,13 @@ class OdinBot(commands.Bot):
                         ("error", "[error", "failed", "traceback")),
                 })
             self._last_op_details[str(message.channel.id)] = _op_tool_details
+
+            # Persist results onto the iteration recorded before execution —
+            # without this the saved trajectory has calls but no outcomes.
+            if _trajectory.iterations:
+                _trajectory.iterations[-1].tool_results = stored_tool_results(
+                    tool_results, _result_store_cap,
+                )
 
             if _cancel.is_set():
                 return _stopped("after_tools")
@@ -4566,9 +4577,10 @@ class OdinBot(commands.Bot):
         _turn_ctx = get_turn() or {}
         _loop_id = str(_turn_ctx.get("loop_id", ""))
         _loop_iter = int(_turn_ctx.get("loop_iteration", 0) or 0)
-        from ..trajectories.saver import ToolIteration, TrajectoryTurn
+        from ..trajectories.saver import ToolIteration, TrajectoryTurn, stored_tool_results
         _obs = getattr(self.config, "observability", None)
         _loop_trace_on = _obs is None or getattr(_obs, "loop_trace", True)
+        _result_store_cap = int(getattr(_obs, "max_tool_result_chars", 2000) or 2000)
         _trace = self._new_context_trace() if _loop_trace_on else None
         _trajectory = None
         _loop_details: list[dict] = []
@@ -4771,6 +4783,13 @@ class OdinBot(commands.Bot):
                          "script failed", "command failed")),
                 })
 
+            # Persist results onto the iteration recorded before execution —
+            # without this the saved trajectory has calls but no outcomes.
+            if _trajectory is not None and _trajectory.iterations:
+                _trajectory.iterations[-1].tool_results = stored_tool_results(
+                    tool_results, _result_store_cap,
+                )
+
         # Scrub final text; posting is handled by _post_response in LoopManager
         if final_text:
             final_text = scrub_output_secrets(final_text)
@@ -4778,6 +4797,10 @@ class OdinBot(commands.Bot):
                 final_text = final_text[:DISCORD_MAX_LEN - 50] + "\n... (truncated)"
             _had_tool_errors = any(d.get("error") for d in _loop_details)
             _first_err = next((d for d in _loop_details if d.get("error")), None)
+            # Iteration succeeded after a mid-flight tool error: the turn is
+            # saved as a success (is_error=False), but the failure detail is
+            # passed through so the reflection gate can learn from recovered
+            # errors without marking the trajectory failed.
             return await _finish(
                 final_text,
                 is_error=False,

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -29,6 +29,7 @@ from ..learning import ConversationReflector
 from ..llm import CircuitOpenError, CodexAuth, CodexChatClient, KimiClient, OllamaClient
 from ..llm.codex_auth import CodexAuthPool
 from ..llm.secret_scrubber import scrub_output_secrets
+from ..observability.correlation import get_turn, set_turn
 from ..llm.system_prompt import build_system_prompt, build_chat_system_prompt
 from ..odin_log import get_logger
 from ..scheduler import Scheduler
@@ -260,8 +261,23 @@ class OdinBot(commands.Bot):
         self.agent_manager = AgentManager()
         # Autonomous loop manager (agent-aware)
         self.loop_manager = LoopManager(agents_enabled=True)
+        # Trajectory savers — constructed before the loop bridge, which
+        # forwards the agent saver into loop-spawned agents
+        from ..agents.trajectory import AgentTrajectorySaver
+        from ..trajectories.saver import TrajectorySaver
+        self.trajectory_saver = TrajectorySaver()
+        self.agent_trajectory_saver = AgentTrajectorySaver()
         # Loop-agent bridge for spawning agents from loop iterations
-        self.loop_agent_bridge = LoopAgentBridge(self.agent_manager)
+        self.loop_agent_bridge = LoopAgentBridge(
+            self.agent_manager, trajectory_saver=self.agent_trajectory_saver,
+        )
+        # Reflection gate for loop iterations — dedup/cooldown so repeated
+        # identical failures teach one lesson, not one per minute
+        from ..learning.loop_reflection import LoopReflectionGate
+        self._loop_reflection_gate = LoopReflectionGate(
+            cooldown_hours=getattr(config.learning, "loop_reflection_cooldown_hours", 12.0),
+            max_per_hour=getattr(config.learning, "loop_reflection_max_per_hour", 10),
+        )
         # Cached merged tool definitions — invalidated on skill create/edit/delete
         self._cached_merged_tools: list[dict] | None = None
         # Cached host string dict — invalidated on context reload
@@ -504,10 +520,6 @@ class OdinBot(commands.Bot):
 
         # Trajectory savers — message-level + agent-level. Always on; writes
         # to date-partitioned JSONL under data/trajectories/.
-        from ..trajectories.saver import TrajectorySaver
-        from ..agents.trajectory import AgentTrajectorySaver
-        self.trajectory_saver = TrajectorySaver()
-        self.agent_trajectory_saver = AgentTrajectorySaver()
 
         # Stuck-loop tracker — instantiated per-iteration in the tool loop, but
         # store the class on the bot for tests and external introspection.
@@ -879,6 +891,23 @@ class OdinBot(commands.Bot):
         self._memory_cache[user_id] = (now, memory)
         return memory
 
+    def _record_user_content(self, trajectory, content: str) -> None:
+        """Store the request on the trajectory turn — capped, secret-scrubbed,
+        with explicit truncation metadata. Config-gated; never raises."""
+        try:
+            obs = getattr(self.config, "observability", None)
+            if obs is not None and not obs.trajectory_user_content:
+                return
+            cap = getattr(obs, "max_user_content_chars", 4000) if obs else 4000
+            scrubbed = scrub_output_secrets(content)
+            if len(scrubbed) > cap:
+                trajectory.user_content_truncated = True
+                trajectory.user_content_original_chars = len(scrubbed)
+                scrubbed = scrubbed[:cap]
+            trajectory.user_content = scrubbed
+        except Exception:  # noqa: BLE001 — recording must never break the turn
+            log.debug("user_content recording failed (non-fatal)", exc_info=True)
+
     def _new_context_trace(self):
         """Create a context-trace collector when observability is enabled.
 
@@ -1106,12 +1135,21 @@ class OdinBot(commands.Bot):
 
         return prompt
 
-    async def _inject_tool_hints(self, system_prompt: str, query: str, user_id: str | None = None) -> str:
+    async def _inject_tool_hints(
+        self, system_prompt: str, query: str, user_id: str | None = None,
+        trace=None,
+    ) -> str:
         """Return system_prompt with tool use pattern hints appended (async, needs embedder).
 
         Returns the original prompt unchanged if hints are unavailable or an error occurs.
+        Recorded on the context trace as a prompt section — hints were the one
+        prompt input invisible to observability because injection happens after
+        _build_system_prompt.
         """
         try:
+            tm_cfg = getattr(self.config, "tool_memory", None)
+            if tm_cfg is not None and not tm_cfg.inject_hints:
+                return system_prompt
             tm = getattr(self, "tool_memory", None)
             if not tm or not hasattr(tm, "format_hints"):
                 return system_prompt
@@ -1122,6 +1160,14 @@ class OdinBot(commands.Bot):
                 query, allowed_tools=allowed, embedder=embedder,
             )
             if hints:
+                if trace is not None:
+                    trace.section(
+                        "tool_hints", tokens=len(hints) // 4,
+                        sequences=hints.count("\n- "),
+                        max_sequence_len=max(
+                            (line.count("->") + 1 for line in hints.splitlines()
+                             if line.startswith("- ")), default=0),
+                    )
                 return system_prompt + f"\n\n{hints}"
         except Exception as e:
             log.warning("Tool selection hints failed: %s", e)
@@ -1533,6 +1579,47 @@ class OdinBot(commands.Bot):
         if any(marker in req for marker in self._REFLECT_CORRECTION_MARKERS):
             return True
         return len(tools_used) >= self._REFLECT_MIN_TOOLS
+
+    def _maybe_loop_reflect(
+        self, *, loop_id: str, prompt: str, outcome: str, is_error: bool,
+        failure_class: str, error_text: str, tool_details: list[dict],
+        user_id: str | None,
+    ) -> None:
+        """Gated reflection for loop iterations (fire-and-forget)."""
+        try:
+            if not getattr(self.config.learning, "loop_reflection_enabled", True):
+                return
+            if not hasattr(self, "reflector") or not tool_details:
+                return
+            if is_error or any(d.get("error") for d in tool_details):
+                effective_error = error_text or next(
+                    (d["result"] for d in tool_details if d.get("error")), "",
+                )
+                if not failure_class:
+                    from ..observability.failure_classes import classify_failure
+                    failure_class = classify_failure(effective_error)["class"]
+                should, reason = self._loop_reflection_gate.evaluate(
+                    loop_id, is_error=True,
+                    failure_class=failure_class, error_text=effective_error,
+                )
+            else:
+                should, reason = self._loop_reflection_gate.evaluate(
+                    loop_id, is_error=False,
+                )
+            if not should:
+                log.debug("Loop reflection suppressed (%s) for %s", reason, loop_id)
+                return
+            log.info("Loop reflection triggered (%s) for %s", reason, loop_id)
+            fire_and_forget(self.reflector.reflect_on_operation(
+                user_request=f"[autonomous loop {loop_id}] {prompt[:300]}",
+                tools_used=[d["tool"] for d in tool_details][:20],
+                tool_details=tool_details,
+                final_response=outcome,
+                is_error=is_error,
+                user_id=user_id,
+            ), name="loop_reflection")
+        except Exception:  # noqa: BLE001 — reflection must never break a loop
+            log.debug("Loop reflection wiring failed (non-fatal)", exc_info=True)
 
     async def _operational_reflection(
         self, user_request: str, tools_used: list[str],
@@ -2363,7 +2450,7 @@ class OdinBot(commands.Bot):
                     _sp = self._build_system_prompt(
                         channel=message.channel, user_id=user_id, query=content,
                     )
-                _sp = await self._inject_tool_hints(_sp, content, user_id)
+                _sp = await self._inject_tool_hints(_sp, content, user_id, trace=_trace)
                 log.info("Routing to Codex with tools")
                 # Use abbreviated history to reduce poisoning from stale responses
                 # (get_task_history handles compaction internally)
@@ -2748,11 +2835,22 @@ class OdinBot(commands.Bot):
                 model=getattr(self.llm_client, "model", "") or "",
             )
         _op_tool_details: list[dict] = []
+        _turn_ctx = get_turn() or {}
         _trajectory = TrajectoryTurn(
             message_id=str(getattr(message, "id", "")),
             channel_id=str(getattr(message.channel, "id", "")),
             user_id=user_id,
             user_name=str(getattr(message.author, "display_name", "")),
+            source=str(_turn_ctx.get("source") or getattr(message, "_odin_source", "discord")),
+        )
+        self._record_user_content(_trajectory, getattr(message, "content", "") or "")
+        # No explicit reset — each message/loop handler runs in its own
+        # asyncio task, so the context var dies with the task.
+        set_turn(
+            turn_id=_trajectory.message_id or None,
+            source=_trajectory.source,
+            channel_id=_trajectory.channel_id,
+            **{k: v for k, v in _turn_ctx.items() if k in ("loop_id", "loop_iteration")},
         )
 
         # Post-mutation validation state — persists across iterations
@@ -4235,6 +4333,9 @@ class OdinBot(commands.Bot):
             parent_id=parent_id_arg,
             max_depth=max_depth,
             tool_timeouts=self.config.tools.tool_timeouts,
+            # The saver existed since the feature shipped but was never passed —
+            # data/trajectories/agents/ has been empty in production forever.
+            trajectory_saver=self.agent_trajectory_saver,
         )
 
         if agent_id.startswith("Error"):
@@ -4459,6 +4560,28 @@ class OdinBot(commands.Bot):
                 break
         msg_proxy = _LoopMessageProxy(channel, user_id, requester_name)
 
+        # Observability: loop iterations get the same trajectory + context
+        # trace coverage as chat turns (they were previously invisible —
+        # 10% of all tool executions had no recorded narrative).
+        _turn_ctx = get_turn() or {}
+        _loop_id = str(_turn_ctx.get("loop_id", ""))
+        _loop_iter = int(_turn_ctx.get("loop_iteration", 0) or 0)
+        from ..trajectories.saver import ToolIteration, TrajectoryTurn
+        _obs = getattr(self.config, "observability", None)
+        _loop_trace_on = _obs is None or getattr(_obs, "loop_trace", True)
+        _trace = self._new_context_trace() if _loop_trace_on else None
+        _trajectory = None
+        _loop_details: list[dict] = []
+        if _loop_trace_on:
+            _trajectory = TrajectoryTurn(
+                message_id=str(_turn_ctx.get("turn_id", "")),
+                channel_id=str(getattr(channel, "id", "")),
+                user_id=user_id,
+                user_name=requester_name,
+                source="loop",
+            )
+            self._record_user_content(_trajectory, prompt)
+
         # Build messages for the iteration
         messages: list[dict] = []
         if prev_context:
@@ -4473,8 +4596,40 @@ class OdinBot(commands.Bot):
         messages.append({"role": "user", "content": prompt})
 
         # Build system prompt and tool definitions
-        system_prompt = self._build_system_prompt(channel=channel, user_id=user_id)
+        if _trace is not None:
+            with _trace.phase("system_prompt"):
+                system_prompt = self._build_system_prompt(
+                    channel=channel, user_id=user_id, trace=_trace,
+                )
+            _trace.continuity("loop")
+            if prev_context:
+                _trace.section("loop_prev_context", tokens=len(prev_context) // 4)
+        else:
+            system_prompt = self._build_system_prompt(channel=channel, user_id=user_id)
         tools = self._merged_tool_definitions() if self.config.tools.enabled else None
+
+        async def _finish(outcome_text: str, *, is_error: bool = False,
+                          failure_class: str = "", error_text: str = "") -> str:
+            """Persist the loop turn and run gated reflection at every exit."""
+            if _trajectory is not None:
+                await self._save_turn_trajectory(
+                    _trajectory,
+                    error=error_text if is_error else "",
+                    final_response=outcome_text if not is_error else "",
+                    tools_used=[d["tool"] for d in _loop_details],
+                    trace=_trace,
+                )
+            self._maybe_loop_reflect(
+                loop_id=_loop_id or channel_id_str,
+                prompt=prompt,
+                outcome=outcome_text,
+                is_error=is_error,
+                failure_class=failure_class,
+                error_text=error_text,
+                tool_details=_loop_details,
+                user_id=user_id,
+            )
+            return outcome_text
 
         final_text = ""
         tool_timeout = self.config.tools.tool_timeout_seconds
@@ -4489,7 +4644,22 @@ class OdinBot(commands.Bot):
                 )
             except Exception as e:
                 log.warning("Loop iteration Codex call failed: %s", e)
-                return f"LLM call failed: {e}"
+                return await _finish(
+                    f"LLM call failed: {e}", is_error=True,
+                    failure_class="provider", error_text=str(e),
+                )
+
+            if _trajectory is not None:
+                _trajectory.iterations.append(ToolIteration(
+                    iteration=_iteration,
+                    tool_calls=[
+                        {"id": tc.id, "name": tc.name, "input": tc.input}
+                        for tc in (response.tool_calls or [])
+                    ],
+                    llm_text=response.text or "",
+                    input_tokens=getattr(response, "input_tokens", 0) or 0,
+                    output_tokens=getattr(response, "output_tokens", 0) or 0,
+                ))
 
             if response.text:
                 final_text = response.text
@@ -4582,12 +4752,38 @@ class OdinBot(commands.Bot):
             )
             messages.append({"role": "user", "content": list(tool_results)})
 
+            _results_by_id = {
+                r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)
+            }
+            for _tc in response.tool_calls:
+                if _trace is not None and _tc.id not in _results_by_id:
+                    _trace.warning(
+                        "TOOL_RESULT_CONTINUATION_MISMATCH", "error",
+                        f"loop tool {_tc.name} call has no paired result",
+                    )
+                _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
+                _loop_details.append({
+                    "tool": _tc.name,
+                    "input": _tc.input,
+                    "result": _rcontent[:300],
+                    "error": _rcontent.lstrip().lower().startswith(
+                        ("error", "[error", "failed", "traceback",
+                         "script failed", "command failed")),
+                })
+
         # Scrub final text; posting is handled by _post_response in LoopManager
         if final_text:
             final_text = scrub_output_secrets(final_text)
             if len(final_text) > DISCORD_MAX_LEN:
                 final_text = final_text[:DISCORD_MAX_LEN - 50] + "\n... (truncated)"
-            return final_text
+            _had_tool_errors = any(d.get("error") for d in _loop_details)
+            _first_err = next((d for d in _loop_details if d.get("error")), None)
+            return await _finish(
+                final_text,
+                is_error=False,
+                failure_class="command_failed" if _had_tool_errors else "",
+                error_text=_first_err["result"] if _first_err else "",
+            )
 
         # No final text produced. If we exhausted the cap without Codex ever
         # returning a tool-free response, say so — the previous "(no response)"
@@ -4598,14 +4794,16 @@ class OdinBot(commands.Bot):
                 "Loop tool-iteration cap hit (%d) after %d tool calls; no final summary from Codex",
                 loop_cap, tool_calls_made,
             )
-            return (
+            return await _finish(
                 f"Iteration hit the loop tool-iteration cap ({loop_cap}) "
                 f"after {tool_calls_made} tool calls. No final summary was "
                 f"produced by Codex. Raise `tools.max_tool_iterations_loop` "
-                f"in config (or via the web UI) if this happens repeatedly."
+                f"in config (or via the web UI) if this happens repeatedly.",
+                is_error=True, failure_class="cancelled",
+                error_text=f"loop iteration cap {loop_cap} reached",
             )
 
-        return "(no response)"
+        return await _finish("(no response)")
 
     async def _dispatch_loop_tool(
         self,

--- a/src/learning/loop_reflection.py
+++ b/src/learning/loop_reflection.py
@@ -1,0 +1,118 @@
+"""Reflection gating for autonomous loop iterations.
+
+Loops repeat — a 60-second loop hitting the same DNS timeout all night must
+produce ONE lesson, not sixty. This gate implements the agreed policy:
+
+reflect on
+- the FIRST occurrence of a failure signature per loop,
+- a CHANGED failure signature (something new is wrong),
+- RECOVERY after repeated failure (what fixed it is worth learning),
+
+and suppress
+- repeats of the same signature within the cooldown window,
+- routine successes,
+- everything beyond the global hourly volume cap.
+
+State is in-memory by design: a restart resets cooldowns, which at worst
+allows one duplicate lesson per signature — the learned store's merge-by-key
+absorbs that.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+
+from ..odin_log import get_logger
+
+log = get_logger("learning")
+
+_DIGITS = re.compile(r"\d+")
+
+
+def failure_signature(loop_id: str, failure_class: str, error_text: str) -> str:
+    """Stable signature for 'the same thing failing the same way'."""
+    normalized = _DIGITS.sub("N", (error_text or "")[:200].lower())
+    digest = hashlib.sha1(
+        f"{loop_id}|{failure_class}|{normalized}".encode(),
+    ).hexdigest()[:12]
+    return f"{failure_class}:{digest}"
+
+
+class LoopReflectionGate:
+    """Decides whether a completed loop iteration deserves reflection."""
+
+    def __init__(
+        self,
+        *,
+        cooldown_hours: float = 12.0,
+        max_per_hour: int = 10,
+    ) -> None:
+        self._cooldown_seconds = cooldown_hours * 3600
+        self._max_per_hour = max_per_hour
+        # signature -> last reflected timestamp
+        self._reflected_at: dict[str, float] = {}
+        # loop_id -> (last failure signature, consecutive failure count)
+        self._loop_state: dict[str, tuple[str | None, int]] = {}
+        # timestamps of recent reflections (global volume cap)
+        self._recent: list[float] = []
+
+    def _over_global_cap(self, now: float) -> bool:
+        cutoff = now - 3600
+        self._recent = [t for t in self._recent if t > cutoff]
+        return len(self._recent) >= self._max_per_hour
+
+    def _grant(self, now: float, signature: str | None, reason: str) -> tuple[bool, str]:
+        if signature is not None:
+            self._reflected_at[signature] = now
+        self._recent.append(now)
+        return True, reason
+
+    def evaluate(
+        self,
+        loop_id: str,
+        *,
+        is_error: bool,
+        failure_class: str = "",
+        error_text: str = "",
+    ) -> tuple[bool, str]:
+        """Return (should_reflect, reason). Never raises."""
+        try:
+            now = time.time()
+            last_sig, fail_streak = self._loop_state.get(loop_id, (None, 0))
+
+            if is_error:
+                sig = failure_signature(loop_id, failure_class or "unknown", error_text)
+                self._loop_state[loop_id] = (sig, fail_streak + 1)
+                if self._over_global_cap(now):
+                    return False, "global_cap"
+                last_reflected = self._reflected_at.get(sig)
+                if last_reflected is None:
+                    # A signature never reflected before: if the loop was
+                    # previously failing differently, the change is the story.
+                    # (A flip-flop BACK to a recently-reflected signature still
+                    # suppresses below — alternating errors can't spam.)
+                    reason = (
+                        "signature_change"
+                        if last_sig is not None and sig != last_sig
+                        else "first_occurrence"
+                    )
+                    return self._grant(now, sig, reason)
+                if now - last_reflected >= self._cooldown_seconds:
+                    return self._grant(now, sig, "cooldown_expired")
+                return False, "duplicate_suppressed"
+
+            # Success path: only a recovery after repeated failure is a lesson
+            self._loop_state[loop_id] = (None, 0)
+            if fail_streak >= 2:
+                if self._over_global_cap(now):
+                    return False, "global_cap"
+                return self._grant(now, None, "recovery")
+            return False, "routine_success"
+        except Exception:  # noqa: BLE001 — gating must never break the loop
+            log.debug("Loop reflection gate failed (non-fatal)", exc_info=True)
+            return False, "gate_error"
+
+    def forget_loop(self, loop_id: str) -> None:
+        """Drop per-loop state (call when a loop is stopped/removed)."""
+        self._loop_state.pop(loop_id, None)

--- a/src/observability/correlation.py
+++ b/src/observability/correlation.py
@@ -1,0 +1,32 @@
+"""Turn correlation context — joins trajectories, audit entries, and loop
+iterations without threading parameters through every call signature.
+
+The processing entry points (chat tool loop, web chat, loop iterations) set
+the current turn context; downstream writers (audit logger, trajectory
+construction) read it. contextvars propagate into tasks spawned via
+asyncio.gather, so concurrent tool executions inherit the turn they belong
+to. Pure metadata — never used for control flow.
+"""
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+
+current_turn: ContextVar[dict | None] = ContextVar("odin_current_turn", default=None)
+
+
+def set_turn(**fields) -> Token:
+    """Begin a turn context. Returns a token for reset_turn()."""
+    clean = {k: v for k, v in fields.items() if v not in (None, "")}
+    return current_turn.set(clean or None)
+
+
+def reset_turn(token: Token) -> None:
+    try:
+        current_turn.reset(token)
+    except ValueError:
+        # Token from another context — never let correlation cleanup raise
+        current_turn.set(None)
+
+
+def get_turn() -> dict | None:
+    return current_turn.get()

--- a/src/observability/failure_classes.py
+++ b/src/observability/failure_classes.py
@@ -30,6 +30,7 @@ FAILURE_CLASSES = (
     "remote_state",
     "network",
     "bad_input",
+    "command_failed",
     "provider",
     "unknown",
 )
@@ -51,8 +52,9 @@ _RULES: tuple[tuple[str, str, str, re.Pattern, float], ...] = (
     # -- auth ----------------------------------------------------------------
     ("auth_401_v1", "auth", "unauthorized",
      re.compile(
-         r"\b401\b|unauthorized|invalid[ _]token|token.{0,20}(expired|"
-         r"invalidated)|authentication failed|sign in again|"
+         r"\b401\b|\b403\b|forbidden|unauthorized|invalid[ _]token|"
+         r"token.{0,20}(expired|invalidated)|"
+         r"authentication failed|sign in again|"
          r"invalid credentials|oauth",
          re.I), 0.88),
     # -- rate limit / quota --------------------------------------------------
@@ -121,6 +123,12 @@ _RULES: tuple[tuple[str, str, str, re.Pattern, float], ...] = (
          r"expecting value|unrecognized arguments|usage:|missing required|"
          r"valueerror|typeerror",
          re.I), 0.8),
+    # -- plain nonzero exit (the bulk of real-world failures) ---------------
+    ("cmd_exit_v1", "command_failed", "nonzero_exit",
+     re.compile(
+         r"(script|command) failed \(exit|exited with (code|status) [1-9]|"
+         r"non-zero exit|returned exit code [1-9]",
+         re.I), 0.85),
     # -- provider/upstream --------------------------------------------------------------
     ("provider_5xx_v1", "provider", "upstream_error",
      re.compile(

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -210,17 +210,22 @@ class LoopManager:
                 # Run the LLM iteration. The correlation context lets the
                 # iteration runner, audit logger, and trajectory saver stamp
                 # which loop+iteration the work belongs to without threading
-                # parameters through the callback signature.
+                # parameters through the callback signature. iteration_count
+                # was already incremented above, so it IS the 1-based number
+                # of the iteration about to run.
                 try:
-                    from ..observability.correlation import set_turn
-                    set_turn(
+                    from ..observability.correlation import reset_turn, set_turn
+                    _turn_token = set_turn(
                         source="loop",
                         loop_id=info.id,
-                        loop_iteration=info.iteration_count + 1,
-                        turn_id=f"loop:{info.id}:{info.iteration_count + 1}",
+                        loop_iteration=info.iteration_count,
+                        turn_id=f"loop:{info.id}:{info.iteration_count}",
                         channel_id=info.channel_id,
                     )
-                    response = await iteration_callback(prompt, channel, prev_context)
+                    try:
+                        response = await iteration_callback(prompt, channel, prev_context)
+                    finally:
+                        reset_turn(_turn_token)
                     response = scrub_output_secrets(response.strip()) if response else ""
                     consecutive_errors = 0  # Reset on success
                 except Exception as e:

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -207,8 +207,19 @@ class LoopManager:
                 if info._iteration_history:
                     prev_context = "\n---\n".join(info._iteration_history[-MAX_CONTEXT_HISTORY:])
 
-                # Run the LLM iteration
+                # Run the LLM iteration. The correlation context lets the
+                # iteration runner, audit logger, and trajectory saver stamp
+                # which loop+iteration the work belongs to without threading
+                # parameters through the callback signature.
                 try:
+                    from ..observability.correlation import set_turn
+                    set_turn(
+                        source="loop",
+                        loop_id=info.id,
+                        loop_iteration=info.iteration_count + 1,
+                        turn_id=f"loop:{info.id}:{info.iteration_count + 1}",
+                        channel_id=info.channel_id,
+                    )
                     response = await iteration_callback(prompt, channel, prev_context)
                     response = scrub_output_secrets(response.strip()) if response else ""
                     consecutive_errors = 0  # Reset on success

--- a/src/trajectories/saver.py
+++ b/src/trajectories/saver.py
@@ -61,6 +61,9 @@ class TrajectoryTurn:
     # Observability: prompt-assembly decision metadata (PR #104) — counters,
     # reasons, hashed keys; never content. None when tracing is disabled.
     context_trace: dict | None = None
+    # user_content truncation metadata (set when the request exceeded the cap)
+    user_content_truncated: bool = False
+    user_content_original_chars: int = 0
 
     total_input_tokens: int = 0
     total_output_tokens: int = 0
@@ -124,6 +127,9 @@ class TrajectoryTurn:
         }
         if self.context_trace is not None:
             d["context_trace"] = self.context_trace
+        if self.user_content_truncated:
+            d["user_content_truncated"] = True
+            d["user_content_original_chars"] = self.user_content_original_chars
         return d
 
 

--- a/src/trajectories/saver.py
+++ b/src/trajectories/saver.py
@@ -24,6 +24,10 @@ log = get_logger("trajectories")
 
 DEFAULT_TRAJECTORY_DIR = "./data/trajectories"
 MAX_TOOL_OUTPUT_CHARS = 12_000
+# Storage-side cap per stored tool result (model-facing content is already
+# capped at TOOL_OUTPUT_MAX_CHARS=12000); keeps heavy turns from bloating
+# the daily JSONL files the WebUI reads whole.
+TOOL_RESULT_STORE_CAP = 2_000
 
 
 @dataclass(slots=True)
@@ -36,6 +40,32 @@ class ToolIteration:
     input_tokens: int = 0
     output_tokens: int = 0
     duration_ms: int = 0
+
+
+def stored_tool_results(
+    tool_results: list | None,
+    max_chars: int = TOOL_RESULT_STORE_CAP,
+) -> list[dict]:
+    """Shape tool_result continuation blocks for trajectory storage.
+
+    Content arriving here is already secret-scrubbed and capped to what the
+    model itself saw; this applies the smaller storage cap with truncation
+    metadata so replay tooling knows when it is looking at a prefix.
+    """
+    out: list[dict] = []
+    for r in tool_results or []:
+        if not isinstance(r, dict):
+            continue
+        content = str(r.get("content", ""))
+        entry: dict = {
+            "tool_use_id": str(r.get("tool_use_id", "")),
+            "content": content[:max_chars],
+        }
+        if len(content) > max_chars:
+            entry["truncated"] = True
+            entry["original_chars"] = len(content)
+        out.append(entry)
+    return out
 
 
 @dataclass

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -131,6 +131,8 @@ class WebMessage:
     from a discord.Message object.
     """
 
+    _odin_source = "web"  # trajectory source marker (was recorded as "discord")
+
     def __init__(self, channel_id: str, user_id: str, username: str, content: str = "",
                  allowed_tools: list[str] | None = None):
         self.id = next(_msg_id_counter)
@@ -232,7 +234,7 @@ async def _do_process_web_chat(
         sp = bot._build_system_prompt(
             channel=None, user_id=user_id, query=content, trace=trace,
         )
-        sp = await bot._inject_tool_hints(sp, content, user_id)
+        sp = await bot._inject_tool_hints(sp, content, user_id, trace=trace)
         history = await bot.sessions.get_task_history(
             channel_id, max_messages=160, current_query=content, trace=trace,
         )

--- a/tests/test_trajectory_completeness.py
+++ b/tests/test_trajectory_completeness.py
@@ -217,6 +217,206 @@ class TestUserContentRecording:
 
 
 # ---------------------------------------------------------------------------
+# Tool results persisted into trajectory iterations
+# ---------------------------------------------------------------------------
+
+class TestStoredToolResults:
+    def test_under_cap_passthrough(self):
+        from src.trajectories.saver import stored_tool_results
+        out = stored_tool_results(
+            [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+        )
+        assert out == [{"tool_use_id": "t1", "content": "ok"}]
+
+    def test_caps_with_metadata(self):
+        from src.trajectories.saver import stored_tool_results
+        out = stored_tool_results(
+            [{"tool_use_id": "t1", "content": "x" * 5000}], max_chars=100,
+        )
+        assert len(out[0]["content"]) == 100
+        assert out[0]["truncated"] is True
+        assert out[0]["original_chars"] == 5000
+
+    def test_skips_non_dicts_and_tolerates_missing_keys(self):
+        from src.trajectories.saver import stored_tool_results
+        out = stored_tool_results(["garbage", None, {}])
+        assert out == [{"tool_use_id": "", "content": ""}]
+        assert stored_tool_results(None) == []
+
+
+class _LoopIterClient:
+    """Fake client binding the REAL _run_loop_iteration + _record_user_content."""
+    from src.discord.client import OdinBot as _C  # noqa: N814
+    _run_loop_iteration = _C._run_loop_iteration
+    _record_user_content = _C._record_user_content
+
+    def __init__(self, responses, tool_output="hi out", result_cap=2000):
+        from types import SimpleNamespace
+
+        class _Obs:
+            loop_trace = True
+            trajectory_user_content = True
+            max_user_content_chars = 4000
+            max_tool_result_chars = result_cap
+
+        class _Tools:
+            enabled = True
+            tool_timeout_seconds = 5
+            max_tool_iterations_loop = 4
+
+        class _Cfg:
+            observability = _Obs()
+            tools = _Tools()
+
+        self.config = _Cfg()
+        self.loop_manager = SimpleNamespace(_loops={})
+        self._responses = list(responses)
+        self._tool_output = tool_output
+        self.saved = []          # (trajectory, kwargs) per _save_turn_trajectory
+        self.reflected = []      # kwargs per _maybe_loop_reflect
+
+        async def _chat_with_tools(**kwargs):
+            return self._responses.pop(0)
+
+        async def _log_execution(**kwargs):
+            pass
+
+        self.llm_client = SimpleNamespace(chat_with_tools=_chat_with_tools)
+        self.audit = SimpleNamespace(log_execution=_log_execution)
+
+    def _new_context_trace(self):
+        return None
+
+    def _build_system_prompt(self, **kwargs):
+        return "sys"
+
+    def _merged_tool_definitions(self):
+        return [{"name": "run_command"}]
+
+    async def _dispatch_loop_tool(self, tool_name, tool_input, msg_proxy, user_id):
+        return self._tool_output
+
+    async def _save_turn_trajectory(self, trajectory, **kwargs):
+        self.saved.append((trajectory, kwargs))
+
+    def _maybe_loop_reflect(self, **kwargs):
+        self.reflected.append(kwargs)
+
+
+def _tool_call_response(text="", calls=()):
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        text=text,
+        tool_calls=[
+            SimpleNamespace(id=i, name=n, input=inp) for (i, n, inp) in calls
+        ],
+        input_tokens=10,
+        output_tokens=5,
+    )
+
+
+class TestLoopIterationTrajectory:
+    @pytest.mark.asyncio
+    async def test_persists_tool_calls_and_results(self):
+        from types import SimpleNamespace
+        fake = _LoopIterClient([
+            _tool_call_response(calls=[("t1", "run_command", {"command": "echo hi"})]),
+            _tool_call_response(text="done"),
+        ])
+        token = set_turn(source="loop", loop_id="l1", loop_iteration=1,
+                         turn_id="loop:l1:1", channel_id="c1")
+        try:
+            out = await fake._run_loop_iteration(
+                "do the thing", SimpleNamespace(id="c1"), None, "42",
+            )
+        finally:
+            reset_turn(token)
+
+        assert out == "done"
+        assert len(fake.saved) == 1
+        traj, save_kwargs = fake.saved[0]
+        assert traj.source == "loop"
+        assert traj.message_id == "loop:l1:1"
+        assert traj.user_content == "do the thing"
+        assert save_kwargs["final_response"] == "done"
+        # The iteration must hold BOTH halves: the call and its result
+        assert traj.iterations[0].tool_calls[0]["name"] == "run_command"
+        assert traj.iterations[0].tool_results[0]["tool_use_id"] == "t1"
+        assert traj.iterations[0].tool_results[0]["content"] == "hi out"
+        assert fake.reflected and fake.reflected[0]["is_error"] is False
+
+    @pytest.mark.asyncio
+    async def test_results_respect_storage_cap(self):
+        from types import SimpleNamespace
+        fake = _LoopIterClient(
+            [
+                _tool_call_response(calls=[("t1", "run_command", {"command": "x"})]),
+                _tool_call_response(text="done"),
+            ],
+            tool_output="y" * 5000,
+            result_cap=100,
+        )
+        token = set_turn(source="loop", loop_id="l1", loop_iteration=1,
+                         turn_id="loop:l1:1", channel_id="c1")
+        try:
+            await fake._run_loop_iteration(
+                "go", SimpleNamespace(id="c1"), None, "42",
+            )
+        finally:
+            reset_turn(token)
+        stored = fake.saved[0][0].iterations[0].tool_results[0]
+        assert len(stored["content"]) == 100
+        assert stored["truncated"] is True
+        assert stored["original_chars"] == 5000
+
+
+# ---------------------------------------------------------------------------
+# Loop manager correlation stamp — first iteration must be :1, not :2
+# ---------------------------------------------------------------------------
+
+class TestLoopManagerStamp:
+    @pytest.mark.asyncio
+    async def test_first_iteration_stamped_one_and_reset_after(self):
+        import asyncio
+
+        from src.tools.autonomous_loop import LoopManager
+
+        mgr = LoopManager()
+        stamps = []
+        holder = {}
+
+        class _Chan:
+            id = "c9"
+            def __init__(self):
+                self.send_stamps = []
+            async def send(self, *a, **k):
+                self.send_stamps.append(get_turn())
+
+        chan = _Chan()
+
+        async def callback(prompt, channel, prev_context):
+            stamps.append(dict(get_turn() or {}))
+            mgr._loops[holder["lid"]]._cancel_event.set()
+            return "ok"
+
+        lid = mgr.start_loop(
+            goal="g", channel=chan, requester_id="1", requester_name="n",
+            iteration_callback=callback, interval_seconds=10,
+            mode="silent", max_iterations=1,
+        )
+        assert not lid.startswith("Error")
+        holder["lid"] = lid
+        await asyncio.wait_for(mgr._loops[lid]._task, timeout=5)
+
+        assert stamps and stamps[0]["loop_iteration"] == 1
+        assert stamps[0]["turn_id"] == f"loop:{lid}:1"
+        assert stamps[0]["source"] == "loop"
+        # The manager resets the stamp after the callback, so post-iteration
+        # sends (completion notices etc.) carry no stale turn context.
+        assert chan.send_stamps and all(s is None for s in chan.send_stamps)
+
+
+# ---------------------------------------------------------------------------
 # Agent trajectory saver wiring — the production-orphaned saver
 # ---------------------------------------------------------------------------
 

--- a/tests/test_trajectory_completeness.py
+++ b/tests/test_trajectory_completeness.py
@@ -1,0 +1,252 @@
+"""Tests for trajectory completeness (PR: complete trajectory coverage and
+prompt-input observability).
+
+Covers: user_content recording (cap/scrub/metadata/kill-switch), the loop
+reflection gate (dedup/cooldown/recovery/global cap), turn correlation
+context, the command_failed classifier class, and the agent trajectory-saver
+wiring that was orphaned in production.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.learning.loop_reflection import LoopReflectionGate, failure_signature
+from src.observability.correlation import get_turn, reset_turn, set_turn
+from src.observability.failure_classes import classify_failure
+from src.trajectories.saver import TrajectoryTurn
+
+# ---------------------------------------------------------------------------
+# Loop reflection gate — Odin's spec: one lesson, not sixty
+# ---------------------------------------------------------------------------
+
+class TestLoopReflectionGate:
+    def test_first_occurrence_reflects(self):
+        gate = LoopReflectionGate()
+        ok, reason = gate.evaluate("loop1", is_error=True,
+                                   failure_class="network", error_text="ECONNRESET")
+        assert ok and reason == "first_occurrence"
+
+    def test_identical_failure_suppressed_all_night(self):
+        gate = LoopReflectionGate(cooldown_hours=12)
+        gate.evaluate("loop1", is_error=True, failure_class="network",
+                      error_text="dns timeout host 10.0.0.5")
+        suppressed = [
+            gate.evaluate("loop1", is_error=True, failure_class="network",
+                          error_text="dns timeout host 10.0.0.7")  # digits normalized
+            for _ in range(60)
+        ]
+        assert all(not ok for ok, _ in suppressed)
+        assert {r for _, r in suppressed} == {"duplicate_suppressed"}
+
+    def test_signature_change_reflects(self):
+        gate = LoopReflectionGate()
+        gate.evaluate("loop1", is_error=True, failure_class="network",
+                      error_text="dns timeout")
+        ok, reason = gate.evaluate("loop1", is_error=True, failure_class="auth",
+                                   error_text="401 unauthorized")
+        assert ok and reason == "signature_change"
+
+    def test_recovery_after_repeated_failure_reflects_once(self):
+        gate = LoopReflectionGate()
+        for _ in range(3):
+            gate.evaluate("loop1", is_error=True, failure_class="timeout",
+                          error_text="timed out")
+        ok, reason = gate.evaluate("loop1", is_error=False)
+        assert ok and reason == "recovery"
+        # Next success is routine again
+        ok2, reason2 = gate.evaluate("loop1", is_error=False)
+        assert not ok2 and reason2 == "routine_success"
+
+    def test_single_failure_then_success_is_not_recovery(self):
+        gate = LoopReflectionGate()
+        gate.evaluate("loop1", is_error=True, failure_class="timeout",
+                      error_text="timed out")
+        ok, reason = gate.evaluate("loop1", is_error=False)
+        assert not ok and reason == "routine_success"
+
+    def test_cooldown_expiry_allows_again(self):
+        gate = LoopReflectionGate(cooldown_hours=0)  # immediate expiry
+        gate.evaluate("loop1", is_error=True, failure_class="network",
+                      error_text="dns timeout")
+        ok, reason = gate.evaluate("loop1", is_error=True, failure_class="network",
+                                   error_text="dns timeout")
+        assert ok and reason == "cooldown_expired"
+
+    def test_global_hourly_cap(self):
+        gate = LoopReflectionGate(max_per_hour=3)
+        granted = 0
+        for i in range(10):
+            ok, _ = gate.evaluate(f"loop{i}", is_error=True,
+                                  failure_class="network", error_text=f"err {i}")
+            granted += ok
+        assert granted == 3
+
+    def test_loops_are_isolated(self):
+        gate = LoopReflectionGate()
+        gate.evaluate("loop1", is_error=True, failure_class="network",
+                      error_text="dns timeout")
+        ok, reason = gate.evaluate("loop2", is_error=True, failure_class="network",
+                                   error_text="dns timeout")
+        assert ok and reason == "first_occurrence"
+
+    def test_signature_normalizes_digits(self):
+        a = failure_signature("l1", "network", "timeout after 30s on host 10.0.0.5")
+        b = failure_signature("l1", "network", "timeout after 99s on host 10.9.8.7")
+        assert a == b
+
+    def test_gate_never_raises(self):
+        gate = LoopReflectionGate()
+        ok, reason = gate.evaluate(None, is_error=True,  # type: ignore[arg-type]
+                                   failure_class=None, error_text=None)  # type: ignore[arg-type]
+        assert isinstance(ok, bool)
+
+
+# ---------------------------------------------------------------------------
+# Turn correlation context
+# ---------------------------------------------------------------------------
+
+class TestCorrelation:
+    def test_set_get_reset(self):
+        token = set_turn(turn_id="t1", source="loop", loop_id="l1", empty=None)
+        turn = get_turn()
+        assert turn == {"turn_id": "t1", "source": "loop", "loop_id": "l1"}
+        reset_turn(token)
+        assert get_turn() is None
+
+    @pytest.mark.asyncio
+    async def test_propagates_into_gathered_tasks(self):
+        import asyncio
+        set_turn(turn_id="t2", source="discord")
+
+        async def child():
+            return (get_turn() or {}).get("turn_id")
+
+        results = await asyncio.gather(child(), child())
+        assert results == ["t2", "t2"]
+
+    @pytest.mark.asyncio
+    async def test_audit_logger_stamps_turn(self, tmp_path):
+        import json
+
+        from src.audit.logger import AuditLogger
+        logger = AuditLogger(path=str(tmp_path / "audit.jsonl"))
+        set_turn(turn_id="loop:abc:3", source="loop", loop_id="abc", loop_iteration=3)
+        await logger.log_execution(
+            user_id="42", user_name="loop", channel_id="ch1",
+            tool_name="run_command", tool_input={"command": "x"},
+            approved=True, result_summary="ok", execution_time_ms=5,
+        )
+        entry = json.loads((tmp_path / "audit.jsonl").read_text().splitlines()[-1])
+        assert entry["turn"]["turn_id"] == "loop:abc:3"
+        assert entry["turn"]["loop_id"] == "abc"
+        assert entry["turn"]["source"] == "loop"
+
+
+# ---------------------------------------------------------------------------
+# command_failed classification
+# ---------------------------------------------------------------------------
+
+class TestCommandFailedClass:
+    CASES = [
+        ("[governor: allowed — high risk, recursive delete]\nScript failed (exit 1):",
+         "command_failed"),
+        ("Command failed (exit 2):\n/bin/sh: 1: set: Illegal option -o pipefail", "command_failed"),
+        ("process exited with code 3", "command_failed"),
+        ("Error: HTTP 403: Forbidden\n\n[recovery hint: authentication failure]", "auth"),
+        # Specific classes still win over the generic exit class
+        ("Script failed (exit 1):\nModuleNotFoundError: No module named 'x'", "dependency_missing"),
+        ("Script failed (exit 1):\nCONFLICT (content): Merge conflict in a.py", "conflict"),
+    ]
+
+    @pytest.mark.parametrize("text,expected", CASES)
+    def test_matrix(self, text, expected):
+        assert classify_failure(text)["class"] == expected
+
+
+# ---------------------------------------------------------------------------
+# user_content recording
+# ---------------------------------------------------------------------------
+
+class _FakeClient:
+    """Just enough client surface for _record_user_content."""
+    from src.discord.client import OdinBot as _C  # noqa: N814
+    _record_user_content = _C._record_user_content
+
+    def __init__(self, enabled=True, cap=4000):
+        class _Obs:
+            trajectory_user_content = enabled
+            max_user_content_chars = cap
+        class _Cfg:
+            observability = _Obs()
+        self.config = _Cfg()
+
+
+class TestUserContentRecording:
+    def test_records_plain_content(self):
+        turn = TrajectoryTurn()
+        _FakeClient()._record_user_content(turn, "fix the nginx config")
+        assert turn.user_content == "fix the nginx config"
+        assert turn.user_content_truncated is False
+        assert "user_content_truncated" not in turn.to_dict()
+
+    def test_caps_with_metadata(self):
+        turn = TrajectoryTurn()
+        _FakeClient(cap=100)._record_user_content(turn, "x" * 500)
+        assert len(turn.user_content) == 100
+        assert turn.user_content_truncated is True
+        assert turn.user_content_original_chars == 500
+        d = turn.to_dict()
+        assert d["user_content_truncated"] is True
+        assert d["user_content_original_chars"] == 500
+
+    def test_kill_switch(self):
+        turn = TrajectoryTurn()
+        _FakeClient(enabled=False)._record_user_content(turn, "secret request")
+        assert turn.user_content == ""
+
+    def test_secrets_scrubbed(self):
+        turn = TrajectoryTurn()
+        _FakeClient()._record_user_content(
+            turn, "use key sk-abcdefghijklmnopqrstuvwx1234 for the api",
+        )
+        assert "sk-abcdefghijklmnopqrstuvwx1234" not in turn.user_content
+
+    def test_never_raises(self):
+        turn = TrajectoryTurn()
+        _FakeClient()._record_user_content(turn, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Agent trajectory saver wiring — the production-orphaned saver
+# ---------------------------------------------------------------------------
+
+class TestAgentSaverWiring:
+    def test_loop_bridge_forwards_saver(self):
+        from src.agents.loop_bridge import LoopAgentBridge
+
+        class RecordingManager:
+            def __init__(self):
+                self.kwargs = None
+            def spawn(self, **kwargs):
+                self.kwargs = kwargs
+                return "agent-1"
+
+        mgr = RecordingManager()
+        sentinel = object()
+        bridge = LoopAgentBridge(mgr, trajectory_saver=sentinel)
+        bridge.spawn_agents_for_loop(
+            loop_id="l1", iteration=1, loop_goal="g",
+            tasks=[{"label": "a", "goal": "t"}],
+            channel_id="c", requester_id="u", requester_name="n",
+            iteration_callback=None, tool_executor_callback=None,
+        )
+        assert mgr.kwargs is not None
+        assert mgr.kwargs.get("trajectory_saver") is sentinel
+
+    def test_chat_spawn_passes_saver(self):
+        # The omission hid for months because nothing asserted the call site.
+        import inspect
+
+        from src.discord.client import OdinBot
+        src = inspect.getsource(OdinBot._handle_spawn_agent)
+        assert "trajectory_saver=self.agent_trajectory_saver" in src


### PR DESCRIPTION
## Summary

Closes the evaluation blockers from the behavioral assessment (Findings 4 & 5), built to the consult scope. Same contract discipline as PR #104: recording never influences behavior, and broken recording never breaks a turn.

## What was dark, now lit

**`user_content`** — empty in all 1,522 turns ever recorded. The field, serialization, and a helper accepting it all existed; the live construction simply never set it (the helper had zero callers). Now recorded on chat, web, and loop turns: secret-scrubbed, capped at 4,000 chars with explicit truncation metadata, config kill-switch, never-raises helper. Web turns also stop masquerading as `source='discord'`.

**Loop iterations** — 10% of all-time tool executions had no trajectory, no trace, and extracted zero lessons. `_run_loop_iteration` now writes a full `TrajectoryTurn` per iteration (`source='loop'`, `loop:<id>:<n>` turn ids, complete `ToolIteration` records, context trace, single `_finish()` exit path). Correlation context is set by `LoopManager` — **no callback signature changes**, so existing callbacks and tests are untouched.

**Loop reflection** — gated by the agreed dedup/cooldown spec (`src/learning/loop_reflection.py`): reflect on first occurrence of a failure signature, signature change, and recovery after repeated failure; suppress identical repeats (digit-normalized signature, 12h cooldown), routine successes, and anything past a global hourly cap. **Tests prove 60 consecutive identical failures yield zero additional reflections** — one lesson, not sixty. Flip-flopping between two known errors can't spam either.

**Audit ↔ trajectory correlation** — the 'two halves of a broken map': a task-scoped contextvar (`src/observability/correlation.py`) is set by the chat and loop entry points; `AuditLogger` stamps `entry['turn']` (turn_id / source / loop_id / iteration). Propagates through `asyncio.gather` into concurrent tool executions — verified by test.

**Agent trajectories** — the saver was orphaned in production (never passed into `spawn()`; `data/trajectories/agents/` empty forever). Wired at `_handle_spawn_agent`, forwarded through `LoopAgentBridge` for loop-spawned agents, constructor ordering fixed, and a call-site assertion test so the omission can't silently return.

**Tool hints** — now recorded as a `tool_hints` context-trace section (tokens, sequence count, max chain length); previously the one prompt input invisible to observability because injection happens after `_build_system_prompt`. New `tool_memory.inject_hints` kill-switch, pending the eval-harness A/B verdict — this PR deliberately does **not** decide the hint system's fate.

**Classifier** — `command_failed` class for plain nonzero exits (65% of historical 'unknown' in the 48-day retro-classification); 403/Forbidden now classifies as `auth`. Specific classes (dependency_missing, conflict) still win over the generic exit rule.

## Config (all kill-switched)

`observability.trajectory_user_content` / `max_user_content_chars` / `loop_trace`; `learning.loop_reflection_enabled` / `loop_reflection_cooldown_hours` / `loop_reflection_max_per_hour`; `tool_memory.inject_hints`. Live config.yml is skip-worktree'd — the template changed, so the deploy uses the recovery procedure; all new keys default sensibly when absent.

## Verification

26 new tests (gate matrix, correlation propagation + audit stamping, classifier, user_content cap/scrub/kill-switch, saver wiring). Full suite: 5,684 passed — failure set **byte-identical** to the v3.30.0 baseline (29 environmental, zero new). Zero new ruff violations.

## What this unblocks

The behavioral eval harness now has everything it was missing: recorded requests, complete coverage of chat/web/loop work, joinable audit data, and visible hint injections. Behavioral changes can now be vetted against golden trajectories instead of vibes.