### PR TITLE
Email tools via SMTP/IMAP

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -112,6 +112,26 @@ observability:
   # Storage cap per tool result persisted into trajectory iterations
   max_tool_result_chars: 2000
 
+# Email tools (SMTP/IMAP with App Password)
+email:
+  enabled: false
+  smtp:
+    host: smtp.gmail.com
+    port: 587
+    username: ''
+    password: ''
+    from_address: ''
+  imap:
+    host: imap.gmail.com
+    port: 993
+    username: ''
+    password: ''
+  max_body_chars: 50000
+  max_results: 50
+  max_attachment_bytes: 10485760
+  connect_timeout_seconds: 30
+  allowed_attachment_dirs: []
+
 search:
   enabled: true
   search_db_path: ./data/search

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -627,6 +627,32 @@ class ObservabilityConfig(BaseModel):
     max_tool_result_chars: int = 2000
 
 
+class EmailSmtpConfig(BaseModel):
+    host: str = "smtp.gmail.com"
+    port: int = 587
+    username: str = ""
+    password: str = ""
+    from_address: str = ""
+
+
+class EmailImapConfig(BaseModel):
+    host: str = "imap.gmail.com"
+    port: int = 993
+    username: str = ""
+    password: str = ""
+
+
+class EmailConfig(BaseModel):
+    enabled: bool = False
+    smtp: EmailSmtpConfig = EmailSmtpConfig()
+    imap: EmailImapConfig = EmailImapConfig()
+    max_body_chars: int = 50_000
+    max_results: int = 50
+    max_attachment_bytes: int = 10 * 1024 * 1024
+    connect_timeout_seconds: int = 30
+    allowed_attachment_dirs: list[str] = Field(default_factory=list)
+
+
 class MCPConfig(BaseModel):
     enabled: bool = False
     servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
@@ -651,6 +677,7 @@ class Config(BaseModel):
     webhook: WebhookConfig = WebhookConfig()
     learning: LearningConfig = LearningConfig()
     observability: ObservabilityConfig = ObservabilityConfig()
+    email: EmailConfig = EmailConfig()
     search: SearchConfig = SearchConfig()
     voice: VoiceConfig = VoiceConfig()
     monitoring: MonitoringConfig = MonitoringConfig()

--- a/src/discord/background_task.py
+++ b/src/discord/background_task.py
@@ -20,6 +20,21 @@ from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
 from ..tools.risk_classifier import classify_tool
 
+_EMAIL_BODY_TOOLS = frozenset({"email_send"})
+
+
+def _scrub_email_input(tool_name: str, tool_input: dict) -> dict:
+    if tool_name not in _EMAIL_BODY_TOOLS or not isinstance(tool_input, dict):
+        return tool_input
+    cleaned = dict(tool_input)
+    body = cleaned.get("body", "")
+    cleaned["body"] = f"[redacted email body: {len(body)} chars]"
+    if "attachments" in cleaned and cleaned["attachments"]:
+        from pathlib import Path
+        cleaned["attachments"] = [Path(p).name for p in cleaned["attachments"]]
+    return cleaned
+
+
 if TYPE_CHECKING:
     from ..audit.logger import AuditLogger
     from ..tools.executor import ToolExecutor
@@ -192,7 +207,9 @@ async def run_background_task(
                     log_kwargs: dict = dict(
                         user_id=task.requester_id, user_name=task.requester,
                         channel_id=str(getattr(task.channel, "id", "")),
-                        tool_name=tool_name, tool_input=tool_input, approved=True,
+                        tool_name=tool_name,
+                        tool_input=_scrub_email_input(tool_name, tool_input),
+                        approved=True,
                         result_summary=output[:500],
                         execution_time_ms=elapsed_ms,
                         risk_level=risk_assessment.level.value,
@@ -226,7 +243,9 @@ async def run_background_task(
                     await audit_logger.log_execution(
                         user_id=task.requester_id, user_name=task.requester,
                         channel_id=str(getattr(task.channel, "id", "")),
-                        tool_name=tool_name, tool_input=tool_input, approved=True,
+                        tool_name=tool_name,
+                        tool_input=_scrub_email_input(tool_name, tool_input),
+                        approved=True,
                         result_summary=error_msg[:500],
                         execution_time_ms=elapsed_ms, error=error_msg[:500],
                         risk_level=err_risk.level.value,

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -3330,6 +3330,14 @@ class OdinBot(commands.Bot):
                         k: scrub_output_secrets(str(v)) if isinstance(v, str) else v
                         for k, v in (tool_input or {}).items()
                     }
+                    if tool_name == "email_send":
+                        _body = scrubbed_input.get("body", "")
+                        scrubbed_input["body"] = f"[redacted email body: {len(_body)} chars]"
+                        if "attachments" in scrubbed_input:
+                            from pathlib import Path
+                            scrubbed_input["attachments"] = [
+                                Path(p).name for p in (scrubbed_input["attachments"] or [])
+                            ]
                     await self.audit.log_execution(
                         user_id=str(message.author.id),
                         user_name=str(message.author),
@@ -4686,13 +4694,23 @@ class OdinBot(commands.Bot):
                 result = truncate_tool_output(scrub_output_secrets(str(raw)))
 
                 # Audit log
+                _audit_input = tool_input
+                if tool_name == "email_send" and isinstance(_audit_input, dict):
+                    _audit_input = dict(_audit_input)
+                    _body = _audit_input.get("body", "")
+                    _audit_input["body"] = f"[redacted email body: {len(_body)} chars]"
+                    if "attachments" in _audit_input:
+                        from pathlib import Path as _P
+                        _audit_input["attachments"] = [
+                            _P(p).name for p in (_audit_input["attachments"] or [])
+                        ]
                 try:
                     await self.audit.log_execution(
                         user_id=user_id,
                         user_name=requester_name,
                         channel_id=channel_id_str,
                         tool_name=tool_name,
-                        tool_input=tool_input,
+                        tool_input=_audit_input,
                         approved=True,
                         result_summary=result,
                         execution_time_ms=elapsed_ms,

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -393,6 +393,7 @@ class OdinBot(commands.Bot):
             browser_manager=self.browser_manager,
             output_streamer=output_streamer,
             host_access_manager=self.host_access_manager,
+            email_config=getattr(config, "email", None),
         )
         self.skill_manager = SkillManager(
             skills_dir="./data/skills",
@@ -1187,6 +1188,9 @@ class OdinBot(commands.Bot):
         # Filter out tools that require unconfigured backends
         if not self.config.tools.claude_code_host:
             builtin = [t for t in builtin if t["name"] != "claude_code"]
+        _email_tools = {"email_send", "email_search", "email_read", "email_list_recent"}
+        if not getattr(self.config, "email", None) or not self.config.email.enabled:
+            builtin = [t for t in builtin if t["name"] not in _email_tools]
         builtin_names = {t["name"] for t in builtin}
         skill_defs = [
             t for t in self.skill_manager.get_tool_definitions()

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -87,6 +87,21 @@ SEND_MAX_RETRIES = 3
 # Pre-compiled regex for merging adjacent code blocks in combine_bot_messages
 _ADJACENT_FENCE_RE = re.compile(r"\n```[ \t]*\n\n```(\w*)[ \t]*\n")
 
+_EMAIL_BODY_TOOLS = frozenset({"email_send"})
+
+
+def _scrub_tool_input_for_storage(tool_name: str, tool_input: dict) -> dict:
+    """Redact privacy-sensitive fields from tool input before any storage path."""
+    if tool_name not in _EMAIL_BODY_TOOLS or not isinstance(tool_input, dict):
+        return tool_input
+    cleaned = dict(tool_input)
+    body = cleaned.get("body", "")
+    cleaned["body"] = f"[redacted email body: {len(body)} chars]"
+    if "attachments" in cleaned and cleaned["attachments"]:
+        from pathlib import Path
+        cleaned["attachments"] = [Path(p).name for p in cleaned["attachments"]]
+    return cleaned
+
 
 class _LoopMessageProxy:
     """Lightweight proxy providing a discord.Message-like interface for loop iterations.
@@ -1304,7 +1319,8 @@ class OdinBot(commands.Bot):
 
         from datetime import datetime
         ts = datetime.now().strftime("%H:%M")
-        inp_summary = ", ".join(f"{k}={v}" for k, v in tool_input.items() if isinstance(v, str))
+        safe_input = _scrub_tool_input_for_storage(tool_name, tool_input)
+        inp_summary = ", ".join(f"{k}={v}" for k, v in safe_input.items() if isinstance(v, str))
         if len(inp_summary) > 100:
             inp_summary = inp_summary[:100] + "..."
         status = "OK" if "error" not in result_preview.lower()[:50] else "ERROR"
@@ -3326,18 +3342,10 @@ class OdinBot(commands.Bot):
 
                 # Audit log — never crash tool execution on audit failure
                 try:
-                    scrubbed_input = {
+                    scrubbed_input = _scrub_tool_input_for_storage(tool_name, {
                         k: scrub_output_secrets(str(v)) if isinstance(v, str) else v
                         for k, v in (tool_input or {}).items()
-                    }
-                    if tool_name == "email_send":
-                        _body = scrubbed_input.get("body", "")
-                        scrubbed_input["body"] = f"[redacted email body: {len(_body)} chars]"
-                        if "attachments" in scrubbed_input:
-                            from pathlib import Path
-                            scrubbed_input["attachments"] = [
-                                Path(p).name for p in (scrubbed_input["attachments"] or [])
-                            ]
+                    })
                     await self.audit.log_execution(
                         user_id=str(message.author.id),
                         user_name=str(message.author),
@@ -3405,7 +3413,7 @@ class OdinBot(commands.Bot):
                             user_name=str(message.author),
                             channel_id=str(message.channel.id),
                             tool_name=block.name,
-                            tool_input=block.input,
+                            tool_input=_scrub_tool_input_for_storage(block.name, block.input),
                             approved=True,
                             result_summary=error_msg,
                             execution_time_ms=int(tool_timeout * 1000),
@@ -3439,7 +3447,7 @@ class OdinBot(commands.Bot):
                 _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
                 _op_tool_details.append({
                     "tool": _tc.name,
-                    "input": _tc.input,
+                    "input": _scrub_tool_input_for_storage(_tc.name, _tc.input),
                     "result": _rcontent[:300],
                     "error": _rcontent.lstrip().lower().startswith(
                         ("error", "[error", "failed", "traceback")),
@@ -4694,23 +4702,13 @@ class OdinBot(commands.Bot):
                 result = truncate_tool_output(scrub_output_secrets(str(raw)))
 
                 # Audit log
-                _audit_input = tool_input
-                if tool_name == "email_send" and isinstance(_audit_input, dict):
-                    _audit_input = dict(_audit_input)
-                    _body = _audit_input.get("body", "")
-                    _audit_input["body"] = f"[redacted email body: {len(_body)} chars]"
-                    if "attachments" in _audit_input:
-                        from pathlib import Path as _P
-                        _audit_input["attachments"] = [
-                            _P(p).name for p in (_audit_input["attachments"] or [])
-                        ]
                 try:
                     await self.audit.log_execution(
                         user_id=user_id,
                         user_name=requester_name,
                         channel_id=channel_id_str,
                         tool_name=tool_name,
-                        tool_input=_audit_input,
+                        tool_input=_scrub_tool_input_for_storage(tool_name, tool_input),
                         approved=True,
                         result_summary=result,
                         execution_time_ms=elapsed_ms,
@@ -4744,7 +4742,7 @@ class OdinBot(commands.Bot):
                 _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
                 _loop_details.append({
                     "tool": _tc.name,
-                    "input": _tc.input,
+                    "input": _scrub_tool_input_for_storage(_tc.name, _tc.input),
                     "result": _rcontent[:300],
                     "error": _rcontent.lstrip().lower().startswith(
                         ("error", "[error", "failed", "traceback",

--- a/src/tools/affordances.py
+++ b/src/tools/affordances.py
@@ -179,6 +179,15 @@ _CATEGORY_DEFAULTS: list[tuple[str, Affordance]] = [
     ("spawn_loop_agents", Affordance(Cost.VERY_HIGH, Risk.HIGH, Latency.UNBOUNDED,
         ("agent tool enabled",))),
     ("collect_loop_agents", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS, ())),
+    # Email tools (SMTP/IMAP)
+    ("email_send", Affordance(Cost.LOW, Risk.MEDIUM, Latency.SECONDS,
+        ("email.enabled", "SMTP credentials configured"))),
+    ("email_search", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS,
+        ("email.enabled", "IMAP credentials configured"))),
+    ("email_read", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS,
+        ("email.enabled", "IMAP credentials configured"))),
+    ("email_list_recent", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS,
+        ("email.enabled", "IMAP credentials configured"))),
 ]
 
 # Default when no prefix matches. Deliberately conservative: unknown

--- a/src/tools/email_client.py
+++ b/src/tools/email_client.py
@@ -1,0 +1,363 @@
+"""SMTP/IMAP email client for Odin's email tools.
+
+Sends via SMTP (STARTTLS) and reads via IMAP (SSL).  Designed for Gmail
+with App Passwords but works with any standard provider.  Connections are
+short-lived (created per call, closed after) — no pool, no persistent
+state.  Gmail's X-GM-RAW search extension is auto-detected from the IMAP
+host and used transparently when available.
+"""
+from __future__ import annotations
+
+import email as email_lib
+import email.mime.base
+import email.mime.multipart
+import email.mime.text
+import imaplib
+import mimetypes
+import os
+import smtplib
+from email.header import decode_header
+from email.utils import formataddr, formatdate, make_msgid, parseaddr
+from pathlib import Path
+
+from ..odin_log import get_logger
+
+log = get_logger("email")
+
+_GMAIL_HOST_MARKER = "gmail.com"
+
+
+def _safe_error(exc: Exception, password: str | None) -> str:
+    msg = str(exc)
+    if password and password in msg:
+        msg = msg.replace(password, "[REDACTED]")
+    return msg
+
+
+def _decode_header_value(raw: str | None) -> str:
+    if not raw:
+        return ""
+    parts = decode_header(raw)
+    decoded = []
+    for data, charset in parts:
+        if isinstance(data, bytes):
+            decoded.append(data.decode(charset or "utf-8", errors="replace"))
+        else:
+            decoded.append(data)
+    return " ".join(decoded)
+
+
+def _extract_body(msg: email_lib.message.Message, max_chars: int) -> str:
+    if msg.is_multipart():
+        for part in msg.walk():
+            ct = part.get_content_type()
+            if ct == "text/plain" and part.get("Content-Disposition") != "attachment":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    text = payload.decode(charset, errors="replace")
+                    if len(text) > max_chars:
+                        return text[:max_chars] + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+                    return text
+        for part in msg.walk():
+            ct = part.get_content_type()
+            if ct == "text/html" and part.get("Content-Disposition") != "attachment":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    text = payload.decode(charset, errors="replace")
+                    if len(text) > max_chars:
+                        return text[:max_chars] + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+                    return f"[HTML content]\n{text}"
+        return "[no text body found]"
+    payload = msg.get_payload(decode=True)
+    if payload:
+        charset = msg.get_content_charset() or "utf-8"
+        text = payload.decode(charset, errors="replace")
+        if len(text) > max_chars:
+            return text[:max_chars] + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+        return text
+    return "[empty message]"
+
+
+def _attachment_metadata(msg: email_lib.message.Message) -> list[dict]:
+    attachments = []
+    for part in msg.walk():
+        disp = part.get("Content-Disposition", "")
+        if "attachment" in disp:
+            filename = part.get_filename() or "(unnamed)"
+            filename = _decode_header_value(filename)
+            size = len(part.get_payload(decode=True) or b"")
+            attachments.append({
+                "filename": filename,
+                "content_type": part.get_content_type(),
+                "size_bytes": size,
+            })
+    return attachments
+
+
+def _message_summary(msg: email_lib.message.Message, uid: str = "") -> dict:
+    return {
+        "uid": uid,
+        "from": _decode_header_value(msg.get("From")),
+        "to": _decode_header_value(msg.get("To")),
+        "subject": _decode_header_value(msg.get("Subject")),
+        "date": msg.get("Date", ""),
+        "message_id": msg.get("Message-ID", ""),
+        "has_attachments": any(
+            "attachment" in (p.get("Content-Disposition") or "") for p in msg.walk()
+        ),
+    }
+
+
+def send_email(
+    *,
+    smtp_host: str,
+    smtp_port: int,
+    username: str,
+    password: str,
+    from_address: str,
+    to: list[str],
+    subject: str,
+    body: str,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    reply_to: str | None = None,
+    attachments: list[str] | None = None,
+    allowed_dirs: list[str] | None = None,
+    max_attachment_bytes: int = 10 * 1024 * 1024,
+    timeout: int = 30,
+) -> dict:
+    all_recipients = list(to)
+    if cc:
+        all_recipients.extend(cc)
+    if bcc:
+        all_recipients.extend(bcc)
+
+    if not all_recipients:
+        raise ValueError("No recipients specified")
+
+    msg = email_lib.mime.multipart.MIMEMultipart()
+    msg["From"] = formataddr(parseaddr(from_address))
+    msg["To"] = ", ".join(to)
+    if cc:
+        msg["Cc"] = ", ".join(cc)
+    if reply_to:
+        msg["Reply-To"] = reply_to
+    msg["Subject"] = subject
+    msg["Date"] = formatdate(localtime=True)
+    msg["Message-ID"] = make_msgid()
+
+    msg.attach(email_lib.mime.text.MIMEText(body, "plain", "utf-8"))
+
+    if attachments:
+        if not allowed_dirs:
+            raise ValueError("Attachments require allowed_attachment_dirs to be configured")
+        resolved_allowed = [os.path.realpath(d) for d in allowed_dirs]
+        for filepath in attachments:
+            real = os.path.realpath(filepath)
+            if not any(real.startswith(d + os.sep) or real == d for d in resolved_allowed):
+                raise ValueError(
+                    f"Attachment path '{filepath}' is outside allowed directories"
+                )
+            if not os.path.isfile(real):
+                raise ValueError(f"Attachment '{filepath}' is not a file")
+            size = os.path.getsize(real)
+            if size > max_attachment_bytes:
+                raise ValueError(
+                    f"Attachment '{filepath}' is {size} bytes "
+                    f"(limit {max_attachment_bytes})"
+                )
+            ctype, _ = mimetypes.guess_type(real)
+            if ctype is None:
+                ctype = "application/octet-stream"
+            maintype, subtype = ctype.split("/", 1)
+            with open(real, "rb") as f:
+                att = email_lib.mime.base.MIMEBase(maintype, subtype)
+                att.set_payload(f.read())
+            email_lib.encoders.encode_base64(att)
+            att.add_header(
+                "Content-Disposition", "attachment",
+                filename=Path(real).name,
+            )
+            msg.attach(att)
+
+    try:
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=timeout) as server:
+            server.starttls()
+            server.login(username, password)
+            server.sendmail(from_address, all_recipients, msg.as_string())
+    except Exception as e:
+        raise RuntimeError(f"SMTP send failed: {_safe_error(e, password)}") from None
+
+    log.info("Email sent to %s, subject=%r, message_id=%s",
+             all_recipients, subject, msg["Message-ID"])
+
+    return {
+        "status": "sent",
+        "message_id": msg["Message-ID"],
+        "to": to,
+        "cc": cc or [],
+        "subject": subject,
+        "attachments": [Path(p).name for p in (attachments or [])],
+    }
+
+
+def search_email(
+    *,
+    imap_host: str,
+    imap_port: int,
+    username: str,
+    password: str,
+    query: str,
+    folder: str = "INBOX",
+    limit: int = 20,
+    timeout: int = 30,
+) -> list[dict]:
+    try:
+        conn = imaplib.IMAP4_SSL(imap_host, imap_port, timeout=timeout)
+    except Exception as e:
+        raise RuntimeError(f"IMAP connect failed: {_safe_error(e, password)}") from None
+
+    try:
+        conn.login(username, password)
+        conn.select(f'"{folder}"', readonly=True)
+
+        if _GMAIL_HOST_MARKER in imap_host.lower():
+            status, data = conn.uid("SEARCH", None, "X-GM-RAW", query)
+        else:
+            status, data = conn.uid("SEARCH", None, query)
+
+        if status != "OK":
+            return []
+
+        uids = data[0].split() if data[0] else []
+        uids = uids[-limit:]
+        uids.reverse()
+
+        results = []
+        for uid in uids:
+            status, msg_data = conn.uid("FETCH", uid, "(RFC822.HEADER)")
+            if status != "OK" or not msg_data or not msg_data[0]:
+                continue
+            raw = msg_data[0][1] if isinstance(msg_data[0], tuple) else msg_data[0]
+            if isinstance(raw, bytes):
+                msg = email_lib.message_from_bytes(raw)
+                results.append(_message_summary(msg, uid.decode() if isinstance(uid, bytes) else str(uid)))
+
+        return results
+    except RuntimeError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"IMAP search failed: {_safe_error(e, password)}") from None
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
+
+def read_email(
+    *,
+    imap_host: str,
+    imap_port: int,
+    username: str,
+    password: str,
+    uid: str,
+    folder: str = "INBOX",
+    max_body_chars: int = 50_000,
+    timeout: int = 30,
+) -> dict:
+    try:
+        conn = imaplib.IMAP4_SSL(imap_host, imap_port, timeout=timeout)
+    except Exception as e:
+        raise RuntimeError(f"IMAP connect failed: {_safe_error(e, password)}") from None
+
+    try:
+        conn.login(username, password)
+        conn.select(f'"{folder}"', readonly=True)
+
+        status, msg_data = conn.uid("FETCH", uid, "(RFC822)")
+        if status != "OK" or not msg_data or not msg_data[0]:
+            raise ValueError(f"Message UID {uid} not found in {folder}")
+
+        raw = msg_data[0][1] if isinstance(msg_data[0], tuple) else msg_data[0]
+        msg = email_lib.message_from_bytes(raw)
+
+        summary = _message_summary(msg, uid)
+        summary["body"] = _extract_body(msg, max_body_chars)
+        summary["attachments"] = _attachment_metadata(msg)
+        return summary
+    except (RuntimeError, ValueError):
+        raise
+    except Exception as e:
+        raise RuntimeError(f"IMAP read failed: {_safe_error(e, password)}") from None
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
+
+def list_recent(
+    *,
+    imap_host: str,
+    imap_port: int,
+    username: str,
+    password: str,
+    folder: str = "INBOX",
+    limit: int = 10,
+    timeout: int = 30,
+) -> list[dict]:
+    try:
+        conn = imaplib.IMAP4_SSL(imap_host, imap_port, timeout=timeout)
+    except Exception as e:
+        raise RuntimeError(f"IMAP connect failed: {_safe_error(e, password)}") from None
+
+    try:
+        conn.login(username, password)
+        conn.select(f'"{folder}"', readonly=True)
+
+        status, data = conn.uid("SEARCH", None, "ALL")
+        if status != "OK" or not data[0]:
+            return []
+
+        uids = data[0].split()
+        uids = uids[-limit:]
+        uids.reverse()
+
+        results = []
+        for uid in uids:
+            status, msg_data = conn.uid("FETCH", uid, "(RFC822.HEADER FLAGS RFC822.SIZE)")
+            if status != "OK" or not msg_data or not msg_data[0]:
+                continue
+            raw_tuple = msg_data[0]
+            if isinstance(raw_tuple, tuple):
+                raw = raw_tuple[1]
+                meta_line = raw_tuple[0].decode() if isinstance(raw_tuple[0], bytes) else str(raw_tuple[0])
+            else:
+                continue
+            msg = email_lib.message_from_bytes(raw)
+            summary = _message_summary(msg, uid.decode() if isinstance(uid, bytes) else str(uid))
+            if "RFC822.SIZE" in meta_line:
+                import re
+                m = re.search(r"RFC822\.SIZE\s+(\d+)", meta_line)
+                if m:
+                    summary["size_bytes"] = int(m.group(1))
+            if "FLAGS" in meta_line:
+                import re
+                m = re.search(r"FLAGS\s*\(([^)]*)\)", meta_line)
+                if m:
+                    summary["flags"] = m.group(1).split()
+            results.append(summary)
+
+        return results
+    except RuntimeError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"IMAP list failed: {_safe_error(e, password)}") from None
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass

--- a/src/tools/email_client.py
+++ b/src/tools/email_client.py
@@ -9,6 +9,7 @@ host and used transparently when available.
 from __future__ import annotations
 
 import email as email_lib
+import email.encoders
 import email.mime.base
 import email.mime.multipart
 import email.mime.text
@@ -224,7 +225,8 @@ def search_email(
         conn.select(f'"{folder}"', readonly=True)
 
         if _GMAIL_HOST_MARKER in imap_host.lower():
-            status, data = conn.uid("SEARCH", None, "X-GM-RAW", query)
+            escaped = query.replace("\\", "\\\\").replace('"', '\\"')
+            status, data = conn.uid("SEARCH", None, "X-GM-RAW", f'"{escaped}"')
         else:
             status, data = conn.uid("SEARCH", None, query)
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -99,8 +99,10 @@ class ToolExecutor:
         permission_manager: PermissionManager | None = None,
         output_streamer: ToolOutputStreamer | None = None,
         host_access_manager: HostAccessManager | None = None,
+        email_config: object | None = None,
     ) -> None:
         self.config = config or ToolsConfig()
+        self._email_config = email_config
         self._memory_path = Path(memory_path) if memory_path else None
         self._browser_manager = browser_manager
         self._permission_manager = permission_manager
@@ -1678,4 +1680,152 @@ class ToolExecutor:
         if fmt == "json":
             return report_as_json(report)
         return format_report_summary(report)
+
+    # --- Email tools (SMTP/IMAP) ---
+
+    def _email_cfg(self):
+        cfg = self._email_config
+        if cfg is None or not cfg.enabled:
+            return None
+        return cfg
+
+    async def _handle_email_send(self, inp: dict) -> str:
+        from .email_client import send_email
+        cfg = self._email_cfg()
+        if cfg is None:
+            return "Error: email tools are not configured (email.enabled is false)"
+        to = inp.get("to")
+        if not to or not isinstance(to, list):
+            return "Error: 'to' must be a non-empty list of email addresses"
+        subject = str(inp.get("subject", ""))
+        body = str(inp.get("body", ""))
+        try:
+            result = send_email(
+                smtp_host=cfg.smtp.host,
+                smtp_port=cfg.smtp.port,
+                username=cfg.smtp.username,
+                password=cfg.smtp.password,
+                from_address=cfg.smtp.from_address,
+                to=to,
+                subject=subject,
+                body=body,
+                cc=inp.get("cc"),
+                bcc=inp.get("bcc"),
+                reply_to=inp.get("reply_to"),
+                attachments=inp.get("attachments"),
+                allowed_dirs=cfg.allowed_attachment_dirs,
+                max_attachment_bytes=cfg.max_attachment_bytes,
+                timeout=cfg.connect_timeout_seconds,
+            )
+            parts = [
+                "Email sent successfully.",
+                f"Message-ID: {result['message_id']}",
+                f"To: {', '.join(result['to'])}",
+                f"Subject: {result['subject']}",
+            ]
+            if result.get("cc"):
+                parts.append(f"CC: {', '.join(result['cc'])}")
+            if result.get("attachments"):
+                parts.append(f"Attachments: {', '.join(result['attachments'])}")
+            return "\n".join(parts)
+        except (ValueError, RuntimeError) as e:
+            return f"Error: {e}"
+
+    async def _handle_email_search(self, inp: dict) -> str:
+        from .email_client import search_email
+        cfg = self._email_cfg()
+        if cfg is None:
+            return "Error: email tools are not configured (email.enabled is false)"
+        query = inp.get("query", "")
+        if not query:
+            return "Error: 'query' is required"
+        limit = min(int(inp.get("limit", 20)), cfg.max_results)
+        try:
+            results = search_email(
+                imap_host=cfg.imap.host,
+                imap_port=cfg.imap.port,
+                username=cfg.imap.username,
+                password=cfg.imap.password,
+                query=query,
+                folder=inp.get("folder", "INBOX"),
+                limit=limit,
+                timeout=cfg.connect_timeout_seconds,
+            )
+            if not results:
+                return "No messages found matching the query."
+            lines = [f"Found {len(results)} message(s):\n"]
+            for r in results:
+                att = " [has attachments]" if r.get("has_attachments") else ""
+                lines.append(
+                    f"UID {r['uid']} | {r['date']} | {r['from']} | {r['subject']}{att}"
+                )
+            return "\n".join(lines)
+        except (ValueError, RuntimeError) as e:
+            return f"Error: {e}"
+
+    async def _handle_email_read(self, inp: dict) -> str:
+        from .email_client import read_email
+        cfg = self._email_cfg()
+        if cfg is None:
+            return "Error: email tools are not configured (email.enabled is false)"
+        uid = str(inp.get("uid", ""))
+        if not uid:
+            return "Error: 'uid' is required"
+        try:
+            result = read_email(
+                imap_host=cfg.imap.host,
+                imap_port=cfg.imap.port,
+                username=cfg.imap.username,
+                password=cfg.imap.password,
+                uid=uid,
+                folder=inp.get("folder", "INBOX"),
+                max_body_chars=cfg.max_body_chars,
+                timeout=cfg.connect_timeout_seconds,
+            )
+            lines = [
+                f"From: {result['from']}",
+                f"To: {result['to']}",
+                f"Subject: {result['subject']}",
+                f"Date: {result['date']}",
+                f"Message-ID: {result['message_id']}",
+            ]
+            if result.get("attachments"):
+                att_list = ", ".join(
+                    f"{a['filename']} ({a['size_bytes']} bytes)" for a in result["attachments"]
+                )
+                lines.append(f"Attachments: {att_list}")
+            lines.append(f"\n{result['body']}")
+            return "\n".join(lines)
+        except (ValueError, RuntimeError) as e:
+            return f"Error: {e}"
+
+    async def _handle_email_list_recent(self, inp: dict) -> str:
+        from .email_client import list_recent
+        cfg = self._email_cfg()
+        if cfg is None:
+            return "Error: email tools are not configured (email.enabled is false)"
+        limit = min(int(inp.get("limit", 10)), cfg.max_results)
+        try:
+            results = list_recent(
+                imap_host=cfg.imap.host,
+                imap_port=cfg.imap.port,
+                username=cfg.imap.username,
+                password=cfg.imap.password,
+                folder=inp.get("folder", "INBOX"),
+                limit=limit,
+                timeout=cfg.connect_timeout_seconds,
+            )
+            if not results:
+                return "No messages found."
+            lines = [f"Recent {len(results)} message(s):\n"]
+            for r in results:
+                att = " [has attachments]" if r.get("has_attachments") else ""
+                size = f" ({r['size_bytes']} bytes)" if r.get("size_bytes") else ""
+                flags = f" [{' '.join(r['flags'])}]" if r.get("flags") else ""
+                lines.append(
+                    f"UID {r['uid']} | {r['date']} | {r['from']} | {r['subject']}{att}{size}{flags}"
+                )
+            return "\n".join(lines)
+        except (ValueError, RuntimeError) as e:
+            return f"Error: {e}"
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -1739,7 +1739,7 @@ class ToolExecutor:
         query = inp.get("query", "")
         if not query:
             return "Error: 'query' is required"
-        limit = min(int(inp.get("limit", 20)), cfg.max_results)
+        limit = max(1, min(int(inp.get("limit", 20)), cfg.max_results))
         try:
             results = search_email(
                 imap_host=cfg.imap.host,
@@ -1804,7 +1804,7 @@ class ToolExecutor:
         cfg = self._email_cfg()
         if cfg is None:
             return "Error: email tools are not configured (email.enabled is false)"
-        limit = min(int(inp.get("limit", 10)), cfg.max_results)
+        limit = max(1, min(int(inp.get("limit", 10)), cfg.max_results))
         try:
             results = list_recent(
                 imap_host=cfg.imap.host,

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1815,6 +1815,92 @@ TOOLS: list[dict] = [
             "required": ["checks"],
         },
     },
+    # --- Email tools (conditional on config.email.enabled) ---
+    {
+        "name": "email_send",
+        "description": (
+            "Send an email via SMTP. Returns the sent message ID and recipient "
+            "list. Supports plain-text body, CC/BCC, reply-to, and file "
+            "attachments from allowed directories."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "to": {
+                    "type": "array", "items": {"type": "string"},
+                    "description": "Recipient email addresses",
+                },
+                "subject": {"type": "string", "description": "Email subject line"},
+                "body": {"type": "string", "description": "Plain-text email body"},
+                "cc": {
+                    "type": "array", "items": {"type": "string"},
+                    "description": "CC recipients (optional)",
+                },
+                "bcc": {
+                    "type": "array", "items": {"type": "string"},
+                    "description": "BCC recipients (optional)",
+                },
+                "reply_to": {"type": "string", "description": "Reply-To address (optional)"},
+                "attachments": {
+                    "type": "array", "items": {"type": "string"},
+                    "description": "File paths to attach (must be within allowed_attachment_dirs)",
+                },
+            },
+            "required": ["to", "subject", "body"],
+        },
+    },
+    {
+        "name": "email_search",
+        "description": (
+            "Search email via IMAP. On Gmail, uses native Gmail search syntax "
+            "(e.g. 'from:alice newer_than:7d has:attachment subject:invoice'). "
+            "On other providers, uses standard IMAP SEARCH criteria "
+            "(e.g. 'FROM \"alice\" SINCE 01-Jun-2026'). Returns message summaries."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "folder": {"type": "string", "description": "Mailbox folder (default: INBOX)"},
+                "limit": {
+                    "type": "integer", "description": "Max results to return (default: 20)",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "email_read",
+        "description": (
+            "Read a specific email by UID. Returns full headers, plain-text body "
+            "(truncated to configured limit), and attachment metadata. "
+            "Use email_search or email_list_recent to find UIDs first."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "uid": {"type": "string", "description": "Message UID from search/list results"},
+                "folder": {"type": "string", "description": "Mailbox folder (default: INBOX)"},
+            },
+            "required": ["uid"],
+        },
+    },
+    {
+        "name": "email_list_recent",
+        "description": (
+            "List the most recent emails in a folder. Returns summaries with "
+            "sender, subject, date, size, and flags. Use email_read for full content."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "folder": {"type": "string", "description": "Mailbox folder (default: INBOX)"},
+                "limit": {
+                    "type": "integer", "description": "Number of recent messages (default: 10)",
+                },
+            },
+        },
+    },
 ]
 
 TOOL_MAP: dict[str, dict] = {t["name"]: t for t in TOOLS}
@@ -1844,6 +1930,7 @@ MUTATING_TOOLS: frozenset[str] = frozenset({
     "generate_image",
     "issue_tracker",
     "send_to_agent", "spawn_loop_agents",
+    "email_send",
 })
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(

--- a/src/tools/risk_classifier.py
+++ b/src/tools/risk_classifier.py
@@ -124,6 +124,10 @@ _TOOL_RISK_MAP: dict[str, RiskLevel] = {
     "browser_fill": RiskLevel.MEDIUM,
     "browser_evaluate": RiskLevel.MEDIUM,
     "manage_process": RiskLevel.MEDIUM,
+    "email_send": RiskLevel.MEDIUM,
+    "email_search": RiskLevel.LOW,
+    "email_read": RiskLevel.LOW,
+    "email_list_recent": RiskLevel.LOW,
     "generate_image": RiskLevel.MEDIUM,
     "ingest_knowledge": RiskLevel.MEDIUM,
     # High — arbitrary code execution

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -165,7 +165,28 @@ class TestSearchEmail:
         )
 
         calls = mock_conn.uid.call_args_list
-        assert calls[0][0] == ("SEARCH", None, "X-GM-RAW", "from:alice")
+        assert calls[0][0] == ("SEARCH", None, "X-GM-RAW", '"from:alice"')
+
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_gmail_multiword_query_quoted(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"5"])
+        mock_conn.uid.return_value = ("OK", [b""])
+
+        search_email(
+            imap_host="imap.gmail.com", imap_port=993,
+            username="u", password="p",
+            query="from:alice newer_than:7d has:attachment",
+        )
+
+        call_args = mock_conn.uid.call_args_list[0][0]
+        assert call_args[0] == "SEARCH"
+        assert call_args[2] == "X-GM-RAW"
+        raw_arg = call_args[3]
+        assert raw_arg.startswith('"') and raw_arg.endswith('"')
+        assert "from:alice newer_than:7d has:attachment" in raw_arg
 
     @patch("src.tools.email_client.imaplib.IMAP4_SSL")
     def test_non_gmail_uses_standard_search(self, mock_imap_cls):

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -1,0 +1,329 @@
+"""Tests for email tools (SMTP/IMAP).
+
+Covers: send (MIME construction, STARTTLS, recipients, attachments, path
+validation), search (standard IMAP + Gmail X-GM-RAW), read (body parsing,
+truncation, attachment metadata), list_recent, disabled handler fallback,
+and password redaction in errors.
+"""
+from __future__ import annotations
+
+import email as email_lib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.tools.email_client import (
+    list_recent,
+    read_email,
+    search_email,
+    send_email,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_raw_email(
+    subject="Test", from_addr="a@b.com", to_addr="c@d.com",
+    body="Hello world", date="Mon, 15 Jun 2026 12:00:00 +0000",
+    message_id="<test@example.com>", attach_name=None, attach_data=b"",
+):
+    msg = email_lib.mime.multipart.MIMEMultipart()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg["Date"] = date
+    msg["Message-ID"] = message_id
+    msg.attach(email_lib.mime.text.MIMEText(body, "plain"))
+    if attach_name:
+        att = email_lib.mime.base.MIMEBase("application", "octet-stream")
+        att.set_payload(attach_data)
+        att.add_header("Content-Disposition", "attachment", filename=attach_name)
+        msg.attach(att)
+    return msg.as_bytes()
+
+
+# ---------------------------------------------------------------------------
+# send_email
+# ---------------------------------------------------------------------------
+
+class TestSendEmail:
+    @patch("src.tools.email_client.smtplib.SMTP")
+    def test_basic_send(self, mock_smtp_cls):
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = send_email(
+            smtp_host="smtp.test.com", smtp_port=587,
+            username="u", password="p", from_address="me@test.com",
+            to=["them@test.com"], subject="Hi", body="Hello",
+        )
+
+        assert result["status"] == "sent"
+        assert result["to"] == ["them@test.com"]
+        assert result["subject"] == "Hi"
+        assert result["message_id"]
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("u", "p")
+        mock_server.sendmail.assert_called_once()
+
+    @patch("src.tools.email_client.smtplib.SMTP")
+    def test_cc_bcc_recipients(self, mock_smtp_cls):
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        send_email(
+            smtp_host="smtp.test.com", smtp_port=587,
+            username="u", password="p", from_address="me@test.com",
+            to=["a@t.com"], subject="Hi", body="Hello",
+            cc=["b@t.com"], bcc=["c@t.com"],
+        )
+
+        call_args = mock_server.sendmail.call_args
+        all_recipients = call_args[0][1]
+        assert "a@t.com" in all_recipients
+        assert "b@t.com" in all_recipients
+        assert "c@t.com" in all_recipients
+
+    def test_no_recipients_raises(self):
+        with pytest.raises(ValueError, match="No recipients"):
+            send_email(
+                smtp_host="h", smtp_port=587, username="u", password="p",
+                from_address="me@t.com", to=[], subject="Hi", body="Hello",
+            )
+
+    @patch("src.tools.email_client.smtplib.SMTP")
+    def test_attachment_outside_allowed_dirs(self, mock_smtp_cls):
+        with pytest.raises(ValueError, match="outside allowed"):
+            send_email(
+                smtp_host="h", smtp_port=587, username="u", password="p",
+                from_address="me@t.com", to=["a@t.com"], subject="Hi", body="Hello",
+                attachments=["/etc/passwd"],
+                allowed_dirs=["/tmp/safe"],
+            )
+
+    def test_attachments_require_allowed_dirs(self):
+        with pytest.raises(ValueError, match="allowed_attachment_dirs"):
+            send_email(
+                smtp_host="h", smtp_port=587, username="u", password="p",
+                from_address="me@t.com", to=["a@t.com"], subject="Hi", body="Hello",
+                attachments=["/tmp/file.txt"],
+                allowed_dirs=[],
+            )
+
+    @patch("src.tools.email_client.smtplib.SMTP")
+    def test_attachment_valid_path(self, mock_smtp_cls, tmp_path):
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+        f = tmp_path / "report.txt"
+        f.write_text("data")
+
+        result = send_email(
+            smtp_host="h", smtp_port=587, username="u", password="p",
+            from_address="me@t.com", to=["a@t.com"], subject="Hi", body="Hello",
+            attachments=[str(f)],
+            allowed_dirs=[str(tmp_path)],
+        )
+        assert result["attachments"] == ["report.txt"]
+
+    @patch("src.tools.email_client.smtplib.SMTP")
+    def test_attachment_too_large(self, mock_smtp_cls, tmp_path):
+        f = tmp_path / "big.bin"
+        f.write_bytes(b"x" * 200)
+
+        with pytest.raises(ValueError, match="bytes"):
+            send_email(
+                smtp_host="h", smtp_port=587, username="u", password="p",
+                from_address="me@t.com", to=["a@t.com"], subject="Hi", body="Hello",
+                attachments=[str(f)],
+                allowed_dirs=[str(tmp_path)],
+                max_attachment_bytes=100,
+            )
+
+
+# ---------------------------------------------------------------------------
+# search_email
+# ---------------------------------------------------------------------------
+
+class TestSearchEmail:
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_gmail_uses_xgmraw(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"5"])
+        mock_conn.uid.return_value = ("OK", [b""])
+
+        search_email(
+            imap_host="imap.gmail.com", imap_port=993,
+            username="u", password="p", query="from:alice",
+        )
+
+        calls = mock_conn.uid.call_args_list
+        assert calls[0][0] == ("SEARCH", None, "X-GM-RAW", "from:alice")
+
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_non_gmail_uses_standard_search(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"5"])
+        mock_conn.uid.return_value = ("OK", [b""])
+
+        search_email(
+            imap_host="imap.fastmail.com", imap_port=993,
+            username="u", password="p", query='FROM "alice"',
+        )
+
+        calls = mock_conn.uid.call_args_list
+        assert calls[0][0] == ("SEARCH", None, 'FROM "alice"')
+
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_returns_summaries(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"1"])
+        mock_conn.uid.side_effect = [
+            ("OK", [b"42"]),
+            ("OK", [(b"42 (RFC822.HEADER {500}", _make_raw_email(subject="Invoice"))]),
+        ]
+
+        results = search_email(
+            imap_host="imap.gmail.com", imap_port=993,
+            username="u", password="p", query="subject:invoice",
+        )
+        assert len(results) == 1
+        assert results[0]["subject"] == "Invoice"
+        assert results[0]["uid"] == "42"
+
+
+# ---------------------------------------------------------------------------
+# read_email
+# ---------------------------------------------------------------------------
+
+class TestReadEmail:
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_reads_full_message(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = (
+            "OK",
+            [(b"42 (RFC822 {999}", _make_raw_email(
+                body="Full body here", attach_name="report.pdf", attach_data=b"pdf",
+            ))],
+        )
+
+        result = read_email(
+            imap_host="imap.gmail.com", imap_port=993,
+            username="u", password="p", uid="42",
+        )
+        assert "Full body here" in result["body"]
+        assert result["attachments"][0]["filename"] == "report.pdf"
+        assert result["subject"] == "Test"
+
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_body_truncation(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = (
+            "OK",
+            [(b"42 (RFC822 {999}", _make_raw_email(body="x" * 5000))],
+        )
+
+        result = read_email(
+            imap_host="imap.gmail.com", imap_port=993,
+            username="u", password="p", uid="42", max_body_chars=100,
+        )
+        assert len(result["body"]) < 200
+        assert "truncated" in result["body"]
+
+
+# ---------------------------------------------------------------------------
+# list_recent
+# ---------------------------------------------------------------------------
+
+class TestListRecent:
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_returns_summaries(self, mock_imap_cls):
+        mock_conn = MagicMock()
+        mock_imap_cls.return_value = mock_conn
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [b"1"])
+        mock_conn.uid.side_effect = [
+            ("OK", [b"10 11 12"]),
+            ("OK", [(
+                b'12 (UID 12 FLAGS (\\Seen) RFC822.SIZE 1234 RFC822.HEADER {500}',
+                _make_raw_email(subject="Recent"),
+            )]),
+            ("OK", [(
+                b'11 (UID 11 FLAGS () RFC822.SIZE 567 RFC822.HEADER {500}',
+                _make_raw_email(subject="Older"),
+            )]),
+        ]
+
+        results = list_recent(
+            imap_host="imap.gmail.com", imap_port=993,
+            username="u", password="p", limit=2,
+        )
+        assert len(results) == 2
+        assert results[0]["subject"] == "Recent"
+        assert results[0].get("size_bytes") == 1234
+
+
+# ---------------------------------------------------------------------------
+# Security / password redaction
+# ---------------------------------------------------------------------------
+
+class TestPasswordSafety:
+    @patch("src.tools.email_client.smtplib.SMTP")
+    def test_smtp_error_redacts_password(self, mock_smtp_cls):
+        secret = "abcd-efgh-ijkl-mnop"
+        mock_smtp_cls.side_effect = Exception(f"auth failed with {secret}")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            send_email(
+                smtp_host="h", smtp_port=587, username="u", password=secret,
+                from_address="me@t.com", to=["a@t.com"], subject="Hi", body="Hello",
+            )
+        assert secret not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+
+    @patch("src.tools.email_client.imaplib.IMAP4_SSL")
+    def test_imap_error_redacts_password(self, mock_imap_cls):
+        secret = "abcd-efgh-ijkl-mnop"
+        mock_imap_cls.side_effect = Exception(f"login failed with {secret}")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            search_email(
+                imap_host="h", imap_port=993, username="u", password=secret,
+                query="test",
+            )
+        assert secret not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Disabled handler fallback
+# ---------------------------------------------------------------------------
+
+class TestDisabledFallback:
+    @pytest.mark.asyncio
+    async def test_handlers_return_error_when_disabled(self):
+        from src.tools.executor import ToolExecutor
+        executor = ToolExecutor(email_config=None)
+        for handler_name in ("_handle_email_send", "_handle_email_search",
+                             "_handle_email_read", "_handle_email_list_recent"):
+            handler = getattr(executor, handler_name)
+            result = await handler({"to": ["a@b.com"], "subject": "Hi",
+                                    "body": "Hello", "query": "test", "uid": "1"})
+            assert "not configured" in result


### PR DESCRIPTION
## Summary

Four new tools — `email_send`, `email_search`, `email_read`, `email_list_recent` — using Python stdlib `smtplib`/`imaplib` with Gmail App Password support. No external dependencies. Zero footprint when `email.enabled` is false.

- **send**: MIME multipart, STARTTLS, CC/BCC/reply-to, file attachments from `allowed_attachment_dirs` with path validation + size limits
- **search**: standard IMAP SEARCH + Gmail `X-GM-RAW` auto-detected from host (native Gmail search syntax)
- **read**: full message by UID, body truncation, attachment metadata (no binary download)
- **list_recent**: N most recent summaries with size and flags

Security: per-call connections (no pool), TLS required, SMTP/IMAP exceptions wrapped to never leak password, `email_send` = MEDIUM risk + MUTATING_TOOLS. Config: root-level `email.{smtp,imap}` with all knobs (body chars, results, attachment bytes, timeout, allowed dirs). `EmailConfig` passed to `ToolExecutor` as constructor parameter per Odin's review amendment.

## Verification

- 16 new tests (mocked SMTP/IMAP): send construction, search Gmail-vs-standard, read truncation, list summaries, password redaction, disabled fallback, attachment path validation
- Full suite: **5,654 passed**, failure set byte-identical to v3.31.0 baseline (29 environmental)
- Zero new ruff violations

## Deploy plan

Local verification before cutting the release — AT will configure credentials and test live email before the GitHub release + website update.