### PR TITLE
fix: raise aiohttp read_bufsize to prevent SSE readline overflow

### DIFF
--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -62,6 +62,7 @@ class CodexChatClient:
                 connector=connector,
                 auto_decompress=False,
                 headers={"Accept-Encoding": "identity"},
+                read_bufsize=2**20,
             )
         return self._session
 


### PR DESCRIPTION
## Summary
- aiohttp's `StreamReader.readline()` hard-caps at `read_bufsize * 2` (default 128KB)
- Large SSE events from the Codex API (especially `response.metadata` which echoes the full response) exceed this when conversations carry substantial context
- Sets `read_bufsize=2**20` (1MB) on the ClientSession, giving a 2MB readline ceiling
- One-line change in `_get_session()`

## Root cause
`async for raw_line in resp.content` in both `_read_tool_stream` and `_read_stream` calls `readline()` under the hood. With the v3.29.0 session budget increase to 64K tokens and full tool_results recording in v3.30.1, conversations now routinely produce metadata events >128KB.

## Test plan
- [ ] Trigger a long conversation with substantial context — should no longer get "Got more than 131072 bytes when reading" errors
- [ ] Verify normal streaming responses still work correctly
- [ ] No behavioral change — only the buffer ceiling is raised