### PR TITLE
feat: agent budget awareness, configurable caps, scheduler TZ fix

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -24,7 +24,7 @@ log = get_logger("agents")
 # --- Constants ---
 MAX_CONCURRENT_AGENTS = 5        # per channel
 MAX_AGENT_LIFETIME = 3600        # 1 hour
-MAX_AGENT_ITERATIONS = 30        # LLM turns per agent
+MAX_AGENT_ITERATIONS = 120       # LLM turns per agent (default, overridable via config/spawn)
 STALE_WARN_SECONDS = 120         # 2 min no activity → log warning
 CLEANUP_DELAY = 300              # 5 min after terminal state → remove
 WAIT_DEFAULT_TIMEOUT = 300       # default timeout for wait_for_agents
@@ -321,6 +321,8 @@ class AgentManager:
         trajectory_saver: AgentTrajectorySaver | None = None,
         parent_id: str | None = None,
         max_depth: int = MAX_NESTING_DEPTH,
+        max_iterations: int | None = None,
+        budget_warnings: list[int] | None = None,
     ) -> str:
         """Spawn a new agent. Returns agent_id on success, or 'Error: ...' string."""
         # Check per-channel limit
@@ -398,6 +400,7 @@ class AgentManager:
         agent.messages = [{"role": "user", "content": goal}]
 
         # Start the async task
+        effective_max_iter = min(max_iterations or MAX_AGENT_ITERATIONS, 300)
         task = asyncio.ensure_future(
             _run_agent(
                 agent=agent,
@@ -408,6 +411,8 @@ class AgentManager:
                 announce_callback=announce_callback,
                 tool_timeouts=tool_timeouts or {},
                 trajectory_saver=trajectory_saver,
+                max_iterations=effective_max_iter,
+                budget_warnings=budget_warnings or [20, 10, 5, 1],
             )
         )
         agent._task = task
@@ -730,6 +735,8 @@ async def _run_agent(
     announce_callback: AnnounceCallback | None = None,
     tool_timeouts: dict[str, int] | None = None,
     trajectory_saver: AgentTrajectorySaver | None = None,
+    max_iterations: int = MAX_AGENT_ITERATIONS,
+    budget_warnings: list[int] | None = None,
 ) -> None:
     """Execute an agent's tool loop until completion, error, or timeout.
 
@@ -777,7 +784,9 @@ async def _run_agent(
         # Transition from SPAWNING → READY
         agent.transition(AgentState.READY, "initialization complete")
 
-        for iteration in range(MAX_AGENT_ITERATIONS):
+        _budget_warn_set = set(budget_warnings or [])
+
+        for iteration in range(max_iterations):
             if _check_kill():
                 return
             if _check_lifetime():
@@ -794,6 +803,17 @@ async def _run_agent(
                     log.debug("Agent %s received inbox message", agent.id)
                 except asyncio.QueueEmpty:
                     break
+
+            # Budget warning: inject remaining-iterations notice before LLM call
+            remaining = max_iterations - iteration
+            if remaining in _budget_warn_set:
+                if remaining == 1:
+                    warn_text = "[Agent budget: FINAL iteration. Produce your final summary NOW.]"
+                elif remaining <= 5:
+                    warn_text = f"[Agent budget: {remaining} iterations remaining. Commit any changes, run validation, and produce your final summary.]"
+                else:
+                    warn_text = f"[Agent budget: {remaining} iterations remaining. Begin wrapping up — finish the smallest useful change, validate, and prepare your final summary.]"
+                agent.messages.append({"role": "user", "content": warn_text})
 
             # Transition READY → EXECUTING for LLM call
             agent.transition(AgentState.EXECUTING, f"iteration {iteration + 1}")
@@ -884,11 +904,13 @@ async def _run_agent(
                 )
 
         # Exhausted iterations — transition from READY → COMPLETED
-        agent.transition(AgentState.COMPLETED, f"max iterations ({MAX_AGENT_ITERATIONS}) reached")
+        agent.transition(AgentState.COMPLETED, f"max iterations ({max_iterations}) reached")
         agent.result = _get_last_progress(agent)
+        if agent.result == "(no output)":
+            agent.result = _synthesize_fallback(agent, max_iterations)
         agent.ended_at = time.time()
         elapsed = time.time() - agent.created_at
-        log.info("Agent %s (%s) completed in %ds after %d iterations (max reached), %d tool calls", agent.id, agent.label, int(elapsed), MAX_AGENT_ITERATIONS, len(agent.tools_used))
+        log.info("Agent %s (%s) completed in %ds after %d iterations (max reached), %d tool calls", agent.id, agent.label, int(elapsed), max_iterations, len(agent.tools_used))
 
     except asyncio.CancelledError:
         if not agent._sm.is_terminal:
@@ -978,3 +1000,23 @@ def _get_last_progress(agent: AgentInfo) -> str:
         if msg["role"] == "assistant" and msg.get("content"):
             return msg["content"]
     return "(no output)"
+
+
+def _synthesize_fallback(agent: AgentInfo, max_iterations: int) -> str:
+    """Build a summary from tool activity when the agent produced no text output."""
+    parts = [f"Agent reached max iterations ({max_iterations}) without producing a final response."]
+    if agent.tools_used:
+        parts.append(f"Tools used: {', '.join(agent.tools_used)}")
+    # Extract last few tool results from messages
+    tool_results = []
+    for msg in reversed(agent.messages):
+        content = msg.get("content", "")
+        if msg["role"] == "user" and content.startswith("[Tool result:"):
+            tool_results.append(content[:300])
+            if len(tool_results) >= 3:
+                break
+    if tool_results:
+        parts.append("Last tool results:")
+        for tr in reversed(tool_results):
+            parts.append(f"  {tr}")
+    return "\n".join(parts)

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -400,7 +400,7 @@ class AgentManager:
         agent.messages = [{"role": "user", "content": goal}]
 
         # Start the async task
-        effective_max_iter = min(max_iterations or MAX_AGENT_ITERATIONS, 300)
+        effective_max_iter = max_iterations or MAX_AGENT_ITERATIONS
         task = asyncio.ensure_future(
             _run_agent(
                 agent=agent,

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -121,6 +121,14 @@ class AgentsConfig(BaseModel):
             raise ValueError("agent limits must be >= 1")
         return v
 
+    @field_validator("final_warning_iterations")
+    @classmethod
+    def _validate_warnings(cls, v):
+        for item in v:
+            if item < 1:
+                raise ValueError(f"warning threshold must be >= 1, got {item}")
+        return v
+
 
 class SSHPoolConfig(BaseModel):
     enabled: bool = True

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -114,11 +114,11 @@ class AgentsConfig(BaseModel):
     hard_max_iterations: int = 300
     final_warning_iterations: list[int] = Field(default_factory=lambda: [20, 10, 5, 1])
 
-    @field_validator("max_nesting_depth", "max_children_per_agent")
+    @field_validator("max_nesting_depth", "max_children_per_agent", "max_iterations", "scheduled_max_iterations", "hard_max_iterations")
     @classmethod
     def _agents_non_negative(cls, v):
-        if v < 0:
-            raise ValueError("agent limits must be >= 0")
+        if v < 1:
+            raise ValueError("agent limits must be >= 1")
         return v
 
 

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -109,6 +109,10 @@ class StreamingConfig(BaseModel):
 class AgentsConfig(BaseModel):
     max_nesting_depth: int = 2
     max_children_per_agent: int = 3
+    max_iterations: int = 120
+    scheduled_max_iterations: int = 180
+    hard_max_iterations: int = 300
+    final_warning_iterations: list[int] = Field(default_factory=lambda: [20, 10, 5, 1])
 
     @field_validator("max_nesting_depth", "max_children_per_agent")
     @classmethod

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -4299,10 +4299,11 @@ class OdinBot(commands.Bot):
 
         # Determine iteration cap from config — scheduled spawns get a higher budget
         agents_cfg = getattr(self.config, "agents", None)
+        hard_max = getattr(agents_cfg, "hard_max_iterations", 300) if agents_cfg else 300
         if inp.get("_scheduled"):
-            iter_cap = getattr(agents_cfg, "scheduled_max_iterations", 180) if agents_cfg else 180
+            iter_cap = min(getattr(agents_cfg, "scheduled_max_iterations", 180) if agents_cfg else 180, hard_max)
         else:
-            iter_cap = getattr(agents_cfg, "max_iterations", 120) if agents_cfg else 120
+            iter_cap = min(getattr(agents_cfg, "max_iterations", 120) if agents_cfg else 120, hard_max)
         warnings = list(getattr(agents_cfg, "final_warning_iterations", [20, 10, 5, 1])) if agents_cfg else [20, 10, 5, 1]
 
         agent_id = self.agent_manager.spawn(

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -4297,6 +4297,14 @@ class OdinBot(commands.Bot):
             )
             return str(result) if result is not None else ""
 
+        # Determine iteration cap from config — scheduled spawns get a higher budget
+        agents_cfg = getattr(self.config, "agents", None)
+        if inp.get("_scheduled"):
+            iter_cap = getattr(agents_cfg, "scheduled_max_iterations", 180) if agents_cfg else 180
+        else:
+            iter_cap = getattr(agents_cfg, "max_iterations", 120) if agents_cfg else 120
+        warnings = list(getattr(agents_cfg, "final_warning_iterations", [20, 10, 5, 1])) if agents_cfg else [20, 10, 5, 1]
+
         agent_id = self.agent_manager.spawn(
             label=label,
             goal=goal,
@@ -4310,9 +4318,9 @@ class OdinBot(commands.Bot):
             parent_id=parent_id_arg,
             max_depth=max_depth,
             tool_timeouts=self.config.tools.tool_timeouts,
-            # The saver existed since the feature shipped but was never passed —
-            # data/trajectories/agents/ has been empty in production forever.
             trajectory_saver=self.agent_trajectory_saver,
+            max_iterations=iter_cap,
+            budget_warnings=warnings,
         )
 
         if agent_id.startswith("Error"):
@@ -4324,7 +4332,7 @@ class OdinBot(commands.Bot):
             f"Working on: {goal[:100]}"
         )
 
-    async def _collect_agent_result(self, agent_id: str, timeout: float = 1500) -> str:
+    async def _collect_agent_result(self, agent_id: str, timeout: float = 3660) -> str:
         """Wait for an agent to complete and return formatted results."""
         results = await self.agent_manager.wait_for_agents([agent_id], timeout=timeout)
         r = results.get(agent_id, {})
@@ -5327,6 +5335,10 @@ class OdinBot(commands.Bot):
 
             try:
                 req_name = schedule.get("requester") or schedule.get("created_by") or "scheduler"
+                # Signal to spawn_agent handler that this is a scheduled context
+                if tool_name == "spawn_agent":
+                    tool_input = {**tool_input, "_scheduled": True}
+
                 result = await self._execute_scheduled_tool(
                     tool_name, tool_input, channel, req_id, req_name,
                 )
@@ -5340,8 +5352,8 @@ class OdinBot(commands.Bot):
                     id_end = result_str.find("`", id_start)
                     if 0 < id_start < id_end:
                         agent_id = result_str[id_start:id_end]
-                        timeout = float(step.get("timeout", 1500))
-                        agent_result = await self._collect_agent_result(agent_id, timeout=min(timeout, 3600))
+                        timeout = float(step.get("timeout", 3660))
+                        agent_result = await self._collect_agent_result(agent_id, timeout=min(timeout, 3660))
                         result = ToolResult(output=agent_result, ok=True, tool_name="spawn_agent")
 
                 prev_output = str(result)

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -19,6 +19,16 @@ from .history import ScheduleHistory
 
 log = get_logger("scheduler")
 
+
+def _utc_iso(dt: datetime) -> str:
+    """Ensure datetime is serialized with explicit UTC offset."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.isoformat()
+
+
 # Tools that can be scheduled for "check" actions
 ALLOWED_CHECK_TOOLS = {
     "run_command", "run_command_multi", "run_script",
@@ -96,7 +106,7 @@ class Scheduler:
                     next_run = next_run.replace(tzinfo=None)
                 if next_run < now:
                     cr = croniter(cron_expr, now)
-                    schedule["next_run"] = cr.get_next(datetime).isoformat()
+                    schedule["next_run"] = _utc_iso(cr.get_next(datetime))
                     advanced += 1
             except Exception:
                 continue
@@ -178,7 +188,7 @@ class Scheduler:
             schedule["cron"] = cron
             schedule["one_time"] = False
             cr = croniter(cron, datetime.now(timezone.utc))
-            schedule["next_run"] = cr.get_next(datetime).isoformat()
+            schedule["next_run"] = _utc_iso(cr.get_next(datetime))
         else:
             if run_at:
                 try:
@@ -563,7 +573,7 @@ class Scheduler:
                     target["cron"] = cron
                     target["one_time"] = False
                     cr = croniter(cron, datetime.now(timezone.utc))
-                    target["next_run"] = cr.get_next(datetime).isoformat()
+                    target["next_run"] = _utc_iso(cr.get_next(datetime))
                 elif run_at is not None:
                     try:
                         datetime.fromisoformat(run_at)
@@ -814,7 +824,7 @@ class Scheduler:
 
                 if schedule.get("cron"):
                     cr = croniter(schedule["cron"], now.replace(tzinfo=None))
-                    schedule["next_run"] = cr.get_next(datetime).isoformat()
+                    schedule["next_run"] = _utc_iso(cr.get_next(datetime))
 
             for sid in to_remove:
                 self._schedules = [s for s in self._schedules if s["id"] != sid]

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -195,8 +195,9 @@ class Scheduler:
                     datetime.fromisoformat(run_at)
                 except (ValueError, TypeError):
                     raise ValueError(f"Invalid ISO datetime for run_at: {run_at!r}")
-            schedule["run_at"] = run_at
-            schedule["next_run"] = run_at
+            normalized = _utc_iso(datetime.fromisoformat(run_at))
+            schedule["run_at"] = normalized
+            schedule["next_run"] = normalized
             schedule["one_time"] = True
 
         if action == "reminder":
@@ -579,8 +580,9 @@ class Scheduler:
                         datetime.fromisoformat(run_at)
                     except (ValueError, TypeError):
                         raise ValueError(f"Invalid ISO datetime for run_at: {run_at!r}")
-                    target["run_at"] = run_at
-                    target["next_run"] = run_at
+                    normalized = _utc_iso(datetime.fromisoformat(run_at))
+                    target["run_at"] = normalized
+                    target["next_run"] = normalized
                     target["one_time"] = True
 
             await asyncio.to_thread(self._save)

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1268,7 +1268,7 @@ TOOLS: list[dict] = [
             "Spawns an autonomous agent for a sub-task. Runs silently in background with "
             "isolated context (cannot spawn sub-agents). Results are NOT posted to Discord — "
             "use wait_for_agents to collect results, then deliver a cohesive summary yourself. "
-            "Max 5/channel, 1hr lifetime, 30 LLM turns."
+            "Max 5/channel, 1hr lifetime. Budget warnings injected near iteration limit."
         ),
         "input_schema": {
             "type": "object",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -200,15 +200,16 @@ class TestSchedulerTick:
         sched = await s.add("cron job", "reminder", "chan1", cron="*/5 * * * *")
         old_next = sched["next_run"]
 
-        # Force next_run into the past
+        # Force next_run far enough into the past that the next cron fire differs
         async with s._lock:
             s._schedules[0]["next_run"] = (
-                datetime.now(timezone.utc) - timedelta(minutes=1)
+                datetime.now(timezone.utc) - timedelta(minutes=10)
             ).isoformat()
+        forced_next = s.list_all()[0]["next_run"]
 
         await s._tick()
         new_next = s.list_all()[0]["next_run"]
-        assert new_next != old_next  # next_run was advanced
+        assert new_next != forced_next  # next_run was advanced past the forced value
         assert s._callback.called
 
     async def test_tick_skips_future_schedules(self, tmp_path):


### PR DESCRIPTION
## Summary
Three fixes in one PR — all co-designed with Odin.

### 1. Agent budget awareness and configurable iteration caps
The old hardcoded `MAX_AGENT_ITERATIONS = 30` was too low for meaningful autonomous coding. Agents would exhaust iterations inspecting repos without reaching implementation, then produce "(no output)".

- **New defaults**: 120 iterations (interactive), 180 (scheduled), 300 (hard max)
- **Config fields**: `agents.max_iterations`, `scheduled_max_iterations`, `hard_max_iterations`, `final_warning_iterations`
- **Budget warnings**: injected at 20/10/5/1 remaining iterations, telling the agent to wrap up, validate, commit, and produce a final summary
- **Fallback synthesis**: when an agent hits max iterations with no text output, `_synthesize_fallback()` builds a summary from tool activity instead of returning "(no output)"
- **Scheduled context**: workflow runner passes `_scheduled: True` to spawn_agent so it uses the higher scheduled cap
- **Wait timeout**: aligned with 1hr agent lifetime (3660s) instead of 1500s

### 2. Scheduler timezone fix
`next_run` was stored as naive datetime (no UTC offset). The WebUI interpreted it as local time, showing "4h 9m" for a cron that fires in 9 minutes.

- **`_utc_iso()` helper**: ensures all `next_run` values have explicit `+00:00` suffix
- **Applied to all 4 croniter sites** in scheduler.py

## Test plan
- [x] 79 scheduler tests pass (fixed one assertion that was brittle with TZ-aware strings)
- [x] No new test failures introduced
- [ ] Odin review
- [ ] Manual test: re-run eve-dynamic-intel scheduled task and verify agent uses budget warnings + produces output

Co-designed with Odin (GPT-5.5)