### PR TITLE
fix: circuit breaker in agents/loops, audit search filters, MCP reconnect

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -1006,8 +1006,11 @@ async def _call_llm_with_recovery(
             agent.transition(AgentState.RECOVERING, err_desc)
             log.warning("Agent %s recovering (attempt %d): %s", agent.id, agent.recovery_attempts, err_desc)
 
-            # Brief pause before retry
-            await asyncio.sleep(1)
+            retry_delay = 1
+            if hasattr(first_err, "retry_after"):
+                retry_delay = min(first_err.retry_after, 90.0)
+                log.info("Agent %s: circuit breaker wait %.0fs", agent.id, retry_delay)
+            await asyncio.sleep(retry_delay)
 
             agent.transition(AgentState.EXECUTING, "retry after recovery")
 

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -257,7 +257,13 @@ class AuditLogger:
                 if not err:
                     continue
             if min_duration_ms is not None:
-                dur = entry.get("metadata", {}).get("duration_ms", 0) or entry.get("duration_ms", 0)
+                dur = (
+                    entry.get("execution_time_ms")
+                    or entry.get("metadata", {}).get("duration_ms")
+                    or entry.get("duration_ms")
+                    or entry.get("metadata", {}).get("elapsed_ms")
+                    or 0
+                )
                 if dur < min_duration_ms:
                     continue
 

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -200,9 +200,18 @@ class AuditLogger:
         host: str | None = None,
         keyword: str | None = None,
         date: str | None = None,
+        status: str | None = None,
+        has_error: bool | None = None,
+        min_duration_ms: int | None = None,
         limit: int = 20,
     ) -> list[dict]:
-        """Search audit log (most recent first). Filters are ANDed."""
+        """Search audit log (most recent first). Filters are ANDed.
+
+        New filters:
+        - status: match entries with this status value (e.g. "error", "success")
+        - has_error: True = only entries with non-empty error field
+        - min_duration_ms: only entries with duration_ms >= this value
+        """
         if not self.path.exists():
             return []
 
@@ -214,7 +223,6 @@ class AuditLogger:
             log.error("Failed to read audit log: %s", e)
             return []
 
-        # Read in reverse for most-recent-first
         for line in reversed(lines):
             line = line.strip()
             if not line:
@@ -239,6 +247,18 @@ class AuditLogger:
             if keyword:
                 blob = json.dumps(entry).lower()
                 if keyword.lower() not in blob:
+                    continue
+            if status:
+                entry_status = entry.get("status") or entry.get("metadata", {}).get("status", "")
+                if status.lower() != str(entry_status).lower():
+                    continue
+            if has_error is True:
+                err = entry.get("error") or entry.get("metadata", {}).get("error", "")
+                if not err:
+                    continue
+            if min_duration_ms is not None:
+                dur = entry.get("metadata", {}).get("duration_ms", 0) or entry.get("duration_ms", 0)
+                if dur < min_duration_ms:
                     continue
 
             results.append(entry)

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -4688,6 +4688,8 @@ class OdinBot(commands.Bot):
                 response = await self.llm_client.chat_with_tools(
                     messages=messages, system=system_prompt, tools=tools or [],
                 )
+            except CircuitOpenError:
+                raise
             except Exception as e:
                 log.warning("Loop iteration Codex call failed: %s", e)
                 return await _finish(

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -3891,12 +3891,21 @@ class OdinBot(commands.Bot):
 
     async def _handle_search_audit(self, inp: dict) -> str:
         """Search the audit log."""
+        has_error = inp.get("has_error")
+        if has_error is not None:
+            has_error = bool(has_error)
+        min_dur = inp.get("min_duration_ms")
+        if min_dur is not None:
+            min_dur = int(min_dur)
         results = await self.audit.search(
             tool_name=inp.get("tool_name"),
             user=inp.get("user"),
             host=inp.get("host"),
             keyword=inp.get("keyword"),
             date=inp.get("date"),
+            status=inp.get("status"),
+            has_error=has_error,
+            min_duration_ms=min_dur,
             limit=min(inp.get("limit", 20), 50),
         )
         if not results:

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -233,6 +233,13 @@ class LoopManager:
                     consecutive_errors = 0  # Reset on success
                 except Exception as e:
                     consecutive_errors += 1
+                    if hasattr(e, "retry_after"):
+                        circuit_wait = min(e.retry_after, MAX_BACKOFF_SECONDS)
+                        info.interval_seconds = max(info.interval_seconds, int(circuit_wait))
+                        log.info(
+                            "Loop %s: circuit breaker open, wait %.0fs",
+                            info.id, circuit_wait,
+                        )
                     log.warning(
                         "Loop %s iteration %d failed (%d consecutive): %s",
                         info.id, info.iteration_count, consecutive_errors, e,

--- a/src/tools/mcp_client.py
+++ b/src/tools/mcp_client.py
@@ -326,8 +326,7 @@ class MCPServerConnection:
 
     async def discover_tools(self) -> list[dict]:
         """Fetch the tool list from the server."""
-        if not self._connected:
-            raise MCPError(f"Server {self.name}: not connected")
+        await self._ensure_connected()
 
         resp = await self._send_request("tools/list")
 
@@ -352,15 +351,26 @@ class MCPServerConnection:
         log.info("MCP %s: discovered %d tools", self.name, len(self._tools))
         return self._tools
 
+    async def _ensure_connected(self) -> None:
+        """Reconnect if the connection is dead. Raises MCPError on failure."""
+        if self._connected and self.is_alive:
+            return
+        if not self._connected or not self.is_alive:
+            self._connected = False
+            log.warning("MCP %s: connection dead, attempting reconnect", self.name)
+            try:
+                await self.disconnect()
+            except Exception:
+                pass
+            try:
+                await self.connect()
+                log.info("MCP %s: reconnected successfully", self.name)
+            except Exception as e:
+                raise MCPError(f"Server {self.name}: reconnect failed: {e}") from e
+
     async def call_tool(self, tool_name: str, arguments: dict) -> str:
         """Invoke a tool on the server and return the result as text."""
-        if not self._connected:
-            raise MCPError(f"Server {self.name}: not connected")
-        if not self.is_alive:
-            # Subprocess has exited; mark down and fail fast rather than
-            # dispatching into a dead pipe and blocking until self.timeout.
-            self._connected = False
-            raise MCPError(f"Server {self.name}: connection is dead (subprocess exited)")
+        await self._ensure_connected()
 
         resp = await self._send_request("tools/call", {
             "name": tool_name,

--- a/src/tools/mcp_client.py
+++ b/src/tools/mcp_client.py
@@ -546,10 +546,8 @@ class MCPManager:
 
         server_name, original_name = mapping
         conn = self._servers.get(server_name)
-        if conn is None or not conn.connected:
-            return f"MCP server '{server_name}' is not connected"
-        if not conn.is_alive:
-            return f"MCP server '{server_name}' connection is dead (subprocess exited)"
+        if conn is None:
+            return f"MCP server '{server_name}' is not configured"
 
         try:
             return await asyncio.wait_for(

--- a/src/tools/mcp_client.py
+++ b/src/tools/mcp_client.py
@@ -352,21 +352,27 @@ class MCPServerConnection:
         return self._tools
 
     async def _ensure_connected(self) -> None:
-        """Reconnect if the connection is dead. Raises MCPError on failure."""
+        """Reconnect if the connection died after being established.
+
+        Only attempts reconnect if the server was previously connected
+        (has a process or had a successful connection). A server that was
+        never connected raises MCPError immediately — use connect() first.
+        """
         if self._connected and self.is_alive:
             return
-        if not self._connected or not self.is_alive:
-            self._connected = False
-            log.warning("MCP %s: connection dead, attempting reconnect", self.name)
-            try:
-                await self.disconnect()
-            except Exception:
-                pass
-            try:
-                await self.connect()
-                log.info("MCP %s: reconnected successfully", self.name)
-            except Exception as e:
-                raise MCPError(f"Server {self.name}: reconnect failed: {e}") from e
+        if self._process is None and not self._connected:
+            raise MCPError(f"Server {self.name}: not connected")
+        self._connected = False
+        log.warning("MCP %s: connection dead, attempting reconnect", self.name)
+        try:
+            await self.disconnect()
+        except Exception:
+            pass
+        try:
+            await self.connect()
+            log.info("MCP %s: reconnected successfully", self.name)
+        except Exception as e:
+            raise MCPError(f"Server {self.name}: reconnect failed: {e}") from e
 
     async def call_tool(self, tool_name: str, arguments: dict) -> str:
         """Invoke a tool on the server and return the result as text."""

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -437,7 +437,7 @@ TOOLS: list[dict] = [
     {
         "name": "search_audit",
         "is_core": True,
-        "description": "Searches audit log of tool executions. Returns '[date] tool_name by user (status, Nms)'. Filterable by tool, user, host, keyword, date.",
+        "description": "Searches audit log of tool executions. Returns '[date] tool_name by user (status, Nms)'. Filterable by tool, user, host, keyword, date, status, errors, duration.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -460,6 +460,18 @@ TOOLS: list[dict] = [
                 "date": {
                     "type": "string",
                     "description": "Filter by date prefix (e.g. '2026-03-12')",
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Filter by status (e.g. 'error', 'success')",
+                },
+                "has_error": {
+                    "type": "boolean",
+                    "description": "If true, only return entries with non-empty error fields",
+                },
+                "min_duration_ms": {
+                    "type": "integer",
+                    "description": "Only return entries that took at least this many milliseconds",
                 },
                 "limit": {
                     "type": "integer",

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1114,6 +1114,7 @@ class TestMCPManagerExecute:
     async def test_execute_server_disconnected(self):
         tools = [{"name": "greet", "description": "Hi", "inputSchema": {}}]
         mock_conn = _make_mock_connection("srv", tools=tools, connected=False)
+        mock_conn.call_tool = AsyncMock(side_effect=MCPError("Server srv: not connected"))
 
         with patch("src.tools.mcp_client.MCPServerConnection", return_value=mock_conn):
             mgr = MCPManager()


### PR DESCRIPTION
## Summary
- **Circuit breaker**: agents respect `retry_after` instead of 1s sleep; loops re-raise `CircuitOpenError` so LoopManager adjusts interval to recovery timeout
- **Audit search**: new `status`, `has_error`, `min_duration_ms` filters; duration checks `execution_time_ms` where audit records actually store timing
- **MCP reconnect**: dead stdio subprocesses trigger automatic reconnect instead of permanent failure; manager gate removed so reconnect path is reachable

## Test plan
- [x] 353 tests pass (MCP, agent, scheduler, scheduled workflow, history)
- [x] Odin code-reviewed through 3 rounds (approved)
- [x] Manual audit filter probe verified against live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)