### PR TITLE
fix: consolidation timeout — skip under target, compact prompt, better logging

### DIFF
--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -686,6 +686,31 @@ class ConversationReflector:
             log.info("Reflector: expired %d stale operational/fact entries", expired)
         return kept
 
+    @staticmethod
+    def _compact_for_prompt(entries: list[dict]) -> str:
+        """Serialize entries with only the fields the LLM needs for consolidation.
+
+        Strips timestamps, source, last_used_at, and other metadata that
+        bloats the prompt without helping the LLM make merge/drop decisions.
+        """
+        compact = []
+        for e in entries:
+            item: dict = {
+                "key": e.get("key", ""),
+                "category": e.get("category", ""),
+                "content": e.get("content", ""),
+            }
+            if e.get("topic"):
+                item["topic"] = e["topic"]
+            if e.get("tags"):
+                item["tags"] = e["tags"]
+            if e.get("confidence"):
+                item["confidence"] = e["confidence"]
+            if e.get("user_id"):
+                item["user_id"] = e["user_id"]
+            compact.append(item)
+        return json.dumps(compact, indent=2)
+
     async def _consolidate(self, entries: list[dict]) -> list[dict]:
         """Ask the LLM to merge same-topic duplicates down to the target.
 
@@ -694,6 +719,9 @@ class ConversationReflector:
         together to hit the target count; dropping low-value entries is the
         sanctioned way to shrink.
         """
+        import time as _time
+        t0 = _time.monotonic()
+
         entries = self._expire_entries(entries)
         if not entries:
             return []
@@ -704,7 +732,16 @@ class ConversationReflector:
             return damaged
 
         target = max(1, self._consolidation_target - len(damaged))
-        entries_text = json.dumps(candidates, indent=2)
+
+        if len(candidates) <= target:
+            log.info(
+                "Consolidation skipped: %d candidates already within target %d (+%d damaged)",
+                len(candidates), target, len(damaged),
+            )
+            return candidates + damaged
+
+        entries_text = self._compact_for_prompt(candidates)
+        prompt_chars = len(entries_text)
         prompt = (
             _CONSOLIDATION_HEADER + str(target)
             + " or fewer.\nSTRICT RULES:\n"
@@ -728,6 +765,12 @@ class ConversationReflector:
 
         def _fallback() -> list[dict]:
             candidates.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+            elapsed = _time.monotonic() - t0
+            log.warning(
+                "Consolidation fallback: kept newest %d of %d candidates "
+                "(prompt was %d chars, elapsed %.1fs, %d damaged passed through)",
+                target, len(candidates), prompt_chars, elapsed, len(damaged),
+            )
             return candidates[:target] + damaged
 
         try:
@@ -739,7 +782,10 @@ class ConversationReflector:
                 system_instruction,
             )
         except Exception as e:
-            log.error("Consolidation API call failed: %s", e)
+            log.error(
+                "Consolidation API call failed (%s): %s",
+                type(e).__name__, e,
+            )
             return _fallback()
 
         raw = raw_text.strip()
@@ -757,7 +803,6 @@ class ConversationReflector:
                 orig = orig_by_key[entry["key"]]
                 entry["created_at"] = orig.get("created_at", now)
                 entry["updated_at"] = now
-                # Consolidation must not invent or upgrade metadata it dropped
                 for field in ("user_id", "topic", "tags", "confidence", "source", "last_used_at"):
                     if field not in entry and field in orig:
                         entry[field] = orig[field]
@@ -767,9 +812,10 @@ class ConversationReflector:
                 entry.setdefault("confidence", _default_confidence(entry.get("category", "")))
                 entry.setdefault("source", {"created_by": "consolidation"})
 
+        elapsed = _time.monotonic() - t0
         log.info(
-            "Consolidated %d entries down to %d (+%d damaged passed through)",
-            len(candidates), len(consolidated), len(damaged),
+            "Consolidated %d entries down to %d (+%d damaged) in %.1fs (prompt %d chars)",
+            len(candidates), len(consolidated), len(damaged), elapsed, prompt_chars,
         )
         return consolidated + damaged
 

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -754,7 +754,7 @@ class ConversationReflector:
             "topics, return more entries than the target instead.\n"
             f"- Keep each content under {_SOFT_CONTENT_CHARS} characters.\n"
             "- Preserve key, user_id, topic, tags, and confidence fields "
-            "exactly as-is (null if absent).\n"
+            "when present.\n"
             " Return a JSON array with the same schema:"
             ' [{"key": ..., "category": ..., "content": ..., "user_id": ...,'
             ' "topic": ..., "tags": ..., "confidence": ...}]'

--- a/tests/test_learned_overhaul.py
+++ b/tests/test_learned_overhaul.py
@@ -197,6 +197,85 @@ class TestConsolidationDamagePassThrough:
         assert len(result) == 3
 
 
+class TestConsolidationSkipAndCompact:
+    @pytest.mark.asyncio
+    async def test_skip_when_candidates_within_target(self, tmp_path):
+        """When candidates <= target, _text_fn must NOT be called."""
+        r = ConversationReflector(str(tmp_path / "l.json"),
+                                  max_entries=10, consolidation_target=8)
+        call_count = 0
+
+        async def spy_text_fn(messages, system):
+            nonlocal call_count
+            call_count += 1
+            return "[]"
+
+        r.set_text_fn(spy_text_fn)
+        now = datetime.now(UTC).isoformat(timespec="seconds")
+        entries = [
+            _entry(f"k{i}", content=f"lesson {i}.", created_at=now, updated_at=now)
+            for i in range(5)
+        ]
+        # 5 candidates, target 8 → skip
+        result = await r._consolidate(entries)
+        assert call_count == 0
+        assert len(result) == 5
+        assert {e["key"] for e in result} == {f"k{i}" for i in range(5)}
+
+    @pytest.mark.asyncio
+    async def test_skip_preserves_damaged(self, tmp_path):
+        """Skip path must preserve both candidates and damaged entries."""
+        r = ConversationReflector(str(tmp_path / "l.json"),
+                                  max_entries=10, consolidation_target=8)
+        r.set_text_fn(None)
+        now = datetime.now(UTC).isoformat(timespec="seconds")
+        entries = [
+            _entry("a", content="lesson a.", created_at=now, updated_at=now),
+            _entry("b", content="lesson b.", created_at=now, updated_at=now),
+            _entry("hurt", content="chopped" + _TRUNCATION_MARKER,
+                   damaged=True, created_at=now, updated_at=now),
+        ]
+        # 2 candidates, target 7 (8-1 damaged) → skip
+        result = await r._consolidate(entries)
+        keys = {e["key"] for e in result}
+        assert keys == {"a", "b", "hurt"}
+
+    def test_compact_for_prompt_strips_metadata(self):
+        entries = [
+            _entry("k1", content="lesson one.",
+                   topic="infra", tags=["ssh"], confidence="high",
+                   user_id="42",
+                   created_at="2026-01-01T00:00:00", updated_at="2026-06-01T00:00:00",
+                   last_used_at="2026-06-20T00:00:00",
+                   source={"created_by": "reflection"}),
+        ]
+        compact_json = ConversationReflector._compact_for_prompt(entries)
+        compact = json.loads(compact_json)
+        assert len(compact) == 1
+        item = compact[0]
+        # Preserved
+        assert item["key"] == "k1"
+        assert item["category"] == "operational"
+        assert item["content"] == "lesson one."
+        assert item["topic"] == "infra"
+        assert item["tags"] == ["ssh"]
+        assert item["confidence"] == "high"
+        assert item["user_id"] == "42"
+        # Stripped
+        assert "created_at" not in item
+        assert "updated_at" not in item
+        assert "last_used_at" not in item
+        assert "source" not in item
+
+    def test_compact_for_prompt_omits_absent_optional_fields(self):
+        entries = [_entry("bare", content="minimal.")]
+        compact = json.loads(ConversationReflector._compact_for_prompt(entries))
+        item = compact[0]
+        assert "topic" not in item
+        assert "tags" not in item
+        assert "user_id" not in item
+
+
 class TestInjection:
     def _store(self, tmp_path, entries):
         path = tmp_path / "learned.json"


### PR DESCRIPTION
## Summary
- Root cause: consolidation was sending ~79K chars of metadata-heavy JSON to the LLM for 118 entries, timing out since Jun 23
- Skip LLM consolidation when candidates already within target (would have avoided every recent failure)
- `_compact_for_prompt` strips timestamps/source/metadata, keeps only semantic fields (~31K vs ~79K)
- Error logging shows exception type (TimeoutError was invisible as empty string)
- Consolidation metrics: candidate count, prompt chars, elapsed time, fallback used

## Test plan
- [x] 28 learned overhaul tests pass (4 new: skip path, compact fields)
- [x] Odin code-reviewed through 2 rounds (approved)
- [x] Root cause confirmed by manual reproduction (Odin ran consolidation, got TimeoutError at 180s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)