### PR TITLE
fix: Codex auth reliability — persist rotated tokens, pin accounts, breaker correctness

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -3105,6 +3105,18 @@ class OdinBot(commands.Bot):
                 tool_name = block.name
                 tool_input = block.input
                 log.info("Tool call: %s(%s)", tool_name, tool_input)
+                # The provider could not parse the model's arguments — do NOT
+                # run the tool with a silently-empty input; bounce the error
+                # back so the model retries with valid arguments.
+                if getattr(block, "parse_error", None):
+                    log.warning("Tool call %s not executed: %s", tool_name, block.parse_error)
+                    return {
+                        "type": "tool_result", "tool_use_id": block.id,
+                        "content": (
+                            f"Error: {block.parse_error}. The tool was NOT executed — "
+                            "re-issue the call with valid JSON arguments."
+                        ),
+                    }
                 # Central RBAC gate: Discord-native tools, skills, and MCP tools are
                 # dispatched below WITHOUT going through ToolExecutor.execute() (the only
                 # place check_permission runs). permissions.filter_tools is advisory
@@ -4735,6 +4747,17 @@ class OdinBot(commands.Bot):
                 tool_name = block.name
                 tool_input = block.input
                 log.info("Loop tool call: %s(%s)", tool_name, tool_input)
+                # Provider couldn't parse the model's arguments — don't run
+                # the tool on a silently-empty input (see _run_tool).
+                if getattr(block, "parse_error", None):
+                    log.warning("Loop tool call %s not executed: %s", tool_name, block.parse_error)
+                    return {
+                        "type": "tool_result", "tool_use_id": block.id,
+                        "content": (
+                            f"Error: {block.parse_error}. The tool was NOT executed — "
+                            "re-issue the call with valid JSON arguments."
+                        ),
+                    }
 
                 t0 = time.monotonic()
                 error = None

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -87,10 +87,15 @@ def _decode_jwt_payload(token: str) -> dict:
 
 
 class CodexAuth:
-    def __init__(self, credentials_path: str) -> None:
+    def __init__(self, credentials_path: str, on_save=None) -> None:
         self._path = Path(credentials_path)
         self._credentials: dict | None = None
         self._refresh_lock = asyncio.Lock()
+        # Called with the new creds dict after every successful _save().
+        # OpenAI refresh tokens are single-use, so whoever owns the canonical
+        # multi-account file must see every rotation — otherwise a restart
+        # resurrects a burned refresh token and the account dies on next use.
+        self.on_save = on_save
 
     def is_configured(self) -> bool:
         """Check if credentials file exists and has tokens."""
@@ -116,6 +121,11 @@ class CodexAuth:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         _atomic_write_secure(self._path, json.dumps(creds, indent=2))
         self._credentials = creds
+        if self.on_save is not None:
+            try:
+                self.on_save(creds)
+            except Exception as e:
+                log.warning("Failed to propagate refreshed Codex credentials: %s", e)
 
     async def get_access_token(self) -> str:
         """Return a valid access token, refreshing if needed.
@@ -158,6 +168,30 @@ class CodexAuth:
         """Single-account auth has nothing to rotate to — returns False so the
         caller surfaces the 401 (this account must be re-authed)."""
         return False
+
+    async def force_refresh(self, stale_token: str | None = None) -> bool:
+        """Refresh the token now, regardless of expiry (reactive 401 handling).
+
+        The expiry-driven get_access_token() will happily re-serve a
+        server-revoked-but-unexpired bearer; this actually exercises the
+        refresh token. ``stale_token`` is the bearer the failing request
+        used — if the stored token already differs, another coroutine
+        refreshed first and this call is a no-op success. Returns False
+        when the refresh itself fails (account needs re-auth).
+        """
+        async with self._refresh_lock:
+            try:
+                creds = self._load()
+            except Exception:
+                return False
+            if stale_token and creds.get("access_token") != stale_token:
+                return True
+            try:
+                await self._refresh(creds)
+                return True
+            except Exception as e:
+                log.warning("Reactive Codex token refresh failed: %s", e)
+                return False
 
     async def _refresh(self, creds: dict) -> None:
         """Refresh the access token using the refresh token."""
@@ -356,7 +390,17 @@ class CodexAuthPool:
         self._init_accounts()
 
     def _init_accounts(self) -> None:
-        """Load credentials and create CodexAuth instances."""
+        """Load credentials and create CodexAuth instances.
+
+        Token refreshes rotate single-use refresh tokens into the per-account
+        shadow files, while re-auth/account edits rewrite the canonical file.
+        For the same account (matched by account_id), whichever side is newer
+        (by expires_at) wins — blindly overwriting a rotated shadow with stale
+        canonical creds burns the refresh-token chain, which is how all
+        accounts used to die together on every restart/reload. A different
+        account_id at the same slot (account deleted/reordered) means the
+        canonical entry is authoritative.
+        """
         if not self._path.exists():
             return
         try:
@@ -365,17 +409,35 @@ class CodexAuthPool:
             return
 
         if isinstance(raw, list):
-            # Multi-account format — canonical file is source of truth.
-            # Always sync shadow files and clean up stale ones.
             valid_count = 0
+            canonical_dirty = False
             for i, creds in enumerate(raw):
                 if not isinstance(creds, dict) or not creds.get("access_token"):
                     continue
                 individual_path = self._path.parent / f"codex_auth_{i}.json"
-                _atomic_write_secure(individual_path, json.dumps(creds, indent=2))
-                auth = CodexAuth(str(individual_path))
+                shadow = self._load_creds_file(individual_path)
+                same_account = (
+                    shadow is not None
+                    and bool(creds.get("account_id"))
+                    and shadow.get("account_id") == creds.get("account_id")
+                )
+                if (
+                    same_account
+                    and shadow.get("access_token")
+                    and shadow.get("expires_at", 0) >= creds.get("expires_at", 0)
+                ):
+                    # Shadow holds newer (rotated) tokens — keep it and pull
+                    # the canonical entry up to date instead of the reverse.
+                    if shadow != creds:
+                        raw[i] = shadow
+                        canonical_dirty = True
+                else:
+                    _atomic_write_secure(individual_path, json.dumps(creds, indent=2))
+                auth = CodexAuth(str(individual_path), on_save=self._canonical_sync(i))
                 self._accounts.append(auth)
                 valid_count = i + 1
+            if canonical_dirty:
+                _atomic_write_secure(self._path, json.dumps(raw, indent=2))
             # Remove stale shadow files from previous larger pools
             for j in range(valid_count, valid_count + 20):
                 stale = self._path.parent / f"codex_auth_{j}.json"
@@ -388,6 +450,36 @@ class CodexAuthPool:
             # Single account (backward compat) — use the file directly
             self._accounts.append(CodexAuth(str(self._path)))
             log.info("Codex auth pool: 1 account loaded (single format)")
+
+    @staticmethod
+    def _load_creds_file(path: Path) -> dict | None:
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _canonical_sync(self, index: int):
+        """Build an on_save hook that mirrors account *index* back to the canonical file."""
+        def _sync(creds: dict) -> None:
+            try:
+                raw = json.loads(self._path.read_text())
+            except Exception:
+                return
+            if not isinstance(raw, list) or index >= len(raw):
+                return
+            raw[index] = creds
+            _atomic_write_secure(self._path, json.dumps(raw, indent=2))
+        return _sync
+
+    @staticmethod
+    def _account_label(auth: CodexAuth, index: int) -> str:
+        try:
+            return auth._load().get("email", f"account {index}")
+        except Exception:
+            return f"account {index}"
 
     def is_configured(self) -> bool:
         return any(a.is_configured() for a in self._accounts)
@@ -402,58 +494,95 @@ class CodexAuthPool:
             raise RuntimeError("No Codex credentials configured.")
         return self._accounts[self._current_index]
 
-    async def get_access_token(self) -> str:
-        """Get a token from the current account, rotating on failure or rate-limit."""
+    async def acquire(self) -> tuple[str, str | None, int]:
+        """Pick a healthy account and return (access_token, account_id, index).
+
+        The index pins the account to the request, so failure marking can
+        target the account that actually served it — concurrent requests
+        rotate the pool underneath each other, and penalizing "whatever is
+        current now" benches healthy accounts. Token refresh happens OUTSIDE
+        the pool lock: a slow refresh must not serialize unrelated LLM
+        traffic, and the per-account refresh lock already prevents
+        refresh-token reuse.
+        """
         if not self._accounts:
             raise RuntimeError("No Codex credentials configured.")
-        async with self._pool_lock:
-            errors = []
-            for attempt in range(len(self._accounts)):
-                auth = self._accounts[self._current_index]
+        errors: list[tuple[int, str]] = []
+        for _ in range(len(self._accounts)):
+            async with self._pool_lock:
+                if not self._accounts:
+                    raise RuntimeError("No Codex credentials configured.")
+                self._current_index %= len(self._accounts)
+                idx = self._current_index
+                auth = self._accounts[idx]
                 if auth.is_rate_limited():
                     self._rotate()
                     continue
-                try:
-                    return await auth.get_access_token()
-                except Exception as e:
-                    idx = self._current_index
-                    try:
-                        email = auth._load().get("email", f"account {idx}")
-                    except Exception:
-                        email = f"account {idx}"
-                    log.warning("Codex account %s failed: %s — rotating to next", email, e)
-                    errors.append((idx, str(e)))
+            try:
+                token = await auth.get_access_token()
+            except Exception as e:
+                log.warning(
+                    "Codex account %s failed: %s — rotating to next",
+                    self._account_label(auth, idx), e,
+                )
+                errors.append((idx, str(e)))
+                async with self._pool_lock:
                     auth.mark_rate_limited()
-                    if len(self._accounts) > 1:
+                    if len(self._accounts) > 1 and self._accounts[self._current_index % len(self._accounts)] is auth:
                         self._rotate()
+                continue
+            return token, auth.get_account_id(), idx
+        if errors:
             raise RuntimeError(
                 f"All {len(self._accounts)} Codex accounts failed: "
                 + "; ".join(f"#{i}: {err}" for i, err in errors)
             )
+        raise RuntimeError(
+            f"All {len(self._accounts)} Codex accounts are rate-limited or "
+            "backing off; retry shortly."
+        )
+
+    async def get_access_token(self) -> str:
+        """Get a token from a healthy account, rotating on failure or rate-limit."""
+        token, _, _ = await self.acquire()
+        return token
+
+    async def token_for(self, index: int) -> tuple[str, str | None]:
+        """Return (access_token, account_id) for a specific account index."""
+        async with self._pool_lock:
+            if not self._accounts or index >= len(self._accounts):
+                raise RuntimeError(f"Codex account index {index} out of range")
+            auth = self._accounts[index]
+        return await auth.get_access_token(), auth.get_account_id()
 
     def get_account_id(self) -> str | None:
         if not self._accounts:
             return None
         return self.current.get_account_id()
 
+    async def mark_limited(self, index: int) -> None:
+        """Mark the *given* account rate-limited; rotate only if it is still current."""
+        if not self._accounts:
+            return
+        async with self._pool_lock:
+            if index >= len(self._accounts):
+                return
+            account = self._accounts[index]
+            account.mark_rate_limited()
+            label = self._account_label(account, index)
+            if len(self._accounts) > 1:
+                if self._current_index == index:
+                    self._rotate()
+                log.warning("Codex %s hit rate limit, active account now %d/%d",
+                            label, self._current_index + 1, len(self._accounts))
+            else:
+                log.warning("Codex %s hit rate limit (only account, no rotation)", label)
+
     async def mark_current_limited(self) -> None:
         """Mark the current account as rate-limited and rotate to the next."""
         if not self._accounts:
             return
-        async with self._pool_lock:
-            current = self._accounts[self._current_index]
-            current.mark_rate_limited()
-            try:
-                email = current._load().get("email", f"account {self._current_index}")
-            except Exception:
-                email = f"account {self._current_index}"
-
-            if len(self._accounts) > 1:
-                self._rotate()
-                log.warning("Codex %s hit rate limit, rotated to account %d/%d",
-                            email, self._current_index + 1, len(self._accounts))
-            else:
-                log.warning("Codex %s hit rate limit (only account, no rotation)", email)
+        await self.mark_limited(self._current_index)
 
     async def invalidate_current(self) -> None:
         """Force a token refresh for the *currently active* account.
@@ -472,33 +601,52 @@ class CodexAuthPool:
         # call it outside the pool lock to keep lock ordering simple.
         await current.invalidate_current()
 
-    async def mark_current_auth_failed(self) -> bool:
-        """Mark the current account as auth-failed (401/invalidated) and rotate.
+    async def mark_auth_failed(self, index: int) -> bool:
+        """Mark the *given* account auth-failed (401/invalidated) and rotate off it.
 
         Distinct from rate-limit rotation: an invalidated token won't recover
         until re-auth, so set the account aside for a longer window
-        (AUTH_FAILED_BACKOFF_SECONDS) rather than retrying it every minute, then
-        rotate to the next account. Returns True if it rotated to a *different*
-        account, False if this is the only one (caller should surface the error).
+        (AUTH_FAILED_BACKOFF_SECONDS) rather than retrying it every minute.
+        Rotation happens only if the failed account is still current. Returns
+        True if another account is available, False if this is the only one
+        (caller should surface the error).
         """
         if not self._accounts:
             return False
         async with self._pool_lock:
-            current = self._accounts[self._current_index]
-            current.mark_rate_limited(AUTH_FAILED_BACKOFF_SECONDS)
-            try:
-                email = current._load().get("email", f"account {self._current_index}")
-            except Exception:
-                email = f"account {self._current_index}"
+            if index >= len(self._accounts):
+                return False
+            account = self._accounts[index]
+            account.mark_rate_limited(AUTH_FAILED_BACKOFF_SECONDS)
+            label = self._account_label(account, index)
             if len(self._accounts) > 1:
-                self._rotate()
+                if self._current_index == index:
+                    self._rotate()
                 log.warning(
-                    "Codex %s auth failed (401/invalidated), skipped to account %d/%d",
-                    email, self._current_index + 1, len(self._accounts),
+                    "Codex %s auth failed (401/invalidated), active account now %d/%d",
+                    label, self._current_index + 1, len(self._accounts),
                 )
                 return True
-            log.warning("Codex %s auth failed (401), only account — cannot rotate", email)
+            log.warning("Codex %s auth failed (401), only account — cannot rotate", label)
             return False
+
+    async def mark_current_auth_failed(self) -> bool:
+        """Mark the current account auth-failed and rotate (see mark_auth_failed)."""
+        if not self._accounts:
+            return False
+        return await self.mark_auth_failed(self._current_index)
+
+    async def force_refresh(self, index: int, stale_token: str | None = None) -> bool:
+        """Force an immediate token refresh for the given account (reactive 401)."""
+        if not self._accounts:
+            return False
+        async with self._pool_lock:
+            if index >= len(self._accounts):
+                return False
+            account = self._accounts[index]
+        # The account's own refresh lock guards the single-use refresh token;
+        # run outside the pool lock so a slow refresh doesn't stall the pool.
+        return await account.force_refresh(stale_token)
 
     def _rotate(self) -> None:
         self._current_index = (self._current_index + 1) % len(self._accounts)

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -726,14 +726,17 @@ class CodexChatClient:
                         call_id = item.get("call_id", "")
                         if not any(tc.id == call_id for tc in tool_calls):
                             args_str = item.get("arguments", "")
+                            parse_error = None
                             try:
                                 parsed_args = json.loads(args_str) if args_str else {}
                             except json.JSONDecodeError:
                                 parsed_args = {}
+                                parse_error = f"malformed tool arguments (invalid JSON): {args_str[:200]}"
                             tool_calls.append(ToolCall(
                                 id=call_id,
                                 name=item.get("name", ""),
                                 input=parsed_args,
+                                parse_error=parse_error,
                             ))
 
         text = "".join(text_parts)

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -17,6 +17,10 @@ log = get_logger("codex")
 CODEX_API_URL = "https://chatgpt.com/backend-api/codex/responses"
 
 
+class CodexStreamError(RuntimeError):
+    """The SSE stream reported a terminal failure event (response.failed / error)."""
+
+
 class CodexChatClient:
     """Chat client using OpenAI Codex backend API (ChatGPT subscription)."""
 
@@ -97,6 +101,54 @@ class CodexChatClient:
             "http_pool_total_requests": self._total_requests,
         }
 
+    # ------------------------------------------------------------------
+    # Auth adapters — self.auth may be a CodexAuthPool (multi-account) or a
+    # bare CodexAuth (single). The pool variants pin an account index to the
+    # request so failure marking hits the account that actually served it.
+    # ------------------------------------------------------------------
+
+    async def _acquire_auth(self) -> tuple[str, str | None, int]:
+        """Return (access_token, account_id, account_index) for this request."""
+        if isinstance(self.auth, CodexAuthPool):
+            return await self.auth.acquire()
+        return await self.auth.get_access_token(), self.auth.get_account_id(), 0
+
+    async def _token_for(self, index: int) -> tuple[str, str | None]:
+        """Re-fetch the (token, account_id) pair for a pinned account."""
+        if isinstance(self.auth, CodexAuthPool):
+            return await self.auth.token_for(index)
+        return await self.auth.get_access_token(), self.auth.get_account_id()
+
+    async def _mark_limited(self, index: int) -> None:
+        if isinstance(self.auth, CodexAuthPool):
+            await self.auth.mark_limited(index)
+        elif hasattr(self.auth, "mark_rate_limited"):
+            self.auth.mark_rate_limited()
+
+    async def _mark_auth_failed(self, index: int) -> bool:
+        if isinstance(self.auth, CodexAuthPool):
+            return await self.auth.mark_auth_failed(index)
+        if hasattr(self.auth, "mark_current_auth_failed"):
+            return await self.auth.mark_current_auth_failed()
+        return False
+
+    async def _force_refresh(self, index: int, stale_token: str | None) -> bool:
+        if isinstance(self.auth, CodexAuthPool):
+            return await self.auth.force_refresh(index, stale_token)
+        if hasattr(self.auth, "force_refresh"):
+            return await self.auth.force_refresh(stale_token)
+        return False
+
+    @staticmethod
+    def _auth_headers(token: str, account_id: str | None) -> dict:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        return headers
+
     async def chat(
         self, messages: list[dict], system: str,
         max_tokens: int | None = None,
@@ -107,16 +159,6 @@ class CodexChatClient:
             max_tokens: Per-call token limit override. Falls back to
                         ``self.max_tokens`` when *None*.
         """
-        access_token = await self.auth.get_access_token()
-        account_id = self.auth.get_account_id()
-
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-        }
-        if account_id:
-            headers["ChatGPT-Account-Id"] = account_id
-
         body = {
             "model": self.model,
             "instructions": system,
@@ -128,7 +170,7 @@ class CodexChatClient:
         # Callers needing short responses should use prompt instructions instead.
 
         input_tokens = self._estimate_body_input_tokens(body)
-        text = await self._stream_request(headers, body)
+        text = await self._stream_request(body)
         output_tokens = estimate_tokens(text) if text else 0
         self._last_input_tokens = input_tokens
         self._last_output_tokens = output_tokens
@@ -373,16 +415,6 @@ class CodexChatClient:
         Returns:
             LLMResponse with text, tool_calls, and stop_reason.
         """
-        access_token = await self.auth.get_access_token()
-        account_id = self.auth.get_account_id()
-
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-        }
-        if account_id:
-            headers["ChatGPT-Account-Id"] = account_id
-
         body = {
             "model": self.model,
             "instructions": system,
@@ -394,7 +426,7 @@ class CodexChatClient:
         }
 
         input_tokens = self._estimate_body_input_tokens(body)
-        result = await self._stream_tool_request(headers, body)
+        result = await self._stream_tool_request(body)
         output_chars = len(result.text)
         for tc in result.tool_calls:
             output_chars += len(tc.name) + len(json.dumps(tc.input))
@@ -402,28 +434,72 @@ class CodexChatClient:
         result.output_tokens = estimate_tokens("x" * output_chars) if output_chars else 0
         return result
 
-    async def _stream_tool_request(self, headers: dict, body: dict) -> LLMResponse:
+    async def _stream_tool_request(self, body: dict) -> LLMResponse:
         """Send a streaming request and parse both text and function_call events."""
+        return await self._send_with_retries(
+            body,
+            self._read_tool_stream,
+            lambda r: not (r.text or r.tool_calls),
+        )
+
+    async def _stream_request(self, body: dict) -> str:
+        """Send a streaming request and collect the full response text."""
+        return await self._send_with_retries(
+            body,
+            self._read_stream,
+            lambda r: not r,
+        )
+
+    async def _send_with_retries(self, body: dict, reader, result_is_empty):
+        """Shared retry/rotation/breaker engine for both streaming paths.
+
+        The text and tool paths previously carried duplicated copies of this
+        loop, which is how the 429/5xx breaker double-count crept in (the
+        status branch recorded a failure, then the terminal path fell through
+        to a second record_failure). Invariant here: each failed attempt
+        records exactly ONE breaker failure.
+
+        The account serving the request is pinned by index at acquire time so
+        429/401 marking penalizes the account that actually failed — under
+        concurrent traffic "whatever account is current when I take the lock"
+        is frequently a different, healthy one.
+        """
         self.breaker.check()
         session = await self._get_session()
         self._total_requests += 1
         last_error = None
+        token, account_id, acct_idx = await self._acquire_auth()
 
         for attempt in range(self.max_retries):
             try:
                 async with session.post(
                     CODEX_API_URL,
-                    headers=headers,
+                    headers=self._auth_headers(token, account_id),
                     json=body,
                     timeout=aiohttp.ClientTimeout(total=600),
                 ) as resp:
                     if resp.status == 200:
-                        result = await self._read_tool_stream(resp)
-                        if result.text or result.tool_calls:
+                        try:
+                            result = await reader(resp)
+                        except CodexStreamError as e:
+                            # response.failed / error event: the "200" turned
+                            # out to be a failure mid-stream — retryable.
+                            self.breaker.record_failure()
+                            last_error = str(e)
+                            if attempt < self.max_retries - 1:
+                                wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
+                                log.warning(
+                                    "Codex stream failed (attempt %d/%d): %s. Retrying in %.1fs...",
+                                    attempt + 1, self.max_retries, last_error, wait,
+                                )
+                                await asyncio.sleep(wait)
+                                continue
+                            raise RuntimeError(f"Codex stream failed: {last_error}") from e
+                        if not result_is_empty(result):
                             self.breaker.record_success()
                             return result
                         log.warning(
-                            "Codex tool request returned 200 with empty response (attempt %d/%d)",
+                            "Codex returned 200 with empty response (attempt %d/%d)",
                             attempt + 1, self.max_retries,
                         )
                         if attempt < self.max_retries - 1:
@@ -442,34 +518,21 @@ class CodexChatClient:
                             or "invalidated" in body_l
                             or "sign in again" in body_l
                         )
-                        # Likely-stale cached bearer (generic 401, first try):
-                        # clear + refresh and retry the SAME account once.
-                        if attempt == 0 and not invalidated:
-                            log.warning("Codex auth 401, forcing token refresh...")
-                            await self.auth.invalidate_current()
-                            new_token = await self.auth.get_access_token()
-                            headers["Authorization"] = f"Bearer {new_token}"
-                            account_id = self.auth.get_account_id()
-                            if account_id:
-                                headers["ChatGPT-Account-Id"] = account_id
-                            else:
-                                headers.pop("ChatGPT-Account-Id", None)
+                        # Likely-stale/revoked bearer (generic 401, first try):
+                        # actually exercise the refresh token — merely dropping
+                        # the cached token re-serves the same unexpired bearer —
+                        # then retry the SAME account once.
+                        if attempt == 0 and not invalidated and await self._force_refresh(acct_idx, token):
+                            log.warning("Codex auth 401, token refreshed, retrying...")
+                            token, account_id = await self._token_for(acct_idx)
                             continue
-                        # Invalidated, or a 401 that survived the refresh: this
-                        # account can't authenticate. Skip it and rotate to the
-                        # next account — only on this error, never routine traffic.
-                        rotated = False
-                        if hasattr(self.auth, "mark_current_auth_failed"):
-                            rotated = await self.auth.mark_current_auth_failed()
+                        # Invalidated, refresh failed, or a 401 that survived
+                        # the refresh: this account can't authenticate. Bench
+                        # it (long backoff) and move to the next account.
+                        rotated = await self._mark_auth_failed(acct_idx)
                         if rotated and attempt < self.max_retries - 1:
                             log.warning("Codex 401: skipped failed account, retrying on next...")
-                            new_token = await self.auth.get_access_token()
-                            headers["Authorization"] = f"Bearer {new_token}"
-                            account_id = self.auth.get_account_id()
-                            if account_id:
-                                headers["ChatGPT-Account-Id"] = account_id
-                            else:
-                                headers.pop("ChatGPT-Account-Id", None)
+                            token, account_id, acct_idx = await self._acquire_auth()
                             continue
                         self.breaker.record_failure()
                         raise RuntimeError(
@@ -477,8 +540,7 @@ class CodexChatClient:
                         )
 
                     if resp.status == 429:
-                        if hasattr(self.auth, "mark_current_limited"):
-                            await self.auth.mark_current_limited()
+                        await self._mark_limited(acct_idx)
                         self.breaker.record_failure()
                         last_error = f"HTTP 429: {error_body[:200]}"
                         if attempt < self.max_retries - 1:
@@ -488,13 +550,9 @@ class CodexChatClient:
                                 attempt + 1, self.max_retries, last_error, wait,
                             )
                             await asyncio.sleep(wait)
-                            access_token = await self.auth.get_access_token()
-                            headers["Authorization"] = f"Bearer {access_token}"
-                            if hasattr(self.auth, "get_account_id"):
-                                aid = self.auth.get_account_id()
-                                if aid:
-                                    headers["ChatGPT-Account-Id"] = aid
+                            token, account_id, acct_idx = await self._acquire_auth()
                             continue
+                        raise RuntimeError(f"Codex API error (429): {error_body[:500]}")
 
                     if resp.status in (500, 502, 503, 504):
                         self.breaker.record_failure()
@@ -502,27 +560,31 @@ class CodexChatClient:
                         if attempt < self.max_retries - 1:
                             wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
                             log.warning(
-                                "Codex tool API error (attempt %d/%d): %s. Retrying in %.1fs...",
+                                "Codex API error (attempt %d/%d): %s. Retrying in %.1fs...",
                                 attempt + 1, self.max_retries, last_error, wait,
                             )
                             await asyncio.sleep(wait)
                             continue
+                        raise RuntimeError(f"Codex API error ({resp.status}): {error_body[:500]}")
 
                     self.breaker.record_failure()
                     raise RuntimeError(f"Codex API error ({resp.status}): {error_body[:500]}")
 
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                # asyncio.TimeoutError: the 600s total timeout can fire
+                # mid-stream; it is not an aiohttp.ClientError and previously
+                # escaped both the retry loop and breaker bookkeeping.
                 self.breaker.record_failure()
-                last_error = str(e)
+                last_error = str(e) or type(e).__name__
                 if attempt < self.max_retries - 1:
                     wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
                     log.warning(
-                        "Codex tool connection error (attempt %d/%d): %s. Retrying in %.1fs...",
-                        attempt + 1, self.max_retries, e, wait,
+                        "Codex connection error (attempt %d/%d): %s. Retrying in %.1fs...",
+                        attempt + 1, self.max_retries, last_error, wait,
                     )
                     await asyncio.sleep(wait)
                 else:
-                    raise RuntimeError(f"Codex API connection failed: {e}") from e
+                    raise RuntimeError(f"Codex API connection failed: {last_error}") from e
 
         raise RuntimeError(f"Codex API failed after {self.max_retries} retries: {last_error}")
 
@@ -539,6 +601,7 @@ class CodexChatClient:
         """
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        incomplete = False
 
         # Track in-progress function calls by output_index
         pending_calls: dict[int, dict] = {}  # {index: {"call_id": ..., "name": ..., "args": ""}}
@@ -596,15 +659,18 @@ class CodexChatClient:
                 idx = event.get("output_index", 0)
                 if idx in pending_calls:
                     call_info = pending_calls[idx]
+                    parse_error = None
                     try:
                         parsed_args = json.loads(call_info["args"]) if call_info["args"] else {}
                     except json.JSONDecodeError:
                         parsed_args = {}
+                        parse_error = f"malformed tool arguments (invalid JSON): {call_info['args'][:200]}"
                         log.warning("Failed to parse function call arguments: %s", call_info["args"][:200])
                     tool_calls.append(ToolCall(
                         id=call_info["call_id"],
                         name=call_info["name"],
                         input=parsed_args,
+                        parse_error=parse_error,
                     ))
 
             # Output item done — finalize any remaining pending call at this index
@@ -616,19 +682,33 @@ class CodexChatClient:
                     call_info = pending_calls.pop(idx, None)
                     if call_info and not any(tc.id == call_info["call_id"] for tc in tool_calls):
                         args_str = item.get("arguments", call_info.get("args", ""))
+                        parse_error = None
                         try:
                             parsed_args = json.loads(args_str) if args_str else {}
                         except json.JSONDecodeError:
                             parsed_args = {}
+                            parse_error = f"malformed tool arguments (invalid JSON): {args_str[:200]}"
                         tool_calls.append(ToolCall(
                             id=call_info["call_id"],
                             name=call_info["name"],
                             input=parsed_args,
+                            parse_error=parse_error,
                         ))
 
-            # Content filter / refusal / error events
-            elif event_type in ("response.failed", "response.incomplete", "error"):
-                log.warning("Codex stream event %s: %s", event_type, json.dumps(event)[:500])
+            # Terminal failure events: the HTTP 200 turned out to be a failed
+            # generation — surface it so the retry engine treats it as an
+            # error instead of returning partial output as a completed turn.
+            elif event_type in ("response.failed", "error"):
+                detail = json.dumps(event)[:500]
+                log.warning("Codex stream terminal failure %s: %s", event_type, detail)
+                raise CodexStreamError(f"{event_type}: {detail}")
+
+            # Incomplete (length-capped / filtered): keep the partial output
+            # but mark it so callers can tell it isn't a normal completion.
+            elif event_type == "response.incomplete":
+                incomplete = True
+                reason = ((event.get("response") or {}).get("incomplete_details") or {}).get("reason") or "unknown"
+                log.warning("Codex stream incomplete (reason: %s) — returning partial output", reason)
 
             # Final response object — fallback
             elif event_type == "response.completed":
@@ -661,132 +741,13 @@ class CodexChatClient:
             log.warning("Codex tool stream empty (events: %s, pending: %s)",
                         event_types_seen, list(pending_calls.keys()))
 
-        stop_reason = "tool_use" if tool_calls else "end_turn"
+        if tool_calls:
+            stop_reason = "tool_use"
+        elif incomplete:
+            stop_reason = "incomplete"
+        else:
+            stop_reason = "end_turn"
         return LLMResponse(text=text, tool_calls=tool_calls, stop_reason=stop_reason)
-
-    async def _stream_request(self, headers: dict, body: dict) -> str:
-        """Send a streaming request and collect the full response text."""
-        self.breaker.check()
-        session = await self._get_session()
-        self._total_requests += 1
-        last_error = None
-
-        for attempt in range(self.max_retries):
-            try:
-                async with session.post(
-                    CODEX_API_URL,
-                    headers=headers,
-                    json=body,
-                    timeout=aiohttp.ClientTimeout(total=600),
-                ) as resp:
-                    if resp.status == 200:
-                        result = await self._read_stream(resp)
-                        if result:
-                            self.breaker.record_success()
-                            return result
-                        log.warning(
-                            "Codex returned 200 with empty response (attempt %d/%d)",
-                            attempt + 1, self.max_retries,
-                        )
-                        if attempt < self.max_retries - 1:
-                            wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
-                            await asyncio.sleep(wait)
-                            continue
-                        self.breaker.record_failure()
-                        return result
-
-                    error_body = (await resp.read()).decode("utf-8", errors="replace")
-
-                    if resp.status == 401:
-                        body_l = error_body.lower()
-                        invalidated = (
-                            "token_invalidated" in body_l
-                            or "invalidated" in body_l
-                            or "sign in again" in body_l
-                        )
-                        # Likely-stale cached bearer (generic 401, first try):
-                        # clear + refresh and retry the SAME account once.
-                        if attempt == 0 and not invalidated:
-                            log.warning("Codex auth 401, forcing token refresh...")
-                            await self.auth.invalidate_current()
-                            new_token = await self.auth.get_access_token()
-                            headers["Authorization"] = f"Bearer {new_token}"
-                            account_id = self.auth.get_account_id()
-                            if account_id:
-                                headers["ChatGPT-Account-Id"] = account_id
-                            else:
-                                headers.pop("ChatGPT-Account-Id", None)
-                            continue
-                        # Invalidated, or a 401 that survived the refresh: this
-                        # account can't authenticate. Skip it and rotate to the
-                        # next account — only on this error, never routine traffic.
-                        rotated = False
-                        if hasattr(self.auth, "mark_current_auth_failed"):
-                            rotated = await self.auth.mark_current_auth_failed()
-                        if rotated and attempt < self.max_retries - 1:
-                            log.warning("Codex 401: skipped failed account, retrying on next...")
-                            new_token = await self.auth.get_access_token()
-                            headers["Authorization"] = f"Bearer {new_token}"
-                            account_id = self.auth.get_account_id()
-                            if account_id:
-                                headers["ChatGPT-Account-Id"] = account_id
-                            else:
-                                headers.pop("ChatGPT-Account-Id", None)
-                            continue
-                        self.breaker.record_failure()
-                        raise RuntimeError(
-                            f"Codex 401 (auth failed, no healthy account): {error_body[:200]}"
-                        )
-
-                    if resp.status == 429:
-                        if hasattr(self.auth, "mark_current_limited"):
-                            await self.auth.mark_current_limited()
-                        self.breaker.record_failure()
-                        last_error = f"HTTP 429: {error_body[:200]}"
-                        if attempt < self.max_retries - 1:
-                            wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
-                            log.warning(
-                                "Codex rate limited (attempt %d/%d): %s. Rotating + retry in %.1fs...",
-                                attempt + 1, self.max_retries, last_error, wait,
-                            )
-                            await asyncio.sleep(wait)
-                            access_token = await self.auth.get_access_token()
-                            headers["Authorization"] = f"Bearer {access_token}"
-                            if hasattr(self.auth, "get_account_id"):
-                                aid = self.auth.get_account_id()
-                                if aid:
-                                    headers["ChatGPT-Account-Id"] = aid
-                            continue
-
-                    if resp.status in (500, 502, 503, 504):
-                        self.breaker.record_failure()
-                        last_error = f"HTTP {resp.status}: {error_body[:200]}"
-                        if attempt < self.max_retries - 1:
-                            wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
-                            log.warning(
-                                "Codex API error (attempt %d/%d): %s. Retrying in %.1fs...",
-                                attempt + 1, self.max_retries, last_error, wait,
-                            )
-                            await asyncio.sleep(wait)
-                            continue
-
-                    self.breaker.record_failure()
-                    raise RuntimeError(f"Codex API error ({resp.status}): {error_body[:500]}")
-
-            except aiohttp.ClientError as e:
-                self.breaker.record_failure()
-                last_error = str(e)
-                if attempt < self.max_retries - 1:
-                    wait = compute_backoff(attempt, self.retry_base_delay, self.retry_max_delay)
-                    log.warning(
-                        "Codex connection error (attempt %d/%d): %s. Retrying in %.1fs...",
-                        attempt + 1, self.max_retries, e, wait,
-                    )
-                    await asyncio.sleep(wait)
-                else:
-                    raise RuntimeError(f"Codex API connection failed: {e}") from e
-
-        raise RuntimeError(f"Codex API failed after {self.max_retries} retries: {last_error}")
 
     async def _read_stream(self, resp: aiohttp.ClientResponse) -> str:
         """Read SSE stream and extract text content."""
@@ -821,6 +782,17 @@ class CodexChatClient:
                 done_text = event.get("text", "")
                 if done_text and not text_parts:
                     text_parts.append(done_text)
+
+            # Terminal failure events — surface to the retry engine instead of
+            # returning partial output as a normal completion.
+            elif event_type in ("response.failed", "error"):
+                detail = json.dumps(event)[:500]
+                log.warning("Codex stream terminal failure %s: %s", event_type, detail)
+                raise CodexStreamError(f"{event_type}: {detail}")
+
+            elif event_type == "response.incomplete":
+                reason = ((event.get("response") or {}).get("incomplete_details") or {}).get("reason") or "unknown"
+                log.warning("Codex stream incomplete (reason: %s) — returning partial output", reason)
 
             # response.completed — final response object
             elif event_type == "response.completed":

--- a/src/llm/types.py
+++ b/src/llm/types.py
@@ -14,6 +14,10 @@ class ToolCall:
     id: str  # call_id (OpenAI) or internal tool_use_id
     name: str  # tool name
     input: dict  # parsed tool arguments
+    # Set when the model's arguments were not valid JSON. The dispatcher must
+    # NOT execute such a call with the empty input — feed the error back to
+    # the model instead so it can retry with valid arguments.
+    parse_error: str | None = None
 
 
 @dataclass(slots=True)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3047,7 +3047,13 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         pool = getattr(bot, "codex_client", None)
         pool = getattr(pool, "auth", None) if pool else None
         if pool:
-            pool.reload()
+            # reload() ignores the pool lock and can race in-flight token
+            # operations (account-mutation methods index the list after an
+            # await) — use the locked variant.
+            if hasattr(pool, "reload_async"):
+                await pool.reload_async()
+            else:
+                pool.reload()
 
         return web.json_response({
             "status": "deleted",

--- a/tests/test_codex_reliability.py
+++ b/tests/test_codex_reliability.py
@@ -1,0 +1,553 @@
+"""Tests for Codex auth/provider reliability fixes.
+
+Covers:
+- Rotated refresh-token persistence: shadow files are no longer clobbered by
+  the canonical file on init/reload, and refreshes write back to canonical
+  (the "all 3 accounts die at once" outage).
+- Request-pinned account marking: 429/401 penalize the account that served
+  the failing request, not whatever account is current at lock time.
+- Pool lock is not held across token refresh.
+- Circuit breaker records exactly one failure per failed attempt (no
+  double-count on terminal 429/5xx).
+- Mid-stream timeouts get breaker bookkeeping + retry parity.
+- Stream terminal events (response.failed / error) surface as retryable
+  errors; response.incomplete is marked on the response.
+- Malformed tool-call arguments produce parse_error instead of silently
+  dispatching with empty input.
+- Reactive 401 handling actually refreshes the token.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import aiohttp
+import pytest
+
+from src.llm.codex_auth import CodexAuth, CodexAuthPool
+from src.llm.openai_codex import CodexChatClient, CodexStreamError
+from src.llm.types import ToolCall
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _creds(account_id: str, *, expires_at: int, refresh_token: str = "rt",
+           access_token: str = "at", email: str | None = None) -> dict:
+    data = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_at": expires_at,
+        "account_id": account_id,
+    }
+    if email:
+        data["email"] = email
+    return data
+
+
+def _write_json(path: Path, data) -> None:
+    path.write_text(json.dumps(data, indent=2))
+
+
+class FakeResp:
+    """Minimal aiohttp response stand-in for the streaming paths."""
+
+    def __init__(self, status: int, body: bytes = b"", sse_lines: list[str] | None = None):
+        self.status = status
+        self._body = body
+        self.content = self._iter_lines(sse_lines or [])
+
+    @staticmethod
+    async def _iter_lines(lines: list[str]):
+        for line in lines:
+            yield line.encode()
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    """Yields scripted responses (or raises scripted exceptions) per post()."""
+
+    def __init__(self, script: list):
+        self._script = list(script)
+        self.closed = False
+        self.calls = 0
+
+    def post(self, *args, **kwargs):
+        self.calls += 1
+        item = self._script.pop(0) if self._script else self._script_exhausted()
+        if isinstance(item, Exception):
+            return _RaisingCM(item)
+        return item
+
+    @staticmethod
+    def _script_exhausted():
+        raise AssertionError("FakeSession script exhausted — unexpected extra request")
+
+
+class _RaisingCM:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    async def __aenter__(self):
+        raise self._exc
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSingleAuth:
+    """Bare single-account auth (the non-pool code path)."""
+
+    def __init__(self):
+        self.limited = False
+
+    async def get_access_token(self) -> str:
+        return "tok"
+
+    def get_account_id(self):
+        return None
+
+    def mark_rate_limited(self, seconds: float = 60):
+        self.limited = True
+
+
+def _client(auth=None, max_retries: int = 1) -> CodexChatClient:
+    return CodexChatClient(
+        auth=auth or FakeSingleAuth(),
+        model="gpt-test",
+        max_tokens=100,
+        max_retries=max_retries,
+        retry_base_delay=0.001,
+        retry_max_delay=0.002,
+    )
+
+
+def _sse(events: list[dict], done: bool = True) -> list[str]:
+    lines = [f"data: {json.dumps(e)}\n" for e in events]
+    if done:
+        lines.append("data: [DONE]\n")
+    return lines
+
+
+TEXT_OK_SSE = _sse([{"type": "response.output_text.delta", "delta": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Token persistence (Tier 0.2)
+# ---------------------------------------------------------------------------
+
+def test_newer_shadow_survives_init_and_syncs_canonical(tmp_path):
+    canonical = tmp_path / "codex_auth.json"
+    _write_json(canonical, [
+        _creds("acct-A", expires_at=100, refresh_token="stale-A"),
+        _creds("acct-B", expires_at=100, refresh_token="stale-B"),
+    ])
+    # Account 0's shadow holds rotated (newer) tokens from a running session.
+    rotated = _creds("acct-A", expires_at=200, refresh_token="rotated-A")
+    _write_json(tmp_path / "codex_auth_0.json", rotated)
+
+    pool = CodexAuthPool(str(canonical))
+
+    assert pool.account_count == 2
+    # Shadow was NOT clobbered with the stale canonical creds.
+    shadow = json.loads((tmp_path / "codex_auth_0.json").read_text())
+    assert shadow["refresh_token"] == "rotated-A"
+    # Canonical was pulled up to date from the shadow.
+    canon = json.loads(canonical.read_text())
+    assert canon[0]["refresh_token"] == "rotated-A"
+    # The untouched account still synced canonical -> shadow as before.
+    shadow1 = json.loads((tmp_path / "codex_auth_1.json").read_text())
+    assert shadow1["refresh_token"] == "stale-B"
+
+
+def test_newer_canonical_overwrites_shadow(tmp_path):
+    """Re-auth via WebUI rewrites canonical — that must win over an old shadow."""
+    canonical = tmp_path / "codex_auth.json"
+    _write_json(canonical, [_creds("acct-A", expires_at=500, refresh_token="fresh-login")])
+    _write_json(tmp_path / "codex_auth_0.json",
+                _creds("acct-A", expires_at=100, refresh_token="old-rotation"))
+
+    CodexAuthPool(str(canonical))
+
+    shadow = json.loads((tmp_path / "codex_auth_0.json").read_text())
+    assert shadow["refresh_token"] == "fresh-login"
+
+
+def test_different_account_at_slot_canonical_wins(tmp_path):
+    """After an account deletion the slot holds a different account — the old
+    shadow must not resurrect the deleted account, however new its tokens."""
+    canonical = tmp_path / "codex_auth.json"
+    _write_json(canonical, [_creds("acct-B", expires_at=100, refresh_token="B-token")])
+    _write_json(tmp_path / "codex_auth_0.json",
+                _creds("acct-DELETED", expires_at=99999, refresh_token="zombie"))
+
+    CodexAuthPool(str(canonical))
+
+    shadow = json.loads((tmp_path / "codex_auth_0.json").read_text())
+    assert shadow["account_id"] == "acct-B"
+    assert shadow["refresh_token"] == "B-token"
+
+
+def test_account_save_writes_back_to_canonical(tmp_path):
+    canonical = tmp_path / "codex_auth.json"
+    _write_json(canonical, [
+        _creds("acct-A", expires_at=100),
+        _creds("acct-B", expires_at=100),
+    ])
+    pool = CodexAuthPool(str(canonical))
+
+    # Simulate what _refresh() does after rotating tokens.
+    new_creds = _creds("acct-B", expires_at=999, refresh_token="rotated-B")
+    pool._accounts[1]._save(new_creds)
+
+    canon = json.loads(canonical.read_text())
+    assert canon[1]["refresh_token"] == "rotated-B"
+    assert canon[1]["expires_at"] == 999
+    assert canon[0]["refresh_token"] == "rt"  # sibling untouched
+
+
+def test_reload_preserves_rotated_tokens(tmp_path):
+    """The original bug: reload/restart clobbered every shadow with stale
+    canonical creds, burning the single-use refresh tokens."""
+    canonical = tmp_path / "codex_auth.json"
+    _write_json(canonical, [_creds("acct-A", expires_at=100, refresh_token="login-day")])
+    pool = CodexAuthPool(str(canonical))
+
+    rotated = _creds("acct-A", expires_at=5000, refresh_token="rotated")
+    pool._accounts[0]._save(rotated)
+
+    pool.reload()
+
+    shadow = json.loads((tmp_path / "codex_auth_0.json").read_text())
+    assert shadow["refresh_token"] == "rotated"
+    canon = json.loads(canonical.read_text())
+    assert canon[0]["refresh_token"] == "rotated"
+
+
+# ---------------------------------------------------------------------------
+# Request-pinned account marking (2.1)
+# ---------------------------------------------------------------------------
+
+def _mem_pool(n: int) -> CodexAuthPool:
+    pool = CodexAuthPool.__new__(CodexAuthPool)
+    pool._path = Path("/nonexistent/codex_auth.json")
+    pool._accounts = []
+    pool._current_index = 0
+    pool._pool_lock = asyncio.Lock()
+    for i in range(n):
+        auth = CodexAuth.__new__(CodexAuth)
+        auth._path = Path(f"/nonexistent/codex_auth_{i}.json")
+        auth._credentials = _creds(f"acct-{i}", expires_at=int(time.time()) + 9999,
+                                   access_token=f"tok-{i}", email=f"a{i}@x.com")
+        auth._refresh_lock = asyncio.Lock()
+        auth.on_save = None
+        pool._accounts.append(auth)
+    return pool
+
+
+async def test_acquire_returns_pinned_pair_and_index():
+    pool = _mem_pool(3)
+    token, account_id, idx = await pool.acquire()
+    assert (token, account_id, idx) == ("tok-0", "acct-0", 0)
+
+
+async def test_mark_limited_penalizes_pinned_account_not_current():
+    pool = _mem_pool(3)
+    _, _, idx = await pool.acquire()  # request pinned to account 0
+
+    # Concurrent traffic rotated the pool to account 1 in the meantime.
+    pool._current_index = 1
+
+    await pool.mark_limited(idx)
+
+    assert pool._accounts[0].is_rate_limited() is True      # the real offender
+    assert pool._accounts[1].is_rate_limited() is False     # healthy, untouched
+    assert pool._current_index == 1  # no spurious extra rotation
+
+
+async def test_mark_limited_rotates_when_pinned_is_current():
+    pool = _mem_pool(3)
+    await pool.mark_limited(0)
+    assert pool._accounts[0].is_rate_limited() is True
+    assert pool._current_index == 1
+
+
+async def test_mark_auth_failed_pinned_not_current_keeps_position():
+    pool = _mem_pool(3)
+    pool._current_index = 2
+    rotated = await pool.mark_auth_failed(0)
+    assert rotated is True
+    assert pool._accounts[0].is_rate_limited() is True
+    assert pool._current_index == 2
+
+
+async def test_acquire_skips_rate_limited_accounts():
+    pool = _mem_pool(3)
+    pool._accounts[0].mark_rate_limited()
+    token, account_id, idx = await pool.acquire()
+    assert idx == 1
+    assert token == "tok-1"
+
+
+async def test_all_rate_limited_raises_distinct_error():
+    pool = _mem_pool(2)
+    for acct in pool._accounts:
+        acct.mark_rate_limited()
+    with pytest.raises(RuntimeError, match="rate-limited or backing off"):
+        await pool.acquire()
+
+
+async def test_acquire_does_not_hold_pool_lock_during_refresh():
+    """A slow token refresh on one account must not block the pool."""
+    pool = _mem_pool(2)
+    gate = asyncio.Event()
+
+    async def slow_token():
+        await gate.wait()
+        return "slow-tok"
+
+    pool._accounts[0].get_access_token = slow_token  # type: ignore[method-assign]
+
+    task = asyncio.create_task(pool.acquire())
+    await asyncio.sleep(0.01)
+    assert not task.done()
+
+    # The pool lock must be free while account 0 refreshes.
+    assert pool._pool_lock.locked() is False
+    async with pool._pool_lock:
+        pass
+
+    gate.set()
+    token, _, idx = await task
+    assert (token, idx) == ("slow-tok", 0)
+
+
+# ---------------------------------------------------------------------------
+# Reactive 401 refresh (CodexAuth.force_refresh)
+# ---------------------------------------------------------------------------
+
+async def test_force_refresh_skips_when_token_already_rotated():
+    auth = CodexAuth.__new__(CodexAuth)
+    auth._path = Path("/nonexistent")
+    auth._credentials = {"access_token": "new", "refresh_token": "r"}
+    auth._refresh_lock = asyncio.Lock()
+    auth.on_save = None
+
+    async def boom(creds):
+        raise AssertionError("_refresh must not be called when token already rotated")
+
+    auth._refresh = boom  # type: ignore[method-assign]
+    assert await auth.force_refresh(stale_token="old") is True
+
+
+async def test_force_refresh_refreshes_and_reports_failure():
+    auth = CodexAuth.__new__(CodexAuth)
+    auth._path = Path("/nonexistent")
+    auth._credentials = {"access_token": "stale", "refresh_token": "r"}
+    auth._refresh_lock = asyncio.Lock()
+    auth.on_save = None
+
+    calls = []
+
+    async def fake_refresh(creds):
+        calls.append(creds["access_token"])
+
+    auth._refresh = fake_refresh  # type: ignore[method-assign]
+    assert await auth.force_refresh(stale_token="stale") is True
+    assert calls == ["stale"]
+
+    async def failing_refresh(creds):
+        raise RuntimeError("invalid_grant")
+
+    auth._refresh = failing_refresh  # type: ignore[method-assign]
+    assert await auth.force_refresh(stale_token="stale") is False
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker single-count (2.2) + timeout parity
+# ---------------------------------------------------------------------------
+
+async def test_terminal_429_records_single_breaker_failure(monkeypatch):
+    client = _client(max_retries=1)
+    session = FakeSession([FakeResp(429, body=b"limited")])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    with pytest.raises(RuntimeError, match="429"):
+        await client._stream_request({"model": "m"})
+
+    assert client.breaker._failure_count == 1  # was 2 before the fix
+
+
+async def test_terminal_500_records_single_breaker_failure(monkeypatch):
+    client = _client(max_retries=1)
+    session = FakeSession([FakeResp(500, body=b"boom")])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    with pytest.raises(RuntimeError, match="500"):
+        await client._stream_request({"model": "m"})
+
+    assert client.breaker._failure_count == 1
+
+
+async def test_retried_429_then_success_counts_once_and_resets(monkeypatch):
+    client = _client(max_retries=2)
+    session = FakeSession([
+        FakeResp(429, body=b"limited"),
+        FakeResp(200, sse_lines=TEXT_OK_SSE),
+    ])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    text = await client._stream_request({"model": "m"})
+    assert text == "hello"
+    assert client.breaker._failure_count == 0  # success reset
+    assert client.auth.limited is True  # 429 marked the account
+
+
+async def test_mid_stream_timeout_hits_breaker_and_retries(monkeypatch):
+    client = _client(max_retries=2)
+    session = FakeSession([
+        asyncio.TimeoutError(),
+        FakeResp(200, sse_lines=TEXT_OK_SSE),
+    ])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    text = await client._stream_request({"model": "m"})
+    assert text == "hello"
+    assert session.calls == 2
+
+
+async def test_terminal_timeout_raises_wrapped_error(monkeypatch):
+    client = _client(max_retries=1)
+    session = FakeSession([asyncio.TimeoutError()])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        await client._stream_request({"model": "m"})
+    assert client.breaker._failure_count == 1
+
+
+def _async_return(value):
+    async def _coro():
+        return value
+    return _coro()
+
+
+# ---------------------------------------------------------------------------
+# Stream terminal events + malformed args
+# ---------------------------------------------------------------------------
+
+async def test_response_failed_event_is_retryable_error(monkeypatch):
+    client = _client(max_retries=2)
+    session = FakeSession([
+        FakeResp(200, sse_lines=_sse([{"type": "response.failed", "response": {"error": "x"}}], done=False)),
+        FakeResp(200, sse_lines=TEXT_OK_SSE),
+    ])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    text = await client._stream_request({"model": "m"})
+    assert text == "hello"
+    assert session.calls == 2
+
+
+async def test_response_failed_terminal_raises(monkeypatch):
+    client = _client(max_retries=1)
+    session = FakeSession([
+        FakeResp(200, sse_lines=_sse([{"type": "response.failed", "response": {}}], done=False)),
+    ])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        await client._stream_request({"model": "m"})
+
+
+async def test_incomplete_marks_stop_reason_keeps_partial_text():
+    client = _client()
+    resp = FakeResp(200, sse_lines=_sse([
+        {"type": "response.output_text.delta", "delta": "partial"},
+        {"type": "response.incomplete",
+         "response": {"incomplete_details": {"reason": "max_output_tokens"}}},
+    ]))
+    result = await client._read_tool_stream(resp)
+    assert result.text == "partial"
+    assert result.stop_reason == "incomplete"
+    assert result.is_tool_use is False
+
+
+async def test_malformed_tool_args_set_parse_error():
+    client = _client()
+    resp = FakeResp(200, sse_lines=_sse([
+        {"type": "response.output_item.added", "output_index": 0,
+         "item": {"type": "function_call", "call_id": "c1", "name": "run_command"}},
+        {"type": "response.function_call_arguments.delta", "output_index": 0,
+         "delta": '{"command": "ls'},
+        {"type": "response.function_call_arguments.done", "output_index": 0},
+    ]))
+    result = await client._read_tool_stream(resp)
+    assert len(result.tool_calls) == 1
+    tc = result.tool_calls[0]
+    assert tc.input == {}
+    assert tc.parse_error is not None
+    assert "malformed tool arguments" in tc.parse_error
+
+
+async def test_valid_tool_args_have_no_parse_error():
+    client = _client()
+    resp = FakeResp(200, sse_lines=_sse([
+        {"type": "response.output_item.added", "output_index": 0,
+         "item": {"type": "function_call", "call_id": "c1", "name": "run_command"}},
+        {"type": "response.function_call_arguments.delta", "output_index": 0,
+         "delta": '{"command": "ls"}'},
+        {"type": "response.function_call_arguments.done", "output_index": 0},
+    ]))
+    result = await client._read_tool_stream(resp)
+    tc = result.tool_calls[0]
+    assert tc.input == {"command": "ls"}
+    assert tc.parse_error is None
+    assert result.stop_reason == "tool_use"
+
+
+def test_toolcall_parse_error_defaults_none():
+    tc = ToolCall(id="1", name="t", input={})
+    assert tc.parse_error is None
+
+
+# ---------------------------------------------------------------------------
+# Reactive 401 end-to-end through the provider
+# ---------------------------------------------------------------------------
+
+async def test_generic_401_forces_refresh_and_retries_same_account(tmp_path, monkeypatch):
+    canonical = tmp_path / "codex_auth.json"
+    _write_json(canonical, [_creds("acct-A", expires_at=int(time.time()) + 9999,
+                                   access_token="stale-tok")])
+    pool = CodexAuthPool(str(canonical))
+    refreshed = []
+
+    async def fake_force_refresh(stale_token=None):
+        refreshed.append(stale_token)
+        return True
+
+    pool._accounts[0].force_refresh = fake_force_refresh  # type: ignore[method-assign]
+
+    client = _client(auth=pool, max_retries=2)
+    session = FakeSession([
+        FakeResp(401, body=b"unauthorized"),
+        FakeResp(200, sse_lines=TEXT_OK_SSE),
+    ])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    text = await client._stream_request({"model": "m"})
+    assert text == "hello"
+    assert refreshed == ["stale-tok"]
+    # Same account retried — no rotation, no rate-limit marking.
+    assert pool._accounts[0].is_rate_limited() is False

--- a/tests/test_codex_reliability.py
+++ b/tests/test_codex_reliability.py
@@ -501,6 +501,38 @@ async def test_malformed_tool_args_set_parse_error():
     assert "malformed tool arguments" in tc.parse_error
 
 
+async def test_malformed_tool_args_in_completed_fallback_set_parse_error():
+    """The response.completed fallback path (used when arguments.done/output_item.done
+    never arrived) must also flag malformed JSON instead of coercing to {}."""
+    client = _client()
+    resp = FakeResp(200, sse_lines=_sse([
+        {"type": "response.completed", "response": {"output": [
+            {"type": "function_call", "call_id": "c9", "name": "run_command",
+             "arguments": '{"command": "ls'},  # truncated / invalid JSON
+        ]}},
+    ]))
+    result = await client._read_tool_stream(resp)
+    assert len(result.tool_calls) == 1
+    tc = result.tool_calls[0]
+    assert tc.input == {}
+    assert tc.parse_error is not None
+    assert "malformed tool arguments" in tc.parse_error
+
+
+async def test_valid_tool_args_in_completed_fallback_have_no_parse_error():
+    client = _client()
+    resp = FakeResp(200, sse_lines=_sse([
+        {"type": "response.completed", "response": {"output": [
+            {"type": "function_call", "call_id": "c9", "name": "run_command",
+             "arguments": '{"command": "ls"}'},
+        ]}},
+    ]))
+    result = await client._read_tool_stream(resp)
+    tc = result.tool_calls[0]
+    assert tc.input == {"command": "ls"}
+    assert tc.parse_error is None
+
+
 async def test_valid_tool_args_have_no_parse_error():
     client = _client()
     resp = FakeResp(200, sse_lines=_sse([


### PR DESCRIPTION
First of the fix series for the 2026-07-01 code review (findings confirmed by Odin's independent validation).

## Fixes

**Tier 0.2 — Codex refresh tokens destroyed on restart/reload** (the recurring "all 3 accounts die at once" outage)
- `_init_accounts` no longer unconditionally overwrites shadow files: for the same `account_id`, the newer side (by `expires_at`) wins, and a preserved shadow syncs back into the canonical entry
- `CodexAuth.on_save` hook mirrors every token rotation back to the canonical multi-account file — the persistence path that `src/setup.py` was supposed to provide but which never existed
- `account_id` identity check prevents a stale shadow from resurrecting a deleted account after `/api/codex/account/{i}` DELETE

**2.1 — Concurrent failover corrupts healthy accounts**
- New `CodexAuthPool.acquire()` → `(token, account_id, index)`; 429/401 penalize the pinned index (`mark_limited(i)` / `mark_auth_failed(i)`), not whatever account is current at lock time
- Token + account_id now an atomic pair from the same account (Tier 4 item)
- `acquire()` refreshes outside the pool lock — a slow 30s refresh no longer serializes all LLM traffic (Tier 4 item)
- All-rate-limited raises a distinct message instead of `"All 3 accounts failed: "` with an empty reason list (Tier 4 item)

**2.2 — Breaker double-counts terminal 429/5xx**
- The text and tool retry loops were duplicated copies carrying the same fall-through bug; unified into one `_send_with_retries` engine — exactly ONE `record_failure()` per failed attempt

**Reactive 401 never actually refreshes**
- `force_refresh()` exercises the refresh token immediately; `invalidate_current()` only dropped the cache and re-served the same revoked-but-unexpired bearer. Skip-if-already-rotated guard avoids concurrent double-refresh

**Stream failure/incomplete events swallowed**
- `response.failed`/`error` → `CodexStreamError` → retry/breaker path
- `response.incomplete` → partial text kept, `stop_reason="incomplete"`
- Mid-stream `asyncio.TimeoutError` (600s total) now gets breaker bookkeeping + retry parity

**Malformed tool-call args coerced to `{}`**
- Sets `ToolCall.parse_error`; both dispatchers in `client.py` return the error to the model instead of executing the tool with empty input

**Misc**
- Account-delete endpoint uses locked `reload_async()` instead of lock-ignoring sync `reload()`

## Tests
- 26 new tests (`tests/test_codex_reliability.py`): shadow preservation/write-back/identity, pinned marking, pool-lock scope during refresh, breaker single-count, timeout parity, terminal stream events, parse_error, reactive-401 e2e
- Full suite: **5757 passed, 8 skipped**