### PR TITLE
fix: session/archive persistence reliability

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -674,17 +674,22 @@ class OdinBot(commands.Bot):
 
     def _wire_llm_callbacks(self) -> None:
         """Attach LLM-backed compaction and reflection callbacks using the active provider."""
+        # Compaction emits a segment of up to ~2500 chars (≈625 tokens) plus
+        # structured header lines; reflection emits multi-lesson JSON. The old
+        # 300/500 caps guaranteed mid-output truncation on providers that honor
+        # max_tokens (Ollama/Kimi) — truncated reflection JSON parsed to [] and
+        # silently dropped lessons. (Codex ignores max_tokens entirely.)
         async def _llm_compaction(messages: list[dict], system: str) -> str:
             client = self.llm_client
             if not client:
                 raise RuntimeError("No LLM provider configured")
-            return await client.chat(messages=messages, system=system, max_tokens=300)
+            return await client.chat(messages=messages, system=system, max_tokens=1500)
 
         async def _llm_reflection(messages: list[dict], system: str) -> str:
             client = self.llm_client
             if not client:
                 raise RuntimeError("No LLM provider configured")
-            return await client.chat(messages=messages, system=system, max_tokens=500)
+            return await client.chat(messages=messages, system=system, max_tokens=2000)
 
         self.sessions.set_compaction_fn(_llm_compaction)
         self.reflector.set_text_fn(_llm_reflection)

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -61,6 +61,12 @@ TOOL_SUMMARY_THRESHOLD = 10  # summarize when this many tool calls occurred
 TOOL_SUMMARY_MAX_CHARS = 2000  # max chars for summarized tool response in history
 CHAT_RESPONSE_MAX_CHARS = 4000  # max chars for text-only (no-tool) response in history
 
+# Max chars of each source message fed into a compaction summary. Must be at
+# least CHAT_RESPONSE_MAX_CHARS or assistant responses (which persist up to
+# 4000 chars) get clipped to 500 before summarizing, permanently losing
+# identifiers past that point despite the "preserve verbatim" prompt.
+COMPACTION_SOURCE_MAX_CHARS = CHAT_RESPONSE_MAX_CHARS
+
 # Context budget constants. The send budget is configurable
 # (sessions.context_token_budget, per-channel overrides) — this is the default.
 CONTEXT_TOKEN_BUDGET = 64_000  # max estimated tokens for history sent to LLM
@@ -297,6 +303,13 @@ class Message:
     user_id: str | None = None
 
 
+# Per-message token overhead — role tag + structural/JSON framing the raw
+# content-length estimate ignores. Without it the estimator undercounts and
+# the always-kept recent window can overshoot the send budget on dense
+# code/JSON messages.
+MESSAGE_TOKEN_OVERHEAD = 4
+
+
 def _estimate_session_tokens(
     messages: list[Message], summary: str, segments: list | None = None,
 ) -> int:
@@ -305,9 +318,10 @@ def _estimate_session_tokens(
     if summary:
         total += estimate_tokens(summary)
     for seg in segments or []:
-        total += estimate_tokens(seg.get("summary", ""))
+        total += estimate_tokens(seg.get("summary", "")) + MESSAGE_TOKEN_OVERHEAD
     for m in messages:
         total += estimate_tokens(m.content if isinstance(m.content, str) else str(m.content))
+        total += MESSAGE_TOKEN_OVERHEAD
     return total
 
 
@@ -429,19 +443,24 @@ class SessionManager:
             candidates.append((ts, path))
         if not candidates:
             return None
-        candidates.sort()
-        _, latest = candidates[-1]
-        try:
-            data = json.loads(latest.read_text())
-            session = self._session_from_dict(data)
-        except Exception as e:
-            log.error("Failed to restore archive %s: %s", latest, e)
-            return None
-        log.info(
-            "Restored session for channel %s from archive %s (%d messages, %d segments)",
-            channel_id, latest.name, len(session.messages), len(session.summary_segments),
-        )
-        return session
+        # Newest first, but fall back to older archives if the newest is
+        # corrupt (truncated by a crash mid-write) instead of giving up and
+        # starting the channel fresh.
+        candidates.sort(reverse=True)
+        for ts, path in candidates:
+            try:
+                data = json.loads(path.read_text())
+                session = self._session_from_dict(data)
+            except Exception as e:
+                log.error("Skipping corrupt archive %s: %s", path, e)
+                continue
+            log.info(
+                "Restored session for channel %s from archive %s (%d messages, %d segments)",
+                channel_id, path.name, len(session.messages), len(session.summary_segments),
+            )
+            return session
+        log.error("All %d archive(s) for channel %s were unreadable", len(candidates), channel_id)
+        return None
 
     def add_message(
         self, channel_id: str, role: str, content: str,
@@ -922,7 +941,7 @@ class SessionManager:
         convo_lines = []
         for m in to_summarize:
             speaker = f"{m.role}[{m.user_id}]" if m.user_id else m.role
-            convo_lines.append(f"{speaker}: {m.content[:500]}")
+            convo_lines.append(f"{speaker}: {m.content[:COMPACTION_SOURCE_MAX_CHARS]}")
         convo_text = "\n".join(convo_lines)
 
         system_instruction = (
@@ -1149,7 +1168,12 @@ class SessionManager:
         timestamp = int(session.last_active)
         path = archive_dir / f"{channel_id}_{timestamp}.json"
         data = asdict(session)
-        path.write_text(json.dumps(data, indent=2))
+        # Atomic write: a bare write_text left a truncated newest archive on an
+        # OOM/crash mid-write, and _restore_from_archive aborts on the newest
+        # file — so one bad write erased the channel despite good older archives.
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(path)
         log.info("Archived session %s (%d messages)", channel_id, len(session.messages))
         self._prune_old_archives(archive_dir)
 
@@ -1182,19 +1206,33 @@ class SessionManager:
         """
         try:
             files = sorted(archive_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
-            pruned = 0
             total_bytes = sum(f.stat().st_size for f in files)
-            while files and (
-                total_bytes > self.archive_max_bytes
-                or len(files) > self.archive_max_files
-            ):
-                oldest = files.pop(0)
-                total_bytes -= oldest.stat().st_size
-                oldest.unlink()
+
+            # Protect each channel's most-recent archive so a high-traffic
+            # channel can't evict a quiet channel's only restore point.
+            # Eviction order: oldest non-protected first; the protected
+            # newest-per-channel files are only touched as a last resort to
+            # honor a hard cap.
+            newest_per_channel: dict[str, Path] = {}
+            for f in files:  # ascending mtime → last write per channel wins
+                newest_per_channel[f.stem.rsplit("_", 1)[0]] = f
+            protected = set(newest_per_channel.values())
+            evict_order = [f for f in files if f not in protected]
+            evict_order += [f for f in files if f in protected]
+
+            pruned = 0
+            over_cap = lambda: total_bytes > self.archive_max_bytes or len(files) > self.archive_max_files
+            for f in evict_order:
+                if not over_cap():
+                    break
+                total_bytes -= f.stat().st_size
+                f.unlink()
+                files.remove(f)
                 pruned += 1
             if pruned:
                 log.info(
-                    "Pruned %d oldest archive(s) from %s (caps: %d bytes / %d files)",
+                    "Pruned %d archive(s) from %s (caps: %d bytes / %d files; "
+                    "newest-per-channel protected)",
                     pruned, archive_dir, self.archive_max_bytes, self.archive_max_files,
                 )
         except Exception as e:
@@ -1227,10 +1265,13 @@ class SessionManager:
                 arch_cid = data.get("channel_id", "unknown")
                 if channel_id and arch_cid != channel_id:
                     continue
+                # Content at or before the channel's reset epoch was purged —
+                # it must not resurface via search, mirroring restore.
+                reset_epoch = self._reset_epochs.get(arch_cid, 0.0)
                 summary = data.get("summary", "")
                 if summary and query_lower in summary.lower():
                     ts = data.get("last_active", 0)
-                    if (after and ts < after) or (before and ts > before):
+                    if (after and ts < after) or (before and ts > before) or ts <= reset_epoch:
                         pass
                     else:
                         results.append({
@@ -1246,6 +1287,8 @@ class SessionManager:
                     if after and ts < after:
                         continue
                     if before and ts > before:
+                        continue
+                    if ts <= reset_epoch:
                         continue
                     content = msg.get("content", "")
                     if query_lower in content.lower():
@@ -1353,6 +1396,9 @@ class SessionManager:
                     ts = hr.get("timestamp", 0)
                     if not _ts_ok(ts):
                         continue
+                    # Reset content stays purged from the semantic index too.
+                    if ts <= self._reset_epochs.get(hr.get("channel_id", ""), 0.0):
+                        continue
                     key = (hr["channel_id"], ts)
                     if key not in seen:
                         results.append(hr)
@@ -1441,28 +1487,45 @@ class SessionManager:
             log.error("Compaction reflection failed: %s", e)
 
     def save(self) -> None:
-        """Persist only sessions that changed since the last save."""
-        to_save = set(self._dirty)
-        self._dirty -= to_save
-        for cid in to_save:
+        """Persist only sessions that changed since the last save.
+
+        A channel is cleared from the dirty set only AFTER its write
+        succeeds. The old code cleared dirty up-front, so any write failure
+        (disk full, permission, tmp collision with the web-chat save) silently
+        dropped that session's changes forever.
+        """
+        for cid in list(self._dirty):
             session = self._sessions.get(cid)
             if session is None:
+                self._dirty.discard(cid)
                 continue
-            path = self.persist_dir / f"{cid}.json"
-            data = asdict(session)
-            tmp = path.with_suffix(".tmp")
-            tmp.write_text(json.dumps(data, indent=2))
-            tmp.replace(path)
+            try:
+                path = self.persist_dir / f"{cid}.json"
+                data = asdict(session)
+                tmp = path.with_suffix(".tmp")
+                tmp.write_text(json.dumps(data, indent=2))
+                tmp.replace(path)
+            except Exception as e:
+                log.error("Failed to save session %s (kept dirty for retry): %s", cid, e)
+                continue
+            self._dirty.discard(cid)
 
     def save_all(self) -> None:
         """Persist every session (used during shutdown)."""
+        failed: set[str] = set()
         for cid, session in list(self._sessions.items()):
-            path = self.persist_dir / f"{cid}.json"
-            data = asdict(session)
-            tmp = path.with_suffix(".tmp")
-            tmp.write_text(json.dumps(data, indent=2))
-            tmp.replace(path)
-        self._dirty.clear()
+            try:
+                path = self.persist_dir / f"{cid}.json"
+                data = asdict(session)
+                tmp = path.with_suffix(".tmp")
+                tmp.write_text(json.dumps(data, indent=2))
+                tmp.replace(path)
+            except Exception as e:
+                log.error("Failed to save session %s during save_all: %s", cid, e)
+                failed.add(cid)
+        # Keep any channel that failed to write marked dirty so a later save
+        # can retry it, rather than dropping its changes.
+        self._dirty = {cid for cid in self._dirty if cid in failed}
 
     @staticmethod
     def _session_from_dict(data: dict) -> Session:

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -1427,9 +1427,13 @@ class SessionManager:
                     ts = cr.get("timestamp", 0)
                     if not _ts_ok(ts):
                         continue
-                    if channel_id and cr.get("channel_id", "") != channel_id:
+                    cr_cid = cr.get("channel_id", "")
+                    if channel_id and cr_cid != channel_id:
                         continue
-                    key = (cr.get("channel_id", ""), ts)
+                    # Reset content stays purged from channel-log search too.
+                    if ts <= self._reset_epochs.get(cr_cid, 0.0):
+                        continue
+                    key = (cr_cid, ts)
                     if key not in seen:
                         results.append(cr)
                         seen.add(key)
@@ -1523,9 +1527,11 @@ class SessionManager:
             except Exception as e:
                 log.error("Failed to save session %s during save_all: %s", cid, e)
                 failed.add(cid)
-        # Keep any channel that failed to write marked dirty so a later save
-        # can retry it, rather than dropping its changes.
-        self._dirty = {cid for cid in self._dirty if cid in failed}
+        # After attempting every session, exactly the failed ones remain dirty
+        # so a later save retries them. Assigning the failed set directly (vs
+        # intersecting the old dirty set) also re-marks a session that was
+        # already clean before save_all but whose shutdown write just failed.
+        self._dirty = failed
 
     @staticmethod
     def _session_from_dict(data: dict) -> Session:

--- a/tests/test_session_persistence_reliability.py
+++ b/tests/test_session_persistence_reliability.py
@@ -84,6 +84,26 @@ def test_save_all_keeps_only_failed_dirty(tmp_path, monkeypatch):
     assert mgr._dirty == {"bad"}
 
 
+def test_save_all_remarks_previously_clean_session_on_failure(tmp_path, monkeypatch):
+    """A session already clean before save_all() must be re-marked dirty if its
+    shutdown write fails (Odin's PR#125 blocker)."""
+    mgr = _mgr(tmp_path)
+    mgr.add_message("bad", "user", "x", user_id="u1")
+    mgr.save()                      # 'bad' now clean
+    assert "bad" not in mgr._dirty
+
+    real_write = Path.write_text
+
+    def _fail_bad(self, *a, **k):
+        if "bad" in self.name:
+            raise OSError("disk full")
+        return real_write(self, *a, **k)
+
+    monkeypatch.setattr(Path, "write_text", _fail_bad)
+    mgr.save_all()
+    assert mgr._dirty == {"bad"}
+
+
 # ---------------------------------------------------------------------------
 # 2.10 — atomic archive + restore fallback
 # ---------------------------------------------------------------------------
@@ -200,6 +220,25 @@ async def test_search_excludes_reset_content(tmp_path):
     mgr._reset_epochs["c9"] = 150.0
     hits_after = await mgr.search_history("banana", channel_id="c9")
     assert not any("banana" in h["content"] for h in hits_after)
+
+
+async def test_search_excludes_reset_content_from_channel_logs(tmp_path):
+    """Reset content must not resurface via the Step-4 channel-log fallback
+    either (Odin's PR#125 blocker)."""
+    mgr = _mgr(tmp_path)
+
+    class _FakeLogger:
+        def search(self, query, limit):
+            return [{
+                "type": "user", "content": "banana old log",
+                "timestamp": 100.0, "channel_id": "c9", "user_id": "u",
+            }]
+
+    mgr._channel_logger = _FakeLogger()
+    mgr._reset_epochs["c9"] = 150.0
+
+    hits = await mgr.search_history("banana", channel_id="c9")
+    assert not any("banana" in h.get("content", "") for h in hits)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_persistence_reliability.py
+++ b/tests/test_session_persistence_reliability.py
@@ -1,0 +1,221 @@
+"""Tests for session/archive persistence reliability fixes (PR3).
+
+Covers:
+- 2.9  save()/save_all() clear dirty only after a successful write
+- 2.10 archive write is atomic; restore falls back past a corrupt newest archive
+- token estimator adds per-message overhead (no longer content-only)
+- archive eviction protects each channel's newest archive
+- reset/purge content no longer surfaces via search_history/_search_archives
+- compaction feeds full-length source messages (no 500-char clip)
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from src.sessions.manager import (
+    SessionManager, Session, Message, _estimate_session_tokens,
+    MESSAGE_TOKEN_OVERHEAD, COMPACTION_SOURCE_MAX_CHARS, CHAT_RESPONSE_MAX_CHARS,
+)
+
+
+def _mgr(tmp_path, **kw) -> SessionManager:
+    return SessionManager(
+        max_history=kw.pop("max_history", 50),
+        max_age_hours=kw.pop("max_age_hours", 24),
+        persist_dir=str(tmp_path),
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2.9 — save() dirty handling
+# ---------------------------------------------------------------------------
+
+def test_save_failure_keeps_channel_dirty(tmp_path, monkeypatch):
+    mgr = _mgr(tmp_path)
+    mgr.add_message("chanA", "user", "hello", user_id="u1")
+    assert "chanA" in mgr._dirty
+
+    # Force the write to fail.
+    real_write = Path.write_text
+
+    def _boom(self, *a, **k):
+        if self.name.endswith(".tmp"):
+            raise OSError("disk full")
+        return real_write(self, *a, **k)
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+    mgr.save()
+    # Change was NOT lost — still dirty for the next save.
+    assert "chanA" in mgr._dirty
+
+    # Recover: a normal save now persists it and clears dirty.
+    monkeypatch.setattr(Path, "write_text", real_write)
+    mgr.save()
+    assert "chanA" not in mgr._dirty
+    assert (tmp_path / "chanA.json").exists()
+
+
+def test_successful_save_clears_dirty(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.add_message("chanB", "user", "hi", user_id="u1")
+    mgr.save()
+    assert "chanB" not in mgr._dirty
+
+
+def test_save_all_keeps_only_failed_dirty(tmp_path, monkeypatch):
+    mgr = _mgr(tmp_path)
+    mgr.add_message("good", "user", "x", user_id="u1")
+    mgr.add_message("bad", "user", "y", user_id="u1")
+
+    real_write = Path.write_text
+
+    def _selective(self, *a, **k):
+        if "bad" in self.name:
+            raise OSError("nope")
+        return real_write(self, *a, **k)
+
+    monkeypatch.setattr(Path, "write_text", _selective)
+    mgr.save_all()
+    assert mgr._dirty == {"bad"}
+
+
+# ---------------------------------------------------------------------------
+# 2.10 — atomic archive + restore fallback
+# ---------------------------------------------------------------------------
+
+def test_restore_falls_back_past_corrupt_newest_archive(tmp_path):
+    mgr = _mgr(tmp_path)
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+
+    good = Session(channel_id="c1", messages=[Message(role="user", content="older good")],
+                   last_active=100.0)
+    (archive_dir / "c1_100.json").write_text(json.dumps(_asdict(good)))
+    # Newest archive is truncated / invalid JSON.
+    (archive_dir / "c1_200.json").write_text('{"channel_id": "c1", "messa')
+
+    restored = mgr._restore_from_archive("c1")
+    assert restored is not None
+    assert restored.messages[0].content == "older good"
+
+
+def test_restore_returns_none_when_all_corrupt(tmp_path):
+    mgr = _mgr(tmp_path)
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "c1_100.json").write_text("garbage")
+    (archive_dir / "c1_200.json").write_text("{bad")
+    assert mgr._restore_from_archive("c1") is None
+
+
+def test_archive_write_is_atomic_no_tmp_left(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr._sessions["c2"] = Session(
+        channel_id="c2",
+        messages=[Message(role="user", content="m")],
+        last_active=500.0,
+    )
+    mgr._archive_session("c2")
+    archive_dir = tmp_path / "archive"
+    assert (archive_dir / "c2_500.json").exists()
+    assert list(archive_dir.glob("*.tmp")) == []
+    # And it round-trips.
+    data = json.loads((archive_dir / "c2_500.json").read_text())
+    assert data["channel_id"] == "c2"
+
+
+# ---------------------------------------------------------------------------
+# Token estimator overhead
+# ---------------------------------------------------------------------------
+
+def test_estimator_adds_per_message_overhead():
+    msgs = [Message(role="user", content="hello"), Message(role="assistant", content="hi")]
+    from src.llm.cost_tracker import estimate_tokens
+    content_only = estimate_tokens("hello") + estimate_tokens("hi")
+    est = _estimate_session_tokens(msgs, "")
+    assert est == content_only + 2 * MESSAGE_TOKEN_OVERHEAD
+    assert est > content_only  # strictly more conservative than before
+
+
+# ---------------------------------------------------------------------------
+# Archive eviction protects newest-per-channel
+# ---------------------------------------------------------------------------
+
+def test_eviction_protects_quiet_channels_newest_archive(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.archive_max_files = 3  # tiny cap to force eviction
+    mgr.archive_max_bytes = 10**9
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+
+    # Quiet channel: one old archive. Churny channel: several newer ones.
+    files = {
+        "quiet_100.json": 100,
+        "churn_200.json": 200,
+        "churn_300.json": 300,
+        "churn_400.json": 400,
+        "churn_500.json": 500,
+    }
+    for name, mtime in files.items():
+        p = archive_dir / name
+        p.write_text("{}")
+        import os
+        os.utime(p, (mtime, mtime))
+
+    mgr._prune_old_archives(archive_dir)
+
+    remaining = {p.name for p in archive_dir.glob("*.json")}
+    # The quiet channel's only restore point survives despite being oldest.
+    assert "quiet_100.json" in remaining
+    # Cap respected.
+    assert len(remaining) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Reset content no longer searchable
+# ---------------------------------------------------------------------------
+
+async def test_search_excludes_reset_content(tmp_path):
+    mgr = _mgr(tmp_path)
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    # Archived message at t=100 containing "banana".
+    sess = Session(
+        channel_id="c9",
+        messages=[Message(role="user", content="banana secret", timestamp=100.0)],
+        last_active=100.0,
+    )
+    (archive_dir / "c9_100.json").write_text(json.dumps(_asdict(sess)))
+
+    # Before reset: searchable.
+    hits = await mgr.search_history("banana", channel_id="c9")
+    assert any("banana" in h["content"] for h in hits)
+
+    # Reset the channel (epoch now > 100).
+    mgr._reset_epochs["c9"] = 150.0
+    hits_after = await mgr.search_history("banana", channel_id="c9")
+    assert not any("banana" in h["content"] for h in hits_after)
+
+
+# ---------------------------------------------------------------------------
+# Compaction source length
+# ---------------------------------------------------------------------------
+
+def test_compaction_source_cap_matches_chat_response_cap():
+    # Regression guard: source cap must be >= the length assistant responses
+    # are persisted at, or long responses get clipped before summarizing.
+    assert COMPACTION_SOURCE_MAX_CHARS >= CHAT_RESPONSE_MAX_CHARS
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _asdict(session: Session) -> dict:
+    from dataclasses import asdict
+    return asdict(session)

--- a/tests/test_token_budget.py
+++ b/tests/test_token_budget.py
@@ -26,6 +26,7 @@ from src.llm.cost_tracker import estimate_tokens
 from src.sessions.manager import (
     DEFAULT_SESSION_TOKEN_BUDGET,
     COMPACTION_THRESHOLD,
+    MESSAGE_TOKEN_OVERHEAD,
     Message,
     Session,
     SessionManager,
@@ -76,13 +77,20 @@ class TestEstimateSessionTokens:
     def test_messages_only(self):
         msgs = [_make_message("a" * 40), _make_message("b" * 80)]
         result = _estimate_session_tokens(msgs, "")
-        assert result == estimate_tokens("a" * 40) + estimate_tokens("b" * 80)
+        # Each message carries a small structural overhead beyond its content.
+        assert result == (
+            estimate_tokens("a" * 40) + estimate_tokens("b" * 80)
+            + 2 * MESSAGE_TOKEN_OVERHEAD
+        )
 
     def test_messages_and_summary(self):
         msgs = [_make_message("a" * 100)]
         summary = "b" * 200
         result = _estimate_session_tokens(msgs, summary)
-        assert result == estimate_tokens("a" * 100) + estimate_tokens("b" * 200)
+        assert result == (
+            estimate_tokens("a" * 100) + estimate_tokens("b" * 200)
+            + MESSAGE_TOKEN_OVERHEAD
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +106,7 @@ class TestSessionEstimatedTokens:
         msgs = [_make_message("hello " * 100)]
         session = _make_session(messages=msgs)
         assert session.estimated_tokens > 0
-        assert session.estimated_tokens == estimate_tokens("hello " * 100)
+        assert session.estimated_tokens == estimate_tokens("hello " * 100) + MESSAGE_TOKEN_OVERHEAD
 
     def test_with_summary(self):
         session = _make_session(summary="important context " * 50)
@@ -229,7 +237,9 @@ class TestGetSessionTokenUsage:
         mgr = _make_manager(tmp_path, token_budget=1000)
         mgr.add_message("ch1", "user", "a" * 400)
         usage = mgr.get_session_token_usage()
-        assert usage["ch1"]["budget_pct"] == 10.0
+        # 100 content tokens + per-message overhead, over a 1000 budget.
+        expected_pct = round((100 + MESSAGE_TOKEN_OVERHEAD) / 1000 * 100, 1)
+        assert usage["ch1"]["budget_pct"] == expected_pct
 
     def test_has_summary_field(self, tmp_path):
         mgr = _make_manager(tmp_path)
@@ -260,7 +270,7 @@ class TestGetTokenMetrics:
         mgr.add_message("ch2", "user", "b" * 800)
         metrics = mgr.get_token_metrics()
         assert metrics["session_count"] == 2
-        assert metrics["total_tokens"] == 100 + 200
+        assert metrics["total_tokens"] == 100 + 200 + 2 * MESSAGE_TOKEN_OVERHEAD
         assert len(metrics["per_session"]) == 2
 
     def test_over_budget_count(self, tmp_path):


### PR DESCRIPTION
Third fix batch from the 2026-07-01 review (Odin-validated). Rebased on current master (has #123, #124).

## Fixes

**2.9 — `save()` loses updates on any write failure**
- `save()` clears a channel from `_dirty` only **after** its write succeeds. The old code cleared dirty up-front, so a failed `tmp.write_text`/`replace` (disk, permission, or tmp collision between the Discord `to_thread(save)` and the web-chat save) permanently dropped that session's changes.
- `save_all()` keeps failed channels dirty for a later retry.

**2.10 — Archive write non-atomic; restore aborts on newest corrupt file**
- `_archive_session` writes tmp+rename (atomic); a crash mid-write can no longer leave a truncated newest archive.
- `_restore_from_archive` tries candidates newest-first and **falls back** past a corrupt archive instead of returning `None` on the newest (which started the channel fresh despite dozens of good older archives).

**Tier 3**
- Token estimator adds a per-message overhead (was content-only `len//4`), so the 64K send budget isn't overshot on dense code/JSON.
- Archive cap eviction protects each channel's **newest** archive — a churning channel can't evict a quiet channel's only restore point (was global oldest-by-mtime).
- Reset/purge content no longer surfaces via `search_history`: `_search_archives` and the hybrid path now filter by the channel's reset epoch, mirroring restore. (No vec-delete API needed — filter at query time.)
- Compaction feeds source messages at full length (`COMPACTION_SOURCE_MAX_CHARS = 4000`) instead of clipping to 500 before summarizing, which lost identifiers past char 500.
- Compaction/reflection `max_tokens` raised 300/500 → 1500/2000 so providers that honor the cap (Ollama/Kimi) don't truncate segments / reflection JSON to `[]`.

## Tests
- 19 new (`tests/test_session_persistence_reliability.py`); `test_token_budget` updated for the estimator overhead.
- Full suite: **5769 passed, 8 skipped**.

## Note
Excludes the RRF-merge-keys and embed-failure-backfill items (Odin marked those UNCERTAIN / they belong with the knowledge-store work in the next PR).