### PR TITLE
fix: learning/knowledge reliability — memory cap, injection budget, locks

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -3204,7 +3204,7 @@ class OdinBot(commands.Bot):
                     elif tool_name == "list_knowledge":
                         result = self._handle_list_knowledge()
                     elif tool_name == "delete_knowledge":
-                        result = self._handle_delete_knowledge(tool_input)
+                        result = await self._handle_delete_knowledge(tool_input)
                     elif tool_name == "set_permission":
                         result = await self._handle_set_permission(
                             str(message.author.id), tool_input,
@@ -3896,7 +3896,7 @@ class OdinBot(commands.Bot):
         total = sum(s["chunks"] for s in sources)
         return f"**Knowledge base: {len(sources)} document(s), {total} total chunks**\n" + "\n".join(lines)
 
-    def _handle_delete_knowledge(self, inp: dict) -> str:
+    async def _handle_delete_knowledge(self, inp: dict) -> str:
         """Delete a document from the knowledge base."""
         if not self._knowledge_store:
             return "Knowledge base is not available."
@@ -3905,7 +3905,7 @@ class OdinBot(commands.Bot):
         if not source:
             return "'source' is required."
 
-        count = self._knowledge_store.delete_source(source)
+        count = await self._knowledge_store.delete_source_async(source)
         if count == 0:
             return f"No document found with source '{source}'."
         return f"Deleted '{source}' from knowledge base ({count} chunks removed)."
@@ -5006,7 +5006,7 @@ class OdinBot(commands.Bot):
         if tool_name == "list_knowledge":
             return self._handle_list_knowledge()
         if tool_name == "delete_knowledge":
-            return self._handle_delete_knowledge(tool_input)
+            return await self._handle_delete_knowledge(tool_input)
         if tool_name == "set_permission":
             return await self._handle_set_permission(user_id, tool_input)
         if tool_name == "search_audit":

--- a/src/knowledge/store.py
+++ b/src/knowledge/store.py
@@ -480,6 +480,21 @@ class KnowledgeStore:
             log.error("Failed to delete source '%s': %s", source, e)
         return 0
 
+    async def delete_source_async(self, source: str) -> int:
+        """Delete a source under the write lock, off the event loop.
+
+        delete_source() shares the single SQLite connection with ingest() but
+        took no _write_lock — interleaving a delete with an in-flight ingest
+        could commit half-written chunks. Callers in async contexts must use
+        this wrapper (it also moves the blocking DB work to a thread)."""
+        async with self._write_lock:
+            return await asyncio.to_thread(self.delete_source, source)
+
+    async def merge_sources_async(self, keep_source: str, remove_source: str) -> int:
+        """Merge sources under the write lock, off the event loop (see delete_source_async)."""
+        async with self._write_lock:
+            return await asyncio.to_thread(self.merge_sources, keep_source, remove_source)
+
     async def search_hybrid(
         self, query: str, embedder: LocalEmbedder | None = None, limit: int = 5,
     ) -> list[dict]:

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -17,6 +17,17 @@ TextFn = Callable[[list[dict], str], Awaitable[str]]
 
 log = get_logger("learning")
 
+
+def _neg_iso(iso: str) -> float:
+    """Negative epoch seconds for an ISO timestamp — sorts newest-first when
+    used ascending. Missing/unparseable timestamps sort last (oldest)."""
+    if not iso:
+        return 0.0
+    try:
+        return -datetime.fromisoformat(iso).timestamp()
+    except (ValueError, TypeError):
+        return 0.0
+
 # Content length policy. The soft limit is prompt guidance to the LLM; the
 # hard limit is enforced at storage time — but never as a silent chop.
 # Oversized content is clipped at a sentence boundary, suffixed with
@@ -193,6 +204,9 @@ class ConversationReflector:
         }
 
     def delete_entry(self, key: str) -> bool:
+        """Synchronous delete. Prefer delete_entry_async from async callers —
+        without the lock a delete racing an in-flight reflection is undone when
+        the reflection writes back its pre-delete snapshot."""
         data = self._load()
         entries = data.get("entries", [])
         before = len(entries)
@@ -202,7 +216,16 @@ class ConversationReflector:
             return True
         return False
 
+    async def delete_entry_async(self, key: str) -> bool:
+        """Delete an entry under the reflection lock, so it can't be resurrected
+        by a concurrent reflection/consolidation writing a stale snapshot."""
+        async with self._lock:
+            result = await asyncio.to_thread(self.delete_entry, key)
+        self.invalidate_cache()
+        return result
+
     def update_entry(self, key: str, content: str | None = None, category: str | None = None) -> dict | None:
+        """Synchronous update. Prefer update_entry_async from async callers."""
         data = self._load()
         for e in data.get("entries", []):
             if e.get("key") == key:
@@ -214,6 +237,15 @@ class ConversationReflector:
                 self._save(data)
                 return e
         return None
+
+    async def update_entry_async(
+        self, key: str, content: str | None = None, category: str | None = None,
+    ) -> dict | None:
+        """Update an entry under the reflection lock (see delete_entry_async)."""
+        async with self._lock:
+            result = await asyncio.to_thread(self.update_entry, key, content, category)
+        self.invalidate_cache()
+        return result
 
     # Injection selection caps, applied only when the corpus exceeds the
     # token budget. Corrections and the requester's preferences are pinned;
@@ -288,6 +320,15 @@ class ConversationReflector:
             selected = filtered
             selection_mode = "include_all"
             gated_records: list[dict] = []
+            # If we're over budget (e.g. a query-less caller with a big
+            # corpus), the trim order is priority then recency.
+            priority_order = sorted(
+                filtered,
+                key=lambda e: (
+                    self._INJECTION_PRIORITY.get(e.get("category", ""), 4),
+                    _neg_iso(e.get("updated_at", "")),
+                ),
+            )
         else:
             def entry_text(e: dict) -> str:
                 return " ".join([
@@ -312,6 +353,11 @@ class ConversationReflector:
             # Preserve original corpus order for stable prompts
             chosen = {id(e) for e in (*corrections, *preferences, *operational, *facts)}
             selected = [e for e in filtered if id(e) in chosen]
+            # Budget-trim order keeps the relevance ranking already computed:
+            # corrections, preferences, then operational/facts most relevant to
+            # the query. This is why the enforcement can't just re-sort by
+            # recency — it would drop the most relevant operational entry.
+            priority_order = [*corrections, *preferences, *operational, *facts]
             selection_mode = "gated"
             gated_records = []
             if trace is not None:
@@ -326,6 +372,13 @@ class ConversationReflector:
                 "Learned injection gated: %d/%d entries selected",
                 len(selected), len(filtered),
             )
+
+        # Hard token cap. Two paths could previously blow the nominal budget:
+        # a query-less caller took the include-all branch regardless of size,
+        # and the gated branch unioned up to 72 fixed top-K entries without a
+        # token re-check. Enforce the cap on the final selection either way,
+        # trimming along priority_order (lowest priority/relevance first).
+        selected = self._enforce_injection_budget(selected, priority_order)
 
         self._note_used(selected)
         lines = [fmt(e) for e in selected]
@@ -344,6 +397,36 @@ class ConversationReflector:
                 mode=selection_mode,
             )
         return section_text
+
+    # Priority order for trimming when the selection exceeds the token budget.
+    _INJECTION_PRIORITY = {"correction": 0, "preference": 1, "operational": 2, "fact": 3}
+
+    def _enforce_injection_budget(
+        self, selected: list[dict], priority_order: list[dict],
+    ) -> list[dict]:
+        """Trim *selected* to the injection token budget.
+
+        *priority_order* lists the same entries from most to least important
+        (corrections, preferences, then relevance-ranked operational/facts).
+        We keep the longest prefix of that order which fits the budget — but
+        always at least one entry, so a non-empty corpus never injects nothing.
+        The kept entries are returned in *selected*'s (corpus) order for
+        stable prompts."""
+        def cost(e: dict) -> int:
+            return len(f"- [{e.get('category', '')}] {e.get('content', '')}") // 4
+
+        if sum(cost(e) for e in selected) <= self._injection_token_budget:
+            return selected
+
+        kept: set[int] = set()
+        running = 0
+        for e in priority_order:
+            c = cost(e)
+            if running + c > self._injection_token_budget and kept:
+                break  # keep the first entry even if it alone exceeds budget
+            running += c
+            kept.add(id(e))
+        return [e for e in selected if id(e) in kept]
 
     _REFLECTION_CONTEXT_TOP_K = 30
 
@@ -764,14 +847,26 @@ class ConversationReflector:
         system_instruction = "You consolidate learned entries. Return only valid JSON array."
 
         def _fallback() -> list[dict]:
-            candidates.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+            # Pin high-value, never-expire categories (corrections and
+            # preferences) so an LLM consolidation failure can't evict a long-
+            # standing correction in favor of recent operational trivia. Only
+            # the remaining categories compete for the leftover slots by recency.
+            pinned = [e for e in candidates
+                      if e.get("category") in ("correction", "preference")]
+            rest = [e for e in candidates
+                    if e.get("category") not in ("correction", "preference")]
+            rest.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+            slots = max(0, target - len(pinned))
+            kept = pinned + rest[:slots]
             elapsed = _time.monotonic() - t0
             log.warning(
-                "Consolidation fallback: kept newest %d of %d candidates "
-                "(prompt was %d chars, elapsed %.1fs, %d damaged passed through)",
-                target, len(candidates), prompt_chars, elapsed, len(damaged),
+                "Consolidation fallback: kept %d (%d pinned corrections/prefs "
+                "+ %d newest of %d others; prompt %d chars, elapsed %.1fs, "
+                "%d damaged passed through)",
+                len(kept), len(pinned), min(slots, len(rest)), len(rest),
+                prompt_chars, elapsed, len(damaged),
             )
-            return candidates[:target] + damaged
+            return kept + damaged
 
         try:
             if not self._text_fn:

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -43,6 +43,11 @@ from .ssh_pool import SSHConnectionPool
 
 log = get_logger("tools")
 
+# Max working-memory notes retained per section (global / per-user). The full
+# merged map is injected into every system prompt, so this bounds prompt bloat;
+# oldest-by-write notes are evicted past the cap.
+MEMORY_MAX_KEYS_PER_SECTION = 200
+
 # Request-scoped caller identity, backed by contextvars. asyncio gives each
 # message-handling task (and each gather()-wrapped tool call) its own context
 # copy, so these are isolated across concurrent channels/requests. This replaces
@@ -1147,12 +1152,24 @@ class ToolExecutor:
                     section = f"user_{user_id}"
                 else:
                     section = "global"
-                if section not in all_mem:
-                    all_mem[section] = {}
-                all_mem[section][key] = value
+                section_map = all_mem.setdefault(section, {})
+                # Move-to-end + cap: working memory is injected into every
+                # system prompt, so it must not grow without bound. Re-inserting
+                # gives LRU-by-write order; evict the oldest keys beyond the cap
+                # (never the one just written).
+                section_map.pop(key, None)
+                section_map[key] = value
+                evicted = 0
+                while len(section_map) > MEMORY_MAX_KEYS_PER_SECTION:
+                    oldest = next(iter(section_map))
+                    if oldest == key:
+                        break
+                    del section_map[oldest]
+                    evicted += 1
                 await asyncio.to_thread(self._save_all_memory, all_mem)
                 scope_label = "global" if section == "global" else "personal"
-                return f"Saved {scope_label} note '{key}'."
+                suffix = f" (evicted {evicted} oldest note(s) at cap {MEMORY_MAX_KEYS_PER_SECTION})" if evicted else ""
+                return f"Saved {scope_label} note '{key}'.{suffix}"
 
             elif action == "delete":
                 key = inp.get("key")

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -1884,7 +1884,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
-        deleted = await asyncio.to_thread(store.delete_source, source)
+        deleted = await store.delete_source_async(source)
         if deleted == 0:
             return web.json_response({"error": "source not found"}, status=404)
         return web.json_response({"status": "deleted", "chunks_removed": deleted})
@@ -1959,7 +1959,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response(
                 {"error": "keep_source and remove_source are required"}, status=400
             )
-        removed = await asyncio.to_thread(store.merge_sources, keep, remove)
+        removed = await store.merge_sources_async(keep, remove)
         if removed == 0:
             return web.json_response(
                 {"error": "keep_source not found or nothing to merge"}, status=404
@@ -3883,7 +3883,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     @routes.delete("/api/learned/{key}")
     async def delete_learned(request: web.Request) -> web.Response:
         key = request.match_info["key"]
-        if bot.reflector.delete_entry(key):
+        if await bot.reflector.delete_entry_async(key):
             return web.json_response({"status": "deleted", "key": key})
         return web.json_response({"error": "entry not found"}, status=404)
 
@@ -3894,7 +3894,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             data = await request.json()
         except Exception:
             return web.json_response({"error": "invalid JSON body"}, status=400)
-        updated = bot.reflector.update_entry(
+        updated = await bot.reflector.update_entry_async(
             key,
             content=data.get("content"),
             category=data.get("category"),

--- a/tests/test_learned_overhaul.py
+++ b/tests/test_learned_overhaul.py
@@ -305,7 +305,10 @@ class TestInjection:
             )
         ]
         path = self._store(tmp_path, entries)
-        r = ConversationReflector(str(path), injection_token_budget=50)  # force gating
+        # Budget forces gating (whole corpus doesn't fit) but is large enough
+        # that the gated selection — pinned corrections/preferences plus the
+        # top-K relevant operational — fits without being trimmed.
+        r = ConversationReflector(str(path), injection_token_budget=185)
         section = r.get_prompt_section(user_id="42", query="fix the nginx config")
         assert "never do the bad thing." in section
         assert "user likes terse output." in section
@@ -323,14 +326,25 @@ class TestInjection:
         assert "their secret pref." not in section
         assert "global lesson." in section
 
-    def test_no_query_includes_all_in_scope(self, tmp_path):
+    def test_no_query_includes_all_in_scope_when_within_budget(self, tmp_path):
         path = self._store(tmp_path, [
             _entry(f"k{i}", content="x" * 600 + ".") for i in range(40)
         ])
-        r = ConversationReflector(str(path), injection_token_budget=100)
-        # Without a query there is nothing to rank against — include all
+        # Budget large enough to hold the whole corpus → include all.
+        r = ConversationReflector(str(path), injection_token_budget=10_000)
         section = r.get_prompt_section(query=None)
         assert section.count("- [") == 40
+
+    def test_no_query_still_enforces_budget(self, tmp_path):
+        # The old bug: a query-less caller injected the whole corpus regardless
+        # of the budget. Now the budget is a hard cap even without a query.
+        path = self._store(tmp_path, [
+            _entry(f"k{i}", content="x" * 600 + ".") for i in range(40)
+        ])
+        r = ConversationReflector(str(path), injection_token_budget=500)
+        section = r.get_prompt_section(query=None)
+        n = section.count("- [")
+        assert 0 < n < 40  # trimmed to fit — not all, not nothing
 
     @pytest.mark.asyncio
     async def test_use_stamps_persist_via_locked_write(self, tmp_path):

--- a/tests/test_learning_knowledge_reliability.py
+++ b/tests/test_learning_knowledge_reliability.py
@@ -1,0 +1,244 @@
+"""Tests for learning/knowledge reliability fixes (PR4).
+
+Covers:
+- learned-injection budget is a hard cap (query-less and gated paths)
+- consolidation fallback pins corrections/preferences over recent trivia
+- reflector delete/update async wrappers take the lock (no resurrection)
+- working memory is capped per section (bounded prompt injection)
+- knowledge delete_source/merge_sources async wrappers take the write lock
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from src.learning.reflector import ConversationReflector
+
+
+def _entry(key, category="operational", content="a lesson.", **kw):
+    e = {"key": key, "category": category, "content": content,
+         "updated_at": kw.pop("updated_at", "2026-01-01T00:00:00+00:00")}
+    e.update(kw)
+    return e
+
+
+def _store(tmp_path, entries) -> str:
+    path = tmp_path / "learned.json"
+    path.write_text(json.dumps({
+        "version": 2, "last_reflection": None, "entries": entries,
+    }))
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Injection budget hard cap
+# ---------------------------------------------------------------------------
+
+def test_queryless_injection_respects_budget(tmp_path):
+    path = _store(tmp_path, [_entry(f"k{i}", content="x" * 600 + ".") for i in range(30)])
+    r = ConversationReflector(path, injection_token_budget=400)
+    section = r.get_prompt_section(query=None)
+    # Rough token check: the section must not blow the budget by much.
+    assert len(section) // 4 <= 400 + 200  # small formatting slack
+    assert section.count("- [") < 30
+
+
+def test_injection_keeps_at_least_one_entry(tmp_path):
+    # A single entry larger than the whole budget still gets injected (better
+    # than silently injecting nothing).
+    path = _store(tmp_path, [_entry("big", content="y" * 4000 + ".")])
+    r = ConversationReflector(path, injection_token_budget=50)
+    section = r.get_prompt_section(query=None)
+    assert section.count("- [") == 1
+
+
+def test_gated_injection_prioritizes_corrections(tmp_path):
+    entries = [_entry("c", category="correction", content="pinned correction.")]
+    entries += [_entry(f"op{i}", content="x" * 300 + ".") for i in range(20)]
+    path = _store(tmp_path, entries)
+    r = ConversationReflector(path, injection_token_budget=200)
+    section = r.get_prompt_section(query="something", user_id=None)
+    # The correction survives the budget trim even though it's outnumbered.
+    assert "pinned correction." in section
+
+
+# ---------------------------------------------------------------------------
+# Consolidation fallback pinning
+# ---------------------------------------------------------------------------
+
+async def test_consolidation_fallback_pins_corrections(tmp_path):
+    # Old corrections must survive when the consolidation LLM fails, even
+    # against newer operational trivia.
+    corrections = [
+        _entry(f"corr{i}", category="correction", content=f"old correction {i}.",
+               updated_at="2020-01-01T00:00:00+00:00")
+        for i in range(5)
+    ]
+    trivia = [
+        _entry(f"op{i}", category="operational", content=f"recent trivia {i}.",
+               updated_at="2026-06-01T00:00:00+00:00")
+        for i in range(30)
+    ]
+    r = ConversationReflector(
+        _store(tmp_path, []), max_entries=40, consolidation_target=10,
+    )
+    # No text_fn configured → consolidation takes the fallback path.
+    result = await r._consolidate(corrections + trivia)
+    kept_keys = {e["key"] for e in result}
+    for i in range(5):
+        assert f"corr{i}" in kept_keys  # all corrections pinned
+
+
+async def test_consolidation_fallback_pins_preferences(tmp_path):
+    prefs = [
+        _entry(f"pref{i}", category="preference", content=f"old pref {i}.",
+               updated_at="2020-01-01T00:00:00+00:00")
+        for i in range(4)
+    ]
+    trivia = [
+        _entry(f"op{i}", category="operational", content=f"trivia {i}.",
+               updated_at="2026-06-01T00:00:00+00:00")
+        for i in range(20)
+    ]
+    r = ConversationReflector(_store(tmp_path, []), max_entries=25, consolidation_target=6)
+    result = await r._consolidate(prefs + trivia)
+    kept_keys = {e["key"] for e in result}
+    for i in range(4):
+        assert f"pref{i}" in kept_keys
+
+
+# ---------------------------------------------------------------------------
+# Reflector async delete/update under lock
+# ---------------------------------------------------------------------------
+
+async def test_delete_entry_async_removes_and_persists(tmp_path):
+    path = _store(tmp_path, [_entry("a"), _entry("b")])
+    r = ConversationReflector(path)
+    assert await r.delete_entry_async("a") is True
+    keys = {e["key"] for e in r.get_all_entries()}
+    assert keys == {"b"}
+
+
+async def test_delete_entry_async_not_resurrected_by_concurrent_reflection(tmp_path):
+    """A delete while a reflection holds the lock must apply to post-reflection
+    data, not be overwritten by the reflection's stale snapshot."""
+    path = _store(tmp_path, [_entry("keep"), _entry("victim")])
+    r = ConversationReflector(path)
+
+    release = asyncio.Event()
+
+    async def _slow_text_fn(messages, system):
+        await release.wait()
+        return "[]"  # no new entries
+
+    r.set_text_fn(_slow_text_fn)
+
+    # Start a reflection that grabs the lock and stalls inside the LLM call.
+    reflect_task = asyncio.create_task(
+        r._reflect("some conversation", full=True, user_ids=[]),
+    )
+    await asyncio.sleep(0.05)  # let it acquire the lock
+
+    # Delete must block on the lock until the reflection finishes.
+    del_task = asyncio.create_task(r.delete_entry_async("victim"))
+    await asyncio.sleep(0.05)
+    assert not del_task.done()  # blocked on the lock
+
+    release.set()
+    await reflect_task
+    assert await del_task is True
+
+    keys = {e["key"] for e in r.get_all_entries()}
+    assert "victim" not in keys  # stayed deleted
+    assert "keep" in keys
+
+
+async def test_update_entry_async_applies(tmp_path):
+    path = _store(tmp_path, [_entry("a", content="before.")])
+    r = ConversationReflector(path)
+    updated = await r.update_entry_async("a", content="after.")
+    assert updated is not None and updated["content"] == "after."
+    assert r.get_all_entries()[0]["content"] == "after."
+
+
+# ---------------------------------------------------------------------------
+# Working memory cap
+# ---------------------------------------------------------------------------
+
+async def test_working_memory_capped_per_section(tmp_path, monkeypatch):
+    import src.tools.executor as ex_mod
+    from src.tools.executor import ToolExecutor
+
+    monkeypatch.setattr(ex_mod, "MEMORY_MAX_KEYS_PER_SECTION", 5)
+
+    execu = ToolExecutor.__new__(ToolExecutor)
+    execu._memory_path = tmp_path / "memory.json"
+    execu._memory_lock = asyncio.Lock()
+
+    # Write more keys than the cap into the global section.
+    for i in range(8):
+        await execu._handle_memory_manage(
+            {"action": "save", "key": f"note{i}", "value": f"v{i}", "scope": "global"},
+        )
+
+    data = json.loads((tmp_path / "memory.json").read_text())
+    assert len(data["global"]) == 5
+    # Oldest evicted, newest retained.
+    assert "note0" not in data["global"]
+    assert "note7" in data["global"]
+
+
+async def test_working_memory_update_existing_key_no_growth(tmp_path, monkeypatch):
+    import src.tools.executor as ex_mod
+    from src.tools.executor import ToolExecutor
+    monkeypatch.setattr(ex_mod, "MEMORY_MAX_KEYS_PER_SECTION", 5)
+
+    execu = ToolExecutor.__new__(ToolExecutor)
+    execu._memory_path = tmp_path / "memory.json"
+    execu._memory_lock = asyncio.Lock()
+    for _ in range(3):
+        await execu._handle_memory_manage(
+            {"action": "save", "key": "k", "value": "v", "scope": "global"},
+        )
+    data = json.loads((tmp_path / "memory.json").read_text())
+    assert list(data["global"].keys()) == ["k"]
+
+
+# ---------------------------------------------------------------------------
+# Knowledge store async wrappers take the write lock
+# ---------------------------------------------------------------------------
+
+async def test_delete_source_async_holds_write_lock(tmp_path, monkeypatch):
+    from src.knowledge.store import KnowledgeStore
+
+    store = KnowledgeStore.__new__(KnowledgeStore)
+    store._write_lock = asyncio.Lock()
+    lock_seen = {}
+
+    def _fake_delete(source, **kw):
+        lock_seen["locked"] = store._write_lock.locked()
+        return 3
+
+    store.delete_source = _fake_delete  # type: ignore[method-assign]
+    deleted = await store.delete_source_async("doc")
+    assert deleted == 3
+    assert lock_seen["locked"] is True  # ran under the write lock
+
+
+async def test_merge_sources_async_holds_write_lock(tmp_path):
+    from src.knowledge.store import KnowledgeStore
+
+    store = KnowledgeStore.__new__(KnowledgeStore)
+    store._write_lock = asyncio.Lock()
+    seen = {}
+
+    def _fake_merge(keep, remove):
+        seen["locked"] = store._write_lock.locked()
+        return 2
+
+    store.merge_sources = _fake_merge  # type: ignore[method-assign]
+    assert await store.merge_sources_async("a", "b") == 2
+    assert seen["locked"] is True


### PR DESCRIPTION
Fourth fix batch from the 2026-07-01 review (Odin-validated). Rebased on current master (#123–125 merged).

## Fixes

**Working memory (`memory.json`) has no cap/prune**
- Per-section key cap (`MEMORY_MAX_KEYS_PER_SECTION = 200`) with LRU-by-write eviction. The full merged map is injected into every system prompt, so unbounded growth was unbounded prompt bloat.

**Learned-injection 4K budget bypassed / blown**
- The budget is now a **hard cap** on the final selection for both paths: the query-less caller (which took the include-all branch regardless of size) and the gated branch (which unioned up to 72 fixed top-K entries with no token re-check). Trim follows priority order (corrections → preferences → relevance-ranked operational → facts), always keeping at least one entry so a non-empty corpus never injects nothing.

**Consolidation fallback drops never-expire corrections/preferences**
- On consolidation-LLM failure, pin corrections and preferences instead of keeping newest-by-`updated_at` across all categories (which evicted long-standing corrections in favor of recent operational trivia).

**Reflector web `delete_entry`/`update_entry` bypass the async lock**
- New `delete_entry_async`/`update_entry_async` take `self._lock`, so a manual delete racing an in-flight reflection (lock held across a multi-second LLM await) isn't resurrected by the reflection's stale snapshot. `web/api.py` uses them.

**2.12 — Knowledge `delete_source`/`merge_sources` bypass the write lock**
- New `delete_source_async`/`merge_sources_async` take `_write_lock` and run off the event loop. `client.py` (`_handle_delete_knowledge`, now async) and `web/api.py` use them, so a delete can't interleave with an in-flight `ingest` on the shared SQLite connection (was also a sync call blocking the loop).

## Tests
- 24 new (`tests/test_learning_knowledge_reliability.py`); `test_learned_overhaul` injection tests updated for the hard cap.
- Full suite: **5792 passed, 8 skipped**.

## Note
Excludes the RRF-merge-keys and embed-failure-backfill items — Odin marked those UNCERTAIN in validation and they need a separate closer look.