### PR TITLE
fix: web security + SSRF — admin gate, fail-closed auth, redaction, proxy IPs

### DIFF
--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -456,8 +456,19 @@ class WebConfig(BaseModel):
     enabled: bool = True
     api_token: str = ""
     api_tokens: list[ApiTokenIdentity] = Field(default_factory=list)
-    session_timeout_minutes: int = 0
+    # Sessions expire after this many minutes of the token's lifetime. 0 meant
+    # "never expire", so a leaked WebUI session id was valid forever; default to
+    # a bounded lifetime (set to 0 explicitly to opt back into no-expiry).
+    session_timeout_minutes: int = 720  # 12 hours
     port: int = 3000
+    # Bind address. Historically hardcoded 0.0.0.0 (exposed on LAN/Tailscale);
+    # now configurable so a deployment can bind localhost and front it with a
+    # reverse proxy.
+    host: str = "0.0.0.0"
+    # Trusted reverse-proxy IPs. When the request's peer is one of these, the
+    # left-most X-Forwarded-For entry is used as the client IP for rate-limiting
+    # and audit — otherwise all clients behind the proxy collapse to one IP.
+    trusted_proxies: list[str] = Field(default_factory=list)
 
     @field_validator("port")
     @classmethod

--- a/src/context/loader.py
+++ b/src/context/loader.py
@@ -7,6 +7,12 @@ from ..odin_log import get_logger
 
 log = get_logger("context")
 
+# Per-file and total size caps. A context file is injected into EVERY LLM
+# request, so an oversized/binary file would silently bloat every prompt (or,
+# with the old unguarded read_text, crash boot on one undecodable byte).
+MAX_CONTEXT_FILE_BYTES = 256 * 1024      # 256 KB per file
+MAX_CONTEXT_TOTAL_BYTES = 1024 * 1024    # 1 MB total across all files
+
 SECRET_PATTERNS = [
     re.compile(r"(?i)(password|passwd|pwd)\s*[:=]\s*\S+"),
     re.compile(r"(?i)(api[_-]?key|apikey)\s*[:=]\s*\S+"),
@@ -29,8 +35,32 @@ class ContextLoader:
             return self._context
 
         parts: list[str] = []
+        total = 0
         for md_file in sorted(self.directory.glob("*.md")):
-            content = md_file.read_text()
+            try:
+                size = md_file.stat().st_size
+            except OSError as e:
+                log.warning("Skipping context file %s (stat failed: %s)", md_file.name, e)
+                continue
+            if size > MAX_CONTEXT_FILE_BYTES:
+                log.warning(
+                    "Skipping context file %s: %d bytes exceeds per-file cap (%d)",
+                    md_file.name, size, MAX_CONTEXT_FILE_BYTES,
+                )
+                continue
+            if total + size > MAX_CONTEXT_TOTAL_BYTES:
+                log.warning(
+                    "Context total cap (%d bytes) reached; skipping remaining files from %s",
+                    MAX_CONTEXT_TOTAL_BYTES, md_file.name,
+                )
+                break
+            try:
+                # errors="replace": one undecodable byte must not crash boot.
+                content = md_file.read_text(encoding="utf-8", errors="replace")
+            except OSError as e:
+                log.warning("Skipping context file %s (read failed: %s)", md_file.name, e)
+                continue
+            total += size
             self._scan_secrets(md_file.name, content)
             parts.append(f"# {md_file.stem}\n\n{content}")
 

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -5258,9 +5258,15 @@ class OdinBot(commands.Bot):
             # Validate URL scheme to prevent SSRF via file://, ftp://, etc.
             if not url.startswith(("http://", "https://")):
                 return "Only http:// and https:// URLs are supported."
+            # DNS-rebind-aware SSRF guard — scheme-only validation let this
+            # reach 169.254.169.254 / internal hosts.
+            from ..tools.url_safety import is_url_blocked
+            if is_url_blocked(url):
+                return ("URL blocked: targets a private, loopback, link-local, "
+                        "or cloud-metadata address (SSRF protection).")
             try:
                 async with aiohttp.ClientSession() as session:
-                    async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                    async with session.get(url, timeout=aiohttp.ClientTimeout(total=30), allow_redirects=False) as resp:
                         if resp.status != 200:
                             return f"Failed to fetch image from URL (HTTP {resp.status})"
                         ct = resp.headers.get("Content-Type", "")

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -48,6 +48,45 @@ AUTH_PUBLIC_EXACT = frozenset({"/api/auth/login"})
 _AUTH_SKIP_PREFIXES = AUTH_PUBLIC_PREFIXES
 _AUTH_SKIP_PATHS = AUTH_PUBLIC_EXACT
 
+# Control-plane prefixes that require the ADMIN tier for ANY method. These grant
+# privileges or reconfigure the bot (permission/host-access grants, config,
+# self-update, LLM/codex credentials, skills, tokens), so a non-admin scoped
+# token must never reach them. Enforced centrally by the admin middleware
+# because per-route _require_admin historically covered only a handful of the
+# ~80 mutating routes, leaving a self-escalation path.
+ADMIN_ONLY_PREFIXES = (
+    "/api/config", "/api/reload", "/api/setup",
+    "/api/permissions", "/api/host-access",
+    "/api/update", "/api/codex", "/api/llm",
+    "/api/ollama", "/api/kimi", "/api/skills",
+    "/api/mcp", "/api/tokens", "/api/personality",
+    "/api/tools/timeouts", "/api/pools",
+    "/api/outbound-webhooks", "/api/grafana-alerts", "/api/slack",
+)
+
+
+def _is_admin_only_path(path: str) -> bool:
+    return any(
+        path == prefix or path.startswith(prefix + "/")
+        for prefix in ADMIN_ONLY_PREFIXES
+    )
+
+
+def _client_ip(request: web.Request, trusted_proxies: tuple[str, ...] = ()) -> str:
+    """Resolve the real client IP for rate-limiting and audit.
+
+    Behind a reverse proxy every request's peer is the proxy, so without this
+    all clients collapse to one IP (one client could 429 everyone, and audit
+    records the proxy). Only honor X-Forwarded-For when the immediate peer is a
+    configured trusted proxy — otherwise a client could spoof the header."""
+    peer = request.remote or "unknown"
+    if trusted_proxies and peer in trusted_proxies:
+        fwd = request.headers.get("X-Forwarded-For", "")
+        if fwd:
+            # Left-most entry is the original client.
+            return fwd.split(",")[0].strip() or peer
+    return peer
+
 # Rate-limit: max requests per window per IP on /api/ routes
 _RATE_LIMIT_MAX = 120
 _RATE_LIMIT_WINDOW = 60  # seconds
@@ -238,8 +277,37 @@ def _make_auth_middleware(
     return auth_middleware
 
 
-def _make_rate_limit_middleware() -> web.middleware:
-    """Simple in-memory rate limiter for /api/ routes (per remote IP)."""
+def _make_admin_middleware(web_config) -> web.middleware:
+    """Enforce the admin tier on control-plane prefixes (ADMIN_ONLY_PREFIXES).
+
+    Runs after auth_middleware, so request._api_identity is already resolved.
+    Dev mode (no tokens configured) is unaffected — auth is disabled wholesale
+    there, matching auth_middleware's own behavior.
+    """
+    @web.middleware
+    async def admin_middleware(
+        request: web.Request,
+        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+    ) -> web.StreamResponse:
+        if not _is_admin_only_path(request.path):
+            return await handler(request)
+        token = web_config.api_token
+        tm = request.app.get("token_manager")
+        has_any_token = (
+            token or getattr(web_config, "api_tokens", None) or (tm and tm.list_tokens())
+        )
+        if not has_any_token:
+            return await handler(request)  # dev mode
+        identity = getattr(request, "_api_identity", None)
+        if getattr(identity, "tier", None) != "admin":
+            return web.json_response({"error": "admin access required"}, status=403)
+        return await handler(request)
+
+    return admin_middleware
+
+
+def _make_rate_limit_middleware(trusted_proxies: tuple[str, ...] = ()) -> web.middleware:
+    """Simple in-memory rate limiter for /api/ routes (per client IP)."""
     # {ip: [timestamp, ...]}
     _buckets: dict[str, list[float]] = defaultdict(list)
     _last_eviction = [0.0]  # mutable container for nonlocal access
@@ -251,7 +319,7 @@ def _make_rate_limit_middleware() -> web.middleware:
     ) -> web.StreamResponse:
         if not request.path.startswith("/api/"):
             return await handler(request)
-        ip = request.remote or "unknown"
+        ip = _client_ip(request, trusted_proxies)
         now = time.monotonic()
         window_start = now - _RATE_LIMIT_WINDOW
         # Prune old entries for this IP
@@ -344,7 +412,7 @@ def _make_csrf_middleware() -> web.middleware:
     return csrf_middleware
 
 
-def _make_web_audit_middleware() -> web.middleware:
+def _make_web_audit_middleware(trusted_proxies: tuple[str, ...] = ()) -> web.middleware:
     """Log state-changing API requests to the audit log."""
 
     @web.middleware
@@ -370,7 +438,7 @@ def _make_web_audit_middleware() -> web.middleware:
                     method=request.method,
                     path=request.path,
                     status=response.status,
-                    ip=request.remote or "",
+                    ip=_client_ip(request, trusted_proxies),
                     execution_time_ms=elapsed_ms,
                     diff=config_diff,
                     user_id=getattr(identity, "user_id", "") if identity else "",
@@ -454,11 +522,13 @@ class HealthServer:
 
         middlewares = []
         if self._web_config.enabled:
+            trusted_proxies = tuple(getattr(self._web_config, "trusted_proxies", ()) or ())
             middlewares.append(_make_security_headers_middleware())
-            middlewares.append(_make_rate_limit_middleware())
+            middlewares.append(_make_rate_limit_middleware(trusted_proxies))
             middlewares.append(_make_csrf_middleware())
             middlewares.append(_make_auth_middleware(self._web_config, self._session_manager))
-            middlewares.append(_make_web_audit_middleware())
+            middlewares.append(_make_admin_middleware(self._web_config))
+            middlewares.append(_make_web_audit_middleware(trusted_proxies))
         self._app = web.Application(middlewares=middlewares, client_max_size=10 * 1024 * 1024)
         # Store session_manager on app for access by API routes
         self._app["session_manager"] = self._session_manager
@@ -586,9 +656,10 @@ class HealthServer:
     async def start(self) -> None:
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, "0.0.0.0", self.port)
+        bind_host = getattr(self._web_config, "host", "0.0.0.0") or "0.0.0.0"
+        site = web.TCPSite(self._runner, bind_host, self.port)
         await site.start()
-        log.info("Health server listening on port %d", self.port)
+        log.info("Health server listening on %s:%d", bind_host, self.port)
 
     async def stop(self) -> None:
         if self._slack_notifier:

--- a/src/tools/http_probe_ops.py
+++ b/src/tools/http_probe_ops.py
@@ -24,6 +24,20 @@ MAX_RETRY_DELAY = 30
 DEFAULT_RETRY_DELAY = 1
 MAX_BODY_SIZE = 50000  # 50KB body limit
 
+# Cloud-metadata endpoints to neutralize on redirect. is_metadata_url() checks
+# the INITIAL url, but curl -L follows redirects, so a public URL that 302s to
+# 169.254.169.254 would still reach metadata. curl has no per-IP connect deny,
+# so we sinkhole these hosts to a closed local port via --connect-to; a redirect
+# into metadata then fails to connect instead of leaking instance credentials.
+# Ports 80/443 are the only ports the metadata services listen on.
+_METADATA_SINKHOLE_HOSTS = (
+    "169.254.169.254",
+    "metadata.google.internal",
+    "[fd00:ec2::254]",
+)
+_SINKHOLE_PORTS = (80, 443)
+_SINKHOLE_TARGET = "127.0.0.1:9"  # discard port, effectively closed
+
 _TIMING_FORMAT = (
     r"\n---PROBE-RESULTS---"
     r"\nstatus_code: %{http_code}"
@@ -113,6 +127,11 @@ def build_http_probe_command(params: dict) -> str:
     if follow:
         parts.append("-L")
         parts.append("--max-redirs 10")
+        # Block redirect-to-metadata: is_metadata_url() only guards the initial
+        # URL, so sinkhole the metadata endpoints for any followed hop too.
+        for mhost in _METADATA_SINKHOLE_HOSTS:
+            for mport in _SINKHOLE_PORTS:
+                parts.append(f"--connect-to {_sq(f'{mhost}:{mport}:{_SINKHOLE_TARGET}')}")
 
     # SSL verification
     verify_ssl = params.get("verify_ssl", True)

--- a/src/tools/http_probe_ops.py
+++ b/src/tools/http_probe_ops.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import shlex
 from urllib.parse import urlparse
 
+from .url_safety import is_metadata_url
+
 ALLOWED_METHODS = frozenset({
     "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
 })
@@ -54,6 +56,14 @@ def validate_url(url: str) -> str:
         )
     if not parsed.netloc:
         raise ValueError("URL must include a host (e.g., https://example.com)")
+    # SSRF guard: block cloud-metadata endpoints (DNS-rebind aware). http_probe
+    # is an infra tool that legitimately probes internal/localhost services, so
+    # we block only the metadata service (never a legitimate probe target and
+    # the one that hands out instance credentials) rather than all private IPs.
+    if is_metadata_url(url):
+        raise ValueError(
+            "URL blocked: targets a cloud-metadata endpoint (SSRF protection)."
+        )
     return url
 
 

--- a/src/tools/url_safety.py
+++ b/src/tools/url_safety.py
@@ -31,6 +31,37 @@ def _is_ip_blocked(addr_str: str) -> bool:
 
 
 _METADATA_HOSTS = frozenset({"169.254.169.254", "metadata.google.internal"})
+_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
+
+
+def is_metadata_url(url: str, resolve_dns: bool = True) -> bool:
+    """Return True if a URL targets a cloud-metadata endpoint.
+
+    Narrower than is_url_blocked: it does NOT block general private/loopback
+    addresses, so tools that legitimately probe internal infrastructure
+    (http_probe) still work, while the one target that is never legitimate —
+    the cloud-metadata service that hands out instance credentials — is blocked
+    even via DNS rebinding.
+    """
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+    except Exception:
+        return True
+    if not host:
+        return False
+    if host in _METADATA_HOSTS or host in _METADATA_IPS:
+        return True
+    if resolve_dns:
+        try:
+            resolved = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+            for _f, _t, _p, _c, sockaddr in resolved:
+                if sockaddr[0] in _METADATA_IPS:
+                    log.warning("Metadata SSRF blocked: %s resolves to %s", host, sockaddr[0])
+                    return True
+        except (socket.gaierror, OSError):
+            return False
+    return False
 
 
 def _matches_allowlist(parsed, allowed_urls: list[str]) -> bool:

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -36,11 +36,27 @@ if TYPE_CHECKING:
 
 log = get_logger("web.api")
 
-# Sensitive config fields that should be redacted in API responses
+# Sensitive config fields that should be redacted in API responses (exact
+# names kept for backward-compat / clarity).
 _SENSITIVE_FIELDS = frozenset({
     "token", "api_token", "secret", "ssh_key_path", "credentials_path",
-    "api_key", "password",
+    "api_key", "password", "hmac_key",
 })
+
+# Substrings that mark a key as sensitive regardless of its exact name. Key-name
+# EXACT matching missed fields like `hmac_key`, `webhook_url`, `*_secret`, and
+# `app_password`, leaking them (or future additions) through GET /api/config.
+_SENSITIVE_KEY_SUBSTRINGS = (
+    "token", "secret", "password", "api_key", "apikey",
+    "hmac", "webhook_url", "webhook_urls", "private_key", "credential",
+)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    if key in _SENSITIVE_FIELDS:
+        return True
+    kl = key.lower()
+    return any(s in kl for s in _SENSITIVE_KEY_SUBSTRINGS)
 
 
 # Input validation limits
@@ -125,7 +141,7 @@ def _redact_config(obj: Any, *, _depth: int = 0) -> Any:
         return "..."
     if isinstance(obj, dict):
         return {
-            k: "••••••••" if k in _SENSITIVE_FIELDS and isinstance(v, str) and v
+            k: "••••••••" if _is_sensitive_key(k) and isinstance(v, str) and v
             else _redact_config(v, _depth=_depth + 1)
             for k, v in obj.items()
         }
@@ -2687,7 +2703,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/permissions/tiers")
     async def list_tiers(_request: web.Request) -> web.Response:
-        pm = getattr(bot, "permission_manager", None)
+        # Bot attribute is `permissions` (PermissionManager); the old
+        # "permission_manager" name never resolved, so these RBAC endpoints 503'd.
+        pm = getattr(bot, "permissions", None)
         if not pm:
             return web.json_response({"error": "permission manager not available"}, status=503)
         from ..permissions.manager import VALID_TIERS, USER_TIER_TOOLS
@@ -2703,7 +2721,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/permissions/user/{user_id}")
     async def get_user_tier(request: web.Request) -> web.Response:
-        pm = getattr(bot, "permission_manager", None)
+        # Bot attribute is `permissions` (PermissionManager); the old
+        # "permission_manager" name never resolved, so these RBAC endpoints 503'd.
+        pm = getattr(bot, "permissions", None)
         if not pm:
             return web.json_response({"error": "permission manager not available"}, status=503)
         uid = request.match_info["user_id"]
@@ -2717,7 +2737,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.put("/api/permissions/user/{user_id}")
     async def set_user_tier(request: web.Request) -> web.Response:
-        pm = getattr(bot, "permission_manager", None)
+        # Bot attribute is `permissions` (PermissionManager); the old
+        # "permission_manager" name never resolved, so these RBAC endpoints 503'd.
+        pm = getattr(bot, "permissions", None)
         if not pm:
             return web.json_response({"error": "permission manager not available"}, status=503)
         uid = request.match_info["user_id"]
@@ -2748,7 +2770,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.delete("/api/permissions/user/{user_id}")
     async def delete_user_tier(request: web.Request) -> web.Response:
-        pm = getattr(bot, "permission_manager", None)
+        # Bot attribute is `permissions` (PermissionManager); the old
+        # "permission_manager" name never resolved, so these RBAC endpoints 503'd.
+        pm = getattr(bot, "permissions", None)
         if not pm:
             return web.json_response({"error": "permission manager not available"}, status=503)
         uid = request.match_info["user_id"]
@@ -3641,9 +3665,23 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     # API Token Management
     # ------------------------------------------------------------------
 
+    def _auth_configured() -> bool:
+        tm = getattr(bot, "api_token_manager", None)
+        return bool(
+            bot.config.web.api_token
+            or bot.config.web.api_tokens
+            or (tm and tm.list_tokens())
+        )
+
     def _require_admin(request: web.Request) -> web.Response | None:
         identity = getattr(request, "_api_identity", None)
-        if identity and getattr(identity, "tier", "admin") != "admin":
+        if identity is None:
+            # Fail closed: a missing identity is allowed only in dev mode
+            # (no tokens configured, so auth is disabled wholesale).
+            if _auth_configured():
+                return web.json_response({"error": "admin access required"}, status=403)
+            return None
+        if getattr(identity, "tier", "admin") != "admin":
             return web.json_response({"error": "admin access required"}, status=403)
         return None
 

--- a/tests/test_web_security_reliability.py
+++ b/tests/test_web_security_reliability.py
@@ -1,0 +1,183 @@
+"""Tests for web-security / SSRF reliability fixes (PR5).
+
+Covers:
+- admin-only prefix enforcement (centralized control-plane gate)
+- _is_admin_only_path matching
+- _client_ip honors X-Forwarded-For only from trusted proxies
+- config redaction is substring-aware (hmac_key, webhook urls, *_secret)
+- SSRF: http_probe blocks cloud-metadata but allows internal probes;
+  is_metadata_url vs is_url_blocked scoping
+- context loader tolerates bad encoding and caps size
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.health.server import _is_admin_only_path, _client_ip, ADMIN_ONLY_PREFIXES
+from src.web.api import _redact_config, _is_sensitive_key
+from src.tools.url_safety import is_metadata_url, is_url_blocked
+from src.tools.http_probe_ops import validate_url, build_http_probe_command
+from src.context.loader import ContextLoader, MAX_CONTEXT_FILE_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Admin-only path matching
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path", [
+    "/api/permissions/user/42",
+    "/api/host-access/default-policy",
+    "/api/config",
+    "/api/update/apply",
+    "/api/llm/switch",
+    "/api/codex/account/0/activate",
+    "/api/skills",
+    "/api/tokens",
+    "/api/mcp/servers",
+])
+def test_admin_only_paths_matched(path):
+    assert _is_admin_only_path(path) is True
+
+
+@pytest.mark.parametrize("path", [
+    "/api/chat",
+    "/api/execute",
+    "/api/sessions/123",
+    "/api/loops",
+    "/api/schedules",
+    "/api/status",
+    "/api/configuration-notes",  # must NOT match /api/config by accident
+])
+def test_non_admin_paths_not_matched(path):
+    assert _is_admin_only_path(path) is False
+
+
+def test_admin_prefix_exact_and_subpath():
+    # exact prefix and subpaths both match; a longer unrelated name does not
+    assert _is_admin_only_path("/api/llm")
+    assert _is_admin_only_path("/api/llm/status")
+    assert not _is_admin_only_path("/api/llmfoo")
+
+
+# ---------------------------------------------------------------------------
+# Client IP resolution (X-Forwarded-For only from trusted proxies)
+# ---------------------------------------------------------------------------
+
+def _req(remote, xff=None):
+    headers = {}
+    if xff is not None:
+        headers["X-Forwarded-For"] = xff
+    return SimpleNamespace(remote=remote, headers=headers)
+
+
+def test_client_ip_ignores_xff_from_untrusted_peer():
+    req = _req("203.0.113.9", xff="10.0.0.1")
+    assert _client_ip(req, trusted_proxies=()) == "203.0.113.9"
+    assert _client_ip(req, trusted_proxies=("192.168.1.1",)) == "203.0.113.9"
+
+
+def test_client_ip_uses_xff_from_trusted_proxy():
+    req = _req("192.168.1.1", xff="198.51.100.7, 192.168.1.1")
+    assert _client_ip(req, trusted_proxies=("192.168.1.1",)) == "198.51.100.7"
+
+
+def test_client_ip_falls_back_when_no_xff():
+    req = _req("192.168.1.1")
+    assert _client_ip(req, trusted_proxies=("192.168.1.1",)) == "192.168.1.1"
+
+
+# ---------------------------------------------------------------------------
+# Config redaction
+# ---------------------------------------------------------------------------
+
+def test_redaction_covers_hmac_and_webhook_and_secret():
+    cfg = {
+        "audit": {"hmac_key": "supersecretkey"},
+        "slack": {"webhook_url": "https://hooks.slack.com/T/abc"},
+        "some_secret": "s3cr3t",
+        "app_password": "pw",
+        "nested": {"api_token": "tok"},
+        "plain": "visible",
+    }
+    red = _redact_config(cfg)
+    assert red["audit"]["hmac_key"] == "••••••••"
+    assert red["slack"]["webhook_url"] == "••••••••"
+    assert red["some_secret"] == "••••••••"
+    assert red["app_password"] == "••••••••"
+    assert red["nested"]["api_token"] == "••••••••"
+    assert red["plain"] == "visible"  # non-sensitive untouched
+
+
+def test_is_sensitive_key_substring():
+    assert _is_sensitive_key("hmac_key")
+    assert _is_sensitive_key("gitea_webhook_url")
+    assert _is_sensitive_key("db_password")
+    assert not _is_sensitive_key("hostname")
+
+
+def test_redaction_leaves_empty_values():
+    # Empty sensitive values aren't masked (nothing to hide, keeps UI honest).
+    red = _redact_config({"api_token": ""})
+    assert red["api_token"] == ""
+
+
+# ---------------------------------------------------------------------------
+# SSRF scoping
+# ---------------------------------------------------------------------------
+
+def test_metadata_url_blocks_metadata_ip():
+    assert is_metadata_url("http://169.254.169.254/latest/meta-data/") is True
+    assert is_metadata_url("http://metadata.google.internal/") is True
+
+
+def test_metadata_url_allows_internal_and_public():
+    # metadata scoping does NOT block general private/loopback
+    assert is_metadata_url("http://127.0.0.1:11434/api") is False
+    assert is_metadata_url("http://192.168.1.13:8080/health") is False
+    assert is_metadata_url("https://example.com/") is False
+
+
+def test_is_url_blocked_still_blocks_private():
+    # The stricter guard (used by analyze_image/fetch_url) blocks private too.
+    assert is_url_blocked("http://169.254.169.254/") is True
+    assert is_url_blocked("http://127.0.0.1/") is True
+    assert is_url_blocked("http://192.168.1.13/") is True
+
+
+def test_http_probe_blocks_metadata():
+    with pytest.raises(ValueError, match="cloud-metadata"):
+        validate_url("http://169.254.169.254/latest/meta-data/")
+
+
+def test_http_probe_allows_internal_target():
+    # Internal infra probing remains supported.
+    url = validate_url("http://192.168.1.13:9090/-/healthy")
+    assert url == "http://192.168.1.13:9090/-/healthy"
+    cmd = build_http_probe_command({"url": url})
+    assert "curl" in cmd and "192.168.1.13" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Context loader robustness
+# ---------------------------------------------------------------------------
+
+def test_context_loader_tolerates_bad_encoding(tmp_path):
+    (tmp_path / "good.md").write_text("clean content")
+    # An undecodable byte must not crash the load.
+    (tmp_path / "bad.md").write_bytes(b"\xff\xfe bad bytes here")
+    loader = ContextLoader(str(tmp_path))
+    ctx = loader.load()  # must not raise
+    assert "clean content" in ctx
+
+
+def test_context_loader_skips_oversized_file(tmp_path):
+    (tmp_path / "small.md").write_text("keep me")
+    big = "x" * (MAX_CONTEXT_FILE_BYTES + 10)
+    (tmp_path / "huge.md").write_text(big)
+    loader = ContextLoader(str(tmp_path))
+    ctx = loader.load()
+    assert "keep me" in ctx
+    assert big not in ctx  # oversized file excluded

--- a/tests/test_web_security_reliability.py
+++ b/tests/test_web_security_reliability.py
@@ -160,6 +160,27 @@ def test_http_probe_allows_internal_target():
     assert "curl" in cmd and "192.168.1.13" in cmd
 
 
+def test_http_probe_sinkholes_metadata_on_redirect():
+    # Following redirects sinkholes metadata endpoints so a public URL that
+    # 302s into 169.254.169.254 can't reach the metadata service.
+    cmd = build_http_probe_command({
+        "url": "https://example.com/", "follow_redirects": True,
+    })
+    assert "-L" in cmd
+    assert "--connect-to" in cmd
+    assert "169.254.169.254:80:127.0.0.1:9" in cmd
+    assert "169.254.169.254:443:127.0.0.1:9" in cmd
+    assert "metadata.google.internal:80:127.0.0.1:9" in cmd
+
+
+def test_http_probe_no_sinkhole_when_not_following():
+    cmd = build_http_probe_command({
+        "url": "https://example.com/", "follow_redirects": False,
+    })
+    assert "-L" not in cmd
+    assert "--connect-to" not in cmd
+
+
 # ---------------------------------------------------------------------------
 # Context loader robustness
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fifth fix batch from the 2026-07-01 review (Odin-validated). Rebased on current master (#123–126 merged). Security-focused — worth a close read.

## Fixes

**Authorization gap on the control plane (non-admin token could self-escalate)**
- `_require_admin` guarded only ~8 of ~80 mutating routes. Rather than edit 80 routes, added a centralized `_make_admin_middleware` that enforces the **admin** tier on `ADMIN_ONLY_PREFIXES` (permissions, host-access, config, update, codex, llm, ollama, kimi, skills, mcp, tokens, personality, tool-timeouts, pools, outbound-webhooks, grafana-alerts, slack) for any method. Dev mode (no tokens configured) is unaffected, matching the existing auth middleware.
- `_require_admin` now fails **closed** on a missing identity when auth is configured (was: missing identity → allowed).

**1.1 web half — `permission_manager` attr mismatch**
- The RBAC endpoints read `getattr(bot, "permission_manager")` but the bot attribute is `permissions`, so all 4 sites always 503'd. Fixed.

**`GET /api/config` redaction leaked future secrets**
- `_redact_config` was key-name-**exact**; now substring-aware (`_is_sensitive_key`) so `hmac_key`, webhook URLs, `*_secret`, `*_password`, `private_key`, `credential` are redacted.

**2.7 SSRF**
- `http_probe`: blocks cloud-metadata endpoints (`is_metadata_url`, DNS-rebind aware) but **still allows** legitimate internal/localhost infra probing — the tool's core purpose (full private-blocking would break monitoring; the tests encode internal probing as intended). Metadata (169.254.169.254 / metadata.google.internal) is the credential-theft target that's never legitimate.
- `analyze_image` URL fetch now calls the full `is_url_blocked` (private/loopback/metadata) and disables redirect-following.

**Hardening**
- `session_timeout_minutes` defaults to **720** (was `0` = never expire → a leaked session id was valid forever).
- `web.host` bind config (was hardcoded `0.0.0.0`) + `web.trusted_proxies`.
- Rate-limit and audit use `_client_ip`: `X-Forwarded-For` honored only when the peer is a trusted proxy (else all clients behind a proxy collapse to one IP — one client could 429 everyone).
- Context loader reads with `errors="replace"` and per-file (256 KB) / total (1 MB) size caps — one undecodable byte no longer crashes boot; oversized files are skipped.

## Note on scope
`http_probe` uses **metadata-only** blocking by design (it's an infra tool). If you'd rather it block all private ranges and route internal probing through `run_command`, say so and I'll change it — but that's a behavioral change to the tool's contract, so I kept internal probing working.

## Tests
- 30 new (`tests/test_web_security_reliability.py`): admin-path matching, client-IP trust, redaction, SSRF scoping, context-loader robustness.
- Full suite: **5791 passed, 8 skipped**.