### PR TITLE
fix: discord loop / audit / config reliability (Tier 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An autonomous execution agent on Discord. Norse god of wisdom and war, stuck managing mortal infrastructure for eternity.
 
-Odin executes real work from Discord: incident response, deploys, investigations, code review, automation, and scheduled operations across 70 tools (25 core, 47 skill). It runs shell commands on managed hosts, uses browser automation, orchestrates agents and workflows, and verifies results automatically after service changes.
+Odin executes real work from Discord: incident response, deploys, investigations, code review, automation, and scheduled operations across 74 built-in tools plus user-created skills. It runs shell commands on managed hosts, uses browser automation, orchestrates agents and workflows, and verifies results automatically after service changes.
 
 ## Why operators pick Odin
 
@@ -70,7 +70,7 @@ Tell Odin things like:
 ```
 Discord ──> OdinBot (client.py)
                │
-               ├── Tool Executor ──> 70 tools (shell, browser, git, docker, etc.)
+               ├── Tool Executor ──> 74 tools (shell, browser, git, docker, email, etc.)
                │       │
                │       ├── CommandGovernor (blocks dangerous commands)
                │       ├── Risk Classifier (observability tags)
@@ -212,7 +212,7 @@ src/
     cogs/                  9 moderation/utility cog extensions
   tools/
     executor.py            Tool dispatch + recovery
-    registry.py            72 tool definitions (25 core, 47 skill)
+    registry.py            74 built-in tool definitions
     skill_manager.py       Skill CRUD + AST validation
     risk_classifier.py    CommandGovernor + risk classification
     post_validation.py     validate_action implementation

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from collections import deque
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -17,6 +19,25 @@ log = get_logger("audit")
 
 
 DEFAULT_RESULT_CAP = 4000
+# Max serialized size of a single entry's tool_input. A full write_file payload
+# was stored uncapped (68 KB lines observed); oversized inputs are replaced with
+# a truncation marker so one big call can't bloat the log.
+DEFAULT_TOOL_INPUT_CAP = 4000
+# Rotate the audit file once it exceeds this size, keeping this many old files.
+# Without rotation the file grew unbounded (48 MB / 65k lines observed).
+DEFAULT_MAX_BYTES = 100 * 1024 * 1024  # 100 MB
+DEFAULT_MAX_FILES = 5
+
+
+def _cap_tool_input(tool_input: dict, cap: int) -> dict | str:
+    """Bound the serialized size of an audit entry's tool_input."""
+    try:
+        blob = json.dumps(tool_input, default=str)
+    except Exception:
+        return "<unserializable tool_input>"
+    if len(blob) <= cap:
+        return tool_input
+    return f"<tool_input truncated: {len(blob)} bytes>" + blob[:cap]
 
 
 class AuditLogger:
@@ -26,6 +47,9 @@ class AuditLogger:
         self, path: str = "./data/audit.jsonl", *,
         hmac_key: str = "", classify_failures: bool = True,
         result_cap: int = DEFAULT_RESULT_CAP,
+        tool_input_cap: int = DEFAULT_TOOL_INPUT_CAP,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        max_files: int = DEFAULT_MAX_FILES,
     ) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -33,6 +57,72 @@ class AuditLogger:
         self._signer: AuditSigner | None = AuditSigner(hmac_key) if hmac_key else None
         self._classify_failures = classify_failures
         self._result_cap = result_cap
+        self._tool_input_cap = tool_input_cap
+        self._max_bytes = max_bytes
+        self._max_files = max_files
+
+    def _maybe_rotate(self) -> None:
+        """Rotate audit.jsonl → .1 → .2 … once it exceeds max_bytes.
+
+        Called before each append. Bounds total growth to roughly
+        max_bytes * (max_files + 1). HMAC chaining (if ever enabled) resets at
+        each rotation boundary — acceptable; it is disabled live."""
+        try:
+            if not self.path.exists() or self.path.stat().st_size < self._max_bytes:
+                return
+        except OSError:
+            return
+        try:
+            oldest = self.path.with_name(self.path.name + f".{self._max_files}")
+            if oldest.exists():
+                oldest.unlink()
+            for i in range(self._max_files - 1, 0, -1):
+                src = self.path.with_name(self.path.name + f".{i}")
+                if src.exists():
+                    src.rename(self.path.with_name(self.path.name + f".{i + 1}"))
+            self.path.rename(self.path.with_name(self.path.name + ".1"))
+            log.info("Rotated audit log at %d bytes", self._max_bytes)
+        except OSError as e:
+            log.error("Audit log rotation failed: %s", e)
+
+    def _rotated_paths_newest_first(self) -> list[Path]:
+        """Current file plus existing rotated files, newest → oldest."""
+        paths = [self.path]
+        for i in range(1, self._max_files + 1):
+            p = self.path.with_name(self.path.name + f".{i}")
+            if p.exists():
+                paths.append(p)
+        return paths
+
+    async def _collect_matches(self, predicate: Callable[[dict], bool], limit: int) -> list[dict]:
+        """Return up to *limit* matching entries, most-recent first, streaming.
+
+        Streams line-by-line into a bounded deque instead of readlines()-ing the
+        whole file into RAM (a multi-hundred-MB read per query as the log grew).
+        Reads the current file first, then rotated files, until *limit* is met."""
+        collected: list[dict] = []
+        for path in self._rotated_paths_newest_first():
+            per_file: deque[dict] = deque(maxlen=limit)
+            try:
+                async with aiofiles.open(path, "r") as f:
+                    async for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            entry = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if predicate(entry):
+                            per_file.append(entry)  # keeps newest `limit` in-file
+            except OSError as e:
+                log.error("Failed to read audit log %s: %s", path, e)
+                continue
+            for entry in reversed(per_file):  # newest first within the file
+                collected.append(entry)
+                if len(collected) >= limit:
+                    return collected
+        return collected
 
     def set_event_callback(self, callback: Callable) -> None:
         """Set a callback to be invoked with each audit entry (for live WS events)."""
@@ -60,7 +150,7 @@ class AuditLogger:
             "user_name": user_name,
             "channel_id": channel_id,
             "tool_name": tool_name,
-            "tool_input": tool_input,
+            "tool_input": _cap_tool_input(tool_input, self._tool_input_cap),
             "approved": approved,
             "result_summary": result_summary[:self._result_cap],
             "execution_time_ms": execution_time_ms,
@@ -85,6 +175,7 @@ class AuditLogger:
             self._signer.sign(entry)
         line = json.dumps(entry, default=str) + "\n"
         try:
+            self._maybe_rotate()
             async with aiofiles.open(self.path, "a") as f:
                 await f.write(line)
         except Exception as e:
@@ -233,47 +324,31 @@ class AuditLogger:
         if not self.path.exists():
             return []
 
-        results: list[dict] = []
-        try:
-            async with aiofiles.open(self.path, "r") as f:
-                lines = await f.readlines()
-        except Exception as e:
-            log.error("Failed to read audit log: %s", e)
-            return []
-
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
+        def _match(entry: dict) -> bool:
             if tool_name and entry.get("tool_name") != tool_name:
-                continue
+                return False
             if user and user.lower() not in (
                 entry.get("user_name", "").lower() + entry.get("user_id", "")
             ):
-                continue
+                return False
             if host:
                 inp = entry.get("tool_input", {})
                 if isinstance(inp, dict) and inp.get("host") != host:
-                    continue
+                    return False
             if date and not entry.get("timestamp", "").startswith(date):
-                continue
+                return False
             if keyword:
                 blob = json.dumps(entry).lower()
                 if keyword.lower() not in blob:
-                    continue
+                    return False
             if status:
                 entry_status = entry.get("status") or entry.get("metadata", {}).get("status", "")
                 if status.lower() != str(entry_status).lower():
-                    continue
+                    return False
             if has_error is True:
                 err = entry.get("error") or entry.get("metadata", {}).get("error", "")
                 if not err:
-                    continue
+                    return False
             if min_duration_ms is not None:
                 dur = (
                     entry.get("execution_time_ms")
@@ -283,13 +358,10 @@ class AuditLogger:
                     or 0
                 )
                 if dur < min_duration_ms:
-                    continue
+                    return False
+            return True
 
-            results.append(entry)
-            if len(results) >= limit:
-                break
-
-        return results
+        return await self._collect_matches(_match, limit)
 
     async def search_logs(
         self,
@@ -311,48 +383,27 @@ class AuditLogger:
         if not self.path.exists():
             return []
 
-        try:
-            async with aiofiles.open(self.path, "r") as f:
-                lines = await f.readlines()
-        except Exception as exc:
-            log.error("Failed to read audit log for search_logs: %s", exc)
-            return []
-
-        results: list[dict] = []
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
+        def _match(entry: dict) -> bool:
             ts = entry.get("timestamp", "")
-
             if start_time and ts < start_time:
-                continue
+                return False
             if end_time and ts > end_time:
-                continue
-
+                return False
             if level and level != "all":
                 has_error = bool(entry.get("error"))
                 if level == "error" and not has_error:
-                    continue
+                    return False
                 if level == "info" and has_error:
-                    continue
-
+                    return False
             if tool_name and entry.get("tool_name") != tool_name:
-                continue
-
+                return False
             if keyword:
                 blob = json.dumps(entry).lower()
                 if keyword.lower() not in blob:
-                    continue
+                    return False
+            return True
 
-            results.append(entry)
-            if len(results) >= limit:
-                break
+        results = await self._collect_matches(_match, limit)
 
         return results
 
@@ -407,39 +458,20 @@ class AuditLogger:
         if not self.path.exists():
             return []
 
-        try:
-            async with aiofiles.open(self.path, "r") as f:
-                lines = await f.readlines()
-        except Exception as e:
-            log.error("Failed to read audit log for diffs: %s", e)
-            return []
-
-        results: list[dict] = []
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
+        def _match(entry: dict) -> bool:
             if not entry.get("diff"):
-                continue
+                return False
             if tool_name and entry.get("tool_name") != tool_name:
-                continue
+                return False
             if user and user.lower() not in (
                 entry.get("user_name", "").lower() + entry.get("user_id", "")
             ):
-                continue
+                return False
             if date and not entry.get("timestamp", "").startswith(date):
-                continue
+                return False
+            return True
 
-            results.append(entry)
-            if len(results) >= limit:
-                break
-
-        return results
+        return await self._collect_matches(_match, limit)
 
     async def search_by_risk(
         self,
@@ -452,35 +484,16 @@ class AuditLogger:
         if not self.path.exists():
             return []
 
-        try:
-            async with aiofiles.open(self.path, "r") as f:
-                lines = await f.readlines()
-        except Exception as e:
-            log.error("Failed to read audit log for risk search: %s", e)
-            return []
-
-        results: list[dict] = []
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
+        def _match(entry: dict) -> bool:
             if not entry.get("risk_level"):
-                continue
+                return False
             if risk_level and entry.get("risk_level") != risk_level:
-                continue
+                return False
             if tool_name and entry.get("tool_name") != tool_name:
-                continue
+                return False
+            return True
 
-            results.append(entry)
-            if len(results) >= limit:
-                break
-
-        return results
+        return await self._collect_matches(_match, limit)
 
     async def initialize_chain(self) -> None:
         """Read the last signed entry to resume the HMAC chain state."""

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -13,7 +13,7 @@ import aiofiles
 from ..observability.correlation import get_turn
 from ..observability.failure_classes import classify_failure
 from ..odin_log import get_logger
-from .signer import AuditSigner, verify_log
+from .signer import GENESIS_HASH, AuditSigner, verify_log
 
 log = get_logger("audit")
 
@@ -65,8 +65,11 @@ class AuditLogger:
         """Rotate audit.jsonl → .1 → .2 … once it exceeds max_bytes.
 
         Called before each append. Bounds total growth to roughly
-        max_bytes * (max_files + 1). HMAC chaining (if ever enabled) resets at
-        each rotation boundary — acceptable; it is disabled live."""
+        max_bytes * (max_files + 1). The HMAC chain (if enabled) starts fresh in
+        the new current file — the signer's prev-hash is reset to GENESIS after
+        rotation, so verify_integrity() (which reads the current file from
+        genesis) stays valid instead of chaining across the rotation boundary
+        and failing on the first post-rotation entry."""
         try:
             if not self.path.exists() or self.path.stat().st_size < self._max_bytes:
                 return
@@ -81,6 +84,10 @@ class AuditLogger:
                 if src.exists():
                     src.rename(self.path.with_name(self.path.name + f".{i + 1}"))
             self.path.rename(self.path.with_name(self.path.name + ".1"))
+            if self._signer is not None:
+                # New file = new chain from genesis (the rotated .1 keeps its own
+                # self-consistent chain for offline verification).
+                self._signer.prev_hmac = GENESIS_HASH
             log.info("Rotated audit log at %d bytes", self._max_bytes)
         except OSError as e:
             log.error("Audit log rotation failed: %s", e)
@@ -128,6 +135,29 @@ class AuditLogger:
         """Set a callback to be invoked with each audit entry (for live WS events)."""
         self._event_callback = callback
 
+    async def _persist(self, entry: dict) -> None:
+        """Rotate, sign, append, and fan out one entry.
+
+        Rotation happens BEFORE signing so that when a rotation occurs the entry
+        being written becomes the first line of the fresh file and its
+        _prev_hmac is GENESIS (the signer is reset in _maybe_rotate). Signing
+        after rotation was the bug: the first post-rotation entry chained to the
+        old file and verify_integrity() failed."""
+        self._maybe_rotate()
+        if self._signer:
+            self._signer.sign(entry)
+        line = json.dumps(entry, default=str) + "\n"
+        try:
+            async with aiofiles.open(self.path, "a") as f:
+                await f.write(line)
+        except Exception as e:
+            log.error("Failed to write audit log: %s", e)
+        if self._event_callback:
+            try:
+                await self._event_callback(entry)
+            except Exception:
+                pass
+
     async def log_execution(
         self,
         *,
@@ -171,21 +201,7 @@ class AuditLogger:
             entry["risk_level"] = risk_level
         if risk_reason:
             entry["risk_reason"] = risk_reason
-        if self._signer:
-            self._signer.sign(entry)
-        line = json.dumps(entry, default=str) + "\n"
-        try:
-            self._maybe_rotate()
-            async with aiofiles.open(self.path, "a") as f:
-                await f.write(line)
-        except Exception as e:
-            log.error("Failed to write audit log: %s", e)
-
-        if self._event_callback:
-            try:
-                await self._event_callback(entry)
-            except Exception:
-                pass
+        await self._persist(entry)
 
     async def log_event(
         self,
@@ -214,20 +230,7 @@ class AuditLogger:
             entry["channel_id"] = channel_id
         if metadata:
             entry["metadata"] = metadata
-        if self._signer:
-            self._signer.sign(entry)
-        line = json.dumps(entry, default=str) + "\n"
-        try:
-            async with aiofiles.open(self.path, "a") as f:
-                await f.write(line)
-        except Exception as e:
-            log.error("Failed to write audit event: %s", e)
-
-        if self._event_callback:
-            try:
-                await self._event_callback(entry)
-            except Exception:
-                pass
+        await self._persist(entry)
 
     async def log_web_action(
         self,
@@ -264,20 +267,7 @@ class AuditLogger:
             entry["label"] = label
         if diff:
             entry["diff"] = diff
-        if self._signer:
-            self._signer.sign(entry)
-        line = json.dumps(entry, default=str) + "\n"
-        try:
-            async with aiofiles.open(self.path, "a") as f:
-                await f.write(line)
-        except Exception as e:
-            log.error("Failed to write web audit log: %s", e)
-
-        if self._event_callback:
-            try:
-                await self._event_callback(entry)
-            except Exception:
-                pass
+        await self._persist(entry)
 
     async def count_by_tool(self) -> dict[str, int]:
         """Return execution counts per tool name (most used first)."""

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -765,6 +765,11 @@ def load_config(path: str | Path = "config.yml") -> Config:
             "It must contain a YAML mapping with at least a 'discord' section.\n"
             "See config.yml comments for examples."
         )
+    # Warn on unknown top-level keys. Pydantic silently drops unknown fields by
+    # default, so a typo like "sesions:" or "web_ui:" is ignored with no signal
+    # and the intended setting never applies. We warn rather than error
+    # (extra="forbid") so a slightly-ahead config can't hard-fail boot.
+    _warn_unknown_config_keys(data)
     try:
         return Config(**data)
     except Exception as exc:
@@ -772,3 +777,20 @@ def load_config(path: str | Path = "config.yml") -> Config:
             f"Config validation failed: {exc}\n"
             "Check config.yml values — numeric fields must be within valid ranges."
         ) from exc
+
+
+def _warn_unknown_config_keys(data: dict) -> None:
+    """Log a warning for top-level config keys the schema doesn't define."""
+    from ..odin_log import get_logger
+    known = set(Config.model_fields)
+    # Also accept field aliases if any are defined.
+    for f in Config.model_fields.values():
+        if getattr(f, "alias", None):
+            known.add(f.alias)
+    unknown = [k for k in data if k not in known]
+    if unknown:
+        get_logger("config").warning(
+            "Ignoring unknown config key(s): %s — check for typos "
+            "(known top-level sections: %s)",
+            ", ".join(sorted(unknown)), ", ".join(sorted(known)),
+        )

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -550,7 +550,17 @@ class OdinBot(commands.Bot):
         # voice/browser/comfyui). Always on; subsystems call record_success/
         # record_failure as they operate.
         from ..health.subsystem_guard import SubsystemGuard
-        self.subsystem_guard = SubsystemGuard()
+        # Pass the configured thresholds — the guard was built with no args, so
+        # graceful_degradation.degraded_threshold / unavailable_threshold in
+        # config were silently ignored (always the module defaults).
+        _gd = getattr(config, "graceful_degradation", None)
+        if _gd is not None:
+            self.subsystem_guard = SubsystemGuard(
+                degraded_threshold=_gd.degraded_threshold,
+                unavailable_threshold=_gd.unavailable_threshold,
+            )
+        else:
+            self.subsystem_guard = SubsystemGuard()
         for _name in ("llm_codex", "llm_ollama", "llm_kimi", "codex", "ssh", "knowledge", "voice", "browser", "comfyui"):
             self.subsystem_guard.register(_name)
 
@@ -1249,9 +1259,16 @@ class OdinBot(commands.Bot):
         for channel_id in expired_channels:
             del self._recent_actions[channel_id]
 
-        # Clean up _channel_locks for channels no longer in active sessions
+        # Clean up _channel_locks for channels no longer in active sessions.
+        # A lock that is currently HELD must not be deleted: an in-flight
+        # request in a channel whose session was just reset/purged still owns
+        # its lock, and dropping it lets the next message setdefault() a fresh
+        # lock, so two handlers run concurrently in the same channel.
         active_channels = set(self.sessions.ids())
-        stale_locks = [cid for cid in self._channel_locks if cid not in active_channels]
+        stale_locks = [
+            cid for cid, lock in self._channel_locks.items()
+            if cid not in active_channels and not lock.locked()
+        ]
         for cid in stale_locks:
             del self._channel_locks[cid]
 
@@ -2145,8 +2162,13 @@ class OdinBot(commands.Bot):
             self._processed_messages.popitem(last=False)
 
         # Buffer rapid-fire bot messages (e.g. code blocks split across messages)
-        # Wait 2s after each bot message to see if more follow, then process all at once
-        if message.author.bot and self.config.discord.respond_to_bots:
+        # Wait 2s after each bot message to see if more follow, then process all
+        # at once. Use the per-channel override (not the raw global flag) so this
+        # agrees with the mention gate above — otherwise a channel that opts out
+        # of bot replies still gets its bot messages buffered and answered.
+        if message.author.bot and self.channel_config.should_respond_to_bots(
+            guild_id, channel_id_str, self.config.discord.respond_to_bots,
+        ):
             buf_key = (str(message.channel.id), str(message.author.id))
             if buf_key not in self._bot_msg_buffer:
                 self._bot_msg_buffer[buf_key] = []
@@ -2211,21 +2233,33 @@ class OdinBot(commands.Bot):
         if not content:
             content = "(see attached image)"
 
-        # Check for secrets, scrub from history and delete the message
+        # Check for secrets, scrub from history and delete the message.
         if self._check_for_secrets(content):
             self.sessions.scrub_secrets(str(message.channel.id), content)
+            # Deletion can fail for more than just Forbidden — the message may
+            # already be gone (NotFound) or we may be rate-limited
+            # (HTTPException). Catching only Forbidden let those propagate out
+            # of on_message, so the user never even got the scrub notice.
+            deleted = False
             try:
                 await message.delete()
+                deleted = True
+            except discord.NotFound:
+                deleted = True  # already gone — treat as deleted
+            except (discord.Forbidden, discord.HTTPException) as e:
+                log.warning("Could not delete secret-bearing message: %s", e)
+            note = (
+                "I've deleted it and scrubbed it from my history." if deleted else
+                "I've scrubbed it from my history. I couldn't delete the "
+                "message — please delete it manually."
+            )
+            try:
                 await message.channel.send(
-                    f"{message.author.mention} I detected a secret/credential in your message. "
-                    "I've deleted it and scrubbed it from my history."
+                    f"{message.author.mention} I detected a secret/credential "
+                    f"in your message. {note}"
                 )
-            except discord.Forbidden:
-                await message.channel.send(
-                    f"{message.author.mention} I detected a secret/credential in your message. "
-                    "I've scrubbed it from my history. "
-                    "I couldn't delete the message — please delete it manually."
-                )
+            except discord.HTTPException:
+                pass  # best-effort notice; the scrub already happened
             return
 
         # Voice commands via natural language (short, direct commands only)
@@ -2529,6 +2563,15 @@ class OdinBot(commands.Bot):
             await self._send_with_retry(message, scrub_response_secrets(f"Something went wrong: {e}"))
             self.sessions.remove_last_message(channel_id, "user")
             return
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException, so it bypasses the Exception
+            # handlers here — without this the just-appended user turn is left
+            # orphaned in history (no assistant reply). Clean up synchronously
+            # (no awaits, which could re-raise mid-cancellation) and re-raise so
+            # the cancellation still propagates.
+            self._pending_files.pop(channel_id, None)
+            self.sessions.remove_last_message(channel_id, "user")
+            raise
         except Exception as e:
             await self._set_status(None, task_end=True)
             log.error("Unexpected error processing message: %s", e, exc_info=True)
@@ -2986,7 +3029,11 @@ class OdinBot(commands.Bot):
                         ),
                     })
                     continue
-            if not llm_resp.is_tool_use:
+            # Gate on actual parsed tool calls, not is_tool_use (which is also
+            # true when stop_reason=="tool_use" with zero calls). The sibling
+            # loop already uses this stricter form; matching it prevents an
+            # empty-tool_use response from skipping finalization and re-looping.
+            if not llm_resp.tool_calls:
                 if _cancel.is_set():
                     return _stopped("before_validation")
                 # Enforce pending validation before allowing final response
@@ -4727,6 +4774,7 @@ class OdinBot(commands.Bot):
             return outcome_text
 
         final_text = ""
+        completed_naturally = False  # True only when a tool-free turn ended the loop
         tool_timeout = self.config.tools.tool_timeout_seconds
         channel_id_str = str(getattr(channel, "id", ""))
         loop_cap = self.config.tools.max_tool_iterations_loop
@@ -4762,6 +4810,7 @@ class OdinBot(commands.Bot):
                 final_text = response.text
 
             if not response.tool_calls:
+                completed_naturally = True
                 break
 
             tool_calls_made += len(response.tool_calls)
@@ -4886,8 +4935,14 @@ class OdinBot(commands.Bot):
                     tool_results, _result_store_cap,
                 )
 
-        # Scrub final text; posting is handled by _post_response in LoopManager
-        if final_text:
+        # Scrub final text; posting is handled by _post_response in LoopManager.
+        # Only treat final_text as a clean success when the loop ended NATURALLY
+        # (a tool-free response). If we fell out by exhausting the cap, any
+        # final_text is stale pre-tool text from some earlier iteration —
+        # returning it as is_error=False would silently hide the cap hit (the
+        # cap-warning path below was unreachable whenever any iteration produced
+        # text).
+        if final_text and completed_naturally:
             final_text = scrub_output_secrets(final_text)
             if len(final_text) > DISCORD_MAX_LEN:
                 final_text = final_text[:DISCORD_MAX_LEN - 50] + "\n... (truncated)"
@@ -4904,20 +4959,23 @@ class OdinBot(commands.Bot):
                 error_text=_first_err["result"] if _first_err else "",
             )
 
-        # No final text produced. If we exhausted the cap without Codex ever
-        # returning a tool-free response, say so — the previous "(no response)"
-        # silently hid the fact that the loop did real work but ran out of
-        # budget. Tell the operator what happened and how to tune it.
-        if tool_calls_made >= loop_cap:
+        # Cap exhausted without a tool-free response. Surface it (optionally with
+        # the stale partial text) instead of hiding the truncation.
+        if tool_calls_made >= loop_cap or not completed_naturally:
             log.warning(
-                "Loop tool-iteration cap hit (%d) after %d tool calls; no final summary from Codex",
+                "Loop tool-iteration cap hit (%d) after %d tool calls; no tool-free summary from Codex",
                 loop_cap, tool_calls_made,
             )
+            _partial = ""
+            if final_text:
+                _partial = "\n\nLast partial output before the cap:\n" + scrub_output_secrets(
+                    final_text[:1000],
+                )
             return await _finish(
                 f"Iteration hit the loop tool-iteration cap ({loop_cap}) "
-                f"after {tool_calls_made} tool calls. No final summary was "
-                f"produced by Codex. Raise `tools.max_tool_iterations_loop` "
-                f"in config (or via the web UI) if this happens repeatedly.",
+                f"after {tool_calls_made} tool calls without a final summary. "
+                f"Raise `tools.max_tool_iterations_loop` in config (or via the "
+                f"web UI) if this happens repeatedly." + _partial,
                 is_error=True, failure_class="cancelled",
                 error_text=f"loop iteration cap {loop_cap} reached",
             )

--- a/tests/test_audit_config_reliability.py
+++ b/tests/test_audit_config_reliability.py
@@ -1,0 +1,138 @@
+"""Tests for audit/config reliability fixes (PR7).
+
+Covers:
+- audit tool_input size cap
+- audit size-based rotation (keeps N old files, bounds growth)
+- audit search streams (bounded) and reads across rotated files
+- config loader warns on unknown top-level keys
+- graceful_degradation thresholds are passed into SubsystemGuard
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from src.audit.logger import AuditLogger, _cap_tool_input, DEFAULT_TOOL_INPUT_CAP
+
+
+# ---------------------------------------------------------------------------
+# tool_input cap
+# ---------------------------------------------------------------------------
+
+def test_small_tool_input_unchanged():
+    inp = {"host": "server", "command": "uptime"}
+    assert _cap_tool_input(inp, DEFAULT_TOOL_INPUT_CAP) == inp
+
+
+def test_large_tool_input_truncated():
+    inp = {"content": "x" * 100_000}
+    capped = _cap_tool_input(inp, 4000)
+    assert isinstance(capped, str)
+    assert capped.startswith("<tool_input truncated:")
+    assert len(capped) < 100_000
+
+
+async def test_logged_tool_input_is_capped(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.jsonl"), tool_input_cap=200)
+    await logger.log_execution(
+        user_id="u", user_name="U", channel_id="c",
+        tool_name="write_file", tool_input={"content": "y" * 50_000},
+        approved=True, result_summary="ok", execution_time_ms=1,
+    )
+    line = (tmp_path / "audit.jsonl").read_text().strip()
+    entry = json.loads(line)
+    assert isinstance(entry["tool_input"], str)
+    assert "truncated" in entry["tool_input"]
+
+
+# ---------------------------------------------------------------------------
+# Rotation
+# ---------------------------------------------------------------------------
+
+async def test_rotation_creates_numbered_files_and_bounds_growth(tmp_path):
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(str(path), max_bytes=2000, max_files=2)
+    for i in range(200):
+        await logger.log_execution(
+            user_id="u", user_name="U", channel_id="c",
+            tool_name=f"t{i}", tool_input={"i": i},
+            approved=True, result_summary="r" * 50, execution_time_ms=1,
+        )
+    # Current + at most max_files rotated files exist; older are pruned.
+    assert path.exists()
+    assert (tmp_path / "audit.jsonl.1").exists()
+    assert not (tmp_path / "audit.jsonl.3").exists()  # never keep more than max_files
+    # Current file is bounded near max_bytes (not the full 200-entry history).
+    assert path.stat().st_size < 2000 * 3
+
+
+async def test_search_reads_across_rotation(tmp_path):
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(str(path), max_bytes=1500, max_files=3)
+    for i in range(150):
+        await logger.log_execution(
+            user_id="u", user_name="U", channel_id="c",
+            tool_name="marker" if i == 0 else f"t{i}",
+            tool_input={"i": i}, approved=True,
+            result_summary="r" * 40, execution_time_ms=1,
+        )
+    # The most recent entries are found even though the file has rotated.
+    recent = await logger.search(limit=5)
+    assert len(recent) == 5
+    # Newest first.
+    assert recent[0]["tool_name"] == "t149"
+
+
+async def test_search_is_bounded_by_limit(tmp_path):
+    logger = AuditLogger(str(tmp_path / "audit.jsonl"))
+    for i in range(100):
+        await logger.log_execution(
+            user_id="u", user_name="U", channel_id="c",
+            tool_name="t", tool_input={"i": i}, approved=True,
+            result_summary="ok", execution_time_ms=1,
+        )
+    results = await logger.search(limit=10)
+    assert len(results) == 10
+    assert results[0]["tool_input"]["i"] == 99  # most recent first
+
+
+# ---------------------------------------------------------------------------
+# Config unknown-key warning
+# ---------------------------------------------------------------------------
+
+def test_unknown_config_key_warns(caplog):
+    from src.config.schema import _warn_unknown_config_keys
+    with caplog.at_level(logging.WARNING):
+        _warn_unknown_config_keys({"discord": {}, "sesions": {}, "web_ui": {}})
+    msg = caplog.text
+    # The flagged list (before the "— check" explanation) names only the typos.
+    flagged = msg.split("Ignoring unknown config key(s):")[-1].split("—")[0]
+    assert "sesions" in flagged and "web_ui" in flagged
+    assert "discord" not in flagged  # known key not flagged as unknown
+
+
+def test_known_config_keys_no_warning(caplog):
+    from src.config.schema import _warn_unknown_config_keys
+    with caplog.at_level(logging.WARNING):
+        _warn_unknown_config_keys({"discord": {}, "web": {}, "tools": {}})
+    assert "Ignoring unknown config key" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# graceful_degradation thresholds wired
+# ---------------------------------------------------------------------------
+
+def test_subsystem_guard_receives_configured_thresholds():
+    from src.health.subsystem_guard import SubsystemGuard
+    g = SubsystemGuard(degraded_threshold=2, unavailable_threshold=5)
+    assert g._degraded_threshold == 2
+    assert g._unavailable_threshold == 5
+
+
+def test_graceful_degradation_config_defaults():
+    from src.config.schema import GracefulDegradationConfig
+    cfg = GracefulDegradationConfig()
+    assert cfg.degraded_threshold == 3
+    assert cfg.unavailable_threshold == 10

--- a/tests/test_audit_config_reliability.py
+++ b/tests/test_audit_config_reliability.py
@@ -85,6 +85,25 @@ async def test_search_reads_across_rotation(tmp_path):
     assert recent[0]["tool_name"] == "t149"
 
 
+async def test_hmac_chain_valid_after_rotation(tmp_path):
+    """Rotation resets the signer chain to genesis so verify_integrity() (which
+    reads the current file from genesis) stays valid — the chain no longer runs
+    across the rotation boundary (Odin's PR#129 blocker)."""
+    path = tmp_path / "audit.jsonl"
+    logger = AuditLogger(str(path), hmac_key="secret-key", max_bytes=600, max_files=2)
+    for i in range(60):
+        await logger.log_execution(
+            user_id="u", user_name="U", channel_id="c",
+            tool_name=f"t{i}", tool_input={"i": i},
+            approved=True, result_summary="r" * 30, execution_time_ms=1,
+        )
+    # Rotation must have happened.
+    assert (tmp_path / "audit.jsonl.1").exists()
+    report = await logger.verify_integrity()
+    assert report["valid"] is True, report
+    assert report["verified"] == report["total"]
+
+
 async def test_search_is_bounded_by_limit(tmp_path):
     logger = AuditLogger(str(tmp_path / "audit.jsonl"))
     for i in range(100):


### PR DESCRIPTION
Seventh and final fix batch from the 2026-07-01 review (Odin-validated). Rebased on current master (#123–128 merged).

## Fixes

**2.11 — Audit log: no retention, uncapped input, whole-file reads**
- `tool_input` is size-capped (a full `write_file` payload was stored uncapped — 68 KB lines).
- Size-based rotation (`audit.jsonl → .1 → .2 …`, keeping `max_files`) bounds growth that had hit 48 MB / 65k lines with no retention.
- The four hot-path `search*` methods stream line-by-line into a bounded deque and read across rotated files, instead of `readlines()`-ing the whole file into RAM per query.

**2.8 — Chat tool-loop gate parity**
- Gate on `not llm_resp.tool_calls` (matching the sibling loop) instead of `not is_tool_use`, so a `stop_reason=="tool_use"` response with zero parsed calls can't skip finalization and re-loop.

**Loop cap-hit reported stale text as success**
- The loop kept `response.text` even on turns that also made tool calls, then on cap exhaustion returned that stale pre-tool text with `is_error=False` — making the cap warning unreachable. Now only a natural (tool-free) exit returns `final_text`; cap exhaustion surfaces the cap message (partial text appended).

**Concurrency / correctness**
- `_cleanup_stale_caches` no longer deletes a channel lock that is currently **held** (an in-flight request in a just-reset channel kept its lock; dropping it let the next message `setdefault` a fresh lock → two handlers in one channel).
- Orphaned user turn on cancellation: `on_message`'s `Exception` handlers miss `asyncio.CancelledError` (a `BaseException`); added a handler that cleans up synchronously and re-raises.
- Bot-message buffering uses `channel_config.should_respond_to_bots` (per-channel override), agreeing with the mention gate — a channel that opts out no longer gets its bot messages buffered and answered.
- Secret-scrub message-delete handles `NotFound`/`HTTPException` (not just `Forbidden`), so a rate-limited/already-deleted message no longer propagates out of `on_message` and drops the scrub notice.

**Config / wiring**
- `load_config` warns on unknown top-level keys (typos were silently dropped) — a warning, not `extra="forbid"`, so a slightly-ahead config can't brick boot.
- `graceful_degradation` thresholds are passed into `SubsystemGuard` (built with no args → config ignored).

**Docs**
- README tool counts corrected to 74 (were 70/72) + email mention.

## Tests
- 10 new (`tests/test_audit_config_reliability.py`): rotation, input cap, streaming across rotation, config warning, guard thresholds.
- Full suite: **5904 passed, 8 skipped**.

## Deferred (flagged, not silently dropped)
Lower-severity display/delivery polish I did **not** include, to keep monolith-edit risk down for a final PR — happy to do these as a follow-up if you want them now:
- Code-fence chunking boundary corruption
- `_send_chunked` middle-chunk-drop handling
- `_pending_files` delivery in loop/agent/scheduled contexts
- Trigger-cog `set_config`/`set_scheduler` wiring (was MOSTLY CONFIRMED — needs a verify pass)