### PR TITLE
fix: make ok=False tool results visible to the model

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -36,6 +36,7 @@ from ..scheduler import Scheduler
 from ..sessions import SessionManager
 from ..sessions.manager import CHAT_RESPONSE_MAX_CHARS, summarize_tool_response
 from ..tools import ToolExecutor, SkillManager, ToolResult, get_tool_definitions
+from ..tools.executor import _ERROR_RESULT_PREFIXES
 from ..search import LocalEmbedder, SessionVectorStore
 from ..permissions import PermissionManager
 from ..permissions.host_access import HostAccessManager
@@ -3430,6 +3431,9 @@ class OdinBot(commands.Bot):
                     elapsed_ms = tool_result.duration_ms or elapsed_ms
                     if tool_result.error and not error:
                         error = tool_result.error
+                    if not tool_result.ok and not error:
+                        error = "tool reported failure"
+                    result = self._ensure_failure_visible(result, tool_result.ok)
 
                 # Audit log — never crash tool execution on audit failure
                 try:
@@ -3616,6 +3620,19 @@ class OdinBot(commands.Bot):
             trace=trace,
         )
         return _cap_msg, False, True, tools_used_in_loop, False
+
+    @staticmethod
+    def _ensure_failure_visible(result_text: str, ok: bool) -> str:
+        """Make a structurally-failed tool result visible to the model.
+
+        execute() carries ok=False on ToolResult, but the model only sees
+        str(result) — the raw output. When that text lacks an error prefix
+        (e.g. run_command_multi's per-host markdown aggregate wrapping a
+        denial), the model reads a refused action as success. Prefix it.
+        """
+        if ok or result_text.lstrip().startswith(_ERROR_RESULT_PREFIXES):
+            return result_text
+        return f"Error (tool reported failure):\n{result_text}"
 
     @staticmethod
     def _detect_image_type(data: bytes) -> str | None:
@@ -4877,6 +4894,13 @@ class OdinBot(commands.Bot):
                 # Handle image block returns from analyze_image
                 if isinstance(raw, dict) and "__image_block__" in raw:
                     raw = f"[Image loaded: {raw.get('__prompt__', '')}]"
+
+                # Make structured failure visible (see _ensure_failure_visible)
+                # and propagate it into the audit error field.
+                if isinstance(raw, ToolResult):
+                    if not raw.ok and not error:
+                        error = raw.error or "tool reported failure"
+                    raw = self._ensure_failure_visible(str(raw), raw.ok)
 
                 result = truncate_tool_output(scrub_output_secrets(str(raw)))
 

--- a/tests/test_tool_failure_visibility.py
+++ b/tests/test_tool_failure_visibility.py
@@ -1,0 +1,69 @@
+"""Tool failures must be visible to the model, not just to structured consumers.
+
+Found by Odin's post-deploy v3.44.0 smoke test: run_command_multi's all-denied
+aggregate carried ok=False (audit/scheduler saw the failure) but str(ToolResult)
+is just the output — the markdown-wrapped denial had no error prefix, so the
+model read a refused action as success.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config.schema import Config
+from src.discord.client import OdinBot
+
+
+def _make_bot() -> OdinBot:
+    cfg = Config(
+        discord={"token": "smoke-test-token"},
+        permissions={"default_tier": "admin"},
+    )
+    return OdinBot(cfg)
+
+
+# ---------------------------------------------------------------------------
+# The helper itself
+# ---------------------------------------------------------------------------
+
+def test_ok_result_untouched():
+    text = "### host\n```\nall good\n```"
+    assert OdinBot._ensure_failure_visible(text, True) == text
+
+
+def test_failed_result_without_marker_gets_prefixed():
+    text = "### definitely-not-a-host\n```\nHost access denied: definitely-not-a-host\n```"
+    out = OdinBot._ensure_failure_visible(text, False)
+    assert out.startswith("Error (tool reported failure):")
+    assert "Host access denied" in out
+
+
+def test_failed_result_with_existing_marker_not_double_prefixed():
+    for text in (
+        "Error: something broke",
+        "Command failed (exit 1):\nboom",
+        "Blocked [critical]: nope",
+        "Unknown or disallowed host: x",
+    ):
+        assert OdinBot._ensure_failure_visible(text, False) == text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: run_command_multi denial reaches the model as an error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multi_host_denial_visible_through_executor():
+    bot = _make_bot()
+    result = await bot.tool_executor.execute(
+        "run_command_multi",
+        {"hosts": ["definitely-not-a-host"], "command": "echo hi"},
+        user_id="u1",
+    )
+    # Structured layer: classified as failure (PR#128 fix).
+    assert result.ok is False
+    # Model layer: after the visibility wrapper, the text carries an error marker.
+    rendered = OdinBot._ensure_failure_visible(str(result), result.ok)
+    assert rendered.startswith("Error")
+    assert "Unknown or disallowed host" in rendered or "Host access denied" in rendered


### PR DESCRIPTION
Follow-up from Odin's post-deploy v3.44.0 smoke test (test 2 FAIL).

**Gap:** `run_command_multi`'s all-denied aggregate carries `ok=False` after #128 — audit and the scheduler path classify it correctly — but the model only ever sees `str(ToolResult)`, which is the bare output. The markdown-wrapped denial has no error prefix, so the *model* still read a refused action as success.

**Fix:** `OdinBot._ensure_failure_visible(text, ok)` — when `ok=False` and the text doesn't already start with an `_ERROR_RESULT_PREFIXES` marker, prefix it with `Error (tool reported failure):`. Wired into both dispatchers (`_run_tool`, `_run_loop_tool`); both also propagate the failure into the audit `error` field when it would otherwise be empty. Results already carrying an error marker are not double-prefixed.

**Tests:** 4 new (`tests/test_tool_failure_visibility.py`), including an end-to-end `run_command_multi` unknown-host denial through the real executor. Full suite: **5909 passed**.