### PR TITLE
refactor(client): P0 — characterization harness

### DIFF
--- a/docs/plans/client-decomposition-plan.md
+++ b/docs/plans/client-decomposition-plan.md
@@ -1,0 +1,522 @@
+# RFC-001: Decomposition of `src/discord/client.py`
+
+| | |
+|---|---|
+| **Status** | **APPROVED** (R1) — Odin approved as campaign plan of record, 2026-07-04. Implementation NOT started; each phase requires Aaron's per-phase approval, then branch → PR → Odin review |
+| **Author** | Claude (on behalf of Aaron / Calmingstorm) |
+| **Reviewer** | Odin |
+| **Date** | 2026-07-04 |
+| **Baseline** | `master` @ `081e231` (v3.44.1) |
+| **Scope** | `src/discord/client.py` (5,790 lines) and its test surface |
+
+---
+
+## 1. Executive summary
+
+`src/discord/client.py` is a 5,790-line module containing one god class (`OdinBot`, 111 direct methods/properties by AST; 151 function definitions module-wide including nested closures and module-level helpers) that owns message intake, two hand-duplicated tool loops, prompt assembly, LLM provider management, ~45 Discord-native tool handlers, scheduler callbacks, agent delegation, response delivery, lifecycle, and ~25 mutable state dictionaries. Project history confirms it is the primary bug source, and Odin's own prior analysis (recorded in `tool_loop_helpers.py`'s docstring) called the tool loop "the single worst structural problem," blocked on the absence of an end-to-end harness.
+
+This RFC proposes an **11-phase strangler-fig decomposition** — one reviewable PR per phase — that:
+
+1. Builds the missing **characterization-test harness first** (Phase 0), pinning current behavior including guard ordering, so every later move is provably behavior-neutral.
+2. Extracts responsibilities into ~15 focused modules with **constructor-injected dependencies**, in risk order (composition root and state registry first, the two tool loops last).
+3. Preserves the **entire external attribute/method contract** of `OdinBot` via a delegating facade — required because `web/api.py` reads/writes 54 distinct attributes including private ones.
+4. Deletes the ~490-line duplicated autonomous-loop pipeline by re-basing it on the extracted chat tool-loop runner, with every intentional chat/loop behavioral asymmetry explicitly enumerated and test-pinned.
+5. Ends with `client.py` as a thin Discord adapter (target ≤ ~900 lines), every extracted module unit-testable without a Discord gateway connection.
+
+No behavior changes. No guard, classifier, or response-guard weakening (hard rule). Each phase leaves the full suite green and is independently deployable and revertable.
+
+---
+
+## 2. Problem statement
+
+Measured on the baseline commit:
+
+- `client.py` is **5,790 lines**; the next-largest module in the package is 688 (`response_guards.py`). `OdinBot.__init__` alone is 455 lines; `_process_with_tools` is 855; `close()` is 219; `_handle_message_inner` is 261; `_run_loop_iteration` is 310. (Method lengths AST-measured, reviewer-verified.)
+- **Two parallel tool-execution pipelines** are maintained by hand: `_process_with_tools` (chat, lines 2768–3623) and `_run_loop_iteration` + `_dispatch_loop_tool_inner` (autonomous loops, lines 4698–5214). Their comments cross-reference each other to stay in sync ("matches `_process_with_tools` format", "Mirrors the Discord-native tool dispatch in `_process_with_tools`", "The sibling loop already uses this stricter form"). Every dispatch or safety fix must be applied twice; v3.44.x fixes repeatedly touched both.
+- **Two parallel ~45-branch if/elif dispatch tables** for Discord-native tools (chat: lines 3226–3402; loop: `_dispatch_loop_tool_inner`).
+- **~25 mutable state fields** (per-channel locks, cancel events, pending files, buffers, caches, recent actions) are mutated from intake, both loops, delivery, handlers, slash commands, and the web API, with an 84-line cross-cutting janitor (`_cleanup_stale_caches`) that knows about all of them.
+- The project's own failure-mode record: *"`client.py` monolith (5.8K lines) — most bugs trace here."*
+- Review leverage is degraded: every PR that touches the file asks the reviewer to reason about a 5,790-line shared-state context.
+
+Prior mitigation attempts were real but small: `response_guards.py`, `background_task.py`, `attachments.py`, `voice.py` were extracted, and `tool_loop_helpers.py` (84 lines of pure functions) explicitly documents that further decomposition was deferred **because no end-to-end harness existed**. This RFC is that harness plus the deferred decomposition.
+
+---
+
+## 3. Goals and non-goals
+
+### Goals
+1. `client.py` becomes a thin Discord adapter: event handlers, cog/extension loading, and a stable facade. Target ≤ ~900 lines.
+2. Every extracted module has a single responsibility, explicit constructor dependencies, and unit tests that run without a Discord connection or live LLM.
+3. One tool-execution pipeline, parameterized by policy (chat vs. loop), instead of two hand-synced copies.
+4. One Discord-native tool dispatch registry instead of two if/elif chains.
+5. Behavior preservation, proven by a characterization suite written before any production change.
+6. The external contract (everything `web/api.py`, `health/checker.py`, `web/chat.py`, `__main__.py`, cogs, and tests touch) remains valid throughout.
+
+### Non-goals (explicitly out of scope for this campaign)
+- **No behavior changes** — no guard tuning, no new features, no bug fixes riding along (any bug found gets its own issue/PR).
+- **No framework-independence rewrite** — the pipeline stays `discord.Message`-shaped (formalized as a duck-type Protocol); we do not port to a hexagonal core in this campaign (see §11 Alternatives).
+- **No migration of `web/api.py` off the facade** — it keeps using `bot.<attr>`; migrating it to direct component access is a candidate follow-up campaign.
+- **No changes to `ToolExecutor`, `SessionManager`, `Scheduler`, or other subsystems** — they are already separate modules with no bot reference; this campaign only touches how `client.py` orchestrates them.
+- **No renames of externally-referenced attributes/methods** — even ugly ones (`_knowledge_store` vs `knowledge` naming drift is documented, not fixed).
+
+---
+
+## 4. Current-state analysis
+
+### 4.1 Responsibility clusters in `OdinBot` (111 direct methods, by baseline line ranges)
+
+| Cluster | Lines | ~LOC | Contents |
+|---|---|---|---|
+| Module-level helpers | 94–225 | 130 | `_scrub_tool_input_for_storage`, `_LoopMessageProxy`/`_LoopAuthorProxy`, `scrub_response_secrets`, `truncate_tool_output`, `combine_bot_messages` |
+| Construction (composition root) | 227–681 | 455 | `__init__`: constructs ~30 subsystems + ~25 state fields, then builds prompt, registers commands |
+| LLM provider management | 682–872 | 190 | `llm_client` property, `_wire_llm_callbacks`, reload codex/ollama/kimi (×2 each), `switch_llm_provider`, `codex`/`knowledge` properties |
+| Prompt & context assembly | 873–1345 | 470 | `_build_system_prompt`, `_build_chat_system_prompt`, `_merged_tool_definitions`, caches (`_get_cached_hosts/skills_text/memory`), `_get_reflector_section`, `_invalidate_prompt_caches`, cache janitor (`_cleanup_stale_caches`, `_maybe_cleanup_caches`), `_track_recent_action`, observability helpers (`_record_user_content`, `_new_context_trace`), schedule validation (`_validate_schedule_payload`, `_extract_tool_input_from_steps`), `_invoke_skill_missing_required`, startup logging |
+| Slash commands & gating | 1371–1489 | 120 | `_register_commands` (6 slash commands), `_is_cancelled/_is_allowed_user/_is_allowed_channel/_check_for_secrets`, `_resolve_prefix` |
+| Guarded LLM call & reflection glue | 1490–1703 | 215 | `_codex_call` (lock + subsystem guard + model router + cost tracker), reflection triggers (`_should_reflect_on_operation`, `_maybe_loop_reflect`, `_operational_reflection`), `_save_turn_trajectory`, `_emit_lifecycle_event` |
+| Lifecycle | 1704–2048 | 345 | `setup_hook`, `close` (219 lines of teardown), `_set_status`, `on_ready`, `_backfill_archives`, `on_voice_state_update` |
+| Message intake | 2049–2422 | 375 | `on_message` (249 lines: secret scrub → cogs → bot gates → allowlists → channel config → mention gate → dedup → bot-message buffering → attachments → voice commands), `_process_attachments`, `_on_voice_transcription`, `_handle_message` (lock + thread-context inheritance) |
+| Pipeline orchestration | 2423–2767 | 345 | `_handle_message_inner` (guest route vs tool route, handoff, history persistence, error sanitization, reflection dispatch, delivery), `_classify_completion` + `_parse_classifier_response` + classifier prompt |
+| Chat tool loop | 2768–3649 | 880 | `_process_with_tools` (855 lines: preamble, RBAC/tier/token tool filtering, iteration loop, context compression, typing, stuck-loop tracking, 6-guard cascade, completion classifier, continuation budget, ~45-branch native dispatch, parallel execution w/ timeouts, audit, trajectory, validation enforcement, vision injection, skill handoff, `/stop` cancellation, cap handling), `_ensure_failure_visible`, `_detect_image_type` |
+| Discord-native tool handlers | 3650–4037, 5215–5459 | 630 | 22 `_handle_*` methods: purge, browser_screenshot, generate_file, post_file, schedule CRUD, parse_time, search_history, knowledge CRUD, set_permission, search_audit, read_channel, add_reaction, create_poll, analyze_image, generate_image |
+| Scheduler & monitor callbacks | 4038–4148, 5460–5688 | 340 | `_on_scheduled_digest`, `_format_digest_raw`, `_resolve_mentions`, `_on_monitor_alert`, `_execute_scheduled_tool`, `_run_scheduled_workflow`, `_on_schedule_failure`, `_on_scheduled_task` |
+| Delegation & agents | 4149–4697 | 550 | `_handle_delegate_task`, task list/cancel, loop start/stop/list, `_handle_spawn_agent` (119), agent send/list/kill/results/wait, `_handle_spawn_loop_agents`, `_collect_loop_agents`, `_collect_agent_result` |
+| Autonomous loop pipeline | 4698–5214 | 515 | `_run_loop_iteration` (310 — duplicate of chat loop minus guards), `_dispatch_loop_tool` + `_dispatch_loop_tool_inner` (177 — duplicate dispatch table) |
+| Delivery | 5689–5790 | 100 | `_send_with_retry`, `_send_chunked` (code-fence-aware chunking, file fallback, pending-file attachment) |
+
+### 4.2 Mutable state inventory (the coupling core)
+
+Set in `__init__` and mutated across clusters:
+
+| State | Type | Mutated by |
+|---|---|---|
+| `_channel_locks` | dict[str, Lock] | `_handle_message`, janitor |
+| `_cancel_events`, `_active_request_by_channel` | dicts | `/stop` command, chat loop, janitor |
+| `_pending_files` | dict[str, list] | skill handlers, export_skill, delivery, error paths, janitor |
+| `_processed_messages` | OrderedDict | `on_message` dedup |
+| `_bot_msg_buffer`, `_bot_msg_tasks` | dicts | `on_message` bot buffering |
+| `_recent_actions`, `_last_op_details` | dicts | chat loop, prompt builder, reflection dispatch, janitor |
+| `_background_tasks` | dict | delegate_task handlers |
+| `_cached_merged_tools`, `_cached_skills_text`, `_cached_hosts`, `_memory_cache` | caches | skill CRUD (both loops), config reload, **`web/api.py` writes** |
+| `_system_prompt` | str | `__init__`, `/reload`, skill CRUD, **`web/api.py` writes** |
+| `_llm_provider_lock`, `_llm_active_requests`, `_llm_switching` | lock/counters | `_codex_call`, reloads, switch |
+| Late-bound (NOT set in `__init__`) | — | `startup_report` (setup_hook), `_web_channel_locks` (created by `web/chat.py`!), `mcp_manager`, `_codex_auth_pool`, `_issue_tracker_client`, `compression_stats`, `health_server` (web layer) |
+
+Two subtleties that constrain the design:
+- **`hasattr` semantics are load-bearing.** Code paths use `hasattr(self, "reflector")`, `getattr(config, ...)` defensively; `health/checker.py` reads everything via `getattr`. The facade must not pre-create attributes that are conditionally absent today, and must keep late-bound attributes settable.
+- **The chat loop mutates its own system prompt mid-flight** (skill CRUD → cache invalidation → `nonlocal system_prompt` rebuild at lines 3278–3309, mirrored in the loop dispatch at 4874–4880). Extraction must carry this signal explicitly.
+
+### 4.3 The duplicated pipeline, and its intentional asymmetries
+
+`_run_loop_iteration` docstring: *"Simplified version of `_process_with_tools` for autonomous loops."* The duplication is near-total (LLM call → tool dispatch → parallel execution → audit → trajectory → scrub/truncate → iterate), but the differences are **intentional behavior**, not accidents. Any unification must preserve them:
+
+| Dimension | Chat loop (`_process_with_tools`) | Autonomous loop (`_run_loop_iteration`) |
+|---|---|---|
+| LLM entry | `_codex_call` (provider lock, subsystem guard, model router, cost tracker) | **raw `self.llm_client.chat_with_tools`** — no gateway wiring |
+| Response guards (fabrication/promise/unavail/hedging/code-hedging/premature-failure) | Full cascade, one retry each | **None** |
+| Completion classifier + continuations | Yes (≤3 continuations) | **No** |
+| Stuck-loop tracker | Yes (warn → terminate) | **No** |
+| Request preamble / history separator | Yes | No (prev-context synthetic exchange instead) |
+| Context compression | Yes | No |
+| Typing indicator, status updates | Yes | No |
+| `/stop` cancellation checks | Yes (4 checkpoints) | No (LoopManager owns lifecycle) |
+| Validation enforcement (`[AUTO-VALIDATE]`) | Yes | No |
+| Vision block injection | Yes | analyze_image collapsed to text |
+| Audit events | `tool_start`/`tool_end` + `log_execution` | `loop_tool` + `log_execution` |
+| Iteration cap | `max_tool_iterations_chat`, error text mentions chat cap | `max_tool_iterations_loop`, cap → `_finish(is_error=True, failure_class="cancelled")` |
+| Trajectory source | `"discord"` | `"loop"`, gated by `observability.loop_trace` |
+| Reflection | `_operational_reflection` (fire-and-forget, post-turn) | `_maybe_loop_reflect` (gated by `LoopReflectionGate`) |
+| CircuitOpenError | wait-and-retry once inside the loop | **re-raised** to LoopManager |
+| Return contract | 5-tuple `(text, already_sent, is_error, tools_used, handoff)` to pipeline / web chat | plain text via `_finish(...)`, carrying loop failure metadata (`is_error`, `failure_class`, `error_text`) to LoopManager |
+| `/stop` + active-request bookkeeping | sets/clears `_active_request_by_channel` (own request id only) | none — LoopManager owns lifecycle |
+| Recent-operation details | updates `_last_op_details[channel]` consumed by post-turn reflection | accumulates local `_loop_details` for the loop-reflection gate |
+| Presence / per-tool status labels | `_set_status(_TOOL_STATUS_LABELS…)` per tool | no presence/status side effects |
+| `analyze_image` result shape | dict → pending vision block injected into the **next LLM turn** (shape invariant) | dict collapsed to text `[Image loaded: …]` |
+| Trace mismatch warnings & error recovery | `TOOL_RESULT_CONTINUATION_MISMATCH` on chat trace; guard/classifier drive recovery | loop-specific mismatch warnings; a recovered mid-iteration tool error keeps the turn a success while passing failure detail to reflection |
+
+This table becomes a test fixture in Phase 0 and the acceptance checklist in Phase 8.
+
+### 4.4 External contract (measured, not assumed)
+
+Only 9 files in `src/` touch a bot instance. Ranked by distinct attributes:
+
+1. **`web/api.py` — ~54 distinct attributes, 213 references. The de-facto facade.** Reads most public subsystems (`config`, `sessions`, `scheduler`, `tool_executor`, `loop_manager`, `audit`, `agent_manager`, `reflector`, `skill_manager`, `permissions`, provider clients, `cost_tracker`, `subsystem_guard`, trajectory savers, `api_token_manager`, `host_access_manager`, `channel_config`, `context_loader`, `infra_watcher`, `outbound_webhook_dispatcher`, `model_router`, `startup_report`, `mcp_manager`, …) **and private internals** (`_embedder`, `_system_prompt`, `_cached_merged_tools`, `_cached_skills_text`, `_start_time`, `_codex_auth_pool`, `_issue_tracker_client`, `_llm_provider_lock`). Calls private methods: `_build_system_prompt`, `_invalidate_prompt_caches`, `_merged_tool_definitions`, `_run_loop_iteration`, `_reload_*_inner`. **Writes from outside:** `bot.config` (hot reload), `bot._system_prompt`, `bot._cached_merged_tools = None`, `bot._cached_skills_text = None` (~7 sites).
+2. `health/checker.py` — 14 attrs, all via `getattr`; uses the **`knowledge`** and **`codex`** property aliases.
+3. `__main__.py` — lifecycle: `start/close/is_ready/latency/get_channel` + defensive teardown of `scheduler`, `voice_manager`, `browser_manager`, `sessions`, `cost_tracker`, `trajectory_saver`, `loop_manager`, `infra_watcher`.
+4. `web/chat.py` — calls `_build_system_prompt`, `_new_context_trace`, `_process_with_tools`, `_set_status`; reads `sessions`, `codex_client`; **creates `bot._web_channel_locks`**.
+5. `monitoring/resource_usage.py` (4, via getattr), `health/server.py` (3), `web/websocket.py` (holds ref only), cogs (discord.py-native surface only).
+
+Notably: `src/tools/`, `src/scheduler/`, `src/learning/`, `src/agents/` hold **no** bot reference — they already receive components. Decomposition inside the discord package cannot break them.
+
+### 4.5 Test landscape (what the harness must replace/extend)
+
+- **No shared bot fixture and no shared fake LLM exist.** Each test file builds its own `_make_bot()` and its own scripted `chat_with_tools` fake. `tests/conftest.py` provides only `odin_config` (a real pydantic `Config`) plus generic mocks.
+- Tests call private methods directly (`bot._process_with_tools(...)` — `test_executor_integration_smoke.py:360`; `bot._codex_call(...)`:506; `bot._dispatch_loop_tool(...)`:588; `_run_loop_iteration` rebound onto a fake — `test_trajectory_completeness.py:329`). Moving/renaming these breaks call sites directly → the facade must also preserve **method** names tests use, or the phase updates those tests in the same PR.
+- **`inspect.getsource` structural assertions** exist (`on_message`, `_handle_spawn_agent`, others in `test_executor_integration_smoke.py`, `test_trajectory_completeness.py`, `test_round30_reviewer.py`). These fail on any refactor even with identical behavior. Phase 0 defines the replacement policy (§8.4).
+- Seam caveat: chat-loop tests patch `bot.codex_client.chat_with_tools`; loop tests fake `self.llm_client`. Both seams must keep working until tests are migrated to the shared fake.
+- Closest existing prior art to build on: `test_trajectory_completeness.py`'s scripted-`LLMResponse` pattern, and `test_web_chat.py`'s fake `WebMessage`/`WebChannel`/`WebAuthor` discord objects.
+
+### 4.6 Prior art already in the repo
+
+The extraction idiom is established: `response_guards.py` (pure detectors + message constants), `tool_loop_helpers.py` (pure functions, 1:1 inline replacements), `background_task.py`/`attachments.py`/`voice.py` (classes with injected callbacks). This RFC continues that idiom rather than inventing a new one. `tool_loop_helpers.py`'s docstring records the standing verdict and the prerequisite: *"a full decomposition is too risky without an end-to-end harness."* Phase 0 is that harness.
+
+---
+
+## 5. Guiding principles
+
+1. **Characterize before you move.** No production change lands before the behavior it touches is pinned by a test that survives the move.
+2. **Strangler fig, not big bang.** One phase = one PR = one reviewable concern. Every phase leaves master releasable.
+3. **Move-only vs. reshape, separated.** Within a phase, mechanical relocation (cut/paste + import fixes) and structural change (signature/DI changes) are separate commits, so the diff reviews as a move plus a small delta.
+4. **Constructor injection, no service locator.** Extracted classes receive exactly the dependencies they use, by constructor. Nothing new reaches back into the bot god-object. (`message`-shaped objects are passed per-call, as today.)
+5. **Stable facade.** `OdinBot` keeps every externally-referenced attribute and method as a real attribute or delegating property — including write paths and `hasattr` semantics (Appendix B is the contract; a facade contract test enforces it).
+6. **Behavior identical, byte-identical where cheap.** Prompt text, message-list shapes, audit event fields, error strings, scrub/truncate behavior, and guard **ordering** are pinned. Known asymmetries (§4.3) are preserved, not "fixed."
+7. **Hard rules honored structurally.** Anti-hedging guards, completion classifier, and response guards move only as opaque units; their logic and thresholds are untouched (repo hard rule #5). The guard cascade order — fabrication → promise → tool-unavailable → hedging → code-hedging → premature-failure → completion classifier — is pinned by a dedicated test.
+8. **Every phase ends green.** Full suite (`pytest -q`, ~5,905 + new), `ruff check`, and the characterization suite unchanged (except explicitly-listed test migrations declared in the PR description).
+9. **One phase in flight at a time.** Reduces rebase pain for parallel feature work and keeps Odin's review context small.
+
+---
+
+## 6. Target architecture
+
+### 6.1 Module map (all new modules under `src/discord/` unless noted)
+
+| Module | Class(es) | Responsibility | Est. LOC | Sourced from (baseline lines) |
+|---|---|---|---|---|
+| `wiring.py` | `BotServices` (typed dataclass), `build_services(config) → BotServices`, `shutdown_services(services)` | Composition root: construct/teardown the ~30 subsystems in dependency order | ~550 | 227–681, 1745–1963 |
+| `channel_state.py` | `ChannelStateRegistry` | Owns the per-channel dicts (locks, cancel events, active request, pending files, processed-message dedup, bot buffers, recent actions, last op details) + their housekeeping | ~250 | scattered `__init__` fields, 1246–1342 |
+| `prompts.py` | `PromptBuilder` | Full + chat system prompts; memory/hosts/skills caches; reflector section; invalidation | ~280 | 873–1245 (minus catalog), 981–988 |
+| `tool_catalog.py` | `ToolCatalog` | Merged builtin+skill tool definitions, backend gating, cache + invalidation on skill CRUD | ~90 | 1216–1244 |
+| `llm_gateway.py` | `LLMGateway` | Active-provider resolution; provider lock/switch/reloads; guarded `call_with_tools` (subsystem guard, model router, aux client, cost tracker); compaction/reflection callback wiring | ~330 | 682–872, 1490–1568 |
+| `native_tools/` (package: `registry.py`, `scheduling.py`, `knowledge.py`, `agents_tasks.py`, `media.py`, `channel_ops.py`, `skills.py`) | `NativeToolDispatcher` + per-domain handler classes | The single dispatch registry for Discord-native tools; replaces both if/elif chains. Returns `(result, effects)` where effects carry the prompt-rebuild signal | ~900 total | 3226–3402, 3650–4037, 4149–4697, 5215–5459, 5037–5214, 1006–1074 |
+| `delivery.py` | `ResponseDelivery` | `send_with_retry`, code-fence-aware chunking, long-response file fallback, pending-file attachment, presence/status | ~180 | 5689–5790, 1964–1983 |
+| `completion.py` | `CompletionClassifier` | Classifier prompt (verbatim), `classify`, `parse_response`, start_loop short-circuit. **Boundary note (reviewer):** this is tool-loop policy machinery, not a general completion service — it stays private to `tool_loop.py` and must not grow into a second LLM gateway | ~120 | 2661–2766 |
+| `tool_loop.py` | `ToolLoopRunner`, `LoopPolicy` | THE tool-execution pipeline: iteration loop, guard cascade application, stuck tracking, continuation budget, RBAC gate, parallel execution + timeouts, audit, trajectory, validation, vision injection, handoff, cancellation — parameterized by `LoopPolicy(chat)` / `LoopPolicy(autonomous)` per the §4.3 table | ~700 | 2768–3649 (P7), 4698–5214 (P8) |
+| `intake.py` | `MessageIntake` | The `on_message` gating chain as named steps; bot-message buffering; attachment processing hook; voice-command shortcuts | ~330 | 2049–2347 |
+| `pipeline.py` | `MessagePipeline` | Per-channel lock + thread inheritance; guest vs tool routing; skill handoff; history persistence + error sanitization; reflection dispatch; delivery invocation | ~350 | 2375–2660 |
+| `scheduled_events.py` | `ScheduledEventHandlers` | Scheduler/digest/monitor callbacks, scheduled tool/workflow execution, mention resolution | ~380 | 4038–4148, 5460–5688 |
+| `slash_commands.py` | `register_commands(bot, services)` | The 6 slash commands | ~110 | 1371–1461 |
+| `turn_recorder.py` | `TurnRecorder`, `ReflectionDispatcher` | Trajectory create/save, context-trace creation, user-content recording, recent-action tracking, reflection triggers (chat + loop) | ~260 | 930–966, 1343–1370, 1579–1703 |
+| *(existing)* `tool_loop_helpers.py`, `response_guards.py`, `background_task.py`, `attachments.py`, `voice.py` | — | Unchanged; detectors/messages stay the single source of truth | — | — |
+| *(shrinks)* `client.py` | `OdinBot` | Discord adapter: intents, event handlers (3–10 lines each), cog loading, `setup_hook`/`on_ready`, facade properties (Appendix B), module-level helpers that must stay importable | ≤ ~900 | remainder |
+
+### 6.2 Dependency direction
+
+```
+                       discord.py events
+                              │
+   ┌──────────────────────── OdinBot (adapter + facade) ────────────────────────┐
+   │                                                                            │
+   ▼                                                                            ▼
+MessageIntake ──▶ MessagePipeline ──▶ ToolLoopRunner ◀── LoopManager callback   ScheduledEventHandlers
+                        │              │  │  │  │                                      │
+                        ▼              ▼  ▼  ▼  ▼                                      ▼
+                 ResponseDelivery   LLMGateway  NativeToolDispatcher ──▶ (scheduler, sessions,
+                        │              │        CompletionClassifier      skills, agents, knowledge…)
+                        ▼              ▼        response_guards (existing)
+                 ChannelStateRegistry  providers
+                        ▲
+   PromptBuilder ── ToolCatalog ── TurnRecorder ── wiring.BotServices (constructs everything)
+```
+
+Rules: arrows point downward only (adapter → orchestration → services); no extracted module imports `client.py`; only `client.py` and `wiring.py` know the whole object graph. `web/api.py` keeps talking to the facade.
+
+### 6.3 Key interface sketches (signatures only — final shapes may be adjusted in-phase with reviewer sign-off)
+
+```python
+# wiring.py
+@dataclass
+class BotServices:
+    config: Config
+    sessions: SessionManager
+    tool_executor: ToolExecutor
+    skill_manager: SkillManager
+    scheduler: Scheduler
+    audit: AuditLogger
+    permissions: PermissionManager
+    host_access_manager: HostAccessManager
+    reflector: ConversationReflector
+    agent_manager: AgentManager
+    loop_manager: LoopManager
+    # ... every subsystem currently built in __init__, typed, in construction order
+def build_services(config: Config) -> BotServices: ...
+async def shutdown_services(services: BotServices, *, log: Logger) -> None: ...
+
+# channel_state.py
+class ChannelStateRegistry:
+    def lock_for(self, channel_id: str) -> asyncio.Lock: ...
+    def cancel_event(self, channel_id: str) -> asyncio.Event: ...
+    def set_active_request(self, channel_id: str, req_id: str) -> None: ...
+    def clear_active(self, channel_id: str, req_id: str) -> None: ...
+    def add_pending_file(self, channel_id: str, data: bytes, filename: str) -> None: ...
+    def pop_pending_files(self, channel_id: str) -> list[tuple[bytes, str]]: ...
+    def seen_message(self, message_id: int) -> bool: ...          # dedup, bounded
+    def track_recent_action(self, channel_id: str, entry: str) -> None: ...
+    def recent_actions(self, channel_id: str) -> list[str]: ...
+    def run_housekeeping(self, *, active_channels: set[str]) -> None: ...
+
+# llm_gateway.py
+class LLMGateway:
+    @property
+    def active_client(self): ...                                   # today's llm_client
+    async def call_with_tools(self, *, messages, system, tools,
+                              user_message="", user_id="", channel_id="",
+                              tools_used=None, **kwargs) -> LLMResponse: ...  # today's _codex_call
+    async def reload_codex(self) -> dict: ...
+    async def reload_ollama(self) -> dict: ...
+    async def reload_kimi(self) -> dict: ...
+    async def switch_provider(self, provider: str) -> dict: ...
+    def wire_callbacks(self) -> None: ...
+
+# native_tools/registry.py
+@dataclass
+class NativeToolEffects:
+    rebuild_system_prompt: bool = False        # replaces the `nonlocal system_prompt` mutation
+    pending_image_block: dict | None = None    # analyze_image vision injection
+class NativeToolDispatcher:
+    def handles(self, tool_name: str) -> bool: ...
+    async def dispatch(self, tool_name: str, tool_input: dict, *,
+                       message: MessageLike, user_id: str) -> tuple[str | ToolResult, NativeToolEffects]: ...
+
+# tool_loop.py
+@dataclass(frozen=True)
+class LoopPolicy:            # values per the §4.3 asymmetry table
+    guards: bool
+    completion_classifier: bool
+    stuck_tracking: bool
+    preamble: bool
+    context_compression: bool
+    typing_indicator: bool
+    cancellation: bool
+    validation_enforcement: bool
+    vision_injection: bool
+    llm_via_gateway: bool    # chat=True, autonomous=False (preserved asymmetry)
+    audit_event_style: Literal["chat", "loop"]
+    iteration_cap_key: Literal["chat", "loop"]
+    trajectory_source: str
+CHAT_POLICY: LoopPolicy
+AUTONOMOUS_POLICY: LoopPolicy
+class ToolLoopRunner:
+    async def run(self, *, message: MessageLike, history: list[dict],
+                  system_prompt: str, policy: LoopPolicy,
+                  trace=None) -> ToolLoopResult: ...   # (text, already_sent, is_error, tools_used, handoff)
+
+# MessageLike: typing.Protocol documenting the duck-type contract that
+# discord.Message, _LoopMessageProxy, VoiceMessageProxy, and web WebMessage
+# already satisfy (author.id/display_name/bot, channel.id/send/typing,
+# id, webhook_id, content, attachments?).
+```
+
+### 6.4 The facade after decomposition
+
+`OdinBot` retains, as thin delegators: every subsystem attribute (assigned from `BotServices` — flat attributes, so `getattr`/`hasattr` behavior is unchanged), the `codex`/`knowledge` properties with setters, provider reload/switch methods, `_build_system_prompt`, `_merged_tool_definitions`, `_invalidate_prompt_caches`, `_new_context_trace`, `_set_status`, `_process_with_tools`, `_run_loop_iteration`, `_codex_call`, `_dispatch_loop_tool`, and property-with-setter shims for `_system_prompt`, `_cached_merged_tools`, `_cached_skills_text` (because `web/api.py` writes them). Late-bound attributes (`startup_report`, `_web_channel_locks`, `mcp_manager`, …) remain late-bound. Appendix B is the normative list; a facade contract test asserts it.
+
+---
+
+## 7. Migration phases
+
+Each phase: **one PR**, full suite + characterization green, ruff clean, Odin review, squash-merge, independently revertable (`git revert` of the merge). Estimated diff sizes exclude generated churn (import blocks).
+
+| Phase | Title | Contents | Risk | Est. diff |
+|---|---|---|---|---|
+| **P0** | Characterization harness | Tests only, no `src/` change. §8 in full: shared fakes (`FakeLLM`, fake discord objects, `make_bot`), ~35 golden-flow scenarios, guard-order pin, asymmetry-table pins, facade contract test, getsource-replacement policy | None to prod | +1,500–2,000 test LOC |
+| **P1** | Composition root | `wiring.py`: `BotServices` + `build_services` + `shutdown_services`. `__init__` 455→~80 (intents, super().__init__, services attach, prompt build, command registration); `close()` delegates teardown. Pure move | Low | ~1,100 moved |
+| **P2** | Channel state registry | `channel_state.py`; the 8 per-channel dicts + `_cleanup_stale_caches`/`_maybe_cleanup_caches` become `ChannelStateRegistry` + `run_housekeeping`; call sites re-pointed mechanically. Facade keeps old attr names delegating to the registry (tests/api read some) | Low-med (many call sites, all mechanical) | ~600 |
+| **P3** | Prompt builder + tool catalog | `prompts.py`, `tool_catalog.py`; facade property-with-setter shims for `_system_prompt`/`_cached_*`; `_build_system_prompt`/`_build_chat_system_prompt`/`_merged_tool_definitions` delegate | Low | ~700 |
+| **P4** | LLM gateway | `llm_gateway.py`; `_codex_call` → `gateway.call_with_tools` (facade method retained); reloads/switch/wire_callbacks move; provider lock/counters live in gateway; `llm_client` property delegates | Med (lock semantics — move-only, no logic change) | ~600 |
+| **P5** | Native tool dispatch registry | `native_tools/` package; all `_handle_*` handler bodies move into domain classes; **both** if/elif chains replaced by `NativeToolDispatcher`; `nonlocal system_prompt` → `NativeToolEffects.rebuild_system_prompt`; skill-CRUD cache invalidation centralized in dispatcher. **Two commits mandatory:** (1) move handlers + registry, zero behavior change; (2) swap chat + loop dispatch to the registry. **Declared escape hatch:** if the diff exceeds reviewable size, split into P5a (registry + chat dispatch swap) and P5b (loop dispatch parity) | Med-high (largest semantic surface — reviewer-flagged sleeper risk: prompt rebuild, pending files, image effects, skill callbacks, ToolResult failure visibility) | ~1,600 (mostly moves) |
+| **P6** | Delivery | `delivery.py`; `_send_with_retry`/`_send_chunked`/status; pending files via `ChannelStateRegistry` | Low | ~300 |
+| **P7** | ToolLoopRunner (chat) | `tool_loop.py` + `completion.py`; `_process_with_tools` becomes `runner.run(policy=CHAT_POLICY)` behind the facade; the 855-line coroutine decomposes into ~10 named methods (setup, filter_tools, iterate, call_llm, apply_guards, execute_calls, record_iteration, handle_validation, finalize) | **High** — mitigated by P0 pins + P5 having already extracted dispatch | ~1,100 |
+| **P8** | Autonomous-loop unification | `_run_loop_iteration` reimplemented as `runner.run(policy=AUTONOMOUS_POLICY)`; `_dispatch_loop_tool_inner` deleted (registry already serves both since P5); ~490 duplicated lines deleted. Acceptance = every §4.3 row demonstrated by a passing pinned test. **Scope constraint (review condition):** policy wiring + duplicate deletion ONLY — no handler moves, no guard changes, no gateway changes, no drive-by cleanup | **High** — the one phase with real semantic-drift risk; extra review depth requested | ~900 (net −400) |
+| **P9** | Intake + pipeline | `intake.py` + `pipeline.py`; `on_message` → gating chain (named predicate methods, order pinned by P0); `_handle_message`/`_handle_message_inner` → `MessagePipeline`; `OdinBot.on_message` becomes ~10 lines | Med | ~900 |
+| **P10** | Scheduled events, slash commands, final sweep | `scheduled_events.py`, `slash_commands.py`, `turn_recorder.py` consolidation; dead-code removal; `client.py` final ≤ ~900 lines; docs: `CONTRIBUTING.md` pointer, architecture-memory update; final metrics report vs §10 | Low | ~800 |
+
+**Ordering rationale.** P1–P6 are low-to-medium-risk moves that shrink the blast radius and build the injection points; the two genuinely risky phases (P7, P8) land on a fully-pinned harness with dispatch already externalized; orchestration (P9) extracts last because it depends on delivery, runner, and state registry as injectables; P10 is cleanup. Dependencies: P2 requires P1; P5 requires P2 (pending files) and P3 (catalog invalidation); P7 requires P4+P5+P6; P8 requires P7; P9 requires P6+P7.
+
+**Execution model (R2, per Aaron 2026-07-04 — supersedes the per-phase release mapping below).** The campaign runs on a long-lived integration branch **`refactor/client-decomposition`** cut from master `081e231`. Each phase is a PR from a phase branch (`refactor/client-p<N>-<slug>`) **into the campaign branch**; Odin reviews every phase PR before it merges (hard rule unchanged). **Master is not touched and the release pipeline is not run during the campaign.** After P10, the completed branch is deployed to a local test instance retaining all live data (Codex auth, API tokens, `memory.json`, `learned.json`, knowledge store — standard deploy discipline) and soak-tested extensively with Odin running under the new code; only after that soak does Aaron decide on the final master merge + release pipeline. To prevent drift, master hotfixes landed mid-campaign are merged master → campaign branch as they occur.
+
+*(Original per-phase release mapping, retained for reference but inactive under R2:)* Phases are releasable individually (patch bumps); suggested cadence was deploy after P1–P2, P5, P7, P8, P10, observing audit/trajectory output after each. Any phase can pause the campaign indefinitely without leaving debt: every intermediate state is a coherent, shippable architecture — this property still holds on the campaign branch.
+
+---
+
+## 8. Testing strategy
+
+### 8.1 Phase 0 harness components (all shared, in `tests/`)
+
+1. **`tests/fakes/llm.py` — `FakeLLM`**: scripted sequence of `LLMResponse` objects (text / tool_calls / parse_error / token counts), records every `chat_with_tools`/`chat` invocation (messages, system, tools) for shape assertions. Installable at **both** existing seams (`bot.codex_client` and the `llm_client` property path) until tests migrate.
+2. **`tests/fakes/discord_objects.py`**: `FakeMessage`/`FakeChannel`/`FakeAuthor`/`FakeThread` (promotion of the `test_web_chat.py` pattern), satisfying the `MessageLike` Protocol; records `send`/`reply`/`typing` calls.
+3. **`tests/fakes/bot_factory.py` — `make_bot(config_overrides, *, fake_llm)`**: the one blessed way to build a real `OdinBot` for tests (today re-implemented per file).
+4. **Golden-flow characterization tests** (~35 scenarios): plain chat reply; single tool → final text; multi-tool parallel execution; multi-iteration with tool results fed back; **exact message-list shape** per iteration (preamble placement, assistant tool_use blocks, tool_result pairing); each of the 6 guards firing and retiring (order pinned); completion classifier INCOMPLETE → continuation (≤3); validation `[AUTO-VALIDATE]` injection + enforcement + retry cap; stuck-loop warn → terminate; `/stop` at each checkpoint; iteration-cap exit text; LLM API error path; CircuitOpenError wait-retry; RBAC denial result; skill handoff; skill-CRUD system-prompt rebuild; vision injection; guest chat route; thread context inheritance; secret scrub (both on_message sites); bot-message buffering + mention gate; error-path history sanitization; session persistence on success/error; autonomous-loop iteration (natural finish, cap-hit error, tool error recovery, reflection gating); scheduled check/workflow/reminder/digest; delivery chunking (fences, long-line pre-split, >4× file fallback, pending-file attach); `_send_with_retry` retry/backoff. **Added per Odin review (R1):** parse-error tool call (provider JSON-parse failure → "tool was NOT executed" bounce) in **both** chat and loop paths; `ToolResult(ok=False)` failure-visibility wrapping preserved verbatim in both paths; `invoke_skill` with missing required input fields; skill-CRUD prompt rebuild in **both** paths; pending-file delivery after `export_skill`/`generate_file` including janitor cleanup of leaked files; loop-path `CircuitOpenError` **re-raise** (vs chat wait-retry) specifically; cancellation clears `_active_request_by_channel` only for its **own** request id; scheduled-workflow `on_failure: continue` semantics; web-chat route through `_process_with_tools` (the facade's highest-value consumer — historically where "works in Discord, broke in WebUI" hides).
+5. **Facade contract test**: asserts every Appendix B name exists (attribute, property, or method; settable where marked) on a constructed bot — the tripwire for accidental external breakage.
+6. **Asymmetry pins**: one test per §4.3 row that can drift silently (e.g. "autonomous loop performs no guard retries", "loop cap returns is_error=True with failure_class=cancelled", "loop LLM call bypasses cost tracking").
+
+### 8.2 Per-phase testing
+- Move phases (P1–P6, P9–P10): characterization suite must pass **unmodified**. New unit tests accompany each extracted class (constructor-injected fakes, no Discord).
+- P7/P8: characterization suite passes unmodified; new unit tests for `ToolLoopRunner` cover each policy flag both ways; P8 additionally demonstrates the full asymmetry table.
+- Coverage gate: each new module ≥ 85% line coverage at introduction (soft, reviewer discretion).
+
+### 8.3 What characterization pins deliberately do NOT cover
+Timing-sensitive behavior (bot-buffer 2s delay uses fake-clock/short-delay injection), real Discord API semantics, real LLM output. These stay integration-tested by the existing live deployment discipline.
+
+### 8.4 `inspect.getsource` assertion policy
+Structural source assertions are replaced **in the same PR that moves the asserted code**, with a behavioral equivalent from the P0 suite (e.g. "on_message calls process_commands after scrub" → a FakeMessage-driven ordering test). Each replacement is listed in the PR description. No getsource assertion is deleted without a named replacement.
+
+---
+
+## 9. Risk register
+
+| # | Risk | Phase | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|---|
+| R1 | Hidden state coupling missed in a move (a method reads a dict another cluster mutates) | P2–P9 | Med | Prod bug | ChannelStateRegistry extracted early; per-move grep audit of every touched attribute; characterization shapes |
+| R2 | `web/api.py` breakage via private attr/method (incl. its **writes**) | P3, P4, P7 | Med | WebUI/API outage | Facade property-with-setter shims; facade contract test; grep `bot\.` in web/ per phase |
+| R3 | Guard/classifier behavior drift (hard-rule violation) | P7 | Low | Trust/safety regression | Guards move as opaque imports (already in `response_guards.py`); order + retry-once semantics pinned; no threshold edits permitted in campaign |
+| R4 | Chat/loop unification silently changes loop behavior | P8 | Med-high | Autonomous-loop regressions | §4.3 table = acceptance checklist; per-row pinned tests; deepest-review request to Odin; deploy alone + observe |
+| R5 | asyncio semantics change (CancelledError cleanup, gather, typing CM, fire_and_forget lifetimes, `nonlocal` → effects) | P7–P9 | Med | Hangs/leaks | Move-only commits keep exact structures; dedicated cancellation tests at each checkpoint; effects object is same-iteration, same-ordering |
+| R6 | Test-suite churn explodes PR size (tests import privates) | all | High (known) | Review fatigue | P0 shared fixtures land first; per-phase test migration is enumerated in PR body; facade keeps method names so most tests keep passing untouched |
+| R7 | Parallel feature work conflicts with a phase in flight | all | Med | Rebase pain | One phase in flight; phases sized to merge within a day or two of opening; feature PRs touching client.py rebase after |
+| R8 | Reviewer bandwidth (Odin reviews every PR) | all | Med | Schedule slip | Phases are single-concern; move-only commits reviewable as renames; this RFC pre-agrees the shape so per-PR review is delta-only |
+| R9 | Deploy regression not caught by suite | after deploys | Low | Prod incident | Existing discipline: deploy → diff 3 files → drive real Discord + WebUI flows; audit.jsonl + trajectories checked after each phased deploy |
+| R10 | Campaign stalls mid-way | any | Low | Half-done state | Every phase is a coherent stopping point; no phase leaves dual implementations behind (P5 swaps both dispatch sites in one PR; P8 deletes the duplicate loop in the same PR that re-bases it) |
+
+---
+
+## 10. Success metrics / Definition of Done
+
+Campaign-level (measured at P10, reported against baseline `081e231`):
+1. `src/discord/client.py` ≤ ~900 lines (baseline 5,790); no method > ~120 lines remains in it.
+2. No new module exceeds ~900 lines; every new class constructible in a unit test with fakes only (no gateway, no LLM, no filesystem beyond tmp).
+3. Exactly **one** tool-execution pipeline and **one** native-tool dispatch table exist (`grep`-provable: no `elif tool_name ==` chains outside `native_tools/registry.py`).
+4. The ~490-line autonomous-loop duplicate is deleted; net repo LOC delta for src/ ≈ +300 or better (moves + interfaces − duplication).
+5. Facade contract test green; `web/api.py`, `web/chat.py`, `health/checker.py`, `__main__.py`, cogs unmodified throughout (except if a phase PR explicitly includes a mechanical import fix, called out in its description).
+6. Test count strictly ≥ baseline 5,905 + P0 additions; characterization suite unmodified from P0 through P10 except the declared getsource replacements and per-phase migrations enumerated in PR bodies.
+7. Full suite runtime within +10% of baseline (guards against fixture bloat).
+8. Zero live regressions attributable to the campaign after each phased deploy (audit + trajectory review, real-flow smoke).
+9. Docs updated: `CONTRIBUTING.md` module-map pointer, this RFC marked COMPLETED with final numbers, architecture memory updated.
+
+Per-phase DoD: suite + ruff + characterization green; PR body lists moved symbols, migrated tests, and replaced getsource assertions; Odin approval; squash-merge; revert path stated.
+
+---
+
+## 11. Alternatives considered
+
+1. **Big-bang rewrite of client.py** — Rejected. Unreviewable diff (5.8K lines in flight), guaranteed guard-behavior drift, violates the PR-review process that exists precisely because unreviewed changes shipped bugs.
+2. **Hexagonal/framework-free core first** (abstract away `discord.Message` everywhere) — Rejected for this campaign. The duck-type boundary already exists and works (`_LoopMessageProxy`, `VoiceMessageProxy`, web `WebMessage`); a full port roughly doubles the churn for zero user-visible value and multiplies R3/R5. Formalizing `MessageLike` as a Protocol captures 80% of the benefit; a true port remains available later precisely because this campaign shrinks the surface.
+3. **Continue nibbling with pure-function helpers** (the `tool_loop_helpers.py` path) — Rejected as the only strategy. Two campaigns of it produced 84 lines while the file grew past 5,700; it cannot touch the duplication or the state coupling, which is where the bugs live.
+4. **Decompose by moving whole clusters to other existing packages** (e.g. scheduler callbacks into `src/scheduler/`) — Rejected. Those packages are deliberately bot-free (§4.4); moving Discord-flavored orchestration into them would invert the current clean dependency direction.
+5. **Do nothing** — Rejected by the standing failure-mode record and by the reviewer's own prior verdict.
+
+---
+
+## 12. Rollout & governance
+
+- **Approval gates.** This RFC needs Odin's review (this request) and Aaron's direction approval. Then **each phase separately** goes through the normal per-file-change-list approval with Aaron before any code is written, followed by branch → PR (into the campaign branch, per R2) → Odin review → merge. RFC approval is not approval to code.
+- **Branch/PR conventions.** Branches `refactor/client-p<N>-<slug>`; PR titles `refactor(client): P<N> — <title>`; PR body links this RFC section, lists moved symbols, migrated tests, replaced getsource assertions, and the revert command. No `Co-Authored-By` lines. Public-repo hygiene applies to all text.
+- **Cadence.** One phase in flight; target one phase per working session. Deploys per §7 release mapping with post-deploy verification per house rules.
+- **Change control on this doc.** Material deviations discovered mid-phase (a hidden coupling, a needed signature change) are recorded as an amendment section in this file **before** the deviating PR merges, so the RFC stays the source of truth.
+- **Out-of-scope findings.** Any live bug found while characterizing (P0 is the likeliest place) is filed as its own issue and fixed in its own PR — never folded into a move phase.
+
+---
+
+## Appendix A — Method-to-module mapping (all `OdinBot` methods + module-level defs)
+
+Legend: target modules are §6.1 names. "facade" = a delegating stub remains on `OdinBot`.
+
+| Baseline lines | Symbol(s) | Target |
+|---|---|---|
+| 94–104 | `_scrub_tool_input_for_storage` | `turn_recorder.py` (re-exported from `client.py` for compat) |
+| 107–131 | `_LoopMessageProxy`, `_LoopAuthorProxy` | `tool_loop.py` (used by autonomous policy; re-exported) |
+| 133–153 | `_RESPONSE_EXTRA_PATTERNS`, `scrub_response_secrets` | `delivery.py` (re-exported — `__main__.py` imports it) |
+| 174–190 | `truncate_tool_output` | `tool_loop.py` (re-exported — tests import it) |
+| 193–223 | `combine_bot_messages` | `intake.py` (re-exported — tests import it) |
+| 227–681 | `__init__` (subsystem construction + state fields) | `wiring.py` (`build_services`); state fields → `channel_state.py`; residual ~80-line `__init__` stays |
+| 682–716 | `llm_client` property, `_wire_llm_callbacks`, `_wire_codex_callbacks` | `llm_gateway.py` + facade property |
+| 720–847 | `_reload_codex_inner`, `reload_codex_auth`, `_reload_ollama_inner`, `reload_ollama`, `_reload_kimi_inner`, `reload_kimi`, `switch_llm_provider` | `llm_gateway.py` + facade methods (api.py calls all of them) |
+| 855–871 | `codex` / `knowledge` properties (+setters) | stay on facade (delegate to services) |
+| 873–878 | `_init_allowed_webhook_ids` | `intake.py` (owns the webhook-allowlist gate) |
+| 880–894 | `_log_startup_config` | `wiring.py` |
+| 896–928 | `_get_cached_hosts`, `_get_cached_skills_text`, `_get_cached_memory` | `prompts.py` |
+| 930–965 | `_record_user_content`, `_new_context_trace` | `turn_recorder.py` + facade for `_new_context_trace` (web/chat calls it) |
+| 967–987 | `_get_reflector_section`, `_invalidate_prompt_caches` | `prompts.py` + facade for `_invalidate_prompt_caches` (api.py calls it) |
+| 989–1004 | `_invoke_skill_missing_required` | `native_tools/skills.py` |
+| 1006–1074 | `_validate_schedule_payload`, `_extract_tool_input_from_steps` | `native_tools/scheduling.py` |
+| 1076–1214 | `_build_system_prompt`, `_build_chat_system_prompt` | `prompts.py` + facade (api.py, web/chat call them) |
+| 1216–1244 | `_merged_tool_definitions` | `tool_catalog.py` + facade (api.py calls it) |
+| 1246–1341 | `_cleanup_stale_caches`, `_maybe_cleanup_caches` | `channel_state.py` (`run_housekeeping`) |
+| 1343–1369 | `_track_recent_action` | `channel_state.py` (storage) + `turn_recorder.py` (formatting) |
+| 1371–1460 | `_register_commands` | `slash_commands.py` |
+| 1462–1477 | `_is_cancelled`, `_is_allowed_user`, `_is_allowed_channel`, `_check_for_secrets` | `intake.py` (gating) / `channel_state.py` (`_is_cancelled`) |
+| 1483–1488 | `_resolve_prefix` | stays (commands.Bot contract) |
+| 1490–1568 | `_codex_call` | `llm_gateway.py` (`call_with_tools`) + facade (tests call it) |
+| 1572–1663 | `_REFLECT_*` consts, `_should_reflect_on_operation`, `_maybe_loop_reflect`, `_operational_reflection` | `turn_recorder.py` (`ReflectionDispatcher`) |
+| 1665–1689 | `_save_turn_trajectory` | `turn_recorder.py` |
+| 1691–1702 | `_emit_lifecycle_event` | `turn_recorder.py` (dispatcher injected) |
+| 1704–1743 | `setup_hook` | stays (delegates diagnostics/chain-init to wiring helpers) |
+| 1745–1963 | `close` | stays as ~20 lines delegating to `wiring.shutdown_services` |
+| 1964–1982 | `_set_status` | `delivery.py` + facade (web/chat calls it) |
+| 1984–2004 | `on_ready` | stays |
+| 2006–2021 | `_backfill_archives` | `wiring.py` (startup task) |
+| 2023–2047 | `on_voice_state_update` | stays (delegates to voice manager) |
+| 2049–2296 | `on_message` | stays as thin handler → `intake.py` chain |
+| 2298–2346 | `_process_attachments` | `intake.py` |
+| 2348–2373 | `_on_voice_transcription` | `intake.py` (voice entry) |
+| 2375–2421 | `_handle_message` | `pipeline.py` (lock + thread inheritance) |
+| 2423–2659 | `_handle_message_inner` | `pipeline.py` |
+| 2661–2766 | `_CLASSIFIER_SYSTEM_PROMPT`, `_classify_completion`, `_parse_classifier_response` | `completion.py` |
+| 2768–3622 | `_process_with_tools` | `tool_loop.py` (`ToolLoopRunner`, CHAT_POLICY) + facade (web/chat + tests call it) |
+| 3624–3648 | `_ensure_failure_visible`, `_detect_image_type` | `tool_loop.py` / `native_tools/media.py` |
+| 3650–3688 | `_handle_purge`, `_handle_browser_screenshot`, `_handle_generate_file` | `native_tools/channel_ops.py` / `media.py` |
+| 3690–3764 | `_handle_post_file` | `native_tools/media.py` |
+| 3766–3876 | schedule CRUD handlers + `_handle_parse_time` | `native_tools/scheduling.py` |
+| 3878–3987 | history/knowledge handlers | `native_tools/knowledge.py` |
+| 3989–3999 | `_handle_set_permission` | `native_tools/channel_ops.py` |
+| 4001–4036 | `_handle_search_audit` | `native_tools/knowledge.py` |
+| 4038–4123 | `_on_scheduled_digest`, `_format_digest_raw`, `_resolve_mentions` | `scheduled_events.py` |
+| 4125–4147 | `_on_monitor_alert` | `scheduled_events.py` |
+| 4149–4342 | delegate/tasks/loops handlers | `native_tools/agents_tasks.py` |
+| 4344–4696 | spawn/collect agent handlers | `native_tools/agents_tasks.py` |
+| 4698–5007 | `_run_loop_iteration` | deleted in P8; facade method delegates to runner (api.py calls it) |
+| 5009–5213 | `_dispatch_loop_tool`, `_dispatch_loop_tool_inner` | P5: registry; P8: inner deleted; `_dispatch_loop_tool` facade retained (tests call it) |
+| 5215–5334 | `_handle_read_channel`, `_handle_add_reaction`, `_handle_create_poll` | `native_tools/channel_ops.py` |
+| 5336–5458 | `_handle_analyze_image`, `_handle_generate_image` | `native_tools/media.py` |
+| 5460–5687 | `_execute_scheduled_tool`, `_run_scheduled_workflow`, `_on_schedule_failure`, `_on_scheduled_task` | `scheduled_events.py` |
+| 5689–5790 | `_send_with_retry`, `_send_chunked` | `delivery.py` |
+
+## Appendix B — Facade contract (must exist on `OdinBot` throughout)
+
+**Subsystem attributes** (flat, preserving `getattr`/`hasattr` semantics): `config`*, `sessions`, `scheduler`, `tool_executor`, `skill_manager`, `loop_manager`, `audit`, `agent_manager`, `reflector`, `channel_config`, `channel_logger`, `context_loader`, `infra_watcher`, `voice_manager`, `browser_manager`, `permissions`, `host_access_manager`, `api_token_manager`, `cost_tracker`, `subsystem_guard`, `audit_signer`, `diff_tracker`, `model_router`, `context_compressor`, `prefix_tracker`, `auxiliary_llm_client`, `outbound_webhook_dispatcher`, `trajectory_saver`, `agent_trajectory_saver`, `loop_agent_bridge`, `codex_client`*, `ollama_client`*, `kimi_client`*, `stuck_loop_tracker_cls`, `classify_command_risk`, `classify_tool_risk`.
+**Properties:** `llm_client`, `codex` (get+set), `knowledge` (get+set).
+**Private attrs consumed externally** (property-with-setter where written*): `_system_prompt`*, `_cached_merged_tools`*, `_cached_skills_text`*, `_embedder`, `_knowledge_store`, `_start_time`, `_llm_provider_lock`, `_memory_path`, `_recent_actions` (tests), `_pending_files` (tests), `_channel_locks` (tests), `_cancel_events` (tests), `_last_op_details` (tests).
+**Late-bound (must remain absent until set):** `startup_report`, `_web_channel_locks`, `mcp_manager`, `_codex_auth_pool`, `_issue_tracker_client`, `compression_stats`, `health_server`.
+**Methods:** `reload_codex_auth`, `reload_ollama`, `reload_kimi`, `switch_llm_provider`, `_reload_codex_inner`, `_reload_ollama_inner`, `_reload_kimi_inner`, `_build_system_prompt`, `_build_chat_system_prompt`, `_invalidate_prompt_caches`, `_merged_tool_definitions`, `_new_context_trace`, `_set_status`, `_process_with_tools`, `_run_loop_iteration`, `_codex_call`, `_dispatch_loop_tool`, `_emit_lifecycle_event`, `_classify_completion` (+ `_CLASSIFIER_SYSTEM_PROMPT` class attr — tests), `_is_allowed_user`, `_is_cancelled`.
+**Module-level re-exports from `client.py`:** `OdinBot`, `INITIAL_EXTENSIONS`, `scrub_response_secrets`, `truncate_tool_output`, `combine_bot_messages`, `DISCORD_MAX_LEN`.
+
+**Internal-only (negative contract):** zero external references on baseline (grep-verified) — `_active_request_by_channel`, `_processed_messages`, `_processed_messages_max`, `_bot_msg_buffer`, `_bot_msg_tasks`, `_bot_msg_buffer_delay`, `_bot_msg_buffer_max`, `_cached_hosts`, `_memory_cache`, `_memory_cache_ttl`, `_llm_active_requests`, `_llm_switching`. These move behind `ChannelStateRegistry` / `LLMGateway` / `PromptBuilder` with **no** facade shims. P0 adds a grep-backed contract test asserting no code outside the discord package references them, so nothing starts reaching into them while the corpse is open.
+
+*(Starred = written from outside; see §4.4.)*
+
+---
+
+## Review checklist for Odin
+
+1. §4 — anything factually wrong vs. current master? (Line refs are against `081e231`.)
+2. §4.3 — is the asymmetry table complete? Any chat/loop difference missing that unification could silently erase?
+3. §6 — module boundaries and dependency direction: would you cut anywhere differently?
+4. §7 — phase ordering/sizing: anything you'd split, merge, or resequence? Is P8 acceptable as a single PR?
+5. Appendix B — anything you know reaches into `OdinBot` that isn't listed?
+6. §8 — is the characterization scenario list missing a flow you'd want pinned before we touch the loop?
+7. Verdict: **approve as-is / approve with changes (list them) / revise and resubmit**.
+
+*This is a plan review only — do not implement, branch, or open PRs for any part of this yet.*
+
+---
+
+## Revision log
+
+- **R1 (2026-07-04)** — Odin review verdict: **approve with changes**; all requested changes applied:
+  - Corrected method-count headline to AST-measured values (111 direct `OdinBot` methods / 151 module-wide defs) and adopted reviewer-verified method lengths (855 / 310 / 177 / 84). Both independently re-verified before amending.
+  - Added 6 asymmetry rows to §4.3 (return contract, `/stop` bookkeeping, op-details, status labels, `analyze_image` shape invariant, trace/recovery semantics).
+  - §6.1: `completion.py` boundary note (tool-loop policy machinery, not a second gateway).
+  - §7: P5 two-commit structure + declared P5a/P5b escape hatch; P8 scope constraint (policy wiring + duplicate deletion only).
+  - §8.1: 9 additional characterization scenarios.
+  - Appendix B: internal-only negative contract (12 names, grep-verified zero external refs) + grep-backed contract test in P0.
+  - getsource replacement policy retained unchanged (reviewer: "correct — keep it").
+- **Approval (2026-07-04)** — Odin re-reviewed R1 and **approved** the doc as the campaign plan of record: *"No remaining plan-level blockers. Next step is Phase 0 as its own PR, with the characterization harness doing the heavy lifting before anyone starts carving into the corpse."*
+- **R2 (2026-07-04)** — Execution model set by Aaron (direction approval): long-lived campaign branch `refactor/client-decomposition`; phase PRs merge into it with Odin review each; **no master merge, no release pipeline, no live deploy during the campaign**; post-P10 local soak test with all live data retained, then the pipeline decision. §7 execution-model paragraph updated; original per-phase release mapping retained inactive.

--- a/tests/characterization/__init__.py
+++ b/tests/characterization/__init__.py
@@ -1,0 +1,12 @@
+"""Characterization suite for the client.py decomposition campaign (RFC-001 P0).
+
+These tests pin CURRENT behavior of src/discord/client.py — they must pass
+against the unmodified baseline and stay green through every extraction
+phase. If one fails after a refactor, the refactor changed behavior.
+
+Rules (RFC-001 §8):
+- No test here may be weakened or deleted during the campaign without an
+  explicit note in the PR body of the phase doing it.
+- Where current behavior is surprising, it is pinned AS-IS with a comment;
+  fixes are separate issues, never folded into a move phase.
+"""

--- a/tests/characterization/test_autonomous_loop.py
+++ b/tests/characterization/test_autonomous_loop.py
@@ -1,0 +1,333 @@
+"""Characterization: the autonomous-loop pipeline (_run_loop_iteration +
+_dispatch_loop_tool). Pins the RFC-001 §4.3 chat-vs-loop asymmetries that
+Phase 8 unification must preserve — the rows that could silently drift.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.llm.circuit_breaker import CircuitOpenError
+from src.tools.result_validator import ToolResult
+from tests.fakes import (
+    FakeChannel,
+    FakeLLM,
+    make_bot,
+    parse_error_call,
+    text_response,
+    tool_call_response,
+)
+
+HEDGING_TEXT = "Shall I proceed with the deployment now?"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def build(script, **overrides):
+    fake = FakeLLM(script)
+    bot = make_bot(fake_llm=fake, config_overrides=overrides or None)
+    # Deterministic tests: reflection dispatch is a boundary here
+    bot._maybe_loop_reflect = _ReflectRecorder()
+    return bot, fake
+
+
+class _ReflectRecorder:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+async def run_iteration(bot, prompt="do the loop work", prev=None, user_id="4242"):
+    return await bot._run_loop_iteration(prompt, FakeChannel(id=777), prev, user_id)
+
+
+# ---------------------------------------------------------------------------
+# Core flow and message shape
+# ---------------------------------------------------------------------------
+
+
+class TestLoopFlow:
+    async def test_natural_finish_returns_final_text(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("iteration complete"),
+            ]
+        )
+        result = await run_iteration(bot)
+        assert result == "iteration complete"
+        assert len(fake.calls) == 2
+
+    async def test_prev_context_synthetic_exchange_shape(self):
+        bot, fake = build([text_response("ok")])
+        await run_iteration(bot, prompt="continue the work", prev="found 3 issues")
+        msgs = fake.messages_of_call(0)
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "Previous iteration results:\nfound 3 issues"
+        assert msgs[1]["role"] == "assistant"
+        assert "context from previous iterations" in msgs[1]["content"]
+        assert msgs[2] == {"role": "user", "content": "continue the work"}
+
+    async def test_no_preamble_without_prev_context(self):
+        bot, fake = build([text_response("ok")])
+        await run_iteration(bot, prompt="just this")
+        msgs = fake.messages_of_call(0)
+        assert msgs == [{"role": "user", "content": "just this"}]
+
+    async def test_long_final_text_truncated_to_discord_limit(self):
+        from src.discord.client import DISCORD_MAX_LEN
+
+        bot, fake = build([text_response("x" * (DISCORD_MAX_LEN + 500))])
+        result = await run_iteration(bot)
+        assert len(result) <= DISCORD_MAX_LEN
+        assert result.endswith("... (truncated)")
+
+
+# ---------------------------------------------------------------------------
+# §4.3 asymmetry pins — these are the P8 acceptance tripwires
+# ---------------------------------------------------------------------------
+
+
+class TestAsymmetryPins:
+    async def test_no_response_guards_in_loop(self):
+        """Hedging text is returned as-is: the loop path has NO guard cascade."""
+        bot, fake = build([text_response(HEDGING_TEXT)])
+        result = await run_iteration(bot)
+        assert result == HEDGING_TEXT
+        assert len(fake.calls) == 1  # no retry injection
+
+    async def test_no_completion_classifier_in_loop(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("partial-looking answer"),
+            ]
+        )
+        await run_iteration(bot)
+        assert fake.chat_calls == []  # classifier never consulted
+
+    async def test_llm_called_directly_not_via_codex_call(self):
+        """The loop bypasses _codex_call — no cost tracking, no model routing."""
+        bot, fake = build([text_response("ok")])
+        gateway_calls = []
+        orig = bot._codex_call
+
+        async def spy(**kwargs):
+            gateway_calls.append(kwargs)
+            return await orig(**kwargs)
+
+        bot._codex_call = spy
+        records = []
+        bot.cost_tracker.record = lambda *a, **k: records.append((a, k))
+        await run_iteration(bot)
+        assert gateway_calls == []
+        assert records == []
+        assert len(fake.calls) == 1
+
+    async def test_circuit_open_error_reraised_to_loop_manager(self):
+        bot, fake = build([CircuitOpenError("codex", 5.0)])
+        with pytest.raises(CircuitOpenError):
+            await run_iteration(bot)
+
+    async def test_generic_llm_error_returned_as_text(self):
+        bot, fake = build([RuntimeError("provider exploded")])
+        result = await run_iteration(bot)
+        assert result == "LLM call failed: provider exploded"
+        assert bot._maybe_loop_reflect.calls[-1]["is_error"] is True
+        assert bot._maybe_loop_reflect.calls[-1]["failure_class"] == "provider"
+
+    async def test_cap_exhaustion_is_error_with_failure_class_cancelled(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "a"})),
+                tool_call_response(("parse_time", {"text": "b"})),
+            ],
+            tools={"max_tool_iterations_loop": 2},
+        )
+        result = await run_iteration(bot)
+        assert "Iteration hit the loop tool-iteration cap (2)" in result
+        reflect = bot._maybe_loop_reflect.calls[-1]
+        assert reflect["is_error"] is True
+        assert reflect["failure_class"] == "cancelled"
+
+    async def test_cap_exhaustion_surfaces_stale_partial_text(self):
+        """Pre-tool text from an earlier iteration is surfaced as 'partial',
+        never silently returned as a clean success."""
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "a"}), text="working on it"),
+                tool_call_response(("parse_time", {"text": "b"})),
+            ],
+            tools={"max_tool_iterations_loop": 2},
+        )
+        result = await run_iteration(bot)
+        assert "Last partial output before the cap:" in result
+        assert "working on it" in result
+
+    async def test_recovered_tool_error_is_success_with_failure_detail(self):
+        """A mid-iteration tool error followed by a clean finish returns the
+        final text as a SUCCESS, but passes the failure detail to reflection."""
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "x"})),
+                text_response("recovered and finished"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(side_effect=RuntimeError("ssh died"))
+        result = await run_iteration(bot)
+        assert result == "recovered and finished"
+        reflect = bot._maybe_loop_reflect.calls[-1]
+        assert reflect["is_error"] is False
+        assert reflect["failure_class"] == "command_failed"
+        assert "ssh died" in reflect["error_text"]
+
+    async def test_trajectory_source_is_loop(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("done"),
+            ]
+        )
+        saved = []
+
+        async def spy_save(turn):
+            saved.append(turn)
+
+        bot.trajectory_saver.save = spy_save
+        await run_iteration(bot)
+        assert len(saved) == 1
+        turn = saved[0]
+        assert turn.source == "loop"
+        assert len(turn.iterations) == 2
+        assert turn.iterations[0].tool_calls[0]["name"] == "parse_time"
+        assert turn.iterations[0].tool_results  # results persisted onto the iteration
+
+
+# ---------------------------------------------------------------------------
+# Loop tool dispatch parity (chat-equivalent semantics through the proxy path)
+# ---------------------------------------------------------------------------
+
+
+class TestLoopDispatchParity:
+    async def test_parse_error_not_executed_in_loop(self):
+        bot, fake = build(
+            [
+                parse_error_call("run_command", "bad json"),
+                text_response("retried"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock()
+        await run_iteration(bot)
+        bot.tool_executor.execute.assert_not_awaited()
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert "bad json" in content and "NOT executed" in content
+
+    async def test_ok_false_visibility_in_loop(self):
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "x"})),
+                text_response("noted"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(output="quietly failed", ok=False, tool_name="run_command"),
+        )
+        await run_iteration(bot)
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert content.startswith("Error (tool reported failure):\n")
+
+    async def test_rbac_denial_in_loop_dispatch(self):
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "x"})),
+                text_response("ok"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock()
+        bot.tool_executor.check_permission = lambda tool, uid: "RBAC denied: nope"
+        await run_iteration(bot)
+        bot.tool_executor.execute.assert_not_awaited()
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert content == "RBAC denied: nope"
+
+    async def test_native_tool_dispatches_through_loop_proxy(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "tomorrow 3pm"})),
+                text_response("parsed"),
+            ]
+        )
+        result = await run_iteration(bot)
+        assert result == "parsed"
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert content  # parse_time produced real output through the proxy path
+
+    async def test_skill_crud_rebuilds_prompt_in_loop(self):
+        bot, fake = build(
+            [
+                tool_call_response(("create_skill", {"name": "s1", "code": "# c"})),
+                text_response("made it"),
+            ]
+        )
+        bot.skill_manager.create_skill = lambda name, code: f"Skill '{name}' created."
+        bot._cached_skills_text = "stale"
+        bot._cached_merged_tools = [{"name": "stale"}]
+        await run_iteration(bot)
+        assert bot._cached_merged_tools is None
+        assert bot._cached_skills_text != "stale"
+
+    async def test_export_skill_stages_pending_file_in_loop(self):
+        """Loop-path skill files are STAGED to _pending_files, not sent
+        directly to the channel (chat sends immediately) — §4.3-adjacent
+        parity subtlety worth its own tripwire."""
+        bot, _ = build([text_response("unused")])
+        bot.skill_manager.export_skill = lambda name: (b"zipbytes", "s1_skill.zip")
+        from src.discord.client import _LoopMessageProxy
+
+        proxy = _LoopMessageProxy(FakeChannel(id=777), "4242", "loop")
+        result = await bot._dispatch_loop_tool("export_skill", {"name": "s1"}, proxy, "4242")
+        assert "exported as s1_skill.zip" in result
+        assert bot._pending_files["777"] == [(b"zipbytes", "s1_skill.zip")]
+
+    async def test_invoke_skill_missing_required_fields_errors(self):
+        bot, _ = build([text_response("unused")])
+        from types import SimpleNamespace
+
+        bot.skill_manager.has_skill = lambda name: name == "needy"
+        bot.skill_manager._skills = {
+            "needy": SimpleNamespace(definition={"input_schema": {"required": ["q", "depth"]}}),
+        }
+        from src.discord.client import _LoopMessageProxy
+
+        proxy = _LoopMessageProxy(FakeChannel(id=777), "4242", "loop")
+        result = await bot._dispatch_loop_tool(
+            "invoke_skill",
+            {"name": "needy", "input": {"q": "x"}},
+            proxy,
+            "4242",
+        )
+        assert "missing required fields" in result
+        assert "depth" in result
+
+    async def test_unknown_tool_routes_to_executor_with_user_id(self):
+        bot, _ = build([text_response("unused")])
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(output="ran", tool_name="run_command")
+        )
+        from src.discord.client import _LoopMessageProxy
+
+        proxy = _LoopMessageProxy(FakeChannel(id=777), "4242", "loop")
+        result = await bot._dispatch_loop_tool(
+            "run_command", {"host": "h", "command": "x"}, proxy, "4242"
+        )
+        bot.tool_executor.execute.assert_awaited_once()
+        _, kwargs = bot.tool_executor.execute.await_args
+        assert kwargs.get("user_id") == "4242"
+        assert str(result) == "ran"

--- a/tests/characterization/test_chat_tool_loop.py
+++ b/tests/characterization/test_chat_tool_loop.py
@@ -1,0 +1,643 @@
+"""Characterization: the chat tool loop (_process_with_tools).
+
+Pins message-list shapes, the response-guard cascade (order and one-retry
+semantics), completion-classifier continuations, validation enforcement,
+stuck-loop handling, cancellation, cap/error exits, RBAC, parse-error
+bounce, ok=False visibility, vision injection, and skill handoff — against
+baseline behavior (RFC-001 §8.1).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.discord.response_guards import (
+    _CODE_HEDGING_RETRY_MSG,
+    _FABRICATION_RETRY_MSG,
+    _FAILURE_RETRY_MSG,
+    _HEDGING_RETRY_MSG,
+    _PROMISE_RETRY_MSG,
+    _TOOL_UNAVAIL_RETRY_MSG,
+)
+from src.llm.circuit_breaker import CircuitOpenError
+from src.tools.result_validator import ToolResult
+from tests.fakes import (
+    FakeLLM,
+    FakeMessage,
+    make_bot,
+    parse_error_call,
+    text_response,
+    tool_call_response,
+)
+
+# Known guard-triggering texts (mirrors tests/test_response_guards.py)
+FABRICATION_TEXT = "I ran the command and everything looks fine."
+PROMISE_TEXT = "I'll do that now for you right away."
+UNAVAIL_TEXT = "That tool is not available in this environment."
+HEDGING_TEXT = "Shall I proceed with the deployment now?"
+CODE_HEDGING_TEXT = "You can run this:\n```bash\nls -la\n```"
+FAILURE_TEXT = "I couldn't get the data from the server, it appears to be down."
+# Must trigger NO guard: no action/state claims (fabrication reads "the server
+# is now running" as an unverified result claim), no offers, no code fences.
+INNOCENT_TEXT = "Paris is the capital of France."
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def build(script, chat=None, **overrides):
+    fake = FakeLLM(script, chat_responses=chat)
+    bot = make_bot(fake_llm=fake, config_overrides=overrides or None)
+    return bot, fake
+
+
+async def run_loop(bot, msg, history=None):
+    return await bot._process_with_tools(
+        msg,
+        history if history is not None else [{"role": "user", "content": msg.content}],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic flows and message shapes
+# ---------------------------------------------------------------------------
+
+
+class TestBasicFlows:
+    async def test_plain_text_reply_no_tools(self):
+        bot, fake = build([text_response(INNOCENT_TEXT)])
+        msg = FakeMessage("status?")
+        text, already_sent, is_error, tools_used, handoff = await run_loop(bot, msg)
+        assert text == INNOCENT_TEXT
+        assert already_sent is False
+        assert is_error is False
+        assert tools_used == []
+        assert handoff is False
+        assert len(fake.calls) == 1
+
+    async def test_single_tool_then_final(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "tomorrow 3pm"})),
+                text_response("Parsed it."),
+            ]
+        )
+        msg = FakeMessage("parse tomorrow 3pm")
+        text, _, is_error, tools_used, _ = await run_loop(bot, msg)
+        assert text == "Parsed it."
+        assert is_error is False
+        assert tools_used == ["parse_time"]
+        assert len(fake.calls) == 2
+
+    async def test_no_history_message_shape(self):
+        """With a single-message history the preamble is inserted at the front."""
+        bot, fake = build([text_response("ok")])
+        await run_loop(bot, FakeMessage("hi"))
+        roles = [m["role"] for m in fake.messages_of_call(0)]
+        assert roles == ["developer", "user"]
+        # The no-history preamble is the thin channel-context form
+        dev = fake.developer_messages_of_call(0)[0]
+        assert "Current message ID:" in dev
+        assert "CURRENT REQUEST" not in dev
+
+    async def test_with_history_preamble_before_last_user(self):
+        bot, fake = build([text_response("ok")])
+        history = [
+            {"role": "user", "content": "[tester]: earlier request"},
+            {"role": "assistant", "content": "earlier answer"},
+            {"role": "user", "content": "[tester]: new request"},
+        ]
+        await run_loop(bot, FakeMessage("new request"), history)
+        msgs = fake.messages_of_call(0)
+        roles = [m["role"] for m in msgs]
+        assert roles == ["user", "assistant", "developer", "user"]
+        dev = msgs[2]["content"]
+        assert "=== CURRENT REQUEST [req-" in dev
+        assert "HISTORY ABOVE | REQUEST BELOW" in dev
+
+    async def test_tool_iteration_message_shape(self):
+        """Second LLM call sees assistant tool_use + user tool_result, ids paired."""
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"}), text="Checking."),
+                text_response("done"),
+            ]
+        )
+        await run_loop(bot, FakeMessage("when is now"))
+        msgs = fake.messages_of_call(1)
+        assert [m["role"] for m in msgs] == ["developer", "user", "assistant", "user"]
+        assistant = msgs[2]["content"]
+        assert assistant[0] == {"type": "text", "text": "Checking."}
+        assert assistant[1]["type"] == "tool_use"
+        assert assistant[1]["name"] == "parse_time"
+        results = msgs[3]["content"]
+        assert isinstance(results, list) and len(results) == 1
+        assert results[0]["type"] == "tool_result"
+        assert results[0]["tool_use_id"] == assistant[1]["id"]
+
+    async def test_parallel_tools_single_result_message(self):
+        """N tool calls in one response → one user message with N tool_results."""
+        bot, fake = build(
+            [
+                tool_call_response(
+                    ("parse_time", {"text": "now"}),
+                    ("list_schedules", {}),
+                ),
+                text_response("both done"),
+            ]
+        )
+        _, _, _, tools_used, _ = await run_loop(bot, FakeMessage("do both"))
+        assert tools_used == ["parse_time", "list_schedules"]
+        results = fake.messages_of_call(1)[-1]["content"]
+        assert [r["type"] for r in results] == ["tool_result", "tool_result"]
+        assert {r["tool_use_id"] for r in results} == {"call-1", "call-2"}
+
+    async def test_executor_routed_tool_dispatch(self):
+        """Non-native tools go to ToolExecutor.execute with user_id."""
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "playground", "command": "uptime"})),
+                text_response("ran"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(output="up 3 days", tool_name="run_command"),
+        )
+        msg = FakeMessage("uptime please")
+        await run_loop(bot, msg)
+        bot.tool_executor.execute.assert_awaited_once()
+        args, kwargs = bot.tool_executor.execute.await_args
+        assert args[0] == "run_command"
+        assert kwargs.get("user_id") == str(msg.author.id)
+        result_content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert "up 3 days" in result_content
+
+
+# ---------------------------------------------------------------------------
+# Failure visibility, RBAC, parse errors
+# ---------------------------------------------------------------------------
+
+
+class TestToolFailurePaths:
+    async def test_ok_false_result_gets_error_prefix(self):
+        """ToolResult(ok=False) without an error prefix is wrapped verbatim
+        as 'Error (tool reported failure):\\n<output>' (PR #130 behavior)."""
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "x"})),
+                text_response("noted"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(
+                output="looked fine but was denied", ok=False, tool_name="run_command"
+            ),
+        )
+        await run_loop(bot, FakeMessage("do the thing"))
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert content.startswith("Error (tool reported failure):\n")
+        assert "looked fine but was denied" in content
+
+    async def test_ok_false_with_existing_error_prefix_not_double_wrapped(self):
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "x"})),
+                text_response("noted"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(
+                output="Error: no such host", ok=False, tool_name="run_command"
+            ),
+        )
+        await run_loop(bot, FakeMessage("go"))
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert content.startswith("Error: no such host")
+        assert "tool reported failure" not in content
+
+    async def test_rbac_denial_returned_without_execution(self):
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "x"})),
+                text_response("understood"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock()
+        bot.tool_executor.check_permission = lambda tool, uid: "RBAC denied: tier too low"
+        _, _, is_error, tools_used, _ = await run_loop(bot, FakeMessage("go"))
+        bot.tool_executor.execute.assert_not_awaited()
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert content == "RBAC denied: tier too low"
+        # Pinned as-is: the denied tool is still recorded in tools_used
+        # (names are appended before dispatch).
+        assert tools_used == ["run_command"]
+        assert is_error is False
+
+    async def test_parse_error_call_is_not_executed(self):
+        bot, fake = build(
+            [
+                parse_error_call("run_command", "unterminated string in arguments"),
+                text_response("retrying properly"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock()
+        await run_loop(bot, FakeMessage("go"))
+        bot.tool_executor.execute.assert_not_awaited()
+        content = fake.messages_of_call(1)[-1]["content"][0]["content"]
+        assert "unterminated string in arguments" in content
+        assert "NOT executed" in content
+
+    async def test_llm_api_error_returns_error_tuple(self):
+        bot, fake = build([RuntimeError("boom")])
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert is_error is True
+        assert text == "LLM API error: boom"
+
+    async def test_circuit_open_waits_and_retries_once(self):
+        bot, fake = build(
+            [
+                CircuitOpenError("codex", 0.0),
+                text_response("recovered"),
+            ]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert is_error is False
+        assert text == "recovered"
+        assert len(fake.calls) == 2
+
+    async def test_circuit_open_retry_failure_is_error(self):
+        bot, fake = build(
+            [
+                CircuitOpenError("codex", 0.0),
+                RuntimeError("still down"),
+            ]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert is_error is True
+        assert text.startswith("LLM API error (circuit breaker recovery failed):")
+
+
+# ---------------------------------------------------------------------------
+# Response-guard cascade
+# ---------------------------------------------------------------------------
+
+
+GUARD_CASES = [
+    ("fabrication", FABRICATION_TEXT, _FABRICATION_RETRY_MSG),
+    ("promise", PROMISE_TEXT, _PROMISE_RETRY_MSG),
+    ("tool_unavailable", UNAVAIL_TEXT, _TOOL_UNAVAIL_RETRY_MSG),
+    ("hedging", HEDGING_TEXT, _HEDGING_RETRY_MSG),
+    ("code_hedging", CODE_HEDGING_TEXT, _CODE_HEDGING_RETRY_MSG),
+]
+
+
+class TestGuardCascade:
+    @pytest.mark.parametrize("name,trigger,retry_msg", GUARD_CASES, ids=[c[0] for c in GUARD_CASES])
+    async def test_guard_fires_once_then_accepts(self, name, trigger, retry_msg):
+        """Each pre-tool guard injects its retry message once, then the
+        (still-triggering) second response is accepted as final."""
+        bot, fake = build([text_response(trigger), text_response(trigger)])
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("do something"))
+        assert len(fake.calls) == 2
+        assert fake.messages_of_call(1)[-1] == retry_msg
+        assert text == trigger
+        assert is_error is False
+
+    async def test_guards_do_not_fire_after_tools_used(self):
+        """Pre-tool guards are gated on `not tools_used_in_loop`."""
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response(HEDGING_TEXT),
+            ]
+        )
+        text, _, _, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert text == HEDGING_TEXT
+        assert len(fake.calls) == 2
+
+    async def test_cascade_order_fabrication_before_hedging(self):
+        """A text triggering two guards gets the EARLIER guard's retry;
+        cascading detection catches the second on the next iteration."""
+        both = FABRICATION_TEXT + " " + HEDGING_TEXT
+        bot, fake = build(
+            [
+                text_response(both),
+                text_response(both),
+                text_response(INNOCENT_TEXT),
+            ]
+        )
+        text, _, _, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert fake.messages_of_call(1)[-1] == _FABRICATION_RETRY_MSG
+        assert fake.messages_of_call(2)[-1] == _HEDGING_RETRY_MSG
+        assert text == INNOCENT_TEXT
+
+    async def test_premature_failure_fires_only_with_tools(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response(FAILURE_TEXT),
+                text_response("Recovered: here is the real answer."),
+            ]
+        )
+        text, _, _, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert fake.messages_of_call(2)[-1] == _FAILURE_RETRY_MSG
+        assert text == "Recovered: here is the real answer."
+
+
+# ---------------------------------------------------------------------------
+# Completion classifier + continuations
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionClassifier:
+    async def test_incomplete_injects_continuation_with_reason(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("partial answer"),
+                text_response("full answer"),
+            ],
+            chat=["INCOMPLETE: deployment not performed", "COMPLETE"],
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("deploy it"))
+        assert text == "full answer"
+        assert is_error is False
+        last = fake.messages_of_call(2)[-1]
+        assert last["role"] == "developer"
+        assert last["content"] == (
+            "You are not done. deployment not performed. Continue with tool calls now."
+        )
+        # The rejected partial answer is NOT appended as an assistant message
+        assert all(
+            "partial answer" not in str(m.get("content", "")) for m in fake.messages_of_call(2)
+        )
+
+    async def test_classifier_not_called_without_tools(self):
+        bot, fake = build([text_response(INNOCENT_TEXT)], chat=["INCOMPLETE: x"])
+        await run_loop(bot, FakeMessage("hi"))
+        assert fake.chat_calls == []
+
+    async def test_continuation_budget_is_three(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("t1"),
+                text_response("t2"),
+                text_response("t3"),
+                text_response("t4"),
+            ],
+            chat=["INCOMPLETE: a", "INCOMPLETE: b", "INCOMPLETE: c", "INCOMPLETE: d"],
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
+        # The budget gates the classifier CALL itself: after 3 continuations
+        # the 4th text turn is accepted without consulting the classifier —
+        # only 3 chat calls happen, and the scripted 4th INCOMPLETE is unused.
+        assert text == "t4"
+        assert is_error is False
+        assert len(fake.chat_calls) == 3
+
+    async def test_start_loop_short_circuits_classifier(self):
+        bot, fake = build([])
+        is_complete, reason = await bot._classify_completion(
+            "run 50 iterations", "started", ["start_loop"]
+        )
+        assert is_complete is True and reason == ""
+        assert fake.chat_calls == []
+
+    def test_parse_classifier_response_variants(self):
+        from src.discord.client import OdinBot
+
+        assert OdinBot._parse_classifier_response("COMPLETE") == (True, "")
+        ok, reason = OdinBot._parse_classifier_response("INCOMPLETE: missing deploy")
+        assert ok is False and reason == "missing deploy"
+        ok, reason = OdinBot._parse_classifier_response("INCOMPLETE - no artifact")
+        assert ok is False and reason == "no artifact"
+        assert OdinBot._parse_classifier_response("¯\\_(ツ)_/¯") == (True, "")
+        assert OdinBot._parse_classifier_response("") == (True, "")
+
+
+# ---------------------------------------------------------------------------
+# Validation enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestValidationEnforcement:
+    async def test_mutation_injects_auto_validate_then_forces_continuation(self):
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "restart svc"})),
+                text_response("done early"),
+                text_response("done again"),
+                text_response("final after retries"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(
+                output="restarted",
+                tool_name="run_command",
+                requires_validation=True,
+                validation_reason="service restarted",
+            )
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("restart it"))
+        # After the mutating tool result: [AUTO-VALIDATE] developer message
+        auto = fake.messages_of_call(1)[-1]
+        assert auto["role"] == "developer"
+        assert auto["content"].startswith("[AUTO-VALIDATE]")
+        assert "service restarted" in auto["content"]
+        # Model answered with text twice while validation was pending →
+        # two [VALIDATION REQUIRED] continuations, then the cap (2) lets it through.
+        req1 = fake.messages_of_call(2)[-1]
+        req2 = fake.messages_of_call(3)[-1]
+        assert "[VALIDATION REQUIRED]" in req1["content"]
+        assert "[VALIDATION REQUIRED]" in req2["content"]
+        assert text == "final after retries"
+        assert is_error is False
+
+    async def test_validate_action_call_clears_requirement(self):
+        bot, fake = build(
+            [
+                tool_call_response(("run_command", {"host": "h", "command": "restart svc"})),
+                tool_call_response(("validate_action", {"check": "systemctl status svc"})),
+                text_response("validated and done"),
+            ]
+        )
+        mutating = ToolResult(
+            output="restarted",
+            tool_name="run_command",
+            requires_validation=True,
+            validation_reason="service restarted",
+        )
+        ok_result = ToolResult(output="active (running)", tool_name="validate_action")
+        bot.tool_executor.execute = AsyncMock(side_effect=[mutating, ok_result])
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("restart it"))
+        assert text == "validated and done"
+        assert is_error is False
+        # No [VALIDATION REQUIRED] anywhere — the requirement was satisfied by the call
+        for i in range(len(fake.calls)):
+            for dev in fake.developer_messages_of_call(i):
+                assert "[VALIDATION REQUIRED]" not in dev
+
+
+# ---------------------------------------------------------------------------
+# Stuck-loop tracking, cancellation, iteration cap
+# ---------------------------------------------------------------------------
+
+
+class TestLoopTermination:
+    async def test_stuck_loop_warns_then_terminates(self):
+        same = lambda: tool_call_response(("parse_time", {"text": "now"}))  # noqa: E731
+        bot, fake = build([same(), same(), same(), same(), same(), same()])
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("loop forever"))
+        assert is_error is True
+        assert "stuck tool-call cycle" in text
+        # The nudge was injected before termination
+        nudge_seen = any(
+            "repeating the same tool-call sequence" in dev
+            for i in range(len(fake.calls))
+            for dev in fake.developer_messages_of_call(i)
+        )
+        assert nudge_seen
+
+    async def test_stop_during_llm_call_preempts_tool_execution(self):
+        """Cancel set while the LLM call is in flight → the after_llm
+        checkpoint returns BEFORE any tool runs (no tools note)."""
+        bot = None  # placeholder for closure
+
+        def cancel_then_tool():
+            bot._cancel_events["99"].set()
+            return tool_call_response(("parse_time", {"text": "now"}))
+
+        fake = FakeLLM([cancel_then_tool])
+        bot = make_bot(fake_llm=fake)
+        bot.tool_executor.execute = AsyncMock()
+        msg = FakeMessage("go", channel=None)
+        assert msg.channel.id == 99
+        text, _, is_error, tools_used, _ = await run_loop(bot, msg)
+        assert text == "Task stopped by user."
+        assert is_error is False
+        assert tools_used == []
+        bot.tool_executor.execute.assert_not_awaited()
+        # Active-request bookkeeping cleaned up
+        assert "99" not in bot._active_request_by_channel
+        assert not bot._cancel_events["99"].is_set()
+
+    async def test_stop_during_tool_execution_reports_tools_used(self):
+        """Cancel set while a tool executes → the after_tools checkpoint
+        returns with the tools-used note."""
+        bot = None  # placeholder for closure
+
+        async def tool_sets_cancel(name, tool_input, user_id=None):
+            bot._cancel_events["99"].set()
+            return ToolResult(output="partial work", tool_name=name)
+
+        fake = FakeLLM([tool_call_response(("run_command", {"host": "h", "command": "x"}))])
+        bot = make_bot(fake_llm=fake)
+        bot.tool_executor.execute = tool_sets_cancel
+        msg = FakeMessage("go", channel=None)
+        text, _, is_error, tools_used, _ = await run_loop(bot, msg)
+        assert text.startswith("Task stopped by user.")
+        assert "run_command" in text  # tools note
+        assert is_error is False
+        assert tools_used == ["run_command"]
+        assert "99" not in bot._active_request_by_channel
+
+    async def test_iteration_cap_exit_is_error(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                tool_call_response(("parse_time", {"text": "later"})),
+            ],
+            tools={"max_tool_iterations_chat": 2},
+        )
+        text, _, is_error, tools_used, _ = await run_loop(bot, FakeMessage("go"))
+        assert is_error is True
+        assert "Hit the chat tool-iteration cap (2)" in text
+        assert len(tools_used) == 2
+
+    async def test_normal_exit_clears_active_request(self):
+        bot, fake = build([text_response("done")])
+        msg = FakeMessage("go")
+        await run_loop(bot, msg)
+        assert str(msg.channel.id) not in bot._active_request_by_channel
+
+
+# ---------------------------------------------------------------------------
+# Tool filtering, skill handoff, skill CRUD, vision
+# ---------------------------------------------------------------------------
+
+
+class TestToolSurfaceAndSkills:
+    async def test_api_token_allowed_tools_scope_filters(self):
+        bot, fake = build([text_response("ok")])
+        msg = FakeMessage("go")
+        msg.allowed_tools = ["parse_time"]
+        await run_loop(bot, msg)
+        tool_names = [t["name"] for t in fake.calls[0]["tools"]]
+        assert tool_names == ["parse_time"]
+
+    async def test_skill_handoff_returns_handoff_flag(self):
+        bot, fake = build([tool_call_response(("myskill", {"q": "x"}))])
+        bot.skill_manager.has_skill = lambda name: name == "myskill"
+        bot.skill_manager.should_handoff_to_codex = lambda name: True
+        bot.skill_manager.execute = AsyncMock(return_value="skill output text")
+        text, _, is_error, tools_used, handoff = await run_loop(bot, FakeMessage("use myskill"))
+        assert handoff is True
+        assert is_error is False
+        assert "skill output text" in text
+        assert tools_used == ["myskill"]
+
+    async def test_skill_crud_rebuilds_system_prompt_mid_loop(self):
+        bot, fake = build(
+            [
+                tool_call_response(("create_skill", {"name": "s1", "code": "# code"})),
+                text_response("created"),
+            ],
+        )
+        bot.skill_manager.create_skill = lambda name, code: f"Skill '{name}' created."
+        bot._cached_skills_text = "stale-skills-text"
+        bot._cached_merged_tools = [{"name": "stale"}]
+        rebuild_calls = []
+        orig_build = bot._build_system_prompt
+
+        def spy(*args, **kwargs):
+            rebuild_calls.append(kwargs)
+            return orig_build(*args, **kwargs)
+
+        bot._build_system_prompt = spy
+        await run_loop(bot, FakeMessage("make a skill"))
+        # CRUD invalidated both caches and rebuilt the prompt mid-loop
+        assert rebuild_calls, "system prompt was not rebuilt after skill CRUD"
+        assert bot._cached_skills_text != "stale-skills-text"
+        assert bot._cached_merged_tools is None
+
+    async def test_analyze_image_block_injected_for_next_iteration(self):
+        bot, fake = build(
+            [
+                tool_call_response(("analyze_image", {"url": "https://x/img.png"})),
+                text_response("described the image"),
+            ]
+        )
+        block = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "aGk="},
+        }
+
+        async def fake_analyze(message, tool_input):
+            return {"__image_block__": block, "__prompt__": "describe it"}
+
+        bot._handle_analyze_image = fake_analyze
+        text, _, _, _, _ = await run_loop(bot, FakeMessage("look at this"))
+        assert text == "described the image"
+        vision_msg = fake.messages_of_call(1)[-1]
+        assert vision_msg["role"] == "user"
+        parts = vision_msg["content"]
+        assert parts[0] == block
+        assert "analyze_image" in parts[-1]["text"]
+        # The tool_result itself was replaced with the loaded-image marker
+        result_content = fake.messages_of_call(1)[-2]["content"][0]["content"]
+        assert "Image loaded" in result_content

--- a/tests/characterization/test_delivery.py
+++ b/tests/characterization/test_delivery.py
@@ -1,0 +1,129 @@
+"""Characterization: response delivery (_send_chunked / _send_with_retry).
+
+Pins chunking behavior (code-fence continuity, long-line pre-splitting,
+file fallback for very long responses), pending-file attachment, and the
+send retry/backoff loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.discord.client import DISCORD_MAX_LEN
+from tests.fakes import FakeLLM, FakeMessage, make_bot
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def bot():
+    return make_bot(fake_llm=FakeLLM([]))
+
+
+class TestSendChunked:
+    async def test_short_text_single_reply(self, bot):
+        msg = FakeMessage("q")
+        await bot._send_chunked(msg, "short answer")
+        assert msg.reply_texts == ["short answer"]
+        assert msg.channel.sent == []
+
+    async def test_chunked_first_is_reply_rest_are_sends(self, bot):
+        msg = FakeMessage("q")
+        text = "\n".join(f"line {i} " + "x" * 40 for i in range(90))  # ~4.3K chars
+        await bot._send_chunked(msg, text)
+        assert len(msg.replies) == 1  # first chunk replies to the message
+        assert len(msg.channel.sent) >= 1  # later chunks are plain sends
+        rejoined = "\n".join(t.rstrip("\n") for t in msg.all_delivered_texts())
+        assert "line 0" in rejoined and "line 89" in rejoined
+        for t in msg.all_delivered_texts():
+            assert len(t) <= DISCORD_MAX_LEN
+
+    async def test_code_fence_reopened_across_chunks(self, bot):
+        msg = FakeMessage("q")
+        body = "\n".join("x = 1  # padding padding padding" for _ in range(90))
+        text = f"```python\n{body}\n```"
+        await bot._send_chunked(msg, text)
+        chunks = msg.all_delivered_texts()
+        assert len(chunks) >= 2
+        # Every chunk that opens a block closes it, and continuation chunks
+        # re-open with the original language.
+        assert chunks[0].startswith("```python")
+        assert chunks[0].rstrip().endswith("```")
+        assert chunks[1].startswith("```python\n")
+
+    async def test_single_overlong_line_is_presplit(self, bot):
+        msg = FakeMessage("q")
+        text = "y" * 5000  # one line, no newlines, still under the 4x file threshold
+        await bot._send_chunked(msg, text)
+        chunks = msg.all_delivered_texts()
+        assert len(chunks) >= 3
+        for t in chunks:
+            assert len(t) <= DISCORD_MAX_LEN
+        assert sum(len(t.replace("\n", "")) for t in chunks) == 5000
+
+    async def test_very_long_response_becomes_file(self, bot):
+        msg = FakeMessage("q")
+        await bot._send_chunked(msg, "z" * (DISCORD_MAX_LEN * 4 + 1))
+        assert len(msg.replies) == 1
+        entry = msg.replies[0]
+        assert entry["content"] == "Response too long for chat, attached as file:"
+        assert entry["files"] is not None
+        assert entry["files"][0].filename == "response.md"
+
+    async def test_pending_files_attach_to_first_message_and_are_popped(self, bot):
+        msg = FakeMessage("q")
+        bot._pending_files[str(msg.channel.id)] = [(b"data", "report.txt")]
+        await bot._send_chunked(msg, "here is your file")
+        entry = msg.replies[0]
+        assert entry["content"] == "here is your file"
+        assert [f.filename for f in entry["files"]] == ["report.txt"]
+        assert str(msg.channel.id) not in bot._pending_files
+
+    async def test_pending_files_ride_along_with_file_fallback(self, bot):
+        msg = FakeMessage("q")
+        bot._pending_files[str(msg.channel.id)] = [(b"data", "extra.bin")]
+        await bot._send_chunked(msg, "z" * (DISCORD_MAX_LEN * 4 + 1))
+        names = [f.filename for f in msg.replies[0]["files"]]
+        assert names == ["extra.bin", "response.md"]
+
+
+class TestSendWithRetry:
+    async def test_retries_after_transient_failure(self, bot, monkeypatch):
+        sleeps = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        msg = FakeMessage("q")
+        msg.reply_error = ConnectionError("blip")  # first attempt fails
+        sent = await bot._send_with_retry(msg, "eventually delivered")
+        assert sent is not None
+        assert msg.reply_texts == ["eventually delivered"]
+        assert sleeps == [1]  # backoff is 1 + attempt
+
+    async def test_gives_up_after_three_attempts_returns_none(self, bot, monkeypatch):
+        sleeps = []
+
+        async def fake_sleep(secs):
+            sleeps.append(secs)
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        msg = FakeMessage("q")
+
+        async def always_fail(*a, **k):
+            raise ConnectionError("still down")
+
+        msg.reply = always_fail
+        sent = await bot._send_with_retry(msg, "never arrives")
+        assert sent is None
+        assert sleeps == [1, 2]  # two backoffs between three attempts
+
+    async def test_as_reply_false_uses_channel_send(self, bot):
+        msg = FakeMessage("q")
+        await bot._send_with_retry(msg, "broadcast", as_reply=False)
+        assert msg.replies == []
+        assert msg.channel.sent_texts == ["broadcast"]

--- a/tests/characterization/test_facade_contract.py
+++ b/tests/characterization/test_facade_contract.py
@@ -1,0 +1,256 @@
+"""Characterization: the OdinBot facade contract (RFC-001 Appendix B).
+
+Three enforcement layers:
+1. POSITIVE — every externally-consumed attribute/property/method exists on
+   a constructed bot (and stays settable where external code writes it).
+2. LATE-BOUND — names set after construction must be ABSENT on a fresh bot
+   (hasattr/getattr semantics are load-bearing for health checks).
+3. NEGATIVE — the 12 internal-only names must have zero references outside
+   src/discord/client.py (and outside this campaign's own test infra),
+   enforced by source scan so nothing starts reaching in mid-campaign.
+
+Plus: the web-chat route (the facade's highest-value consumer) driven
+end-to-end through the real _process_with_tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.fakes import FakeLLM, make_bot, text_response
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# --- Appendix B: positive surface -------------------------------------------
+
+SUBSYSTEM_ATTRS = [
+    "config",
+    "sessions",
+    "scheduler",
+    "tool_executor",
+    "skill_manager",
+    "loop_manager",
+    "audit",
+    "agent_manager",
+    "reflector",
+    "channel_config",
+    "channel_logger",
+    "context_loader",
+    "infra_watcher",
+    "voice_manager",
+    "browser_manager",
+    "permissions",
+    "host_access_manager",
+    "api_token_manager",
+    "cost_tracker",
+    "subsystem_guard",
+    "audit_signer",
+    "diff_tracker",
+    "model_router",
+    "context_compressor",
+    "prefix_tracker",
+    "auxiliary_llm_client",
+    "outbound_webhook_dispatcher",
+    "trajectory_saver",
+    "agent_trajectory_saver",
+    "loop_agent_bridge",
+    "codex_client",
+    "ollama_client",
+    "kimi_client",
+    "stuck_loop_tracker_cls",
+    "classify_command_risk",
+    "classify_tool_risk",
+]
+
+PROPERTIES = ["llm_client", "codex", "knowledge"]
+
+PRIVATE_READ_ATTRS = [
+    "_system_prompt",
+    "_cached_merged_tools",
+    "_cached_skills_text",
+    "_embedder",
+    "_knowledge_store",
+    "_start_time",
+    "_llm_provider_lock",
+    "_memory_path",
+    "_recent_actions",
+    "_pending_files",
+    "_channel_locks",
+    "_cancel_events",
+    "_last_op_details",
+]
+
+FACADE_METHODS = [
+    "reload_codex_auth",
+    "reload_ollama",
+    "reload_kimi",
+    "switch_llm_provider",
+    "_reload_codex_inner",
+    "_reload_ollama_inner",
+    "_reload_kimi_inner",
+    "_build_system_prompt",
+    "_build_chat_system_prompt",
+    "_invalidate_prompt_caches",
+    "_merged_tool_definitions",
+    "_new_context_trace",
+    "_set_status",
+    "_process_with_tools",
+    "_run_loop_iteration",
+    "_codex_call",
+    "_dispatch_loop_tool",
+    "_emit_lifecycle_event",
+    "_classify_completion",
+    "_is_allowed_user",
+    "_is_cancelled",
+]
+
+LATE_BOUND_ABSENT = [
+    "startup_report",
+    "_web_channel_locks",
+    "mcp_manager",
+    "_codex_auth_pool",
+    "_issue_tracker_client",
+    "compression_stats",
+    "health_server",
+]
+
+# RFC-001 Appendix B negative contract: internal-only, zero external refs.
+INTERNAL_ONLY = [
+    "_active_request_by_channel",
+    "_processed_messages",
+    "_processed_messages_max",
+    "_bot_msg_buffer",
+    "_bot_msg_tasks",
+    "_bot_msg_buffer_delay",
+    "_bot_msg_buffer_max",
+    "_cached_hosts",
+    "_memory_cache",
+    "_memory_cache_ttl",
+    "_llm_active_requests",
+    "_llm_switching",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def bot():
+    return make_bot(fake_llm=FakeLLM([]))
+
+
+class TestPositiveSurface:
+    def test_subsystem_attributes_exist(self, bot):
+        missing = [a for a in SUBSYSTEM_ATTRS if not hasattr(bot, a)]
+        assert missing == [], f"facade attributes missing: {missing}"
+
+    def test_properties_exist(self, bot):
+        missing = [p for p in PROPERTIES if not hasattr(type(bot), p)]
+        assert missing == [], f"facade properties missing: {missing}"
+
+    def test_private_read_attrs_exist(self, bot):
+        missing = [a for a in PRIVATE_READ_ATTRS if not hasattr(bot, a)]
+        assert missing == [], f"externally-read private attrs missing: {missing}"
+
+    def test_facade_methods_exist_and_callable(self, bot):
+        missing = [m for m in FACADE_METHODS if not callable(getattr(bot, m, None))]
+        assert missing == [], f"facade methods missing: {missing}"
+
+    def test_externally_written_names_are_settable(self, bot):
+        # web/api.py writes these on live config/skill changes:
+        bot._system_prompt = "replaced"
+        assert bot._system_prompt == "replaced"
+        bot._cached_merged_tools = None
+        bot._cached_skills_text = None
+        bot.config = bot.config  # hot-reload assigns a fresh Config
+        # property setters used by tests/reloads:
+        bot.codex = "sentinel"
+        assert bot.codex_client == "sentinel"
+        bot.knowledge = "kstore"
+        assert bot._knowledge_store == "kstore"
+        # web/chat.py lazily creates this:
+        bot._web_channel_locks = {}
+        assert bot._web_channel_locks == {}
+
+    def test_classifier_prompt_class_attr_exists(self, bot):
+        assert isinstance(type(bot)._CLASSIFIER_SYSTEM_PROMPT, str)
+        assert "COMPLETE" in type(bot)._CLASSIFIER_SYSTEM_PROMPT
+
+    def test_module_level_reexports(self):
+        from src.discord.client import (  # noqa: F401
+            DISCORD_MAX_LEN,
+            INITIAL_EXTENSIONS,
+            OdinBot,
+            combine_bot_messages,
+            scrub_response_secrets,
+            truncate_tool_output,
+        )
+
+        assert DISCORD_MAX_LEN == 2000
+        assert isinstance(INITIAL_EXTENSIONS, tuple)
+
+
+class TestLateBoundAbsent:
+    def test_late_bound_names_absent_on_fresh_bot(self, bot):
+        present = [a for a in LATE_BOUND_ABSENT if hasattr(bot, a)]
+        assert present == [], (
+            f"late-bound names unexpectedly present at construction: {present} — "
+            "if a refactor made these eager, health-check hasattr semantics changed."
+        )
+
+
+class TestNegativeContract:
+    """No code outside client.py (and this campaign's test infra) may
+    reference the internal-only names. Keeps the corpse closed while the
+    decomposition operates on it."""
+
+    def _scan(self, root: Path, exclude: set[Path]) -> list[str]:
+        offenders = []
+        for py in sorted(root.rglob("*.py")):
+            if py in exclude or "__pycache__" in py.parts:
+                continue
+            text = py.read_text(encoding="utf-8", errors="replace")
+            for name in INTERNAL_ONLY:
+                if name in text:
+                    offenders.append(f"{py.relative_to(REPO_ROOT)}: {name}")
+        return offenders
+
+    def test_no_src_references_outside_client(self):
+        offenders = self._scan(
+            REPO_ROOT / "src",
+            exclude={REPO_ROOT / "src" / "discord" / "client.py"},
+        )
+        assert offenders == [], (
+            "internal-only OdinBot state referenced outside client.py:\n" + "\n".join(offenders)
+        )
+
+    def test_no_test_references_outside_campaign_infra(self):
+        campaign_dirs = (
+            REPO_ROOT / "tests" / "characterization",
+            REPO_ROOT / "tests" / "fakes",
+        )
+        exclude = {p for d in campaign_dirs for p in d.rglob("*.py")}
+        offenders = self._scan(REPO_ROOT / "tests", exclude=exclude)
+        assert offenders == [], (
+            "internal-only OdinBot state referenced by tests outside the "
+            "campaign infra:\n" + "\n".join(offenders)
+        )
+
+
+class TestWebChatRoute:
+    async def test_process_web_chat_drives_real_tool_loop(self):
+        from src.web.chat import process_web_chat
+
+        fake = FakeLLM([text_response("web answer")])
+        bot = make_bot(fake_llm=fake)
+        result = await process_web_chat(bot, "hello from the web", channel_id="web-42")
+        assert result["is_error"] is False
+        assert result["response"] == "web answer"
+        assert result["tools_used"] == []
+        assert len(fake.calls) == 1  # went through the REAL _process_with_tools
+        # And the lazily-created lock cache now exists (late-bound behavior)
+        assert hasattr(bot, "_web_channel_locks")

--- a/tests/characterization/test_intake_gating.py
+++ b/tests/characterization/test_intake_gating.py
@@ -1,0 +1,210 @@
+"""Characterization: on_message intake gating.
+
+Pins the gating chain ORDER (secret scrub → cog commands → bot gates →
+allowlists → channel enablement → mention gate → dedup → bot buffering →
+attachments), driving the REAL on_message with fake discord objects.
+
+Boundaries stubbed: process_commands (discord.py command framework),
+_handle_message (the pipeline — characterized separately), and
+_process_attachments (attachments.py has its own tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.fakes import FakeAuthor, FakeChannel, FakeLLM, FakeMessage, make_bot
+
+
+class FakeClientUser:
+    """Stands in for bot.user (a discord.ClientUser)."""
+
+    def __init__(self, id: int = 999_000) -> None:
+        self.id = id
+        self.bot = True
+
+    def mentioned_in(self, message) -> bool:
+        return f"<@{self.id}>" in (message.content or "")
+
+    def __str__(self) -> str:
+        return "OdinTest"
+
+
+BOT_USER_ID = 999_000
+
+
+class _FakeGuild:
+    def __init__(self, id: int = 424242) -> None:
+        self.id = id
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def build(**overrides):
+    bot = make_bot(fake_llm=FakeLLM([]), config_overrides=overrides or None)
+    bot._connection.user = FakeClientUser(BOT_USER_ID)
+    bot.process_commands = AsyncMock()
+    bot._handle_message = AsyncMock()
+    bot._process_attachments = AsyncMock(return_value=("", []))
+    return bot
+
+
+def handled_contents(bot) -> list[str]:
+    return [call.args[1] for call in bot._handle_message.await_args_list]
+
+
+class TestGatingChain:
+    async def test_plain_message_reaches_handler(self):
+        bot = build()
+        await bot.on_message(FakeMessage("hello there"))
+        assert handled_contents(bot) == ["hello there"]
+        bot.process_commands.assert_awaited_once()
+
+    async def test_own_message_ignored_but_channel_logged(self):
+        bot = build()
+        logged = []
+        bot.channel_logger.log_message = lambda m: logged.append(m)
+        msg = FakeMessage("from myself")
+        msg.author = bot.user  # message.author == self.user
+        await bot.on_message(msg)
+        assert logged == [msg]  # passive log happens first
+        bot.process_commands.assert_not_awaited()  # then everything else skipped
+        bot._handle_message.assert_not_awaited()
+
+    async def test_secret_scrub_deletes_before_commands_and_handler(self):
+        bot = build()
+        scrubbed = []
+        bot.sessions.scrub_secrets = lambda cid, content: scrubbed.append((cid, content))
+        msg = FakeMessage("my password is hunter2secret")
+        await bot.on_message(msg)
+        assert msg.deleted is True
+        assert scrubbed and scrubbed[0][0] == str(msg.channel.id)
+        notice = msg.channel.sent_texts[0]
+        assert "secret/credential" in notice and "deleted" in notice
+        # The scrub path returns BEFORE cogs and the pipeline see the content
+        bot.process_commands.assert_not_awaited()
+        bot._handle_message.assert_not_awaited()
+
+    async def test_secret_scrub_delete_forbidden_asks_manual_delete(self):
+        import discord
+
+        bot = build()
+        msg = FakeMessage("my password is hunter2secret")
+
+        async def forbidden():
+            raise discord.Forbidden(type("R", (), {"status": 403, "reason": "nope"})(), "nope")
+
+        msg.delete = forbidden
+        await bot.on_message(msg)
+        notice = msg.channel.sent_texts[0]
+        assert "couldn't delete" in notice
+
+    async def test_disallowed_user_dropped(self):
+        bot = build(discord={"allowed_users": ["111"]})
+        await bot.on_message(FakeMessage("hi", author=FakeAuthor(id=222)))
+        bot._handle_message.assert_not_awaited()
+        await bot.on_message(FakeMessage("hi", author=FakeAuthor(id=111)))
+        bot._handle_message.assert_awaited_once()
+
+    async def test_disallowed_channel_dropped(self):
+        bot = build(discord={"channels": ["99"]})
+        await bot.on_message(FakeMessage("hi", channel=FakeChannel(id=42)))
+        bot._handle_message.assert_not_awaited()
+        await bot.on_message(FakeMessage("hi", channel=FakeChannel(id=99)))
+        bot._handle_message.assert_awaited_once()
+
+    async def test_require_mention_drops_unmentioned_guild_message(self):
+        bot = build(discord={"require_mention": True})
+        guild = _FakeGuild()
+        ch = FakeChannel(id=99)
+        ch.guild = guild
+        await bot.on_message(FakeMessage("no mention here", channel=ch, guild=guild))
+        bot._handle_message.assert_not_awaited()
+
+    async def test_require_mention_accepts_mention_and_strips_it(self):
+        bot = build(discord={"require_mention": True})
+        guild = _FakeGuild()
+        ch = FakeChannel(id=99)
+        ch.guild = guild
+        await bot.on_message(
+            FakeMessage(f"<@{BOT_USER_ID}> do the thing", channel=ch, guild=guild),
+        )
+        assert handled_contents(bot) == ["do the thing"]
+
+    async def test_require_mention_bypassed_in_dm(self):
+        bot = build(discord={"require_mention": True})
+        # FakeChannel.guild is None → DM semantics
+        await bot.on_message(FakeMessage("direct message, no mention"))
+        assert handled_contents(bot) == ["direct message, no mention"]
+
+    async def test_duplicate_message_id_processed_once(self):
+        bot = build()
+        msg = FakeMessage("only once")
+        await bot.on_message(msg)
+        await bot.on_message(msg)
+        bot._handle_message.assert_awaited_once()
+
+    async def test_bot_author_dropped_when_respond_to_bots_disabled(self):
+        bot = build()  # respond_to_bots defaults False
+        await bot.on_message(FakeMessage("beep", author=FakeAuthor(id=555, bot=True)))
+        bot._handle_message.assert_not_awaited()
+
+    async def test_attachment_text_appended_to_content(self):
+        bot = build()
+        bot._process_attachments = AsyncMock(return_value=("FILE: notes contents", []))
+        await bot.on_message(FakeMessage("see attached"))
+        assert handled_contents(bot) == ["see attached\n\nFILE: notes contents"]
+
+    async def test_image_only_message_gets_placeholder_content(self):
+        bot = build()
+        block = {"type": "image", "source": {}}
+        bot._process_attachments = AsyncMock(return_value=("", [block]))
+        await bot.on_message(FakeMessage(""))
+        assert handled_contents(bot) == ["(see attached image)"]
+        assert bot._handle_message.await_args.kwargs["image_blocks"] == [block]
+
+    async def test_empty_message_without_attachments_dropped(self):
+        bot = build()
+        await bot.on_message(FakeMessage(""))
+        bot._handle_message.assert_not_awaited()
+
+
+class TestBotMessageBuffering:
+    async def test_rapid_bot_messages_buffered_and_combined(self):
+        bot = build(discord={"respond_to_bots": True})
+        bot._bot_msg_buffer_delay = 0.02
+        other_bot = FakeAuthor(id=555, name="otherbot", bot=True)
+        ch = FakeChannel(id=99)
+        await bot.on_message(FakeMessage("part one", author=other_bot, channel=ch))
+        await bot.on_message(FakeMessage("part two", author=other_bot, channel=ch))
+        bot._handle_message.assert_not_awaited()  # buffered, not yet flushed
+        await asyncio.sleep(0.1)
+        assert handled_contents(bot) == ["part one\n\npart two"]
+
+    async def test_split_code_block_joined_across_bot_messages(self):
+        bot = build(discord={"respond_to_bots": True})
+        bot._bot_msg_buffer_delay = 0.02
+        other_bot = FakeAuthor(id=555, name="otherbot", bot=True)
+        ch = FakeChannel(id=99)
+        await bot.on_message(FakeMessage("```python\nx = 1", author=other_bot, channel=ch))
+        await bot.on_message(FakeMessage("y = 2\n```", author=other_bot, channel=ch))
+        await asyncio.sleep(0.1)
+        # Unclosed fence → continuation joined with single newline
+        assert handled_contents(bot) == ["```python\nx = 1\ny = 2\n```"]
+
+    async def test_buffered_bot_messages_dropped_without_mention_when_required(self):
+        bot = build(discord={"respond_to_bots": True, "require_mention": True})
+        bot._bot_msg_buffer_delay = 0.02
+        other_bot = FakeAuthor(id=555, name="otherbot", bot=True)
+        guild = _FakeGuild()
+        ch = FakeChannel(id=99)
+        ch.guild = guild
+        await bot.on_message(FakeMessage("no mention", author=other_bot, channel=ch, guild=guild))
+        await asyncio.sleep(0.1)
+        bot._handle_message.assert_not_awaited()

--- a/tests/characterization/test_pipeline_persistence.py
+++ b/tests/characterization/test_pipeline_persistence.py
@@ -1,0 +1,243 @@
+"""Characterization: pipeline orchestration (_handle_message /
+_handle_message_inner) — session persistence, error sanitization, guest
+routing, skill handoff, thread context inheritance, CancelledError cleanup,
+and delivery hand-off.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import discord
+from src.sessions.manager import summarize_tool_response
+from tests.fakes import (
+    FakeChannel,
+    FakeLLM,
+    FakeMessage,
+    make_bot,
+    text_response,
+    tool_call_response,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def build(script=None, chat=None, **overrides):
+    fake = FakeLLM(script or [], chat_responses=chat)
+    bot = make_bot(fake_llm=fake, config_overrides=overrides or None)
+    return bot, fake
+
+
+def history_of(bot, channel_id: str):
+    session = bot.sessions.get(channel_id)
+    return [(m.role, m.content) for m in session.messages] if session else []
+
+
+class TestPersistence:
+    async def test_success_persists_tagged_user_and_assistant_turns(self):
+        bot, fake = build([text_response("the answer")])
+        msg = FakeMessage("what is it?")
+        await bot._handle_message(msg, "what is it?")
+        hist = history_of(bot, str(msg.channel.id))
+        assert hist[0] == ("user", "[tester]: what is it?")
+        assert hist[1] == ("assistant", "the answer")
+        assert msg.reply_texts == ["the answer"]
+
+    async def test_tool_loop_response_is_summarized_for_history(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("Detailed multi-tool response " + "x" * 400),
+            ]
+        )
+        msg = FakeMessage("do it")
+        await bot._handle_message(msg, "do it")
+        hist = history_of(bot, str(msg.channel.id))
+        expected = summarize_tool_response(
+            "Detailed multi-tool response " + "x" * 400,
+            ["parse_time"],
+        )
+        assert hist[-1] == ("assistant", expected)
+
+    async def test_error_persists_sanitized_marker_not_raw_error(self):
+        bot, fake = build([RuntimeError("provider meltdown")])
+        msg = FakeMessage("do it")
+        await bot._handle_message(msg, "do it")
+        hist = history_of(bot, str(msg.channel.id))
+        assert hist[-1][0] == "assistant"
+        assert hist[-1][1] == "[Previous request encountered an error before tool execution.]"
+        assert "provider meltdown" not in hist[-1][1]
+        # But the user SEES the real error
+        assert any("provider meltdown" in t for t in msg.reply_texts)
+
+    async def test_error_after_tools_marker_names_tools(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                RuntimeError("mid-loop failure"),
+            ]
+        )
+        msg = FakeMessage("do it")
+        await bot._handle_message(msg, "do it")
+        hist = history_of(bot, str(msg.channel.id))
+        assert "[Previous request used tools (parse_time)" in hist[-1][1]
+
+    async def test_cancelled_error_removes_orphaned_user_turn_and_reraises(self):
+        bot, fake = build()
+        bot._process_with_tools = AsyncMock(side_effect=asyncio.CancelledError())
+        msg = FakeMessage("interrupted")
+        bot._pending_files[str(msg.channel.id)] = [(b"x", "leak.txt")]
+        with pytest.raises(asyncio.CancelledError):
+            await bot._handle_message(msg, "interrupted")
+        assert history_of(bot, str(msg.channel.id)) == []
+        assert str(msg.channel.id) not in bot._pending_files
+
+    async def test_reflection_receives_popped_op_details(self):
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("done"),
+            ]
+        )
+        seen = {}
+
+        async def spy_reflection(
+            content, tools_used, response, is_error, user_id, tool_details=None
+        ):
+            seen["tool_details"] = tool_details
+            seen["tools_used"] = tools_used
+
+        bot._operational_reflection = spy_reflection
+        msg = FakeMessage("do it")
+        await bot._handle_message(msg, "do it")
+        await asyncio.sleep(0.05)  # fire_and_forget task
+        assert seen["tools_used"] == ["parse_time"]
+        assert seen["tool_details"] and seen["tool_details"][0]["tool"] == "parse_time"
+        # And the per-channel stash was consumed
+        assert str(msg.channel.id) not in bot._last_op_details
+
+
+class TestRouting:
+    async def test_guest_tier_routes_to_chat_without_tools(self):
+        bot, fake = build(chat=["guest-tier answer"])
+        bot.permissions.is_guest = lambda uid: True
+        msg = FakeMessage("hello")
+        await bot._handle_message(msg, "hello")
+        assert fake.calls == []  # no tool loop
+        assert len(fake.chat_calls) == 1  # chat route
+        assert msg.reply_texts == ["guest-tier answer"]
+
+    async def test_no_llm_provider_notifies_and_removes_user_turn(self):
+        bot, fake = build()
+        bot.codex_client = None  # llm_client property now resolves to None
+        msg = FakeMessage("hello")
+        await bot._handle_message(msg, "hello")
+        assert any("No LLM provider available" in t for t in msg.reply_texts)
+        assert history_of(bot, str(msg.channel.id)) == []
+
+    async def test_skill_handoff_routes_result_through_chat(self):
+        bot, fake = build(chat=["conversational wrap-up"])
+        bot._process_with_tools = AsyncMock(
+            return_value=("raw skill output", False, False, ["myskill"], True),
+        )
+        msg = FakeMessage("use the skill")
+        await bot._handle_message(msg, "use the skill")
+        assert msg.reply_texts == ["conversational wrap-up"]
+        # The handoff chat saw the tool result as an assistant message
+        handoff_msgs = fake.chat_calls[0]["messages"]
+        assert any("raw skill output" in str(m.get("content")) for m in handoff_msgs)
+
+    async def test_skill_handoff_falls_back_to_skill_output_on_chat_failure(self):
+        bot, fake = build(chat=[RuntimeError("chat down")])
+        bot._process_with_tools = AsyncMock(
+            return_value=("raw skill output", False, False, ["myskill"], True),
+        )
+        msg = FakeMessage("use the skill")
+        await bot._handle_message(msg, "use the skill")
+        assert msg.reply_texts == ["raw skill output"]
+
+    async def test_voice_callback_receives_response(self):
+        bot, fake = build([text_response("spoken words")])
+        spoken = []
+
+        async def voice_cb(text):
+            spoken.append(text)
+
+        msg = FakeMessage("say it")
+        await bot._handle_message(msg, "say it", voice_callback=voice_cb)
+        assert spoken == ["spoken words"]
+        assert msg.reply_texts == ["spoken words"]
+
+
+class TestThreadInheritance:
+    async def test_thread_seeds_summary_from_parent_channel(self):
+        bot, fake = build([text_response("thread answer")])
+        parent = FakeChannel(id=100, name="general")
+        # Parent session with prior conversation
+        bot.sessions.add_message("100", "user", "[tester]: earlier topic")
+        bot.sessions.add_message("100", "assistant", "earlier reply")
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 200
+        thread.parent = parent
+        thread.name = "side-thread"
+        thread.guild = None
+        # Wire the fake channel behaviors the pipeline needs
+        real = FakeChannel(id=200, name="side-thread")
+        thread.send = real.send
+        thread.typing = real.typing
+
+        msg = FakeMessage("continue here", channel=thread)
+        await bot._handle_message(msg, "continue here")
+
+        thread_session = bot.sessions.get("200")
+        assert thread_session.summary.startswith("[INHERITED FROM #general]")
+        assert "earlier topic" in thread_session.summary
+
+    async def test_thread_with_existing_session_not_reseeded(self):
+        bot, fake = build([text_response("ok")])
+        parent = FakeChannel(id=100, name="general")
+        bot.sessions.add_message("100", "user", "[tester]: parent context")
+        bot.sessions.add_message("200", "user", "[tester]: thread already active")
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 200
+        thread.parent = parent
+        thread.name = "side-thread"
+        thread.guild = None
+        real = FakeChannel(id=200)
+        thread.send = real.send
+        thread.typing = real.typing
+
+        msg = FakeMessage("more", channel=thread)
+        await bot._handle_message(msg, "more")
+        assert not (bot.sessions.get("200").summary or "").startswith("[INHERITED")
+
+
+class TestDeliveryHandoff:
+    async def test_pending_files_delivered_with_response(self):
+        bot, fake = build([text_response("here you go")])
+        msg = FakeMessage("give me the file")
+        bot._pending_files[str(msg.channel.id)] = [(b"bytes", "gift.txt")]
+        await bot._handle_message(msg, "give me the file")
+        entry = msg.replies[0]
+        assert entry["content"] == "here you go"
+        assert [f.filename for f in entry["files"]] == ["gift.txt"]
+
+    async def test_already_sent_response_posts_pending_files_separately(self):
+        bot, fake = build()
+        bot._process_with_tools = AsyncMock(
+            return_value=("streamed already", True, False, ["some_tool"], False),
+        )
+        msg = FakeMessage("stream it")
+        bot._pending_files[str(msg.channel.id)] = [(b"bytes", "late.txt")]
+        await bot._handle_message(msg, "stream it")
+        assert msg.replies == []  # not re-sent
+        assert msg.channel.sent  # files posted on their own
+        assert [f.filename for f in msg.channel.sent[0]["files"]] == ["late.txt"]

--- a/tests/characterization/test_scheduled_events.py
+++ b/tests/characterization/test_scheduled_events.py
@@ -1,0 +1,254 @@
+"""Characterization: scheduler/digest/monitor callbacks (_on_scheduled_task,
+_run_scheduled_workflow, _execute_scheduled_tool, _on_monitor_alert,
+_on_schedule_failure).
+
+Pins the action routing, workflow step semantics (conditions, on_failure
+abort vs continue), the structured RBAC failure, and the raise-on-failure
+contract the scheduler's backoff depends on.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.tools.result_validator import ToolResult
+from tests.fakes import FakeChannel, FakeLLM, make_bot
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def bot_and_channel():
+    bot = make_bot(fake_llm=FakeLLM([]))
+    channel = FakeChannel(id=777)
+    bot.get_channel = lambda cid: channel if int(cid) == 777 else None
+    return bot, channel
+
+
+def schedule(**kw) -> dict:
+    base = {"id": "sched-1", "channel_id": "777", "description": "test schedule"}
+    base.update(kw)
+    return base
+
+
+class TestScheduledTaskRouting:
+    async def test_reminder_posts_to_channel(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        await bot._on_scheduled_task(schedule(action="reminder", message="water the servers"))
+        assert channel.sent_texts == ["**Scheduled reminder:** water the servers"]
+
+    async def test_missing_channel_id_is_silently_skipped(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        await bot._on_scheduled_task(schedule(action="reminder", channel_id="", message="x"))
+        assert channel.sent == []
+
+    async def test_unknown_action_is_ignored_without_raise(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        await bot._on_scheduled_task(schedule(action="mystery"))
+        assert channel.sent == []
+
+    async def test_check_success_posts_result(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(output="disk 42% used", tool_name="run_command"),
+        )
+        await bot._on_scheduled_task(
+            schedule(
+                action="check",
+                tool_name="run_command",
+                tool_input={"host": "h", "command": "df"},
+            )
+        )
+        assert len(channel.sent_texts) == 1
+        assert channel.sent_texts[0].startswith("**Scheduled: test schedule**")
+        assert "disk 42% used" in channel.sent_texts[0]
+
+    async def test_check_failure_posts_and_raises(self, bot_and_channel):
+        """The raise is the scheduler's failure signal — its backoff/alerting
+        depends on it. Do not swallow it."""
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(output="host unreachable", ok=False, tool_name="run_command"),
+        )
+        with pytest.raises(RuntimeError, match="Scheduled check failed"):
+            await bot._on_scheduled_task(
+                schedule(
+                    action="check",
+                    tool_name="run_command",
+                    tool_input={"host": "h", "command": "df"},
+                )
+            )
+        assert channel.sent_texts[0].startswith("**Scheduled check failed:**")
+
+
+class TestScheduledWorkflow:
+    async def test_on_failure_abort_is_default_and_stops_workflow(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                ToolResult(output="boom", ok=False, tool_name="run_command"),
+                ToolResult(output="never runs", tool_name="run_command"),
+            ]
+        )
+        sched = schedule(
+            action="workflow",
+            steps=[
+                {"tool_name": "run_command", "tool_input": {"host": "h", "command": "a"}},
+                {"tool_name": "run_command", "tool_input": {"host": "h", "command": "b"}},
+            ],
+        )
+        with pytest.raises(RuntimeError, match="Scheduled workflow failed"):
+            await bot._on_scheduled_task(sched)
+        assert bot.tool_executor.execute.await_count == 1
+        summary = channel.sent_texts[0]
+        assert "FAILED" in summary
+        assert "Workflow aborted" in summary
+
+    async def test_on_failure_continue_keeps_going_and_workflow_succeeds(self, bot_and_channel):
+        """Pinned as-is: a failed step with on_failure=continue does NOT mark
+        the workflow failed — workflow_ok stays True and nothing raises."""
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                ToolResult(output="boom", ok=False, tool_name="run_command"),
+                ToolResult(output="second ran fine", tool_name="run_command"),
+            ]
+        )
+        sched = schedule(
+            action="workflow",
+            steps=[
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "h", "command": "a"},
+                    "on_failure": "continue",
+                },
+                {"tool_name": "run_command", "tool_input": {"host": "h", "command": "b"}},
+            ],
+        )
+        await bot._on_scheduled_task(sched)  # no raise
+        assert bot.tool_executor.execute.await_count == 2
+        summary = channel.sent_texts[0]
+        assert "FAILED" in summary and "second ran fine" in summary
+        assert "Workflow aborted" not in summary
+
+    async def test_condition_skips_step_on_missing_substring(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                ToolResult(output="all healthy", tool_name="run_command"),
+                ToolResult(output="should not run", tool_name="run_command"),
+            ]
+        )
+        sched = schedule(
+            action="workflow",
+            steps=[
+                {"tool_name": "run_command", "tool_input": {"host": "h", "command": "status"}},
+                # condition "error" not present in prev output → skipped
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "h", "command": "restart"},
+                    "condition": "error",
+                },
+            ],
+        )
+        await bot._on_scheduled_task(sched)
+        assert bot.tool_executor.execute.await_count == 1
+        assert "skipped" in channel.sent_texts[0]
+
+    async def test_negated_condition_skips_when_substring_present(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                ToolResult(output="ERROR: broken", tool_name="run_command"),
+                ToolResult(output="should not run", tool_name="run_command"),
+            ]
+        )
+        sched = schedule(
+            action="workflow",
+            steps=[
+                {"tool_name": "run_command", "tool_input": {"host": "h", "command": "status"}},
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "h", "command": "cleanup"},
+                    "condition": "!error",
+                },
+            ],
+        )
+        await bot._on_scheduled_task(sched)
+        assert bot.tool_executor.execute.await_count == 1
+        assert "skipped" in channel.sent_texts[0]
+
+
+class TestExecuteScheduledTool:
+    async def test_rbac_denial_returns_structured_failure(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        bot.tool_executor.check_permission = lambda tool, uid: "RBAC denied: nope"
+        result = await bot._execute_scheduled_tool(
+            "run_command",
+            {"host": "h", "command": "x"},
+            channel,
+            "someuser",
+        )
+        assert isinstance(result, ToolResult)
+        assert result.ok is False
+        assert result.error == "permission_denied"
+        assert "RBAC denied" in result.output
+
+    async def test_dispatch_exception_wrapped_as_execution_error(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        bot.tool_executor.execute = AsyncMock(side_effect=RuntimeError("ssh exploded"))
+        result = await bot._execute_scheduled_tool(
+            "run_command",
+            {"host": "h", "command": "x"},
+            channel,
+            None,
+        )
+        assert result.ok is False
+        assert result.error == "execution_error"
+        assert "ssh exploded" in result.output
+
+    async def test_string_result_wrapped_ok(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        result = await bot._execute_scheduled_tool(
+            "parse_time",
+            {"text": "tomorrow 3pm"},
+            channel,
+            None,
+        )
+        assert isinstance(result, ToolResult)
+        assert result.ok is True
+
+
+class TestAlerts:
+    async def test_monitor_alert_falls_back_to_first_configured_channel(
+        self, tmp_path, monkeypatch
+    ):
+        bot = make_bot(
+            fake_llm=FakeLLM([]),
+            config_overrides={"discord": {"channels": ["777"]}},
+        )
+        channel = FakeChannel(id=777)
+        bot.get_channel = lambda cid: channel if int(cid) == 777 else None
+        await bot._on_monitor_alert("CPU at 99% on desktop")
+        assert channel.sent_texts == ["CPU at 99% on desktop"]
+
+    async def test_monitor_alert_with_no_channel_is_dropped(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        await bot._on_monitor_alert("nowhere to go")
+        assert channel.sent == []
+
+    async def test_schedule_failure_alert_posts_threshold_message(self, bot_and_channel):
+        bot, channel = bot_and_channel
+        await bot._on_schedule_failure(
+            schedule(last_error="timeout talking to host"),
+            consecutive=3,
+        )
+        text = channel.sent_texts[0]
+        assert "Scheduled task failing" in text
+        assert "3 consecutive failures" in text
+        assert "timeout talking to host" in text

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -1,0 +1,41 @@
+"""Shared test fakes for characterization and unit tests.
+
+Introduced by RFC-001 Phase 0 (client.py decomposition campaign). Before
+this package, every test file re-improvised its own bot factory, fake LLM,
+and MagicMock discord objects; these are the blessed shared versions.
+
+Import surface:
+    from tests.fakes import FakeLLM, text_response, tool_call_response
+    from tests.fakes import FakeMessage, FakeChannel, FakeAuthor, FakeThread
+    from tests.fakes import make_bot
+"""
+
+from .bot_factory import make_bot
+from .discord_objects import (
+    FakeAttachment,
+    FakeAuthor,
+    FakeChannel,
+    FakeMessage,
+    FakeSentMessage,
+    FakeThread,
+)
+from .llm import (
+    FakeLLM,
+    parse_error_call,
+    text_response,
+    tool_call_response,
+)
+
+__all__ = [
+    "FakeLLM",
+    "text_response",
+    "tool_call_response",
+    "parse_error_call",
+    "FakeAuthor",
+    "FakeChannel",
+    "FakeThread",
+    "FakeMessage",
+    "FakeAttachment",
+    "FakeSentMessage",
+    "make_bot",
+]

--- a/tests/fakes/bot_factory.py
+++ b/tests/fakes/bot_factory.py
@@ -1,0 +1,77 @@
+"""The one blessed way to build a real OdinBot in tests (RFC-001 Phase 0).
+
+Every characterization test constructs the bot through here so the config
+baseline is shared and future decomposition phases have exactly one factory
+to keep working.
+
+Usage (typical fixture — note the cwd isolation; OdinBot hardcodes
+relative ./data/... paths, so tests must chdir to tmp_path FIRST):
+
+    @pytest.fixture
+    def bot(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        return make_bot()
+
+    @pytest.fixture
+    def bot_with_llm(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        fake = FakeLLM([...script...])
+        return make_bot(fake_llm=fake), fake
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def make_bot(*, config_overrides: dict | None = None, fake_llm=None):
+    """Construct a real OdinBot from a minimal test Config.
+
+    Baseline mirrors tests/test_executor_integration_smoke.py::_make_bot
+    (default_tier=admin matches the live deployment so the RBAC gate does
+    not deny admin-tier tools), plus:
+
+    - search disabled: keeps construction hermetic and fast; tests that
+      characterize knowledge flows opt back in via config_overrides.
+    - openai_codex stays disabled (schema default) → codex_client is None
+      until a FakeLLM is installed.
+
+    If ``fake_llm`` is given it is installed at ``bot.codex_client`` — the
+    single attribute BOTH pipelines resolve their provider from (the chat
+    loop via the llm_client property inside _codex_call, the autonomous
+    loop via self.llm_client directly).
+
+    The caller is responsible for cwd isolation (see module docstring);
+    this function only asserts it is NOT running in the repo root, so a
+    forgotten chdir fails loudly instead of writing ./data into the repo.
+    """
+    if (Path.cwd() / "pyproject.toml").exists() and (Path.cwd() / "src" / "discord").exists():
+        raise AssertionError(
+            "make_bot() called with cwd == repo root. OdinBot writes relative "
+            "./data/... paths; chdir to tmp_path first (monkeypatch.chdir)."
+        )
+    Path("./data").mkdir(exist_ok=True)
+
+    from src.config.schema import Config
+    from src.discord.client import OdinBot
+
+    base: dict = {
+        "discord": {"token": "characterization-test-token"},
+        "permissions": {"default_tier": "admin"},
+        "search": {"enabled": False},
+    }
+    cfg = Config(**_deep_merge(base, config_overrides or {}))
+    bot = OdinBot(cfg)
+    if fake_llm is not None:
+        bot.codex_client = fake_llm
+    return bot

--- a/tests/fakes/discord_objects.py
+++ b/tests/fakes/discord_objects.py
@@ -1,0 +1,180 @@
+"""Fake discord.py objects satisfying the duck-type contract client.py uses.
+
+Promoted from the pattern in tests/test_web_chat.py (WebMessage/WebChannel/
+WebAuthor) per RFC-001 Phase 0. These are plain recording classes — no
+MagicMock — so a typo'd attribute access fails loudly instead of returning
+a new mock.
+
+The contract they satisfy is the informal ``MessageLike`` shape documented
+in RFC-001 §6.3: what discord.Message, _LoopMessageProxy, VoiceMessageProxy,
+and the web-chat proxies all provide.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+_id_counter = itertools.count(500_000)
+
+
+class FakeAuthor:
+    def __init__(
+        self,
+        id: int = 12345,
+        name: str = "tester",
+        *,
+        bot: bool = False,
+        display_name: str | None = None,
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.bot = bot
+        self.display_name = display_name or name
+        # discord.Member-ish extras some paths getattr() for:
+        self.mention = f"<@{id}>"
+        self.voice = None
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class FakeSentMessage:
+    """What FakeChannel.send / FakeMessage.reply return."""
+
+    def __init__(self, content=None, files=None) -> None:
+        self.id = next(_id_counter)
+        self.content = content
+        self.files = files
+        self.edits: list = []
+
+    async def edit(self, *, content=None, **kwargs):
+        self.edits.append(content)
+        self.content = content
+        return self
+
+
+class _TypingContext:
+    def __init__(self, channel: FakeChannel) -> None:
+        self._channel = channel
+
+    async def __aenter__(self):
+        self._channel.typing_entered += 1
+        return self
+
+    async def __aexit__(self, *exc):
+        self._channel.typing_exited += 1
+        return False
+
+
+class FakeChannel:
+    """Records send() calls; supports typing() as an async context manager."""
+
+    def __init__(self, id: int = 99, name: str = "test-channel", guild=None) -> None:
+        self.id = id
+        self.name = name
+        self.guild = guild
+        self.sent: list[dict] = []  # {"content": str|None, "files": list|None}
+        self.typing_entered = 0
+        self.typing_exited = 0
+        self.purged_limits: list[int] = []
+        self.send_error: BaseException | None = None  # set to make send() raise once
+
+    async def send(self, content=None, *, files=None, file=None, **kwargs):
+        if self.send_error is not None:
+            err, self.send_error = self.send_error, None
+            raise err
+        all_files = list(files) if files else ([file] if file else None)
+        entry = {"content": content, "files": all_files, **({k: v for k, v in kwargs.items() if v})}
+        self.sent.append(entry)
+        return FakeSentMessage(content, all_files)
+
+    def typing(self) -> _TypingContext:
+        return _TypingContext(self)
+
+    async def purge(self, limit: int = 100):
+        self.purged_limits.append(limit)
+        return [object()] * min(limit, 3)
+
+    # -- helpers -----------------------------------------------------------
+
+    @property
+    def sent_texts(self) -> list[str]:
+        return [e["content"] for e in self.sent if e["content"]]
+
+
+class FakeThread(FakeChannel):
+    """A thread channel with a parent — client.py checks isinstance(discord.Thread).
+
+    NOTE: client.py's thread checks use ``isinstance(message.channel,
+    discord.Thread)``, which a fake can't satisfy without subclassing the
+    real class. Tests that need the *thread* code path must patch or use a
+    real discord.Thread stand-in; tests that only need "a channel with a
+    .parent" can use this. See test_pipeline_persistence for the pattern.
+    """
+
+    def __init__(
+        self, id: int = 199, name: str = "test-thread", parent: FakeChannel | None = None
+    ) -> None:
+        super().__init__(id=id, name=name)
+        self.parent = parent or FakeChannel(id=99, name="parent-channel")
+
+
+class FakeAttachment:
+    def __init__(
+        self, filename: str = "notes.txt", data: bytes = b"hello", content_type: str = "text/plain"
+    ) -> None:
+        self.filename = filename
+        self.content_type = content_type
+        self.size = len(data)
+        self._data = data
+        self.url = f"https://fake.attachments/{filename}"
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class FakeMessage:
+    """A message-shaped object accepted by the pipeline and tool loop."""
+
+    def __init__(
+        self,
+        content: str = "",
+        *,
+        author: FakeAuthor | None = None,
+        channel: FakeChannel | None = None,
+        id: int | None = None,
+        attachments: list | None = None,
+        webhook_id: int | None = None,
+        guild=None,
+    ) -> None:
+        self.content = content
+        self.author = author or FakeAuthor()
+        self.channel = channel or FakeChannel()
+        self.id = id if id is not None else next(_id_counter)
+        self.attachments = list(attachments or [])
+        self.webhook_id = webhook_id
+        self.guild = guild
+        self.replies: list[dict] = []
+        self.deleted = False
+        self.reply_error: BaseException | None = None  # set to make reply() raise once
+
+    async def reply(self, content=None, *, files=None, **kwargs):
+        if self.reply_error is not None:
+            err, self.reply_error = self.reply_error, None
+            raise err
+        entry = {"content": content, "files": list(files) if files else None}
+        self.replies.append(entry)
+        return FakeSentMessage(content, entry["files"])
+
+    async def delete(self) -> None:
+        self.deleted = True
+
+    # -- helpers -----------------------------------------------------------
+
+    @property
+    def reply_texts(self) -> list[str]:
+        return [r["content"] for r in self.replies if r["content"]]
+
+    def all_delivered_texts(self) -> list[str]:
+        """Replies + channel sends, in rough delivery order."""
+        return self.reply_texts + self.channel.sent_texts

--- a/tests/fakes/llm.py
+++ b/tests/fakes/llm.py
@@ -1,0 +1,171 @@
+"""Scripted fake LLM provider for characterization tests.
+
+Plays a pre-scripted sequence of ``LLMResponse`` objects through
+``chat_with_tools`` and plain strings through ``chat``, recording every
+call it receives (messages, system prompt, tools) so tests can assert the
+exact message-list shape the tool loop constructs per iteration.
+
+Installable at BOTH seams the client currently uses:
+
+- ``bot.codex_client = FakeLLM(...)`` — the chat tool loop reaches the LLM
+  via ``_codex_call`` → the ``llm_client`` property, which resolves to
+  ``codex_client`` under the default ``active_provider: codex``.
+- The autonomous loop (``_run_loop_iteration``) calls
+  ``self.llm_client.chat_with_tools`` directly — same attribute, so the
+  same installation covers it. (RFC-001 §4.3: the loop path deliberately
+  bypasses ``_codex_call``'s cost/router/guard wiring.)
+
+Script entries may be:
+- ``LLMResponse``   — returned as-is
+- ``Exception``     — raised (e.g. ``CircuitOpenError``, ``RuntimeError``)
+- ``callable``      — invoked with no args at consume time; may return an
+                      ``LLMResponse`` or raise. Useful for side effects
+                      like setting a cancel event between iterations.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from src.llm.types import LLMResponse, ToolCall
+
+
+def text_response(text: str, *, input_tokens: int = 10, output_tokens: int = 5) -> LLMResponse:
+    """A plain final-text response (ends the tool loop)."""
+    return LLMResponse(
+        text=text,
+        tool_calls=[],
+        stop_reason="end_turn",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def tool_call_response(
+    *calls: tuple[str, dict],
+    text: str = "",
+    id_prefix: str = "call",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+) -> LLMResponse:
+    """A response containing one or more tool calls.
+
+    ``calls`` are (tool_name, tool_input) pairs; ids are generated as
+    ``{id_prefix}-{n}`` so tests can assert tool_use/tool_result pairing.
+    """
+    tool_calls = [
+        ToolCall(id=f"{id_prefix}-{i}", name=name, input=tool_input)
+        for i, (name, tool_input) in enumerate(calls, 1)
+    ]
+    return LLMResponse(
+        text=text,
+        tool_calls=tool_calls,
+        stop_reason="tool_use",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def parse_error_call(tool_name: str, error: str = "invalid JSON in arguments") -> LLMResponse:
+    """A tool call whose arguments failed to parse (parse_error set).
+
+    The dispatcher must NOT execute the tool; it must bounce the error back.
+    """
+    return LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="parse-err-1", name=tool_name, input={}, parse_error=error)],
+        stop_reason="tool_use",
+    )
+
+
+class FakeLLM:
+    """Scripted LLM provider recording all calls.
+
+    Attributes:
+        calls: recorded ``chat_with_tools`` invocations, each a dict with
+            deep-copied ``messages`` plus ``system`` and ``tools``.
+        chat_calls: recorded plain ``chat`` invocations (classifier, guest
+            route, compaction, handoff).
+    """
+
+    def __init__(
+        self,
+        responses: list | None = None,
+        chat_responses: list | None = None,
+        model: str = "fake-model",
+    ) -> None:
+        self.responses = list(responses or [])
+        self.chat_responses = list(chat_responses or [])
+        self.model = model
+        self.calls: list[dict] = []
+        self.chat_calls: list[dict] = []
+
+    # -- seams ------------------------------------------------------------
+
+    async def chat_with_tools(
+        self, messages: list, system: str = "", tools: list | None = None, **kwargs
+    ):
+        self.calls.append(
+            {
+                "messages": copy.deepcopy(messages),
+                "system": system,
+                "tools": tools,
+                "kwargs": dict(kwargs),
+            }
+        )
+        if not self.responses:
+            raise AssertionError(
+                f"FakeLLM script exhausted after {len(self.calls)} chat_with_tools call(s) — "
+                "the code under test made more LLM calls than the test scripted."
+            )
+        item = self.responses.pop(0)
+        if callable(item) and not isinstance(item, LLMResponse):
+            item = item()
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def chat(self, messages: list, system: str = "", **kwargs) -> str:
+        self.chat_calls.append(
+            {
+                "messages": copy.deepcopy(messages),
+                "system": system,
+                "kwargs": dict(kwargs),
+            }
+        )
+        if not self.chat_responses:
+            # The completion classifier calls chat() after every tool-using
+            # turn and swallows exceptions (fail-open) — a strict exhaustion
+            # error here would be silently eaten. Default to "COMPLETE" so
+            # unrelated tests don't have to script the classifier; tests that
+            # characterize the classifier script chat_responses explicitly.
+            return "COMPLETE"
+        item = self.chat_responses.pop(0)
+        if callable(item) and not isinstance(item, str):
+            item = item()
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def close(self) -> None:  # provider contract
+        return None
+
+    # -- assertion helpers -------------------------------------------------
+
+    @property
+    def exhausted(self) -> bool:
+        return not self.responses and not self.chat_responses
+
+    def messages_of_call(self, index: int) -> list:
+        """The deep-copied message list the given chat_with_tools call received."""
+        return self.calls[index]["messages"]
+
+    def developer_messages_of_call(self, index: int) -> list[str]:
+        """Contents of role=developer messages in the given call, in order."""
+        return [
+            m["content"]
+            for m in self.calls[index]["messages"]
+            if isinstance(m, dict)
+            and m.get("role") == "developer"
+            and isinstance(m.get("content"), str)
+        ]


### PR DESCRIPTION
## RFC-001 Phase 0 — Characterization harness

Part of the client.py decomposition campaign (see `docs/plans/client-decomposition-plan.md`, committed here). **Base branch is the campaign integration branch `refactor/client-decomposition`, not master** — per the R2 execution model, master is untouched for the whole campaign.

### What this adds
- **`tests/fakes/`** — the shared test infrastructure every test file previously re-improvised:
  - `FakeLLM`: scripted `LLMResponse` sequences; records every `chat_with_tools`/`chat` call (deep-copied messages, system, tools) for exact message-shape assertions; installable at both provider seams (`bot.codex_client` and the `llm_client` property path the autonomous loop uses).
  - Fake discord objects (`FakeMessage`/`FakeChannel`/`FakeThread`/`FakeAuthor`/`FakeAttachment`) — plain recording classes, promoted from the `test_web_chat.py` pattern.
  - `make_bot()`: the blessed `OdinBot` factory (mirrors the smoke-test config baseline, asserts cwd isolation so `./data` writes can never touch the repo).
- **`tests/characterization/`** — 127 tests pinning CURRENT behavior, per RFC §8.1:
  - **Chat tool loop** (38): guard cascade order + one-retry semantics + cascading detection, classifier continuations (incl. the budget gating the classifier *call*), `[AUTO-VALIDATE]`/`[VALIDATION REQUIRED]` enforcement + validate_action clearing, stuck-loop warn→terminate, `/stop` at both checkpoints (pre-tool and post-tool), iteration cap, LLM error + CircuitOpenError wait-retry, RBAC denial, parse-error bounce, `ok=False` → `Error (tool reported failure):` verbatim, vision injection, skill handoff, skill-CRUD mid-loop prompt rebuild, message-list shapes per iteration (preamble placement, tool_use/tool_result id pairing).
  - **Autonomous loop** (21): every §4.3 asymmetry that could silently drift — no guards, no classifier, raw `llm_client` seam (no `_codex_call`, no cost tracking), CircuitOpenError **re-raise**, cap → `is_error`/`failure_class=cancelled` + stale-partial surfacing, recovered-tool-error success semantics, trajectory `source=loop`, loop dispatch parity (parse-error, ok=False, RBAC, skill CRUD, export_skill → `_pending_files` staging, invoke_skill missing-fields).
  - **Intake gating** (16): chain order driven through the REAL `on_message` (secret scrub before cogs before gates), allowlists, per-channel mention gate + stripping, DM bypass, dedup, bot-message buffering (combining, split code fences, mention check on flush).
  - **Pipeline** (15): tagged-user persistence, tool-response summarization, sanitized error markers (raw errors never poison history), CancelledError cleanup, reflection receives popped op-details, guest route, no-provider route, handoff + fallback, thread context inheritance, pending-file delivery, already_sent file posting.
  - **Delivery** (10): fence-aware chunking, long-line pre-split, >4× file fallback, pending files, retry backoff (1s, 2s), give-up-returns-None.
  - **Scheduled events** (16): action routing, check-failure raise (the scheduler backoff contract), workflow `on_failure: continue` pinned as-is (failed step does NOT fail the workflow), conditions + negated conditions, structured RBAC failure, monitor/failure alerts.
  - **Facade contract** (11): Appendix B positive surface, external-write setters, late-bound absence, the grep-backed **negative contract** (12 internal-only names, zero references outside client.py), module re-exports, and the web-chat route end-to-end through the real `_process_with_tools`.

### Behaviors discovered while pinning (pinned as-is, no fixes ridden along)
- `detect_fabrication` fires on unverified state claims (e.g. "The server is now running on port 8080") with zero tools used — correct but worth knowing.
- The continuation budget gates the classifier *call itself*: after 3 continuations the 4th text turn is accepted without consulting the classifier.
- A `/stop` during the LLM call preempts tool execution entirely (after_llm checkpoint); only a stop during tool execution reports tools used.
- RBAC-denied tools are still recorded in `tools_used` (names appended before dispatch).

### Guarantees
- **Zero `src/` changes. Zero existing-test changes.** The `inspect.getsource` assertions stay until the code they pin moves (RFC §8.4).
- Full suite: **6040 passed, 4 skipped** (was ~5,905 + these 127). Suite runtime 64s.
- `ruff check` clean on all new files.

### Revert
Single revert of this merge restores baseline exactly (tests + docs only).

### Review checklist for this PR
1. Do the pinned behaviors match your reading of current master? (Especially the four discovered behaviors above.)
2. Are the §4.3 asymmetry pins strong enough to catch a careless P8?
3. Any characterization scenario from RFC §8.1 you consider missing before P1 starts?

🤖 Generated with [Claude Code](https://claude.com/claude-code)