### PR TITLE
fix: background-task steps no longer report ok=False results as success

### DIFF
--- a/src/discord/background_task.py
+++ b/src/discord/background_task.py
@@ -19,6 +19,9 @@ from ..audit.diff_tracker import DIFF_TOOLS, DiffTracker
 from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
 from ..tools.risk_classifier import classify_tool
+from ..tools.executor import _ERROR_RESULT_PREFIXES
+from ..tools.result_validator import ToolResult
+from .tool_loop import ensure_failure_visible
 
 _EMAIL_BODY_TOOLS = frozenset({"email_send"})
 
@@ -177,6 +180,13 @@ async def run_background_task(
                 requester_id=task.requester_id,
             )
             elapsed_ms = int((time.monotonic() - t0) * 1000)
+            structured_ok: bool | None = None
+            if isinstance(output, ToolResult):
+                structured_ok = output.ok
+                # Same canonical marking the chat/loop pipelines apply: a
+                # structurally-failed result gets an explicit Error prefix so
+                # the posted step output cannot read as success.
+                output = ensure_failure_visible(str(output), output.ok)
             output = scrub_output_secrets(output)
             prev_output = output
 
@@ -191,8 +201,12 @@ async def run_background_task(
                 except Exception:
                     pass
 
-            # Detect error strings returned by executor (not raised as exceptions)
-            is_error = _is_error_output(output)
+            # Structured failure signal first (ToolResult.ok), then the
+            # error-string heuristic for plain-string handler branches.
+            if structured_ok is not None:
+                is_error = not structured_ok
+            else:
+                is_error = _is_error_output(output)
             task.results.append(StepResult(
                 index=i, tool_name=tool_name,
                 description=step_desc, status="error" if is_error else "ok",
@@ -305,6 +319,11 @@ def _is_error_output(output: str) -> bool:
     # executor.execute() returns "Permission denied: ..." for RBAC violations
     if output.startswith("Permission denied: "):
         return True
+    # The executor's own canonical error grammar ("Error…", "Command failed",
+    # "Script failed", "Blocked…", "Unknown or disallowed host") — the same
+    # prefix set ensure_failure_visible treats as already-visible failures.
+    if output.startswith(_ERROR_RESULT_PREFIXES):
+        return True
     return False
 
 
@@ -319,8 +338,12 @@ async def _execute_tool(
     step_desc: str = "",
     mcp_manager: MCPManager | None = None,
     requester_id: str = "",
-) -> str:
-    """Execute a single tool, routing to the right handler."""
+) -> str | ToolResult:
+    """Execute a single tool, routing to the right handler.
+
+    The executor path returns the structured ToolResult (the caller consumes
+    .ok); every other branch returns a plain string.
+    """
     # Central RBAC gate for deferred/background execution. Skills, MCP, and the
     # knowledge tools below bypass ToolExecutor.execute() (the only place
     # check_permission runs), and even the final execute() call only enforces
@@ -396,7 +419,10 @@ async def _execute_tool(
         tool_input = {**tool_input, "host": _get_default_host(executor)}
     # run_command/run_script: if 'command'/'script' missing, let executor handle it
     # (it will return an error that _is_error_output catches)
-    return str(await executor.execute(tool_name, tool_input, user_id=requester_id or None))
+    # Return the structured result — run_background_task consumes .ok so a
+    # failed tool can no longer masquerade as a successful step (soak finding
+    # 2026-07-05; same failure class PR #130 fixed for the chat loop).
+    return await executor.execute(tool_name, tool_input, user_id=requester_id or None)
 
 
 def _substitute_vars(

--- a/tests/test_background_task_failure_visibility.py
+++ b/tests/test_background_task_failure_visibility.py
@@ -1,0 +1,215 @@
+"""Background-task step failure visibility (soak finding, 2026-07-05).
+
+Before this fix, run_background_task collapsed the executor's ToolResult to
+a string and _is_error_output only recognized three literal prefixes — so a
+structurally-failed tool (ok=False, e.g. "Unknown or disallowed host: X")
+was recorded as a SUCCESSFUL step and the completion message claimed
+"All N steps succeeded."
+
+Now: ToolResult.ok is consumed directly (structured signal first), the
+failed output gets the canonical "Error (tool reported failure):" marking,
+and the string heuristic additionally recognizes the executor's own error
+prefixes for plain-string branches.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.discord.background_task import (
+    BackgroundTask,
+    _is_error_output,
+    create_task_id,
+    run_background_task,
+)
+from src.tools.result_validator import ToolResult
+from tests.fakes import FakeChannel
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def make_task(steps, channel=None):
+    return BackgroundTask(
+        task_id=create_task_id(),
+        description="failure visibility test",
+        steps=steps,
+        channel=channel or FakeChannel(id=555),
+        requester="tester",
+        requester_id="4242",
+    )
+
+
+class _FakeExecutor:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []
+
+    def check_permission(self, tool_name, user_id):
+        return None  # allow
+
+    async def execute(self, tool_name, tool_input, user_id=None):
+        self.calls.append((tool_name, tool_input, user_id))
+        return self.results.pop(0)
+
+
+class _FakeSkillManager:
+    def has_skill(self, name):
+        return False
+
+
+async def run(task, executor):
+    await run_background_task(task, executor, _FakeSkillManager())
+
+
+class TestStructuredFailureVisibility:
+    async def test_ok_false_steps_are_recorded_as_errors(self):
+        executor = _FakeExecutor(
+            [
+                ToolResult(
+                    output="Unknown or disallowed host: playground",
+                    ok=False,
+                    tool_name="run_command",
+                ),
+                ToolResult(
+                    output="Unknown or disallowed host: playground",
+                    ok=False,
+                    tool_name="run_command",
+                ),
+            ]
+        )
+        channel = FakeChannel(id=555)
+        task = make_task(
+            [
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "playground", "command": "echo hi"},
+                    "on_failure": "continue",
+                },
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "playground", "command": "date"},
+                    "on_failure": "continue",
+                },
+            ],
+            channel=channel,
+        )
+        await run(task, executor)
+        assert [r.status for r in task.results] == ["error", "error"]
+        # The completion message no longer lies
+        all_text = " ".join(channel.sent_texts)
+        assert "All 2 steps succeeded" not in all_text
+        assert "0 succeeded, 2 failed" in all_text
+
+    async def test_ok_true_steps_still_succeed(self):
+        executor = _FakeExecutor(
+            [
+                ToolResult(output="step1", tool_name="run_command"),
+                ToolResult(output="Sun Jul  5 12:00:00 AM EDT 2026", tool_name="run_command"),
+            ]
+        )
+        channel = FakeChannel(id=555)
+        task = make_task(
+            [
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "localhost", "command": "echo step1"},
+                },
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "localhost", "command": "date"},
+                },
+            ],
+            channel=channel,
+        )
+        await run(task, executor)
+        assert [r.status for r in task.results] == ["ok", "ok"]
+        assert "All 2 steps succeeded" in " ".join(channel.sent_texts)
+
+    async def test_failed_output_carries_canonical_error_marking(self):
+        executor = _FakeExecutor(
+            [
+                ToolResult(output="quietly wrong", ok=False, tool_name="run_command"),
+            ]
+        )
+        task = make_task(
+            [
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "h", "command": "x"},
+                    "on_failure": "continue",
+                }
+            ],
+        )
+        await run(task, executor)
+        assert task.results[0].status == "error"
+        assert task.results[0].output.startswith("Error (tool reported failure):")
+
+    async def test_default_on_failure_abort_stops_on_ok_false(self):
+        executor = _FakeExecutor(
+            [
+                ToolResult(
+                    output="Unknown or disallowed host: playground",
+                    ok=False,
+                    tool_name="run_command",
+                ),
+                ToolResult(output="never runs", tool_name="run_command"),
+            ]
+        )
+        task = make_task(
+            [
+                {"tool_name": "run_command", "tool_input": {"host": "playground", "command": "a"}},
+                {"tool_name": "run_command", "tool_input": {"host": "playground", "command": "b"}},
+            ],
+        )
+        await run(task, executor)
+        assert task.status == "failed"
+        assert len(executor.calls) == 1  # second step never executed
+
+    async def test_audit_error_field_populated_for_ok_false(self):
+        executor = _FakeExecutor(
+            [
+                ToolResult(
+                    output="Unknown or disallowed host: playground",
+                    ok=False,
+                    tool_name="run_command",
+                ),
+            ]
+        )
+        audit = AsyncMock()
+        task = make_task(
+            [
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "playground", "command": "a"},
+                    "on_failure": "continue",
+                }
+            ],
+        )
+        await run_background_task(task, executor, _FakeSkillManager(), audit_logger=audit)
+        audit.log_execution.assert_awaited()
+        kwargs = audit.log_execution.await_args.kwargs
+        assert kwargs.get("error"), "audit entry must carry the error field for a failed step"
+
+
+class TestStringHeuristic:
+    def test_canonical_executor_prefixes_detected(self):
+        assert _is_error_output("Unknown or disallowed host: playground") is True
+        assert _is_error_output("Command failed with exit code 1") is True
+        assert _is_error_output("Script failed: boom") is True
+        assert _is_error_output("Blocked by command governor") is True
+        assert _is_error_output("Error (tool reported failure):\nquietly wrong") is True
+
+    def test_legacy_prefixes_still_detected(self):
+        assert _is_error_output("Error executing run_command: boom") is True
+        assert _is_error_output("Unknown tool: frobnicate") is True
+        assert _is_error_output("Permission denied: tier too low") is True
+
+    def test_normal_output_not_flagged(self):
+        assert _is_error_output("Sun Jul  5 12:00:00 AM EDT 2026") is False
+        assert _is_error_output("step1") is False
+        assert _is_error_output("") is False


### PR DESCRIPTION
## The soak finding — "the kind of little lie that becomes an incident wearing a hat"

Your battery's step 8 exposed it: `delegate_task` ran two commands that both returned `Unknown or disallowed host: playground`, and the task reported **"All 2 steps succeeded."** Pre-existing (zero campaign diff in `background_task.py`); same failure class PR #130 fixed for the chat loop.

### Root cause
1. `_execute_tool`'s executor path did `return str(await executor.execute(...))` — the structured `ToolResult.ok` discarded at the boundary.
2. `_is_error_output` recognized only three literal prefixes (`Error executing `, `Unknown tool: `, `Permission denied: `) — the executor's canonical error grammar (`_ERROR_RESULT_PREFIXES`) never consulted.

### Fix (established pattern, minimal churn)
- Executor path returns the `ToolResult` (other branches unchanged, still plain strings).
- `run_background_task` consumes `.ok` directly, and applies `ensure_failure_visible` so the posted step output carries the canonical `Error (tool reported failure):` marking — identical to chat/loop pipelines.
- `_is_error_output` extended with `_ERROR_RESULT_PREFIXES` for plain-string branches.

### Behavior changes (intended)
- Step statuses honest → progress/completion messages and `list_tasks` icons truthful; completion says "X succeeded, Y failed".
- **Default `on_failure=abort` now actually aborts** on a structurally-failed step (previously sailed on).
- Audit entries for failed steps carry the `error` field.

### Verification
8 new tests: ok=False → error status + honest completion text; ok=True unchanged; canonical marking; abort-on-failure; audit error field; heuristic coverage (canonical + legacy prefixes, negatives). Full suite **6048 passed / 4 skipped** (6040 + 8). `background_task.py` lint finding-set byte-identical to baseline.

### Review + deploy plan
On your approval: merge into the campaign branch → redeploy /opt/odin → live re-test over the bridge (delegate_task with a denied host must now report failure; localhost task must still succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)