### PR TITLE
fix: smooth .deb install experience for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,27 +89,69 @@ Discord ──> OdinBot (client.py)
                ├── Knowledge Store ──> FTS5 + vector search
                ├── Session Manager ──> Per-channel history + compaction
                ├── Browser (native Playwright) ──> Screenshots, page reading, JS eval
-               └── Web API (aiohttp) ──> 154 REST endpoints + WebSocket
+               └── Web API (aiohttp) ──> 183 REST endpoints + WebSocket
 ```
 
-## Quick Start
+## Install
+
+### Debian / Ubuntu (recommended)
+
+Odin ships as a `.deb` on the [releases page](https://github.com/Calmingstorm/Odin/releases). It installs to `/opt/odin`, runs as a dedicated `odin` system user under systemd, and keeps config in `/etc/odin` and data in `/var/lib/odin` (FHS layout).
 
 ```bash
-# 1. Clone and install
+# Download the latest release .deb, then:
+sudo apt install ./odin_*.deb
+```
+
+The installer provisions the service (system user, Python venv + dependencies, SSH key, systemd unit) **non-interactively** and prints the first-time-setup steps. It does **not** start Odin automatically — you set the Discord token and LLM credentials first (below). Requires Python ≥ 3.11 (`python3-venv`); dependencies are pulled automatically.
+
+Upgrades preserve `/etc/odin` and `/var/lib/odin` and restart the service if it was running.
+
+### From source (development)
+
+```bash
 git clone https://github.com/Calmingstorm/Odin.git
 cd Odin
 pip install -e ".[dev]"
-playwright install chromium
+playwright install chromium          # optional — enables browser_* tools
 
-# 2. Configure
-cp .env.example .env        # Add your Discord bot token
-edit config.yml              # Set hosts, Codex credentials, etc.
-
-# 3. Run
+cp .env.example .env                 # set DISCORD_TOKEN
+$EDITOR config.yml                   # hosts, LLM, permissions
 python -m src
 ```
 
-The web UI starts automatically at the configured port (default 3000). Set `web.api_token` in config.yml to require authentication.
+The web UI starts automatically on the configured port (default **3000**). Set `web.api_token` in `config.yml` to require authentication.
+
+## First-time setup
+
+After installing the `.deb`, complete these three steps (the service is enabled but not yet started):
+
+**1. Discord bot token.** Create a bot at the [Discord developer portal](https://discord.com/developers/applications), enable **MESSAGE CONTENT INTENT** under Bot settings, then:
+
+```bash
+sudoedit /etc/odin/.env              # set DISCORD_TOKEN=...
+```
+
+**2. LLM backend.** Odin's primary backend is OpenAI Codex (a ChatGPT Plus/Team account). Authenticate as the `odin` user with the installed virtualenv:
+
+```bash
+sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py
+# headless server? add --device for the browserless device-code flow
+```
+
+Repeat to add more accounts for automatic rate-limit rotation. You can instead configure **Kimi** or **Ollama** from the web UI — see [LLM Configuration](#llm-configuration).
+
+**3. Review config and start.**
+
+```bash
+sudoedit /etc/odin/config.yml        # hosts, permissions (localhost + admin tier ship by default)
+sudo systemctl start odin
+sudo journalctl -u odin -f           # watch it connect
+```
+
+Then open the dashboard at **http://localhost:3000**. Set `web.api_token` in `config.yml` to require authentication before exposing it.
+
+*(From-source installs use `data/codex_auth.json` under the repo and `python scripts/codex_login.py` instead of the `/opt/odin` paths above.)*
 
 ## LLM Configuration
 
@@ -125,7 +167,7 @@ All providers are configured from the WebUI with inline auto-save — no config 
 
 ### Codex Authentication
 
-Codex uses OpenAI OAuth tokens stored in `data/codex_auth.json`.
+Codex uses OpenAI OAuth tokens stored in `data/codex_auth.json`. On a `.deb` install, run the login script with the installed virtualenv as the `odin` user (`sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py`); the commands below are the from-source equivalents.
 
 **Browser login** (machine with a browser):
 ```bash
@@ -174,7 +216,7 @@ Tokens auto-refresh at runtime. Re-run the login script if the bot is offline fo
 - **`web`**: port, API token, session timeout
 - **`permissions`**: default tier, per-user overrides
 
-## Tools (70)
+## Tools (74)
 
 | Category | Tools |
 |----------|-------|
@@ -186,17 +228,19 @@ Tokens auto-refresh at runtime. Re-run the login script if the bot is offline fo
 | Skills | `create_skill`, `edit_skill`, `delete_skill`, `list_skills`, `enable_skill`, `disable_skill`, `install_skill`, `export_skill`, `skill_status`, `invoke_skill` |
 | Knowledge & Memory | `memory_manage`, `manage_list`, `search_history`, `search_audit`, `search_knowledge`, `ingest_document`, `bulk_ingest_knowledge`, `list_knowledge`, `delete_knowledge` |
 | Web & Browser | `web_search`, `fetch_url`, `browser_screenshot`, `browser_read_page`, `browser_read_table`, `browser_click`, `browser_fill`, `browser_evaluate` |
+| Email | `email_send`, `email_search`, `email_read`, `email_list_recent` |
 | Discord | `read_channel`, `add_reaction`, `create_poll`, `purge_messages` |
 | Validation & Security | `validate_action`, `set_permission`, `issue_tracker` |
 
 ## Testing
 
 ```bash
-# Full suite (105 files, ~3,584 test functions)
+# Full suite (124 files, 6,000+ tests; asyncio auto mode)
 pytest tests/ -q
 
-# Skip slow/optional tests
-pytest tests/ --ignore=tests/test_tools -q
+# One file or pattern
+pytest tests/test_client.py -q
+pytest tests/ -k scheduler -q
 ```
 
 ## Project Structure
@@ -234,14 +278,14 @@ src/
   knowledge/store.py       FTS5 + vector knowledge base
   health/server.py         aiohttp web server + auth middleware
   web/
-    api.py                 154 REST endpoints
+    api.py                 183 REST endpoints
     websocket.py           Live event streaming + WS chat
   audit/logger.py          HMAC-chainable audit log
   learning/reflector.py    Cross-conversation learning (90-day expiry)
   trajectories/saver.py    Per-turn JSONL trajectory logging
 
 ui/                        Vue 3 + Tailwind web dashboard (19 pages)
-tests/                     105 files, ~3,584 test functions
+tests/                     124 files, 6,000+ tests
 config.yml                 Default configuration template
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ sudoedit /etc/odin/.env              # set DISCORD_TOKEN=...
 **2. LLM backend.** Odin's primary backend is OpenAI Codex (a ChatGPT Plus/Team account). Authenticate as the `odin` user with the installed virtualenv:
 
 ```bash
-sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py
+sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py \
+     --credentials-path /var/lib/odin/codex_auth.json
 # headless server? add --device for the browserless device-code flow
 ```
 
@@ -167,7 +168,7 @@ All providers are configured from the WebUI with inline auto-save — no config 
 
 ### Codex Authentication
 
-Codex uses OpenAI OAuth tokens stored in `data/codex_auth.json`. On a `.deb` install, run the login script with the installed virtualenv as the `odin` user (`sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py`); the commands below are the from-source equivalents.
+Codex uses OpenAI OAuth tokens stored in `data/codex_auth.json`. On a `.deb` install, run the login script with the installed virtualenv as the `odin` user and an **absolute** credentials path (the script writes relative to the caller's cwd otherwise): `sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py --credentials-path /var/lib/odin/codex_auth.json`. The commands below are the from-source equivalents.
 
 **Browser login** (machine with a browser):
 ```bash

--- a/config.yml
+++ b/config.yml
@@ -218,8 +218,8 @@ browser:
   # Allow browser tools to access specific local/private URLs (bypasses SSRF block).
   # Use for validating local WebUI, dev servers, etc.
   allow_private_targets:
-    - "http://127.0.0.1:3002"
-    - "http://localhost:3002"
+    - "http://127.0.0.1:3000"
+    - "http://localhost:3000"
 
 permissions:
   default_tier: admin

--- a/packaging/nfpm.yml
+++ b/packaging/nfpm.yml
@@ -9,8 +9,8 @@ priority: optional
 maintainer: Odin Maintainers <odin@localhost>
 description: |
   Odin — autonomous execution agent on Discord.
-  72 tools, shell access, browser automation, scheduled tasks,
-  sub-agents, knowledge base, and a 19-page web management UI.
+  74 tools, shell access, browser automation, scheduled tasks,
+  sub-agents, knowledge base, and a web management UI.
 vendor: Odin
 homepage: https://github.com/Calmingstorm/Odin
 license: MIT

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Odin .deb post-installation script.
+#
+# Debian policy forbids interactive prompts in maintainer scripts (they run
+# non-interactively under apt/dpkg, cloud-init, Ansible, CI, etc.). This
+# script is therefore fully non-interactive: it provisions the service and
+# prints next-steps. First-time configuration (Discord token, Codex login)
+# is done by the operator afterwards — see the printed instructions and the
+# README "First-time setup" section.
 set -e
 
 SERVICE_USER="odin"
@@ -7,6 +15,7 @@ APP_DIR="/opt/odin"
 CONFIG_DIR="/etc/odin"
 DATA_DIR="/var/lib/odin"
 LOG_DIR="/var/log/odin"
+WEB_PORT="3000"  # matches config.yml default web.port
 
 echo "Odin postinstall: setting up..."
 
@@ -26,11 +35,13 @@ mkdir -p "$CONFIG_DIR"
 mkdir -p "$DATA_DIR"/{sessions,context,skills,search,knowledge,trajectories}
 mkdir -p "$LOG_DIR"
 
-# Enable passwordless sudo for the odin user
+# Enable passwordless sudo for the odin user (Odin runs privileged host
+# operations; scope this down in /etc/sudoers.d/99-odin-passwordless if you
+# want to restrict what it can run — see docs/security.md).
 if [ ! -f /etc/sudoers.d/99-odin-passwordless ]; then
     printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$SERVICE_USER" > /etc/sudoers.d/99-odin-passwordless
     chmod 0440 /etc/sudoers.d/99-odin-passwordless
-    echo "  Passwordless sudo enabled for $SERVICE_USER"
+    echo "  Passwordless sudo enabled for $SERVICE_USER (restrict in /etc/sudoers.d/99-odin-passwordless)"
 fi
 
 # Install config templates (preserve existing on upgrade)
@@ -51,7 +62,6 @@ if [ ! -f "$CONFIG_DIR/.env" ]; then
 DISCORD_TOKEN=
 ENVEOF
     fi
-    FRESH_INSTALL=true
 fi
 
 # Create symlinks so the app sees config/data in its working directory
@@ -68,21 +78,20 @@ if [ ! -d "$APP_DIR/.venv" ]; then
 fi
 
 # Install Python dependencies from pyproject.toml
-echo "  Installing Python dependencies..."
+echo "  Installing Python dependencies (this can take a few minutes)..."
 if [ -f "$APP_DIR/pyproject.toml" ]; then
     "$APP_DIR/.venv/bin/pip" install --quiet "$APP_DIR" 2>/dev/null || \
-        echo "  Warning: pip install from pyproject.toml failed — install dependencies manually"
+        echo "  Warning: pip install failed — run '$APP_DIR/.venv/bin/pip install $APP_DIR' manually"
 fi
 
-# Install Playwright browsers for native browser support
+# Install Playwright browsers for native browser support (optional feature)
 "$APP_DIR/.venv/bin/playwright" install chromium 2>/dev/null || \
-    echo "  Warning: playwright install failed — browser tools may not work"
+    echo "  Note: playwright browser install skipped — the browser_* tools stay disabled until you run '$APP_DIR/.venv/bin/playwright install chromium'"
 
 # Generate SSH key for the odin user if none exists
 if [ ! -f "$APP_DIR/.ssh/id_ed25519" ]; then
     mkdir -p "$APP_DIR/.ssh"
     ssh-keygen -t ed25519 -f "$APP_DIR/.ssh/id_ed25519" -N "" -q
-    chown -R "$SERVICE_USER:$SERVICE_GROUP" "$APP_DIR/.ssh"
     chmod 700 "$APP_DIR/.ssh"
     chmod 600 "$APP_DIR/.ssh/id_ed25519"
     echo "  SSH key generated at $APP_DIR/.ssh/id_ed25519"
@@ -94,99 +103,52 @@ chown -R "$SERVICE_USER:$SERVICE_GROUP" "$CONFIG_DIR"
 chmod 600 "$CONFIG_DIR/.env"
 chown root:root /usr/lib/systemd/system/odin.service
 
-# Enable systemd service
+# Enable the service (do NOT auto-start on a fresh install — it would crash-loop
+# until the Discord token is set). On upgrades, restart only if already running.
 systemctl daemon-reload
-systemctl enable odin.service
+systemctl enable odin.service >/dev/null 2>&1 || true
+if [ "$FRESH_INSTALL" = false ] && systemctl is-active --quiet odin.service; then
+    echo "  Upgrade detected — restarting odin.service..."
+    systemctl restart odin.service || true
+fi
 
 echo ""
-echo "============================================"
-echo "  Odin installed successfully."
-echo "============================================"
+echo "============================================================"
+echo "  Odin installed."
+echo "============================================================"
 
 if [ "$FRESH_INSTALL" = true ]; then
-    echo ""
-    echo "=== Guided Setup ==="
-    echo ""
+    SSH_PUB="$(cat "$APP_DIR/.ssh/id_ed25519.pub" 2>/dev/null || echo '(key not generated)')"
+    cat << SETUPEOF
 
-    # Step 1: Discord token
-    echo "Step 1: Discord Bot Token"
-    echo "  Create a bot at https://discord.com/developers/applications"
-    echo "  Enable MESSAGE CONTENT INTENT under Bot settings"
-    echo ""
-    read -p "  Paste your Discord bot token (or press Enter to skip): " DISCORD_TOKEN_INPUT
-    if [ -n "$DISCORD_TOKEN_INPUT" ]; then
-        sed -i "s|^DISCORD_TOKEN=.*|DISCORD_TOKEN=$DISCORD_TOKEN_INPUT|" "$CONFIG_DIR/.env"
-        echo "  Token saved to $CONFIG_DIR/.env"
-    else
-        echo "  Skipped — set it later: sudo editor $CONFIG_DIR/.env"
-    fi
-    echo ""
+First-time setup (3 steps — the service is enabled but not started yet):
 
-    # Step 2: OpenAI Codex credentials
-    echo "Step 2: OpenAI Codex Credentials"
-    echo "  Odin needs an OpenAI ChatGPT Plus/Team account for the LLM backend."
-    echo "  Run this command to authenticate (opens a browser):"
-    echo ""
-    echo "    cd $APP_DIR && sudo -u $SERVICE_USER python3 scripts/codex_login.py"
-    echo ""
-    echo "  You can do this now or after setup completes."
-    echo "  Multiple accounts can be added for rate-limit rotation."
-    echo ""
+  1. Set your Discord bot token
+       sudoedit $CONFIG_DIR/.env         # set DISCORD_TOKEN=...
+     Create the bot at https://discord.com/developers/applications and
+     enable MESSAGE CONTENT INTENT under the Bot settings.
 
-    # Step 3: localhost host
-    echo "Step 3: Host Configuration"
-    echo "  Odin needs at least localhost configured to run shell commands."
-    if grep -q "hosts:" "$CONFIG_DIR/config.yml" 2>/dev/null; then
-        echo "  Hosts section already exists in config.yml"
-    else
-        echo "  Adding localhost to config.yml..."
-        cat >> "$CONFIG_DIR/config.yml" << 'HOSTEOF'
+  2. Authenticate the LLM backend (OpenAI Codex, ChatGPT Plus/Team account)
+       sudo -u $SERVICE_USER $APP_DIR/.venv/bin/python $APP_DIR/scripts/codex_login.py
+     Add --device on a headless server. Repeat to add more accounts for
+     rate-limit rotation. (Or configure Kimi/Ollama in the web UI instead.)
 
-tools:
-  hosts:
-    localhost:
-      address: 127.0.0.1
-      ssh_user: odin
-      os: linux
-HOSTEOF
-        echo "  localhost added."
-    fi
-    echo ""
+  3. Review config and start Odin
+       sudoedit $CONFIG_DIR/config.yml   # hosts, permissions, etc. (optional)
+       sudo systemctl start odin
+       sudo journalctl -u odin -f        # watch it come up
 
-    # Step 4: Permissions
-    echo "Step 4: Permissions"
-    read -p "  Are you the only user? Set default_tier to admin? (y/N): " ADMIN_CHOICE
-    if [ "$ADMIN_CHOICE" = "y" ] || [ "$ADMIN_CHOICE" = "Y" ]; then
-        if grep -q "default_tier:" "$CONFIG_DIR/config.yml" 2>/dev/null; then
-            sed -i 's|default_tier:.*|default_tier: admin|' "$CONFIG_DIR/config.yml"
-        else
-            cat >> "$CONFIG_DIR/config.yml" << 'PERMEOF'
+  Web dashboard:  http://localhost:$WEB_PORT
+  Config file:    $CONFIG_DIR/config.yml
+  Secrets (.env): $CONFIG_DIR/.env
+  Full guide:     https://github.com/Calmingstorm/Odin#first-time-setup
 
-permissions:
-  default_tier: admin
-PERMEOF
-        fi
-        echo "  Set to admin. All users have full access."
-    else
-        echo "  Keeping default (user tier). Grant admin per-user via web dashboard."
-    fi
-    echo ""
+  This host's SSH public key (add to remote hosts Odin should manage):
+  $SSH_PUB
 
-    # Summary
-    echo "============================================"
-    echo "  Setup Complete!"
-    echo "============================================"
-    echo ""
-    echo "  Start Odin:    sudo systemctl start odin"
-    echo "  Watch logs:    sudo journalctl -u odin -f"
-    echo "  Web dashboard: http://localhost:8080"
-    echo "  Config:        $CONFIG_DIR/config.yml"
-    echo "  Secrets:       $CONFIG_DIR/.env"
-    echo "  Codex login:   cd $APP_DIR && sudo -u $SERVICE_USER python3 scripts/codex_login.py"
-    echo ""
-    echo "  SSH public key (for remote hosts):"
-    echo "  $(cat $APP_DIR/.ssh/id_ed25519.pub 2>/dev/null || echo '  (not generated)')"
-    echo ""
+SETUPEOF
 else
-    echo "Existing config preserved. Restart with: sudo systemctl restart odin"
+    echo ""
+    echo "  Existing config preserved in $CONFIG_DIR."
+    echo "  If the service was not running, start it with: sudo systemctl start odin"
 fi

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -129,7 +129,8 @@ First-time setup (3 steps — the service is enabled but not started yet):
      enable MESSAGE CONTENT INTENT under the Bot settings.
 
   2. Authenticate the LLM backend (OpenAI Codex, ChatGPT Plus/Team account)
-       sudo -u $SERVICE_USER $APP_DIR/.venv/bin/python $APP_DIR/scripts/codex_login.py
+       sudo -u $SERVICE_USER $APP_DIR/.venv/bin/python $APP_DIR/scripts/codex_login.py \\
+            --credentials-path $DATA_DIR/codex_auth.json
      Add --device on a headless server. Repeat to add more accounts for
      rate-limit rotation. (Or configure Kimi/Ollama in the web UI instead.)
 


### PR DESCRIPTION
## Empirically found by actually installing the .deb

I built the `.deb` from this branch with nfpm (same version/flags as `release.yml`), installed it in a **clean Ubuntu 24.04 container**, and followed the docs as a brand-new user. That surfaced a showstopper the file-reading alone wouldn't have proven.

### CRITICAL — the .deb failed to install non-interactively
`postinstall.sh` ran interactive `read -p` prompts under `set -e`. Under apt/dpkg (stdin isn't a TTY), cloud-init, Ansible, or CI, `read` hits EOF → returns non-zero → `set -e` aborts postinstall → **dpkg error 100, broken package**, service enabled but unconfigured. Interactive prompts in a maintainer script also violate Debian policy §6.3.

**Fix:** postinstall is now fully non-interactive — provisions the service and prints copy-paste first-time-setup steps. Service is enabled but **not auto-started** on fresh install (would crash-loop without a token); upgrades restart only if already running.

**Proof (throwaway container, destroyed after):**
| | before | after |
|---|---|---|
| `apt install ./odin.deb` (non-interactive) | **dpkg error 100** | **exit 0, `ii`** |
| systemd start | — | binds `0.0.0.0:3000`, attempts Discord login |

### Wrong info a new user reads
- postinstall said dashboard is at **:8080** → actual is **:3000** (health server bind confirmed).
- codex_login ran with system `python3` but the script imports `src.llm.codex_auth` → needs the venv. Now `/opt/odin/.venv/bin/python`. (README too.)
- `config.yml` `browser.allow_private_targets` listed **:3002** (live-install bleed) → **:3000**.

### Stale numbers
- nfpm: **72 → 74** tools (dropped the brittle "19-page" count).
- README: **154 → 183** REST endpoints (verified via `@routes` decorators); **Tools (70) → (74)** with the 4 missing `email_*` tools added; testing **"105 files, ~3,584" → "124 files, 6,000+ tests"**.

### The mission: README had no .deb path
Added an **Install** section (Debian/Ubuntu `.deb` recommended + from-source) and a **First-time setup** section — token, Codex login, start — on the FHS paths, which the postinstall now links to (`#first-time-setup`).

### Scope / safety
No `src/` changes. `config.yml` still parses against the Pydantic schema. **No master, no release pipeline, /opt/odin soak instance untouched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)