### PR TITLE
refactor(tool_loop): P1 — seam-carve run()/run_autonomous() into phase methods

### DIFF
--- a/src/discord/background_task.py
+++ b/src/discord/background_task.py
@@ -21,7 +21,7 @@ from ..odin_log import get_logger
 from ..tools.risk_classifier import classify_tool
 from ..tools.executor import _ERROR_RESULT_PREFIXES
 from ..tools.result_validator import ToolResult
-from .tool_loop import ensure_failure_visible
+from .tool_loop_helpers import ensure_failure_visible
 
 _EMAIL_BODY_TOOLS = frozenset({"email_send"})
 

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -21,6 +21,17 @@ from .completion import CLASSIFIER_SYSTEM_PROMPT, CompletionClassifier
 from .intake_pipeline import MessageIntake, MessagePipeline
 from .tool_loop import ToolLoopRunner, ensure_failure_visible
 from .tool_loop import _LoopAuthorProxy, _LoopMessageProxy  # noqa: F401 — re-export (tests, proxies)
+
+# Canonical homes moved to tool_loop_helpers (RFC-002 P1) — re-exported here
+# until P7 retires the facade spellings. _ALLOWED_WEBHOOK_IDS is the SAME set
+# object (mutated in place), so this binding stays live across env re-reads.
+from .tool_loop_helpers import (
+    _ALLOWED_WEBHOOK_IDS,  # noqa: F401 — re-export
+    _EMAIL_BODY_TOOLS,  # noqa: F401 — re-export
+    _EMPTY_RESPONSE_FALLBACK,  # noqa: F401 — re-export
+    _scrub_tool_input_for_storage,
+    init_allowed_webhook_ids as _init_allowed_webhook_ids_impl,
+)
 from .delivery import ResponseDelivery
 from .delivery import DISCORD_MAX_LEN  # noqa: F401 — module re-export contract
 from .delivery import SEND_MAX_RETRIES  # noqa: F401 — module re-export contract
@@ -55,13 +66,6 @@ INITIAL_EXTENSIONS: tuple[str, ...] = (
 )
 
 
-# Friendly fallback when Codex returns an empty response after retries
-_EMPTY_RESPONSE_FALLBACK = "I couldn't generate a response. Please try again."
-
-# Webhook IDs allowed to bypass the bot-author check.
-# Populated from ALLOWED_WEBHOOK_IDS env var (comma-separated) at startup.
-_ALLOWED_WEBHOOK_IDS: set[str] = set()
-
 # Patterns that might indicate a secret was pasted
 SECRET_SCRUB_PATTERNS = [
     re.compile(r"sk-[a-zA-Z0-9]{20,}"),
@@ -79,21 +83,6 @@ _LONG_TIMEOUT_TOOL_SET = frozenset({"claude_code"})  # Tools that get extended t
 
 # Pre-compiled regex for merging adjacent code blocks in combine_bot_messages
 _ADJACENT_FENCE_RE = re.compile(r"\n```[ \t]*\n\n```(\w*)[ \t]*\n")
-
-_EMAIL_BODY_TOOLS = frozenset({"email_send"})
-
-
-def _scrub_tool_input_for_storage(tool_name: str, tool_input: dict) -> dict:
-    """Redact privacy-sensitive fields from tool input before any storage path."""
-    if tool_name not in _EMAIL_BODY_TOOLS or not isinstance(tool_input, dict):
-        return tool_input
-    cleaned = dict(tool_input)
-    body = cleaned.get("body", "")
-    cleaned["body"] = f"[redacted email body: {len(body)} chars]"
-    if "attachments" in cleaned and cleaned["attachments"]:
-        from pathlib import Path
-        cleaned["attachments"] = [Path(p).name for p in cleaned["attachments"]]
-    return cleaned
 
 
 
@@ -480,11 +469,8 @@ class OdinBot(commands.Bot):
         self._prompt_builder.cached_skills_text = value
 
     def _init_allowed_webhook_ids(self) -> None:
-        """Populate _ALLOWED_WEBHOOK_IDS from ALLOWED_WEBHOOK_IDS env var."""
-        global _ALLOWED_WEBHOOK_IDS
-        raw = os.environ.get("ALLOWED_WEBHOOK_IDS", "")
-        if raw:
-            _ALLOWED_WEBHOOK_IDS = {wid.strip() for wid in raw.split(",") if wid.strip()}
+        """Populate the test-webhook allowlist from the ALLOWED_WEBHOOK_IDS env var."""
+        _init_allowed_webhook_ids_impl(os.environ.get("ALLOWED_WEBHOOK_IDS", ""))
 
     def _log_startup_config(self) -> None:
         """Log configuration summary at startup to help users verify setup."""

--- a/src/discord/intake_pipeline.py
+++ b/src/discord/intake_pipeline.py
@@ -38,7 +38,7 @@ class MessageIntake:
 
     async def handle(self, message: discord.Message) -> None:
         bot = self.host
-        from .client import _ALLOWED_WEBHOOK_IDS
+        from .tool_loop_helpers import _ALLOWED_WEBHOOK_IDS
 
         # Passive channel log — every guild message, including our own, before any filtering
         bot.channel_logger.log_message(message)
@@ -393,7 +393,7 @@ class MessagePipeline:
         voice_callback: Callable | None = None,
     ) -> None:
         bot = self.host
-        from .client import _EMPTY_RESPONSE_FALLBACK
+        from .tool_loop_helpers import _EMPTY_RESPONSE_FALLBACK
 
         user_id = str(message.author.id)
         # Prefix with display name so the LLM knows who's talking

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -1,24 +1,31 @@
-"""The chat tool-execution pipeline (RFC-001 Phase 7).
+"""The chat + autonomous tool-execution pipelines (RFC-001 P7/P8, RFC-002 P1).
 
-``ToolLoopRunner.run`` is the verbatim body of the old
-``OdinBot._process_with_tools`` — the iteration loop with context
-compression, the response-guard cascade, stuck-loop tracking, completion
-continuations, validation enforcement, parallel tool execution with
-timeouts, audit/trajectory recording, vision injection, skill handoff,
-and /stop cancellation.
+``ToolLoopRunner.run`` is the old ``OdinBot._process_with_tools`` — the
+iteration loop with context compression, the response-guard cascade,
+stuck-loop tracking, completion continuations, validation enforcement,
+parallel tool execution with timeouts, audit/trajectory recording, vision
+injection, skill handoff, and /stop cancellation. ``run_autonomous`` is
+the loop-iteration pipeline sharing the same dispatch table.
 
-Like the dispatch registry (P5a, approved), the runner takes the bot as
-``host`` and the moved body reads dependencies through it — that is the
-honest statement of today's coupling. P8 parameterizes the loop with an
-explicit policy when the autonomous pipeline folds in; interface
-narrowing rides with that phase.
+RFC-002 P1 carved both entry points into phase methods around per-turn
+state objects (``_ChatTurn`` / ``_LoopTurn``): every statement of the old
+bodies lands verbatim in exactly one phase method, with closure locals
+renamed to same-named turn-state fields (the mechanical map + AST gate
+ship with the P1 PR). Phase methods return ``("done", value)`` when the
+turn must return, ``("retry", None)``/None to continue — control flow
+stays in the two orchestrators.
+
+Like the dispatch registry (P5a), the runner still takes the bot as
+``host``; interface narrowing is RFC-002 P4. The chat-vs-loop behavioral
+asymmetries stay pinned as LoopPolicy data + control flow (RFC-001 §4.3)
+— do not unify a documented dimension without a characterization pin.
 """
 
 from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import discord
 
@@ -27,7 +34,6 @@ from ..llm.secret_scrubber import scrub_output_secrets
 from ..observability.correlation import get_turn, set_turn
 from ..odin_log import get_logger
 from ..tools import ToolResult
-from ..tools.executor import _ERROR_RESULT_PREFIXES
 from .delivery import DISCORD_MAX_LEN
 from .response_guards import (
     _CODE_HEDGING_RETRY_MSG,
@@ -45,23 +51,16 @@ from .response_guards import (
     detect_tool_unavailable,
     truncate_tool_output,
 )
+from .tool_loop_helpers import (
+    _ALLOWED_WEBHOOK_IDS,
+    _EMPTY_RESPONSE_FALLBACK,
+    _scrub_tool_input_for_storage,
+    ensure_failure_visible,  # noqa: F401 — re-export (client, tests)
+)
 
 log = get_logger("discord")
 
 _LONG_TIMEOUT_TOOL_SET = frozenset({"claude_code"})
-
-
-def ensure_failure_visible(result_text: str, ok: bool) -> str:
-    """Make a structurally-failed tool result visible to the model.
-
-    execute() carries ok=False on ToolResult, but the model only sees
-    str(result) — the raw output. When that text lacks an error prefix
-    (e.g. run_command_multi's per-host markdown aggregate wrapping a
-    denial), the model reads a refused action as success. Prefix it.
-    """
-    if ok or result_text.lstrip().startswith(_ERROR_RESULT_PREFIXES):
-        return result_text
-    return f"Error (tool reported failure):\n{result_text}"
 
 
 class _LoopMessageProxy:
@@ -151,9 +150,80 @@ def build_assistant_content(response) -> list[dict]:
     return assistant_content
 
 
+@dataclass
+class _ChatTurn:
+    """Per-turn mutable state of the chat pipeline (RFC-002 P1).
+
+    Field names deliberately match the pre-carve closure locals 1:1 —
+    the carve gate normalizes ``st.<name>`` back to ``<name>`` when
+    comparing phase bodies against the old inline blocks.
+    """
+
+    message: discord.Message
+    policy: LoopPolicy
+    trace: object | None
+    system_prompt: str  # rebound on skill-CRUD prompt rebuilds (was `nonlocal`)
+    tools: list | None
+    messages: list
+    user_id: str
+    chat_cap: int
+    stuck_tracker: object
+    _trajectory: object
+    _result_store_cap: int
+    _cancel: asyncio.Event
+    _ch_id: str
+    _req_id: str
+    iteration: int = 0
+    tools_used_in_loop: list = field(default_factory=list)
+    continuation_count: int = 0
+    max_continuations: int = 3
+    fabrication_retried: bool = False
+    promise_retried: bool = False
+    unavail_retried: bool = False
+    hedging_retried: bool = False
+    code_hedging_retried: bool = False
+    premature_failure_retried: bool = False
+    pending_image_blocks: list = field(default_factory=list)
+    _op_tool_details: list = field(default_factory=list)
+    _pending_validations: list = field(default_factory=list)
+    _validation_required: bool = False
+    _validation_retries: int = 0
+    _max_validation_retries: int = 2
+
+
+@dataclass
+class _LoopTurn:
+    """Per-iteration mutable state of the autonomous pipeline (RFC-002 P1)."""
+
+    prompt: str
+    channel: object
+    user_id: str
+    policy: LoopPolicy
+    msg_proxy: _LoopMessageProxy
+    requester_name: str
+    _loop_id: str
+    _trace: object | None
+    _trajectory: object | None
+    _result_store_cap: int
+    messages: list
+    system_prompt: str  # rebound on skill-CRUD rebuilds (was `nonlocal`)
+    tools: list | None
+    tool_timeout: float
+    channel_id_str: str
+    loop_cap: int
+    _loop_details: list = field(default_factory=list)
+    final_text: str = ""
+    completed_naturally: bool = False  # True only when a tool-free turn ended the loop
+    tool_calls_made: int = 0
+
+
 class ToolLoopRunner:
     def __init__(self, host) -> None:
         self.host = host
+
+    # ------------------------------------------------------------------
+    # Chat pipeline (old _process_with_tools) — orchestrator + phases
+    # ------------------------------------------------------------------
 
     async def run(
         self,
@@ -165,20 +235,6 @@ class ToolLoopRunner:
     ) -> tuple[str, bool, bool, list[str], bool]:
         """Process a message with the tool loop — see module docstring.
 
-        Returns (text, already_sent, is_error, tools_used, handoff).
-        """
-        bot = self.host
-        # Late imports from the client module (host of these module-level
-        # globals; a top-level import would be circular). _ALLOWED_WEBHOOK_IDS
-        # is rebound at startup, so the call-time import sees the live set.
-        from .client import (
-            _ALLOWED_WEBHOOK_IDS,
-            _EMPTY_RESPONSE_FALLBACK,
-            _scrub_tool_input_for_storage,
-        )
-
-        """Process a message with Codex tool loop.
-
         Returns (text, already_sent, is_error, tools_used, handoff):
         - text: the response text
         - already_sent: True if the response was streamed to Discord already
@@ -188,6 +244,76 @@ class ToolLoopRunner:
         - tools_used: list of tool names called during this loop
         - handoff: True if the response should be handed off to another handler
         """
+        st = await self._prepare_chat_turn(
+            message, history, system_prompt_override, trace, policy
+        )
+
+        for iteration in range(st.chat_cap):
+            st.iteration = iteration
+            if st._cancel.is_set():
+                return self._stopped(st, "iteration_start")
+
+            self._maybe_compress(st)
+
+            kind, val = await self._call_llm(st)
+            if kind == "done":
+                return val
+            llm_resp = val
+
+            if st._cancel.is_set():
+                return self._stopped(st, "after_llm")
+
+            outcome = await self._check_stuck_and_record(st, llm_resp)
+            if outcome is not None:
+                kind, val = outcome
+                if kind == "done":
+                    return val
+                continue  # nudge injected — next iteration
+
+            # Gate on actual parsed tool calls, not is_tool_use (which is also
+            # true when stop_reason=="tool_use" with zero calls). The sibling
+            # loop already uses this stricter form; matching it prevents an
+            # empty-tool_use response from skipping finalization and re-looping.
+            if not llm_resp.tool_calls:
+                kind, val = await self._finalize_or_retry(st, llm_resp)
+                if kind == "done":
+                    return val
+                continue  # retry/continuation message injected
+
+            # Build internal-format assistant content from LLMResponse
+            # (the R5-extracted fragment; the pre-carve chat body inlined
+            # the byte-identical block).
+            st.messages.append(
+                {"role": "assistant", "content": build_assistant_content(llm_resp)}
+            )
+
+            tool_calls = llm_resp.tool_calls
+            st.tools_used_in_loop.extend(t.name for t in tool_calls)
+
+            tool_results = await self._execute_tool_calls(st, tool_calls)
+
+            outcome = await self._post_iteration(st, tool_calls, tool_results)
+            if outcome is not None:
+                return outcome[1]
+
+            handoff = self._check_skill_handoff(st, tool_calls, tool_results)
+            if handoff is not None:
+                return handoff[1]
+
+        return await self._finalize_cap_hit(st)
+
+    async def _prepare_chat_turn(
+        self,
+        message: discord.Message,
+        history: list[dict],
+        system_prompt_override: str | None,
+        trace,
+        policy: LoopPolicy,
+    ) -> _ChatTurn:
+        """Turn setup: prompt/tools resolution, request preamble, permission
+        filtering, trajectory + correlation init, cancellation wiring."""
+        bot = self.host
+
         system_prompt = system_prompt_override or bot._system_prompt
         tools = bot._merged_tool_definitions() if bot.config.tools.enabled else None
         messages = list(history)
@@ -232,27 +358,6 @@ class ToolLoopRunner:
             # No history — still provide message ID + channel context
             messages.insert(0, preamble)
 
-        # Track which tools are used during this loop for tool memory
-        # Local variable (not instance attr) to avoid cross-channel contamination
-        tools_used_in_loop: list[str] = []
-
-        # Continuation tracking: how many times we've injected continuation prompts
-        # Allow up to 3 continuations to support multi-step tasks
-        continuation_count = 0
-        max_continuations = 3
-
-        # Each first-response detector gets one retry via a flag.
-        # Using flags instead of iteration==0 allows cascading detection:
-        # if fabrication fires on iter 0 and hedging fires on iter 1,
-        # both get caught.  The `not tools_used_in_loop` guard already
-        # ensures these only fire before any tools have been called.
-        fabrication_retried = False
-        promise_retried = False
-        unavail_retried = False
-        hedging_retried = False
-        code_hedging_retried = False
-        premature_failure_retried = False
-
         user_id = str(message.author.id)
 
         # Filter tools based on user permission tier (skip for test webhooks)
@@ -264,9 +369,6 @@ class ToolLoopRunner:
             if api_allowed is not None and tools:
                 allowed_set = set(api_allowed)
                 tools = [t for t in tools if t["name"] in allowed_set]
-
-        # Collect image blocks from analyze_image calls for vision injection
-        pending_image_blocks: list[dict] = []
 
         chat_cap = bot.config.tools.max_tool_iterations_chat
         log.info(
@@ -283,7 +385,7 @@ class ToolLoopRunner:
         stuck_tracker = bot.stuck_loop_tracker_cls()
 
         # Per-turn trajectory accumulator — populated each iteration, saved at end.
-        from ..trajectories.saver import ToolIteration, TrajectoryTurn, stored_tool_results
+        from ..trajectories.saver import TrajectoryTurn
 
         _result_store_cap = int(
             getattr(
@@ -299,7 +401,6 @@ class ToolLoopRunner:
                 name=getattr(provider_cfg, "active_provider", "codex") if provider_cfg else "codex",
                 model=getattr(bot.llm_client, "model", "") or "",
             )
-        _op_tool_details: list[dict] = []
         _turn_ctx = get_turn() or {}
         _trajectory = TrajectoryTurn(
             message_id=str(getattr(message, "id", "")),
@@ -322,639 +423,704 @@ class ToolLoopRunner:
             **{k: v for k, v in _turn_ctx.items() if k in ("loop_id", "loop_iteration")},
         )
 
-        # Post-mutation validation state — persists across iterations
-        _pending_validations: list[str] = []
-        _validation_required: bool = False
-        _validation_retries: int = 0
-        _max_validation_retries = 2
-
         # Per-request cancellation via /stop command
         _ch_id = str(message.channel.id)
         _cancel = bot._cancel_events.setdefault(_ch_id, asyncio.Event())
         _req_id = req_hash
         bot._channel_state.set_active_request(_ch_id, _req_id)
 
-        def _clear_active():
-            bot._channel_state.clear_active_request(_ch_id, _req_id)
+        return _ChatTurn(
+            message=message,
+            policy=policy,
+            trace=trace,
+            system_prompt=system_prompt,
+            tools=tools,
+            messages=messages,
+            user_id=user_id,
+            chat_cap=chat_cap,
+            stuck_tracker=stuck_tracker,
+            _trajectory=_trajectory,
+            _result_store_cap=_result_store_cap,
+            _cancel=_cancel,
+            _ch_id=_ch_id,
+            _req_id=_req_id,
+        )
 
-        def _stopped(where: str) -> tuple[str, bool, bool, list[str], bool]:
-            log.info("Task stopped by /stop in channel %s at %s", _ch_id, where)
-            _clear_active()
-            suffix = ""
-            if _pending_validations or _validation_required:
-                suffix = " Pending post-action validation was not run."
-            tools_note = (
-                f" Tools used: {', '.join(tools_used_in_loop)}." if tools_used_in_loop else ""
-            )
-            return (
-                f"Task stopped by user.{tools_note}{suffix}",
-                False,
-                False,
-                tools_used_in_loop,
-                False,
-            )
+    def _clear_active(self, st: _ChatTurn) -> None:
+        bot = self.host
+        bot._channel_state.clear_active_request(st._ch_id, st._req_id)
 
-        for iteration in range(chat_cap):
-            if _cancel.is_set():
-                return _stopped("iteration_start")
-            # Context auto-compression — when accumulated tool iterations push
-            # the message list over the configured budget, summarise older
-            # iterations into a single text message and keep the most recent N
-            # iterations intact.
-            if bot.context_compressor is not None and iteration > 0:
-                try:
-                    from ..llm.context_compressor import (
-                        compress_tool_context,
-                        estimate_message_chars,
-                    )
+    def _stopped(self, st: _ChatTurn, where: str) -> tuple[str, bool, bool, list[str], bool]:
+        log.info("Task stopped by /stop in channel %s at %s", st._ch_id, where)
+        self._clear_active(st)
+        suffix = ""
+        if st._pending_validations or st._validation_required:
+            suffix = " Pending post-action validation was not run."
+        tools_note = (
+            f" Tools used: {', '.join(st.tools_used_in_loop)}." if st.tools_used_in_loop else ""
+        )
+        return (
+            f"Task stopped by user.{tools_note}{suffix}",
+            False,
+            False,
+            st.tools_used_in_loop,
+            False,
+        )
 
-                    if estimate_message_chars(messages) > bot.context_compressor.max_context_chars:
-                        messages, _saved = compress_tool_context(
-                            messages,
-                            max_context_chars=bot.context_compressor.max_context_chars,
-                            keep_recent=bot.context_compressor.keep_recent_iterations,
-                        )
-                        log.info("context_compressor: trimmed %d chars", _saved)
-                except Exception:
-                    log.exception(
-                        "context_compressor failed (non-fatal); continuing with full context"
-                    )
-
-            # Show typing indicator while waiting for LLM response.
-            # Typing is best-effort — isolate typing setup failures from
-            # LLM call failures so we don't misclassify provider errors.
-            typing_cm = None
+    def _maybe_compress(self, st: _ChatTurn) -> None:
+        """Context auto-compression — when accumulated tool iterations push
+        the message list over the configured budget, summarise older
+        iterations into a single text message and keep the most recent N
+        iterations intact."""
+        bot = self.host
+        if bot.context_compressor is not None and st.iteration > 0:
             try:
-                typing_cm = message.channel.typing()
-                await typing_cm.__aenter__()
-            except (discord.HTTPException, ConnectionError, OSError) as typing_err:
-                log.warning("Typing indicator failed (non-fatal): %s", typing_err)
-                typing_cm = None
+                from ..llm.context_compressor import (
+                    compress_tool_context,
+                    estimate_message_chars,
+                )
 
-            _channel_id = str(message.channel.id)
+                if estimate_message_chars(st.messages) > bot.context_compressor.max_context_chars:
+                    st.messages, _saved = compress_tool_context(
+                        st.messages,
+                        max_context_chars=bot.context_compressor.max_context_chars,
+                        keep_recent=bot.context_compressor.keep_recent_iterations,
+                    )
+                    log.info("context_compressor: trimmed %d chars", _saved)
+            except Exception:
+                log.exception(
+                    "context_compressor failed (non-fatal); continuing with full context"
+                )
+
+    async def _call_llm(self, st: _ChatTurn):
+        """Guarded LLM call with typing indicator and circuit-breaker recovery.
+
+        Returns ("ok", llm_resp) or ("done", <run() return tuple>).
+        """
+        bot = self.host
+        # Show typing indicator while waiting for LLM response.
+        # Typing is best-effort — isolate typing setup failures from
+        # LLM call failures so we don't misclassify provider errors.
+        typing_cm = None
+        try:
+            typing_cm = st.message.channel.typing()
+            await typing_cm.__aenter__()
+        except (discord.HTTPException, ConnectionError, OSError) as typing_err:
+            log.warning("Typing indicator failed (non-fatal): %s", typing_err)
+            typing_cm = None
+
+        _channel_id = str(st.message.channel.id)
+        try:
+            llm_resp = await bot._codex_call(
+                messages=st.messages,
+                system=st.system_prompt,
+                tools=st.tools or [],
+                user_message=getattr(st.message, "content", "") or "",
+                user_id=st.user_id,
+                channel_id=_channel_id,
+                tools_used=st.tools_used_in_loop,
+            )
+        except CircuitOpenError as coe:
+            wait_secs = min(coe.retry_after, 90.0)
+            log.info(
+                "Circuit breaker open for %s, waiting %.0fs for recovery",
+                coe.provider,
+                wait_secs,
+            )
+            await asyncio.sleep(wait_secs)
             try:
                 llm_resp = await bot._codex_call(
-                    messages=messages,
-                    system=system_prompt,
-                    tools=tools or [],
-                    user_message=getattr(message, "content", "") or "",
-                    user_id=user_id,
+                    messages=st.messages,
+                    system=st.system_prompt,
+                    tools=st.tools or [],
+                    user_id=st.user_id,
                     channel_id=_channel_id,
-                    tools_used=tools_used_in_loop,
+                    tools_used=st.tools_used_in_loop,
                 )
-            except CircuitOpenError as coe:
-                wait_secs = min(coe.retry_after, 90.0)
-                log.info(
-                    "Circuit breaker open for %s, waiting %.0fs for recovery",
-                    coe.provider,
-                    wait_secs,
+            except Exception as retry_err:
+                await bot._save_turn_trajectory(
+                    st._trajectory, error=str(retry_err), trace=st.trace
                 )
-                await asyncio.sleep(wait_secs)
-                try:
-                    llm_resp = await bot._codex_call(
-                        messages=messages,
-                        system=system_prompt,
-                        tools=tools or [],
-                        user_id=user_id,
-                        channel_id=_channel_id,
-                        tools_used=tools_used_in_loop,
-                    )
-                except Exception as retry_err:
-                    await bot._save_turn_trajectory(_trajectory, error=str(retry_err), trace=trace)
-                    _clear_active()
-                    return (
+                self._clear_active(st)
+                return (
+                    "done",
+                    (
                         f"LLM API error (circuit breaker recovery failed): {retry_err}",
                         False,
                         True,
-                        tools_used_in_loop,
+                        st.tools_used_in_loop,
                         False,
-                    )
-            except Exception as api_err:
-                err_msg = str(api_err) or f"{type(api_err).__name__} (no message)"
-                log.error("LLM API call failed: %s", err_msg, exc_info=True)
-                await bot._save_turn_trajectory(_trajectory, error=err_msg, trace=trace)
-                _clear_active()
-                return f"LLM API error: {err_msg}", False, True, tools_used_in_loop, False
-            finally:
-                if typing_cm is not None:
-                    try:
-                        await typing_cm.__aexit__(None, None, None)
-                    except Exception:
-                        pass
-
-            if _cancel.is_set():
-                return _stopped("after_llm")
-
-            # Record this iteration's tool calls + LLM text into the trajectory and stuck tracker
-            iter_tool_calls = [
-                {"id": tc.id, "name": tc.name, "input": tc.input}
-                for tc in (llm_resp.tool_calls or [])
-            ]
-            _trajectory.iterations.append(
-                ToolIteration(
-                    iteration=iteration,
-                    tool_calls=iter_tool_calls,
-                    llm_text=llm_resp.text or "",
-                    input_tokens=llm_resp.input_tokens,
-                    output_tokens=llm_resp.output_tokens,
+                    ),
                 )
+        except Exception as api_err:
+            err_msg = str(api_err) or f"{type(api_err).__name__} (no message)"
+            log.error("LLM API call failed: %s", err_msg, exc_info=True)
+            await bot._save_turn_trajectory(st._trajectory, error=err_msg, trace=st.trace)
+            self._clear_active(st)
+            return (
+                "done",
+                (f"LLM API error: {err_msg}", False, True, st.tools_used_in_loop, False),
             )
-            stuck_tracker.record(iter_tool_calls)
-            if stuck_tracker.check():
-                if stuck_tracker.warned:
-                    log.warning("Stuck loop confirmed after warning — terminating tool loop")
-                    await bot._save_turn_trajectory(_trajectory, trace=trace)
-                    await bot._emit_lifecycle_event(
-                        "loop.stuck",
-                        {
-                            "channel_id": str(message.channel.id),
-                            "iteration": iteration,
-                            "tools_used": tools_used_in_loop,
-                        },
-                    )
-                    _clear_active()
-                    return (
+        finally:
+            if typing_cm is not None:
+                try:
+                    await typing_cm.__aexit__(None, None, None)
+                except Exception:
+                    pass
+
+        return ("ok", llm_resp)
+
+    async def _check_stuck_and_record(self, st: _ChatTurn, llm_resp):
+        """Record this iteration's tool calls + LLM text into the trajectory
+        and stuck tracker; terminate or nudge on a confirmed repeat cycle.
+
+        Returns None to proceed, ("retry", None) after injecting the nudge,
+        or ("done", <run() return tuple>) on confirmed-stuck termination.
+        """
+        bot = self.host
+        from ..trajectories.saver import ToolIteration
+
+        iter_tool_calls = [
+            {"id": tc.id, "name": tc.name, "input": tc.input}
+            for tc in (llm_resp.tool_calls or [])
+        ]
+        st._trajectory.iterations.append(
+            ToolIteration(
+                iteration=st.iteration,
+                tool_calls=iter_tool_calls,
+                llm_text=llm_resp.text or "",
+                input_tokens=llm_resp.input_tokens,
+                output_tokens=llm_resp.output_tokens,
+            )
+        )
+        st.stuck_tracker.record(iter_tool_calls)
+        if st.stuck_tracker.check():
+            if st.stuck_tracker.warned:
+                log.warning("Stuck loop confirmed after warning — terminating tool loop")
+                await bot._save_turn_trajectory(st._trajectory, trace=st.trace)
+                await bot._emit_lifecycle_event(
+                    "loop.stuck",
+                    {
+                        "channel_id": str(st.message.channel.id),
+                        "iteration": st.iteration,
+                        "tools_used": st.tools_used_in_loop,
+                    },
+                )
+                self._clear_active(st)
+                return (
+                    "done",
+                    (
                         (
-                            f"Detected a stuck tool-call cycle after {iteration + 1} iterations. "
+                            f"Detected a stuck tool-call cycle after {st.iteration + 1} "
+                            f"iterations. "
                             f"Stopping to avoid burning the iteration budget on a repeat pattern."
                         ),
                         False,
                         True,
-                        tools_used_in_loop,
+                        st.tools_used_in_loop,
                         False,
-                    )
-                else:
-                    stuck_tracker.warned = True
-                    log.info("Stuck pattern detected — injecting nudge")
-                    messages.append(
-                        {
-                            "role": "developer",
-                            "content": (
-                                "You appear to be repeating the same tool-call sequence. "
-                                "Try a different approach or summarise progress and stop."
-                            ),
-                        }
-                    )
-                    continue
-            # Gate on actual parsed tool calls, not is_tool_use (which is also
-            # true when stop_reason=="tool_use" with zero calls). The sibling
-            # loop already uses this stricter form; matching it prevents an
-            # empty-tool_use response from skipping finalization and re-looping.
-            if not llm_resp.tool_calls:
-                if _cancel.is_set():
-                    return _stopped("before_validation")
-                # Enforce pending validation before allowing final response
-                if _validation_required and _validation_retries < _max_validation_retries:
-                    _validation_retries += 1
-                    log.warning(
-                        "Validation required but model returned text — "
-                        "forcing continuation (attempt %d)",
-                        _validation_retries,
-                    )
-                    messages.append(
-                        {
-                            "role": "developer",
-                            "content": (
-                                "[VALIDATION REQUIRED] You have pending post-action validation. "
-                                "Call validate_action before responding to the user."
-                            ),
-                        }
-                    )
-                    continue
-
-                # Fabrication detection: if no tools were called and the
-                # response looks like it fabricated results, retry once.
-                if (
-                    not fabrication_retried
-                    and not tools_used_in_loop
-                    and detect_fabrication(llm_resp.text or "", tools_used_in_loop)
-                ):
-                    log.warning("Fabrication detected — retrying with correction")
-                    fabrication_retried = True
-                    messages.append(_FABRICATION_RETRY_MSG)
-                    continue
-
-                if (
-                    not promise_retried
-                    and not tools_used_in_loop
-                    and detect_promise_without_action(llm_resp.text or "", tools_used_in_loop)
-                ):
-                    log.warning("Promise without action detected — retrying")
-                    promise_retried = True
-                    messages.append(_PROMISE_RETRY_MSG)
-                    continue
-
-                if (
-                    not unavail_retried
-                    and not tools_used_in_loop
-                    and detect_tool_unavailable(llm_resp.text or "", tools_used_in_loop)
-                ):
-                    log.warning("Tool-unavailability fabrication detected — retrying")
-                    unavail_retried = True
-                    messages.append(_TOOL_UNAVAIL_RETRY_MSG)
-                    continue
-
-                # Hedging detection: fires for ALL messages — Odin is an
-                # executor, not a menu system.
-                if (
-                    not hedging_retried
-                    and not tools_used_in_loop
-                    and detect_hedging(llm_resp.text or "", tools_used_in_loop)
-                ):
-                    log.warning("Hedging detected — retrying")
-                    hedging_retried = True
-                    messages.append(_HEDGING_RETRY_MSG)
-                    continue
-
-                if (
-                    not code_hedging_retried
-                    and not tools_used_in_loop
-                    and detect_code_hedging(llm_resp.text or "", tools_used_in_loop)
-                ):
-                    log.warning("Code-block hedging detected — retrying")
-                    code_hedging_retried = True
-                    messages.append(_CODE_HEDGING_RETRY_MSG)
-                    continue
-
-                # Premature failure: tools were called but gave up after one error
-                if (
-                    not premature_failure_retried
-                    and tools_used_in_loop
-                    and detect_premature_failure(llm_resp.text or "", tools_used_in_loop)
-                ):
-                    log.warning("Premature failure detected — retrying")
-                    premature_failure_retried = True
-                    messages.append(_FAILURE_RETRY_MSG)
-                    continue
-
-                # Tier 3: Completion classifier — uses LLM to judge whether
-                # the user's request was fully addressed.
-                if tools_used_in_loop and continuation_count < max_continuations:
-                    is_complete, reason = await bot._classify_completion(
-                        message.content,
-                        llm_resp.text or "",
-                        tools_used_in_loop,
-                    )
-                    if not is_complete:
-                        log.info(
-                            "Completion classifier: INCOMPLETE (%d/%d) "
-                            "after %d tool calls — injecting continuation",
-                            continuation_count + 1,
-                            max_continuations,
-                            len(tools_used_in_loop),
-                        )
-                        # Do NOT append the incomplete response as an assistant
-                        # message — inject the continuation nudge alone so
-                        # the model responds fresh with tool calls.
-                        if reason:
-                            messages.append(
-                                {
-                                    "role": "developer",
-                                    "content": (
-                                        f"You are not done. {reason}. Continue with tool calls now."
-                                    ),
-                                }
-                            )
-                        else:
-                            messages.append(_CONTINUATION_MSG)
-                        continuation_count += 1
-                        continue
-
-                _final = llm_resp.text or _EMPTY_RESPONSE_FALLBACK
-                await bot._save_turn_trajectory(
-                    _trajectory,
-                    final_response=_final,
-                    tools_used=tools_used_in_loop,
-                    trace=trace,
+                    ),
                 )
-                _clear_active()
-                return _final, False, False, tools_used_in_loop, False
-
-            # Build internal-format assistant content from LLMResponse
-            assistant_content: list[dict] = []
-            if llm_resp.text:
-                assistant_content.append({"type": "text", "text": llm_resp.text})
-            for tc in llm_resp.tool_calls:
-                assistant_content.append(
-                    {
-                        "type": "tool_use",
-                        "id": tc.id,
-                        "name": tc.name,
-                        "input": tc.input,
-                    }
-                )
-            messages.append({"role": "assistant", "content": assistant_content})
-
-            tool_calls = llm_resp.tool_calls
-            tools_used_in_loop.extend(t.name for t in tool_calls)
-
-            # Execute tools in parallel
-            async def _run_tool(block):
-                nonlocal system_prompt, pending_image_blocks
-                tool_name = block.name
-                tool_input = block.input
-                log.info("Tool call: %s(%s)", tool_name, tool_input)
-                # The provider could not parse the model's arguments — do NOT
-                # run the tool with a silently-empty input; bounce the error
-                # back so the model retries with valid arguments.
-                if getattr(block, "parse_error", None):
-                    log.warning("Tool call %s not executed: %s", tool_name, block.parse_error)
-                    return {
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": (
-                            f"Error: {block.parse_error}. The tool was NOT executed — "
-                            "re-issue the call with valid JSON arguments."
-                        ),
-                    }
-                # Central RBAC gate: Discord-native tools, skills, and MCP tools are
-                # dispatched below WITHOUT going through ToolExecutor.execute() (the only
-                # place check_permission runs). permissions.filter_tools is advisory
-                # (offer-time) only, so enforce permission here for EVERY tool.
-                _uid = str(message.author.id)
-                _rbac_denial = bot.tool_executor.check_permission(tool_name, _uid)
-                if isinstance(_rbac_denial, str) and _rbac_denial:  # str = deny, None = allow
-                    log.warning("RBAC gate denied tool %s for user %s", tool_name, _uid)
-                    return {"type": "tool_result", "tool_use_id": block.id, "content": _rbac_denial}
-                await bot._set_status(
-                    bot._TOOL_STATUS_LABELS.get(tool_name, f"Running: {tool_name}")
-                )
-
-                try:
-                    await bot.audit.log_event(
-                        event_type="tool_start",
-                        action=tool_name,
-                        actor=str(message.author.id),
-                        channel_id=str(message.channel.id),
-                        metadata={
-                            "tool_input_keys": list((tool_input or {}).keys()),
-                            "iteration": iteration,
-                        },
-                    )
-                except Exception:
-                    pass
-
-                t0 = time.monotonic()
-                error = None
-                tool_result = None
-                # Handle Discord-native tools
-                try:
-                    if bot._native_tools.handles(tool_name):
-                        result, _effects = await bot._native_tools.dispatch(
-                            tool_name,
-                            tool_input,
-                            message=message,
-                            user_id=user_id,
-                            skill_file_delivery=policy.skill_file_delivery,
-                        )
-                        if _effects.rebuild_system_prompt:
-                            system_prompt = bot._build_system_prompt(
-                                channel=message.channel,
-                                user_id=user_id,
-                            )
-                    else:
-                        tool_result = await bot.tool_executor.execute(
-                            tool_name,
-                            tool_input,
-                            user_id=user_id,
-                        )
-                        result = str(tool_result)
-                except TimeoutError as e:
-                    error = str(e)
-                    result = f"Tool {tool_name} timed out: {e}"
-                    tool_result = None
-                    log.warning("Tool %s timed out after %.1fs", tool_name, time.monotonic() - t0)
-                except (ValueError, KeyError, TypeError) as e:
-                    error = str(e)
-                    result = f"Tool {tool_name} input error: {e}"
-                    tool_result = None
-                except Exception as e:
-                    error = str(e)
-                    result = f"Error executing {tool_name}: {e}"
-                    tool_result = None
-                    log.warning("Unexpected tool error for %s: %s", tool_name, e)
-
-                elapsed_ms = int((time.monotonic() - t0) * 1000)
-
-                # Handle special image block return from analyze_image
-                if isinstance(result, dict) and "__image_block__" in result:
-                    pending_image_blocks.append(result["__image_block__"])
-                    result = (
-                        f"[Image loaded. Analyze it with this instruction: {result['__prompt__']}]"
-                    )
-
-                # Scrub secrets from tool output
-                result = scrub_output_secrets(result)
-
-                # Use structured metadata from ToolResult when available
-                if tool_result is not None:
-                    elapsed_ms = tool_result.duration_ms or elapsed_ms
-                    if tool_result.error and not error:
-                        error = tool_result.error
-                    if not tool_result.ok and not error:
-                        error = "tool reported failure"
-                    result = bot._ensure_failure_visible(result, tool_result.ok)
-
-                # Audit log — never crash tool execution on audit failure
-                try:
-                    scrubbed_input = _scrub_tool_input_for_storage(
-                        tool_name,
-                        {
-                            k: scrub_output_secrets(str(v)) if isinstance(v, str) else v
-                            for k, v in (tool_input or {}).items()
-                        },
-                    )
-                    await bot.audit.log_execution(
-                        user_id=str(message.author.id),
-                        user_name=str(message.author),
-                        channel_id=str(message.channel.id),
-                        tool_name=tool_name,
-                        tool_input=scrubbed_input,
-                        approved=True,
-                        result_summary=result,
-                        execution_time_ms=elapsed_ms,
-                        error=error,
-                        risk_level=tool_result.risk_level if tool_result else None,
-                        risk_reason=tool_result.risk_reason if tool_result else None,
-                    )
-                    await bot.audit.log_event(
-                        event_type="tool_end",
-                        action=tool_name,
-                        actor=str(message.author.id),
-                        channel_id=str(message.channel.id),
-                        detail=result[:150],
-                        metadata={"elapsed_ms": elapsed_ms, "error": error, "iteration": iteration},
-                    )
-                except Exception as audit_err:
-                    log.warning("Audit log failed for %s: %s", tool_name, audit_err)
-
-                # Track for conversational context
-                try:
-                    bot._track_recent_action(
-                        tool_name,
-                        tool_input,
-                        result[:200],
-                        elapsed_ms,
-                        channel_id=str(message.channel.id),
-                    )
-                except Exception:
-                    pass  # Non-critical tracking
-
-                # Track mutations requiring post-action validation
-                if tool_result is not None and tool_result.requires_validation and tool_result.ok:
-                    _pending_validations.append(f"{tool_name}: {tool_result.validation_reason}")
-
-                # Truncate large outputs before sending back to the LLM.
-                tool_content = truncate_tool_output(result)
-
-                return {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": tool_content,
-                }
-
-            # Run all tool calls concurrently with per-tool timeout
-            tool_timeout = bot.config.tools.tool_timeout_seconds
-
-            async def _run_tool_with_timeout(block):
-                t = 3660 if block.name in _LONG_TIMEOUT_TOOL_SET else tool_timeout
-                try:
-                    return await asyncio.wait_for(
-                        _run_tool(block),
-                        timeout=t,
-                    )
-                except TimeoutError:
-                    error_msg = f"Tool '{block.name}' timed out after {t}s"
-                    try:
-                        await bot.audit.log_execution(
-                            user_id=str(message.author.id),
-                            user_name=str(message.author),
-                            channel_id=str(message.channel.id),
-                            tool_name=block.name,
-                            tool_input=_scrub_tool_input_for_storage(block.name, block.input),
-                            approved=True,
-                            result_summary=error_msg,
-                            execution_time_ms=int(tool_timeout * 1000),
-                            error=error_msg,
-                        )
-                    except Exception:
-                        pass
-                    return {
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": error_msg,
-                    }
-
-            async with message.channel.typing():
-                tool_results = await asyncio.gather(
-                    *[_run_tool_with_timeout(b) for b in tool_calls],
-                )
-            messages.append({"role": "user", "content": list(tool_results)})
-
-            # Pair calls with results for post-operation reflection. Stashed
-            # per iteration so every loop exit path leaves the latest state.
-            _results_by_id = {r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)}
-            for _tc in tool_calls:
-                if trace is not None and _tc.id not in _results_by_id:
-                    trace.warning(
-                        "TOOL_RESULT_CONTINUATION_MISMATCH",
-                        "error",
-                        f"tool {_tc.name} call has no paired result",
-                    )
-                _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
-                _op_tool_details.append(
-                    {
-                        "tool": _tc.name,
-                        "input": _scrub_tool_input_for_storage(_tc.name, _tc.input),
-                        "result": _rcontent[:300],
-                        "error": _rcontent.lstrip()
-                        .lower()
-                        .startswith(("error", "[error", "failed", "traceback")),
-                    }
-                )
-            bot._last_op_details[str(message.channel.id)] = _op_tool_details
-
-            # Persist results onto the iteration recorded before execution —
-            # without this the saved trajectory has calls but no outcomes.
-            if _trajectory.iterations:
-                _trajectory.iterations[-1].tool_results = stored_tool_results(
-                    tool_results,
-                    _result_store_cap,
-                )
-
-            if _cancel.is_set():
-                return _stopped("after_tools")
-
-            # Clear validation requirement if validate_action was called this iteration
-            if _validation_required and "validate_action" in [t.name for t in tool_calls]:
-                _validation_required = False
-                _validation_retries = 0
-
-            # Auto-inject validation instruction when mutations were detected
-            if _pending_validations:
-                mutation_list = "; ".join(_pending_validations)
-                _validation_required = True
-                messages.append(
+            else:
+                st.stuck_tracker.warned = True
+                log.info("Stuck pattern detected — injecting nudge")
+                st.messages.append(
                     {
                         "role": "developer",
                         "content": (
-                            f"[AUTO-VALIDATE] Operational mutation(s) detected: {mutation_list}. "
-                            "You MUST call validate_action now to confirm the change took effect. "
-                            "Infer appropriate checks from the mutation type."
+                            "You appear to be repeating the same tool-call sequence. "
+                            "Try a different approach or summarise progress and stop."
                         ),
                     }
                 )
-                _pending_validations.clear()
+                return ("retry", None)
+        return None
 
-            # Inject pending image blocks as vision content for the next LLM call.
-            # This reuses the same base64 image block format as _process_attachments.
-            if pending_image_blocks:
-                vision_content: list[dict] = list(pending_image_blocks)
-                vision_content.append(
-                    {
-                        "type": "text",
-                        "text": (
-                            "The image(s) above were fetched by analyze_image. "
-                            "Describe and analyze them."
-                        ),
-                    }
-                )
-                messages.append({"role": "user", "content": vision_content})
+    async def _finalize_or_retry(self, st: _ChatTurn, llm_resp):
+        """The text-only-response branch: validation enforcement, the
+        response-guard cascade (order pinned by characterization), the
+        completion classifier, and final trajectory persistence.
+
+        Returns ("done", <run() return tuple>) or ("retry", None) after
+        injecting a retry/continuation message.
+        """
+        bot = self.host
+        if st._cancel.is_set():
+            return ("done", self._stopped(st, "before_validation"))
+        # Enforce pending validation before allowing final response
+        if st._validation_required and st._validation_retries < st._max_validation_retries:
+            st._validation_retries += 1
+            log.warning(
+                "Validation required but model returned text — "
+                "forcing continuation (attempt %d)",
+                st._validation_retries,
+            )
+            st.messages.append(
+                {
+                    "role": "developer",
+                    "content": (
+                        "[VALIDATION REQUIRED] You have pending post-action validation. "
+                        "Call validate_action before responding to the user."
+                    ),
+                }
+            )
+            return ("retry", None)
+
+        # Fabrication detection: if no tools were called and the
+        # response looks like it fabricated results, retry once.
+        if (
+            not st.fabrication_retried
+            and not st.tools_used_in_loop
+            and detect_fabrication(llm_resp.text or "", st.tools_used_in_loop)
+        ):
+            log.warning("Fabrication detected — retrying with correction")
+            st.fabrication_retried = True
+            st.messages.append(_FABRICATION_RETRY_MSG)
+            return ("retry", None)
+
+        if (
+            not st.promise_retried
+            and not st.tools_used_in_loop
+            and detect_promise_without_action(llm_resp.text or "", st.tools_used_in_loop)
+        ):
+            log.warning("Promise without action detected — retrying")
+            st.promise_retried = True
+            st.messages.append(_PROMISE_RETRY_MSG)
+            return ("retry", None)
+
+        if (
+            not st.unavail_retried
+            and not st.tools_used_in_loop
+            and detect_tool_unavailable(llm_resp.text or "", st.tools_used_in_loop)
+        ):
+            log.warning("Tool-unavailability fabrication detected — retrying")
+            st.unavail_retried = True
+            st.messages.append(_TOOL_UNAVAIL_RETRY_MSG)
+            return ("retry", None)
+
+        # Hedging detection: fires for ALL messages — Odin is an
+        # executor, not a menu system.
+        if (
+            not st.hedging_retried
+            and not st.tools_used_in_loop
+            and detect_hedging(llm_resp.text or "", st.tools_used_in_loop)
+        ):
+            log.warning("Hedging detected — retrying")
+            st.hedging_retried = True
+            st.messages.append(_HEDGING_RETRY_MSG)
+            return ("retry", None)
+
+        if (
+            not st.code_hedging_retried
+            and not st.tools_used_in_loop
+            and detect_code_hedging(llm_resp.text or "", st.tools_used_in_loop)
+        ):
+            log.warning("Code-block hedging detected — retrying")
+            st.code_hedging_retried = True
+            st.messages.append(_CODE_HEDGING_RETRY_MSG)
+            return ("retry", None)
+
+        # Premature failure: tools were called but gave up after one error
+        if (
+            not st.premature_failure_retried
+            and st.tools_used_in_loop
+            and detect_premature_failure(llm_resp.text or "", st.tools_used_in_loop)
+        ):
+            log.warning("Premature failure detected — retrying")
+            st.premature_failure_retried = True
+            st.messages.append(_FAILURE_RETRY_MSG)
+            return ("retry", None)
+
+        # Tier 3: Completion classifier — uses LLM to judge whether
+        # the user's request was fully addressed.
+        if st.tools_used_in_loop and st.continuation_count < st.max_continuations:
+            is_complete, reason = await bot._classify_completion(
+                st.message.content,
+                llm_resp.text or "",
+                st.tools_used_in_loop,
+            )
+            if not is_complete:
                 log.info(
-                    "Injected %d image block(s) into tool loop messages", len(pending_image_blocks)
+                    "Completion classifier: INCOMPLETE (%d/%d) "
+                    "after %d tool calls — injecting continuation",
+                    st.continuation_count + 1,
+                    st.max_continuations,
+                    len(st.tools_used_in_loop),
                 )
-                pending_image_blocks.clear()
+                # Do NOT append the incomplete response as an assistant
+                # message — inject the continuation nudge alone so
+                # the model responds fresh with tool calls.
+                if reason:
+                    st.messages.append(
+                        {
+                            "role": "developer",
+                            "content": (
+                                f"You are not done. {reason}. Continue with tool calls now."
+                            ),
+                        }
+                    )
+                else:
+                    st.messages.append(_CONTINUATION_MSG)
+                st.continuation_count += 1
+                return ("retry", None)
 
-            # Check if all tool calls in this iteration are skills that want
-            # Codex to handle the response instead of another tool-loop iteration.
-            tool_names_this_round = [b.name for b in tool_calls]
-            if bot.llm_client and all(
-                bot.skill_manager.should_handoff_to_codex(n) is True for n in tool_names_this_round
-            ):
-                # Collect skill results as context for Codex
-                skill_output = "\n".join(r["content"] for r in tool_results if isinstance(r, dict))
-                _clear_active()
-                return skill_output, False, False, tools_used_in_loop, True  # handoff=True
+        _final = llm_resp.text or _EMPTY_RESPONSE_FALLBACK
+        await bot._save_turn_trajectory(
+            st._trajectory,
+            final_response=_final,
+            tools_used=st.tools_used_in_loop,
+            trace=st.trace,
+        )
+        self._clear_active(st)
+        return ("done", (_final, False, False, st.tools_used_in_loop, False))
 
-        _clear_active()
+    async def _run_one_tool(self, st: _ChatTurn, block) -> dict:
+        """Execute a single tool call: RBAC gate, native/executor dispatch,
+        failure visibility, audit, recent-action tracking, validation
+        bookkeeping. (The old `_run_tool` closure.)"""
+        bot = self.host
+        tool_name = block.name
+        tool_input = block.input
+        log.info("Tool call: %s(%s)", tool_name, tool_input)
+        # The provider could not parse the model's arguments — do NOT
+        # run the tool with a silently-empty input; bounce the error
+        # back so the model retries with valid arguments.
+        if getattr(block, "parse_error", None):
+            log.warning("Tool call %s not executed: %s", tool_name, block.parse_error)
+            return {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": (
+                    f"Error: {block.parse_error}. The tool was NOT executed — "
+                    "re-issue the call with valid JSON arguments."
+                ),
+            }
+        # Central RBAC gate: Discord-native tools, skills, and MCP tools are
+        # dispatched below WITHOUT going through ToolExecutor.execute() (the only
+        # place check_permission runs). permissions.filter_tools is advisory
+        # (offer-time) only, so enforce permission here for EVERY tool.
+        _uid = str(st.message.author.id)
+        _rbac_denial = bot.tool_executor.check_permission(tool_name, _uid)
+        if isinstance(_rbac_denial, str) and _rbac_denial:  # str = deny, None = allow
+            log.warning("RBAC gate denied tool %s for user %s", tool_name, _uid)
+            return {"type": "tool_result", "tool_use_id": block.id, "content": _rbac_denial}
+        await bot._set_status(
+            bot._TOOL_STATUS_LABELS.get(tool_name, f"Running: {tool_name}")
+        )
+
+        try:
+            await bot.audit.log_event(
+                event_type="tool_start",
+                action=tool_name,
+                actor=str(st.message.author.id),
+                channel_id=str(st.message.channel.id),
+                metadata={
+                    "tool_input_keys": list((tool_input or {}).keys()),
+                    "iteration": st.iteration,
+                },
+            )
+        except Exception:
+            pass
+
+        t0 = time.monotonic()
+        error = None
+        tool_result = None
+        # Handle Discord-native tools
+        try:
+            if bot._native_tools.handles(tool_name):
+                result, _effects = await bot._native_tools.dispatch(
+                    tool_name,
+                    tool_input,
+                    message=st.message,
+                    user_id=st.user_id,
+                    skill_file_delivery=st.policy.skill_file_delivery,
+                )
+                if _effects.rebuild_system_prompt:
+                    st.system_prompt = bot._build_system_prompt(
+                        channel=st.message.channel,
+                        user_id=st.user_id,
+                    )
+            else:
+                tool_result = await bot.tool_executor.execute(
+                    tool_name,
+                    tool_input,
+                    user_id=st.user_id,
+                )
+                result = str(tool_result)
+        except TimeoutError as e:
+            error = str(e)
+            result = f"Tool {tool_name} timed out: {e}"
+            tool_result = None
+            log.warning("Tool %s timed out after %.1fs", tool_name, time.monotonic() - t0)
+        except (ValueError, KeyError, TypeError) as e:
+            error = str(e)
+            result = f"Tool {tool_name} input error: {e}"
+            tool_result = None
+        except Exception as e:
+            error = str(e)
+            result = f"Error executing {tool_name}: {e}"
+            tool_result = None
+            log.warning("Unexpected tool error for %s: %s", tool_name, e)
+
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+        # Handle special image block return from analyze_image
+        if isinstance(result, dict) and "__image_block__" in result:
+            st.pending_image_blocks.append(result["__image_block__"])
+            result = (
+                f"[Image loaded. Analyze it with this instruction: {result['__prompt__']}]"
+            )
+
+        # Scrub secrets from tool output
+        result = scrub_output_secrets(result)
+
+        # Use structured metadata from ToolResult when available
+        if tool_result is not None:
+            elapsed_ms = tool_result.duration_ms or elapsed_ms
+            if tool_result.error and not error:
+                error = tool_result.error
+            if not tool_result.ok and not error:
+                error = "tool reported failure"
+            result = bot._ensure_failure_visible(result, tool_result.ok)
+
+        await self._audit_tool_outcome(
+            st, tool_name, tool_input, result, elapsed_ms, error, tool_result
+        )
+
+        # Track for conversational context
+        try:
+            bot._track_recent_action(
+                tool_name,
+                tool_input,
+                result[:200],
+                elapsed_ms,
+                channel_id=str(st.message.channel.id),
+            )
+        except Exception:
+            pass  # Non-critical tracking
+
+        # Track mutations requiring post-action validation
+        if tool_result is not None and tool_result.requires_validation and tool_result.ok:
+            st._pending_validations.append(f"{tool_name}: {tool_result.validation_reason}")
+
+        # Truncate large outputs before sending back to the LLM.
+        tool_content = truncate_tool_output(result)
+
+        return {
+            "type": "tool_result",
+            "tool_use_id": block.id,
+            "content": tool_content,
+        }
+
+    async def _audit_tool_outcome(
+        self, st: _ChatTurn, tool_name, tool_input, result, elapsed_ms, error, tool_result
+    ) -> None:
+        """Write execution + tool_end audit records — never crash tool
+        execution on audit failure. (Inline block of the old `_run_tool`.)"""
+        bot = self.host
+        # Audit log — never crash tool execution on audit failure
+        try:
+            scrubbed_input = _scrub_tool_input_for_storage(
+                tool_name,
+                {
+                    k: scrub_output_secrets(str(v)) if isinstance(v, str) else v
+                    for k, v in (tool_input or {}).items()
+                },
+            )
+            await bot.audit.log_execution(
+                user_id=str(st.message.author.id),
+                user_name=str(st.message.author),
+                channel_id=str(st.message.channel.id),
+                tool_name=tool_name,
+                tool_input=scrubbed_input,
+                approved=True,
+                result_summary=result,
+                execution_time_ms=elapsed_ms,
+                error=error,
+                risk_level=tool_result.risk_level if tool_result else None,
+                risk_reason=tool_result.risk_reason if tool_result else None,
+            )
+            await bot.audit.log_event(
+                event_type="tool_end",
+                action=tool_name,
+                actor=str(st.message.author.id),
+                channel_id=str(st.message.channel.id),
+                detail=result[:150],
+                metadata={"elapsed_ms": elapsed_ms, "error": error, "iteration": st.iteration},
+            )
+        except Exception as audit_err:
+            log.warning("Audit log failed for %s: %s", tool_name, audit_err)
+
+    async def _run_one_tool_with_timeout(self, st: _ChatTurn, block, tool_timeout) -> dict:
+        """Per-tool timeout wrapper around _run_one_tool (the old
+        `_run_tool_with_timeout` closure)."""
+        bot = self.host
+        t = 3660 if block.name in _LONG_TIMEOUT_TOOL_SET else tool_timeout
+        try:
+            return await asyncio.wait_for(
+                self._run_one_tool(st, block),
+                timeout=t,
+            )
+        except TimeoutError:
+            error_msg = f"Tool '{block.name}' timed out after {t}s"
+            try:
+                await bot.audit.log_execution(
+                    user_id=str(st.message.author.id),
+                    user_name=str(st.message.author),
+                    channel_id=str(st.message.channel.id),
+                    tool_name=block.name,
+                    tool_input=_scrub_tool_input_for_storage(block.name, block.input),
+                    approved=True,
+                    result_summary=error_msg,
+                    execution_time_ms=int(tool_timeout * 1000),
+                    error=error_msg,
+                )
+            except Exception:
+                pass
+            return {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": error_msg,
+            }
+
+    async def _execute_tool_calls(self, st: _ChatTurn, tool_calls) -> list:
+        """Run all tool calls concurrently with per-tool timeout; append the
+        result block to the message list (gather preserves call order)."""
+        bot = self.host
+        tool_timeout = bot.config.tools.tool_timeout_seconds
+
+        async with st.message.channel.typing():
+            tool_results = await asyncio.gather(
+                *[self._run_one_tool_with_timeout(st, b, tool_timeout) for b in tool_calls],
+            )
+        st.messages.append({"role": "user", "content": list(tool_results)})
+        return tool_results
+
+    async def _post_iteration(self, st: _ChatTurn, tool_calls, tool_results):
+        """Post-execution bookkeeping: op-details pairing for reflection,
+        trajectory result persistence, cancellation, validation state, and
+        vision injection. Returns ("done", <tuple>) on /stop, else None."""
+        bot = self.host
+        from ..trajectories.saver import stored_tool_results
+
+        # Pair calls with results for post-operation reflection. Stashed
+        # per iteration so every loop exit path leaves the latest state.
+        _results_by_id = {r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)}
+        for _tc in tool_calls:
+            if st.trace is not None and _tc.id not in _results_by_id:
+                st.trace.warning(
+                    "TOOL_RESULT_CONTINUATION_MISMATCH",
+                    "error",
+                    f"tool {_tc.name} call has no paired result",
+                )
+            _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
+            st._op_tool_details.append(
+                {
+                    "tool": _tc.name,
+                    "input": _scrub_tool_input_for_storage(_tc.name, _tc.input),
+                    "result": _rcontent[:300],
+                    "error": _rcontent.lstrip()
+                    .lower()
+                    .startswith(("error", "[error", "failed", "traceback")),
+                }
+            )
+        bot._last_op_details[str(st.message.channel.id)] = st._op_tool_details
+
+        # Persist results onto the iteration recorded before execution —
+        # without this the saved trajectory has calls but no outcomes.
+        if st._trajectory.iterations:
+            st._trajectory.iterations[-1].tool_results = stored_tool_results(
+                tool_results,
+                st._result_store_cap,
+            )
+
+        if st._cancel.is_set():
+            return ("done", self._stopped(st, "after_tools"))
+
+        # Clear validation requirement if validate_action was called this iteration
+        if st._validation_required and "validate_action" in [t.name for t in tool_calls]:
+            st._validation_required = False
+            st._validation_retries = 0
+
+        # Auto-inject validation instruction when mutations were detected
+        if st._pending_validations:
+            mutation_list = "; ".join(st._pending_validations)
+            st._validation_required = True
+            st.messages.append(
+                {
+                    "role": "developer",
+                    "content": (
+                        f"[AUTO-VALIDATE] Operational mutation(s) detected: {mutation_list}. "
+                        "You MUST call validate_action now to confirm the change took effect. "
+                        "Infer appropriate checks from the mutation type."
+                    ),
+                }
+            )
+            st._pending_validations.clear()
+
+        # Inject pending image blocks as vision content for the next LLM call.
+        # This reuses the same base64 image block format as _process_attachments.
+        if st.pending_image_blocks:
+            vision_content: list[dict] = list(st.pending_image_blocks)
+            vision_content.append(
+                {
+                    "type": "text",
+                    "text": (
+                        "The image(s) above were fetched by analyze_image. "
+                        "Describe and analyze them."
+                    ),
+                }
+            )
+            st.messages.append({"role": "user", "content": vision_content})
+            log.info(
+                "Injected %d image block(s) into tool loop messages",
+                len(st.pending_image_blocks),
+            )
+            st.pending_image_blocks.clear()
+
+        return None
+
+    def _check_skill_handoff(self, st: _ChatTurn, tool_calls, tool_results):
+        """Check if all tool calls in this iteration are skills that want
+        Codex to handle the response instead of another tool-loop iteration.
+        Returns ("done", <tuple with handoff=True>) or None."""
+        bot = self.host
+        tool_names_this_round = [b.name for b in tool_calls]
+        if bot.llm_client and all(
+            bot.skill_manager.should_handoff_to_codex(n) is True for n in tool_names_this_round
+        ):
+            # Collect skill results as context for Codex
+            skill_output = "\n".join(r["content"] for r in tool_results if isinstance(r, dict))
+            self._clear_active(st)
+            return ("done", (skill_output, False, False, st.tools_used_in_loop, True))
+        return None
+
+    async def _finalize_cap_hit(self, st: _ChatTurn) -> tuple[str, bool, bool, list[str], bool]:
+        """The for-loop fell through: iteration cap exhausted."""
+        bot = self.host
+        self._clear_active(st)
         log.warning(
             "Chat tool-iteration cap hit (%d) after %d tool calls; exiting loop",
-            chat_cap,
-            len(tools_used_in_loop),
+            st.chat_cap,
+            len(st.tools_used_in_loop),
         )
         _cap_msg = (
-            f"Hit the chat tool-iteration cap ({chat_cap}) after "
-            f"{len(tools_used_in_loop)} tool calls. Task may be partially "
+            f"Hit the chat tool-iteration cap ({st.chat_cap}) after "
+            f"{len(st.tools_used_in_loop)} tool calls. Task may be partially "
             f"complete. Raise `tools.max_tool_iterations_chat` in config "
             f"(or via the web UI) if this happens often."
         )
         await bot._save_turn_trajectory(
-            _trajectory,
+            st._trajectory,
             final_response=_cap_msg,
-            tools_used=tools_used_in_loop,
-            trace=trace,
+            tools_used=st.tools_used_in_loop,
+            trace=st.trace,
         )
-        return _cap_msg, False, True, tools_used_in_loop, False
+        return (_cap_msg, False, True, st.tools_used_in_loop, False)
+
+    # ------------------------------------------------------------------
+    # Autonomous pipeline (old _run_loop_iteration) — orchestrator + phases
+    # ------------------------------------------------------------------
 
     async def run_autonomous(
         self,
@@ -966,14 +1132,47 @@ class ToolLoopRunner:
     ) -> str:
         """Run a single loop iteration through Codex with full tool access.
 
-        Simplified version of _process_with_tools for autonomous loops:
-        same Codex + tool execution pipeline but without detection retries.
+        Simplified version of the chat pipeline for autonomous loops: same
+        Codex + tool execution pipeline but without detection retries.
         """
         bot = self.host
-        from .client import _scrub_tool_input_for_storage
-
         if not bot.llm_client:
             return "LLM provider not available."
+
+        st = self._prepare_loop_turn(prompt, channel, prev_context, user_id, policy)
+
+        for _iteration in range(st.loop_cap):
+            kind, val = await self._call_loop_llm(st)
+            if kind == "done":
+                return val
+            response = val
+
+            if self._record_loop_iteration(st, response, _iteration):
+                break
+
+            st.tool_calls_made += len(response.tool_calls)
+
+            # Build assistant content with tool_use blocks (matches the chat
+            # pipeline's format)
+            st.messages.append(
+                {"role": "assistant", "content": build_assistant_content(response)}
+            )
+
+            await self._execute_loop_tools(st, response)
+
+        return await self._finalize_loop(st)
+
+    def _prepare_loop_turn(
+        self,
+        prompt: str,
+        channel: object,
+        prev_context: str | None,
+        user_id: str,
+        policy: LoopPolicy,
+    ) -> _LoopTurn:
+        """Iteration setup: requester resolution, trajectory/trace init,
+        message + system prompt + tool-definition assembly."""
+        bot = self.host
 
         # Resolve requester name for audit logging and message proxy
         requester_name = "loop"
@@ -988,15 +1187,14 @@ class ToolLoopRunner:
         # 10% of all tool executions had no recorded narrative).
         _turn_ctx = get_turn() or {}
         _loop_id = str(_turn_ctx.get("loop_id", ""))
-        _loop_iter = int(_turn_ctx.get("loop_iteration", 0) or 0)
-        from ..trajectories.saver import ToolIteration, TrajectoryTurn, stored_tool_results
+        _loop_iter = int(_turn_ctx.get("loop_iteration", 0) or 0)  # noqa: F841 — kept from the pre-carve body
+        from ..trajectories.saver import TrajectoryTurn
 
         _obs = getattr(bot.config, "observability", None)
         _loop_trace_on = _obs is None or getattr(_obs, "loop_trace", True)
         _result_store_cap = int(getattr(_obs, "max_tool_result_chars", 2000) or 2000)
         _trace = bot._new_context_trace() if _loop_trace_on else None
         _trajectory = None
-        _loop_details: list[dict] = []
         if _loop_trace_on:
             _trajectory = TrajectoryTurn(
                 message_id=str(_turn_ctx.get("turn_id", "")),
@@ -1039,240 +1237,282 @@ class ToolLoopRunner:
             system_prompt = bot._build_system_prompt(channel=channel, user_id=user_id)
         tools = bot._merged_tool_definitions() if bot.config.tools.enabled else None
 
-        async def _finish(
-            outcome_text: str,
-            *,
-            is_error: bool = False,
-            failure_class: str = "",
-            error_text: str = "",
-        ) -> str:
-            """Persist the loop turn and run gated reflection at every exit."""
-            if _trajectory is not None:
-                await bot._save_turn_trajectory(
-                    _trajectory,
-                    error=error_text if is_error else "",
-                    final_response=outcome_text if not is_error else "",
-                    tools_used=[d["tool"] for d in _loop_details],
-                    trace=_trace,
-                )
-            bot._maybe_loop_reflect(
-                loop_id=_loop_id or channel_id_str,
-                prompt=prompt,
-                outcome=outcome_text,
-                is_error=is_error,
-                failure_class=failure_class,
-                error_text=error_text,
-                tool_details=_loop_details,
-                user_id=user_id,
-            )
-            return outcome_text
-
-        final_text = ""
-        completed_naturally = False  # True only when a tool-free turn ended the loop
         tool_timeout = bot.config.tools.tool_timeout_seconds
         channel_id_str = str(getattr(channel, "id", ""))
         loop_cap = bot.config.tools.max_tool_iterations_loop
-        tool_calls_made = 0
 
-        for _iteration in range(loop_cap):
-            try:
-                response = await bot.llm_client.chat_with_tools(
-                    messages=messages,
-                    system=system_prompt,
-                    tools=tools or [],
-                )
-            except CircuitOpenError:
-                raise
-            except Exception as e:
-                log.warning("Loop iteration Codex call failed: %s", e)
-                return await _finish(
+        return _LoopTurn(
+            prompt=prompt,
+            channel=channel,
+            user_id=user_id,
+            policy=policy,
+            msg_proxy=msg_proxy,
+            requester_name=requester_name,
+            _loop_id=_loop_id,
+            _trace=_trace,
+            _trajectory=_trajectory,
+            _result_store_cap=_result_store_cap,
+            messages=messages,
+            system_prompt=system_prompt,
+            tools=tools,
+            tool_timeout=tool_timeout,
+            channel_id_str=channel_id_str,
+            loop_cap=loop_cap,
+        )
+
+    async def _finish_loop(
+        self,
+        st: _LoopTurn,
+        outcome_text: str,
+        *,
+        is_error: bool = False,
+        failure_class: str = "",
+        error_text: str = "",
+    ) -> str:
+        """Persist the loop turn and run gated reflection at every exit.
+        (The old `_finish` closure.)"""
+        bot = self.host
+        if st._trajectory is not None:
+            await bot._save_turn_trajectory(
+                st._trajectory,
+                error=error_text if is_error else "",
+                final_response=outcome_text if not is_error else "",
+                tools_used=[d["tool"] for d in st._loop_details],
+                trace=st._trace,
+            )
+        bot._maybe_loop_reflect(
+            loop_id=st._loop_id or st.channel_id_str,
+            prompt=st.prompt,
+            outcome=outcome_text,
+            is_error=is_error,
+            failure_class=failure_class,
+            error_text=error_text,
+            tool_details=st._loop_details,
+            user_id=st.user_id,
+        )
+        return outcome_text
+
+    async def _call_loop_llm(self, st: _LoopTurn):
+        """LLM call for one loop iteration. CircuitOpenError re-raises to the
+        loop manager (policy asymmetry — the manager owns backoff).
+
+        Returns ("ok", response) or ("done", <run_autonomous() return str>).
+        """
+        bot = self.host
+        try:
+            response = await bot.llm_client.chat_with_tools(
+                messages=st.messages,
+                system=st.system_prompt,
+                tools=st.tools or [],
+            )
+        except CircuitOpenError:
+            raise
+        except Exception as e:
+            log.warning("Loop iteration Codex call failed: %s", e)
+            return (
+                "done",
+                await self._finish_loop(
+                    st,
                     f"LLM call failed: {e}",
                     is_error=True,
                     failure_class="provider",
                     error_text=str(e),
-                )
-
-            if _trajectory is not None:
-                _trajectory.iterations.append(
-                    ToolIteration(
-                        iteration=_iteration,
-                        tool_calls=[
-                            {"id": tc.id, "name": tc.name, "input": tc.input}
-                            for tc in (response.tool_calls or [])
-                        ],
-                        llm_text=response.text or "",
-                        input_tokens=getattr(response, "input_tokens", 0) or 0,
-                        output_tokens=getattr(response, "output_tokens", 0) or 0,
-                    )
-                )
-
-            if response.text:
-                final_text = response.text
-
-            if not response.tool_calls:
-                completed_naturally = True
-                break
-
-            tool_calls_made += len(response.tool_calls)
-
-            # Build assistant content with tool_use blocks (matches _process_with_tools format)
-            messages.append({"role": "assistant", "content": build_assistant_content(response)})
-
-            # Execute tools concurrently with per-tool timeout
-            async def _run_loop_tool(block):
-                nonlocal system_prompt
-                tool_name = block.name
-                tool_input = block.input
-                log.info("Loop tool call: %s(%s)", tool_name, tool_input)
-                # Provider couldn't parse the model's arguments — don't run
-                # the tool on a silently-empty input (see _run_tool).
-                if getattr(block, "parse_error", None):
-                    log.warning("Loop tool call %s not executed: %s", tool_name, block.parse_error)
-                    return {
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": (
-                            f"Error: {block.parse_error}. The tool was NOT executed — "
-                            "re-issue the call with valid JSON arguments."
-                        ),
-                    }
-
-                t0 = time.monotonic()
-                error = None
-                try:
-                    _t = 3660 if tool_name in _LONG_TIMEOUT_TOOL_SET else tool_timeout
-                    raw = await asyncio.wait_for(
-                        bot._dispatch_loop_tool(
-                            tool_name,
-                            tool_input,
-                            msg_proxy,
-                            user_id,
-                        ),
-                        timeout=_t,
-                    )
-                    # Skill CRUD invalidates caches
-                    if tool_name in (
-                        "create_skill",
-                        "edit_skill",
-                        "delete_skill",
-                        "enable_skill",
-                        "disable_skill",
-                        "install_skill",
-                    ):
-                        system_prompt = bot._build_system_prompt(
-                            channel=channel,
-                            user_id=user_id,
-                        )
-                except TimeoutError:
-                    error = f"Tool '{tool_name}' timed out after {_t}s"
-                    raw = error
-                except (ValueError, KeyError, TypeError) as e:
-                    error = str(e)
-                    raw = f"Tool {tool_name} input error: {e}"
-                except Exception as e:
-                    error = str(e)
-                    raw = f"Error executing {tool_name}: {e}"
-                    log.warning("Unexpected loop tool error for %s: %s", tool_name, e)
-
-                elapsed_ms = int((time.monotonic() - t0) * 1000)
-
-                # Handle image block returns from analyze_image
-                if isinstance(raw, dict) and "__image_block__" in raw:
-                    raw = f"[Image loaded: {raw.get('__prompt__', '')}]"
-
-                # Make structured failure visible (see _ensure_failure_visible)
-                # and propagate it into the audit error field.
-                if isinstance(raw, ToolResult):
-                    if not raw.ok and not error:
-                        error = raw.error or "tool reported failure"
-                    raw = bot._ensure_failure_visible(str(raw), raw.ok)
-
-                result = truncate_tool_output(scrub_output_secrets(str(raw)))
-
-                # Audit log
-                try:
-                    await bot.audit.log_execution(
-                        user_id=user_id,
-                        user_name=requester_name,
-                        channel_id=channel_id_str,
-                        tool_name=tool_name,
-                        tool_input=_scrub_tool_input_for_storage(tool_name, tool_input),
-                        approved=True,
-                        result_summary=result,
-                        execution_time_ms=elapsed_ms,
-                        error=error,
-                    )
-                except OSError as audit_err:
-                    log.warning("Audit write failed (I/O): %s", audit_err)
-                except Exception as audit_err:
-                    log.warning("Audit write failed: %s", audit_err)
-
-                return {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result,
-                }
-
-            tool_results = await asyncio.gather(
-                *[_run_loop_tool(tc) for tc in response.tool_calls],
+                ),
             )
-            messages.append({"role": "user", "content": list(tool_results)})
+        return ("ok", response)
 
-            _results_by_id = {r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)}
-            for _tc in response.tool_calls:
-                if _trace is not None and _tc.id not in _results_by_id:
-                    _trace.warning(
-                        "TOOL_RESULT_CONTINUATION_MISMATCH",
-                        "error",
-                        f"loop tool {_tc.name} call has no paired result",
-                    )
-                _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
-                _loop_details.append(
-                    {
-                        "tool": _tc.name,
-                        "input": _scrub_tool_input_for_storage(_tc.name, _tc.input),
-                        "result": _rcontent[:300],
-                        "error": _rcontent.lstrip()
-                        .lower()
-                        .startswith(
-                            (
-                                "error",
-                                "[error",
-                                "failed",
-                                "traceback",
-                                "script failed",
-                                "command failed",
-                            )
-                        ),
-                    }
+    def _record_loop_iteration(self, st: _LoopTurn, response, _iteration: int) -> bool:
+        """Record the iteration into the trajectory; update final text.
+        Returns True when the loop ended naturally (tool-free response)."""
+        from ..trajectories.saver import ToolIteration
+
+        if st._trajectory is not None:
+            st._trajectory.iterations.append(
+                ToolIteration(
+                    iteration=_iteration,
+                    tool_calls=[
+                        {"id": tc.id, "name": tc.name, "input": tc.input}
+                        for tc in (response.tool_calls or [])
+                    ],
+                    llm_text=response.text or "",
+                    input_tokens=getattr(response, "input_tokens", 0) or 0,
+                    output_tokens=getattr(response, "output_tokens", 0) or 0,
                 )
+            )
 
-            # Persist results onto the iteration recorded before execution —
-            # without this the saved trajectory has calls but no outcomes.
-            if _trajectory is not None and _trajectory.iterations:
-                _trajectory.iterations[-1].tool_results = stored_tool_results(
-                    tool_results,
-                    _result_store_cap,
+        if response.text:
+            st.final_text = response.text
+
+        if not response.tool_calls:
+            st.completed_naturally = True
+            return True
+        return False
+
+    async def _run_one_loop_tool(self, st: _LoopTurn, block) -> dict:
+        """Execute a single loop tool call through the shared dispatch path,
+        with failure visibility and audit. (The old `_run_loop_tool` closure.)"""
+        bot = self.host
+        tool_name = block.name
+        tool_input = block.input
+        log.info("Loop tool call: %s(%s)", tool_name, tool_input)
+        # Provider couldn't parse the model's arguments — don't run
+        # the tool on a silently-empty input (see _run_one_tool).
+        if getattr(block, "parse_error", None):
+            log.warning("Loop tool call %s not executed: %s", tool_name, block.parse_error)
+            return {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": (
+                    f"Error: {block.parse_error}. The tool was NOT executed — "
+                    "re-issue the call with valid JSON arguments."
+                ),
+            }
+
+        t0 = time.monotonic()
+        error = None
+        try:
+            _t = 3660 if tool_name in _LONG_TIMEOUT_TOOL_SET else st.tool_timeout
+            raw = await asyncio.wait_for(
+                bot._dispatch_loop_tool(
+                    tool_name,
+                    tool_input,
+                    st.msg_proxy,
+                    st.user_id,
+                ),
+                timeout=_t,
+            )
+            # Skill CRUD invalidates caches
+            if tool_name in (
+                "create_skill",
+                "edit_skill",
+                "delete_skill",
+                "enable_skill",
+                "disable_skill",
+                "install_skill",
+            ):
+                st.system_prompt = bot._build_system_prompt(
+                    channel=st.channel,
+                    user_id=st.user_id,
                 )
+        except TimeoutError:
+            error = f"Tool '{tool_name}' timed out after {_t}s"
+            raw = error
+        except (ValueError, KeyError, TypeError) as e:
+            error = str(e)
+            raw = f"Tool {tool_name} input error: {e}"
+        except Exception as e:
+            error = str(e)
+            raw = f"Error executing {tool_name}: {e}"
+            log.warning("Unexpected loop tool error for %s: %s", tool_name, e)
 
-        # Scrub final text; posting is handled by _post_response in LoopManager.
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+        # Handle image block returns from analyze_image
+        if isinstance(raw, dict) and "__image_block__" in raw:
+            raw = f"[Image loaded: {raw.get('__prompt__', '')}]"
+
+        # Make structured failure visible (see ensure_failure_visible)
+        # and propagate it into the audit error field.
+        if isinstance(raw, ToolResult):
+            if not raw.ok and not error:
+                error = raw.error or "tool reported failure"
+            raw = bot._ensure_failure_visible(str(raw), raw.ok)
+
+        result = truncate_tool_output(scrub_output_secrets(str(raw)))
+
+        # Audit log
+        try:
+            await bot.audit.log_execution(
+                user_id=st.user_id,
+                user_name=st.requester_name,
+                channel_id=st.channel_id_str,
+                tool_name=tool_name,
+                tool_input=_scrub_tool_input_for_storage(tool_name, tool_input),
+                approved=True,
+                result_summary=result,
+                execution_time_ms=elapsed_ms,
+                error=error,
+            )
+        except OSError as audit_err:
+            log.warning("Audit write failed (I/O): %s", audit_err)
+        except Exception as audit_err:
+            log.warning("Audit write failed: %s", audit_err)
+
+        return {
+            "type": "tool_result",
+            "tool_use_id": block.id,
+            "content": result,
+        }
+
+    async def _execute_loop_tools(self, st: _LoopTurn, response) -> list:
+        """Execute tools concurrently with per-tool timeout; append results
+        and pair them into loop-details + the trajectory iteration."""
+        tool_results = await asyncio.gather(
+            *[self._run_one_loop_tool(st, tc) for tc in response.tool_calls],
+        )
+        st.messages.append({"role": "user", "content": list(tool_results)})
+
+        _results_by_id = {r.get("tool_use_id"): r for r in tool_results if isinstance(r, dict)}
+        for _tc in response.tool_calls:
+            if st._trace is not None and _tc.id not in _results_by_id:
+                st._trace.warning(
+                    "TOOL_RESULT_CONTINUATION_MISMATCH",
+                    "error",
+                    f"loop tool {_tc.name} call has no paired result",
+                )
+            _rcontent = str(_results_by_id.get(_tc.id, {}).get("content", ""))
+            st._loop_details.append(
+                {
+                    "tool": _tc.name,
+                    "input": _scrub_tool_input_for_storage(_tc.name, _tc.input),
+                    "result": _rcontent[:300],
+                    "error": _rcontent.lstrip()
+                    .lower()
+                    .startswith(
+                        (
+                            "error",
+                            "[error",
+                            "failed",
+                            "traceback",
+                            "script failed",
+                            "command failed",
+                        )
+                    ),
+                }
+            )
+
+        # Persist results onto the iteration recorded before execution —
+        # without this the saved trajectory has calls but no outcomes.
+        if st._trajectory is not None and st._trajectory.iterations:
+            from ..trajectories.saver import stored_tool_results
+
+            st._trajectory.iterations[-1].tool_results = stored_tool_results(
+                tool_results,
+                st._result_store_cap,
+            )
+        return tool_results
+
+    async def _finalize_loop(self, st: _LoopTurn) -> str:
+        """Loop exits: natural completion, cap exhaustion, or no response.
+        Scrub final text; posting is handled by _post_response in LoopManager."""
         # Only treat final_text as a clean success when the loop ended NATURALLY
         # (a tool-free response). If we fell out by exhausting the cap, any
         # final_text is stale pre-tool text from some earlier iteration —
         # returning it as is_error=False would silently hide the cap hit (the
         # cap-warning path below was unreachable whenever any iteration produced
         # text).
-        if final_text and completed_naturally:
-            final_text = scrub_output_secrets(final_text)
+        if st.final_text and st.completed_naturally:
+            final_text = scrub_output_secrets(st.final_text)
             if len(final_text) > DISCORD_MAX_LEN:
                 final_text = final_text[: DISCORD_MAX_LEN - 50] + "\n... (truncated)"
-            _had_tool_errors = any(d.get("error") for d in _loop_details)
-            _first_err = next((d for d in _loop_details if d.get("error")), None)
+            _had_tool_errors = any(d.get("error") for d in st._loop_details)
+            _first_err = next((d for d in st._loop_details if d.get("error")), None)
             # Iteration succeeded after a mid-flight tool error: the turn is
             # saved as a success (is_error=False), but the failure detail is
             # passed through so the reflection gate can learn from recovered
             # errors without marking the trajectory failed.
-            return await _finish(
+            return await self._finish_loop(
+                st,
                 final_text,
                 is_error=False,
                 failure_class="command_failed" if _had_tool_errors else "",
@@ -1281,29 +1521,34 @@ class ToolLoopRunner:
 
         # Cap exhausted without a tool-free response. Surface it (optionally with
         # the stale partial text) instead of hiding the truncation.
-        if tool_calls_made >= loop_cap or not completed_naturally:
+        if st.tool_calls_made >= st.loop_cap or not st.completed_naturally:
             log.warning(
                 "Loop tool-iteration cap hit (%d) after %d tool calls; "
                 "no tool-free summary from Codex",
-                loop_cap,
-                tool_calls_made,
+                st.loop_cap,
+                st.tool_calls_made,
             )
             _partial = ""
-            if final_text:
+            if st.final_text:
                 _partial = "\n\nLast partial output before the cap:\n" + scrub_output_secrets(
-                    final_text[:1000],
+                    st.final_text[:1000],
                 )
-            return await _finish(
-                f"Iteration hit the loop tool-iteration cap ({loop_cap}) "
-                f"after {tool_calls_made} tool calls without a final summary. "
+            return await self._finish_loop(
+                st,
+                f"Iteration hit the loop tool-iteration cap ({st.loop_cap}) "
+                f"after {st.tool_calls_made} tool calls without a final summary. "
                 f"Raise `tools.max_tool_iterations_loop` in config (or via the "
                 f"web UI) if this happens repeatedly." + _partial,
                 is_error=True,
                 failure_class="cancelled",
-                error_text=f"loop iteration cap {loop_cap} reached",
+                error_text=f"loop iteration cap {st.loop_cap} reached",
             )
 
-        return await _finish("(no response)")
+        return await self._finish_loop(st, "(no response)")
+
+    # ------------------------------------------------------------------
+    # Loop tool dispatch (unchanged by the P1 carve)
+    # ------------------------------------------------------------------
 
     async def dispatch_loop_tool(
         self,
@@ -1314,7 +1559,7 @@ class ToolLoopRunner:
     ) -> str | dict:
         """Dispatch a tool call to the correct handler within a loop iteration.
 
-        Mirrors the Discord-native tool dispatch in _process_with_tools, using
+        Mirrors the Discord-native tool dispatch in the chat pipeline, using
         a lightweight message proxy instead of a real Discord message.
         """
         bot = self.host

--- a/src/discord/tool_loop_helpers.py
+++ b/src/discord/tool_loop_helpers.py
@@ -1,12 +1,13 @@
-"""Small, pure helpers extracted from the Discord tool loop.
+"""Shared leaf helpers for the tool-execution pipelines.
 
-The main tool loop (`_process_with_tools`) is a ~700-line coroutine that
-does most of its work in place. That size made Odin's brainstorm call it
-out as the single worst structural problem — but a full decomposition is
-too risky without an end-to-end harness. This module collects *safe*
-pieces: pure functions with no hidden state, no side effects, and easy
-unit tests. Each extracted piece replaces an inline block in the loop
-1:1 and should be callable from isolation.
+Originally the "safe pure pieces" carved out of the old ~700-line chat
+tool loop. RFC-002 P1 widened the charter slightly: this is now the
+shared LEAF module for symbols the tool loop, the message intake, the
+background-task runner, and the client module all need — it imports
+nothing from ``src.discord``, which is what dissolves the old
+``tool_loop → client`` late-import cycle. Besides the pure functions it
+holds exactly one piece of module state, the test-webhook allowlist
+(mutated in place so every importer sees updates).
 """
 
 from __future__ import annotations
@@ -14,6 +15,59 @@ from __future__ import annotations
 import hashlib
 import time
 from typing import Any
+
+from ..tools.executor import _ERROR_RESULT_PREFIXES
+
+# Friendly fallback when the LLM returns an empty response after retries
+# (moved verbatim from client.py, RFC-002 P1).
+_EMPTY_RESPONSE_FALLBACK = "I couldn't generate a response. Please try again."
+
+# Webhook IDs allowed to bypass the bot-author check. Populated from the
+# ALLOWED_WEBHOOK_IDS env var at startup via init_allowed_webhook_ids().
+# MUTATED IN PLACE (never rebound) so `from ... import _ALLOWED_WEBHOOK_IDS`
+# bindings held by other modules always observe the live contents.
+_ALLOWED_WEBHOOK_IDS: set[str] = set()
+
+
+def init_allowed_webhook_ids(raw: str) -> None:
+    """(Re)populate the test-webhook allowlist from a comma-separated string.
+
+    Matches the original client.py semantics exactly: an empty value leaves
+    the existing contents untouched; a non-empty value replaces them.
+    """
+    if raw:
+        _ALLOWED_WEBHOOK_IDS.clear()
+        _ALLOWED_WEBHOOK_IDS.update(wid.strip() for wid in raw.split(",") if wid.strip())
+
+
+_EMAIL_BODY_TOOLS = frozenset({"email_send"})
+
+
+def _scrub_tool_input_for_storage(tool_name: str, tool_input: dict) -> dict:
+    """Redact privacy-sensitive fields from tool input before any storage path."""
+    if tool_name not in _EMAIL_BODY_TOOLS or not isinstance(tool_input, dict):
+        return tool_input
+    cleaned = dict(tool_input)
+    body = cleaned.get("body", "")
+    cleaned["body"] = f"[redacted email body: {len(body)} chars]"
+    if "attachments" in cleaned and cleaned["attachments"]:
+        from pathlib import Path
+
+        cleaned["attachments"] = [Path(p).name for p in cleaned["attachments"]]
+    return cleaned
+
+
+def ensure_failure_visible(result_text: str, ok: bool) -> str:
+    """Make a structurally-failed tool result visible to the model.
+
+    execute() carries ok=False on ToolResult, but the model only sees
+    str(result) — the raw output. When that text lacks an error prefix
+    (e.g. run_command_multi's per-host markdown aggregate wrapping a
+    denial), the model reads a refused action as success. Prefix it.
+    """
+    if ok or result_text.lstrip().startswith(_ERROR_RESULT_PREFIXES):
+        return result_text
+    return f"Error (tool reported failure):\n{result_text}"
 
 
 def build_request_preamble(

--- a/tests/characterization/test_p1_carve_semantics.py
+++ b/tests/characterization/test_p1_carve_semantics.py
@@ -1,0 +1,126 @@
+"""Characterization: mutation semantics the P1 seam-carve must preserve.
+
+The RFC-002 P1 carve moved the chat/loop closure state onto per-turn
+dataclasses. These tests pin the mutation-order properties the closures
+provided implicitly (RFC-002 R1 gate): the caller's history list is never
+mutated, tool results keep gather (call) order even when completion order
+reverses, and op-details accumulate across iterations in execution order.
+The retry-flag one-shot semantics, cascade order, cancel-check placement,
+and validation state transitions are already pinned by
+test_chat_tool_loop.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+
+import pytest
+
+from tests.fakes import (
+    FakeLLM,
+    FakeMessage,
+    make_bot,
+    text_response,
+    tool_call_response,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def build(script):
+    fake = FakeLLM(script)
+    bot = make_bot(fake_llm=fake)
+    return bot, fake
+
+
+class TestCarveMutationSemantics:
+    async def test_caller_history_list_not_mutated(self):
+        """run() works on a COPY of history — preamble insertion, guard
+        retries, and tool-result appends must never leak into the caller's
+        session list."""
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("done"),
+            ]
+        )
+        history = [
+            {"role": "user", "content": "earlier request"},
+            {"role": "assistant", "content": "earlier answer"},
+            {"role": "user", "content": "parse the time"},
+        ]
+        snapshot = copy.deepcopy(history)
+        history_id = id(history)
+
+        await bot._process_with_tools(FakeMessage("parse the time"), history)
+
+        assert id(history) == history_id
+        assert history == snapshot, "caller's history list was mutated by the turn"
+        # ...while the LLM-visible list grew: preamble + assistant + results
+        assert len(fake.messages_of_call(1)) > len(snapshot)
+
+    async def test_gather_results_keep_call_order_under_reversed_completion(self):
+        """Two parallel tools where the FIRST is slower: completion order
+        reverses, but the single tool_result message preserves CALL order
+        (asyncio.gather ordering — the trajectory/audit pairing relies on it)."""
+        bot, fake = build(
+            [
+                tool_call_response(
+                    ("parse_time", {"text": "slow"}),
+                    ("list_schedules", {}),
+                ),
+                text_response("both done"),
+            ]
+        )
+        completion_order: list[str] = []
+
+        async def slow_parse_time(inp):
+            await asyncio.sleep(0.05)
+            completion_order.append("parse_time")
+            return "slow-result"
+
+        async def fast_list_schedules():
+            completion_order.append("list_schedules")
+            return "fast-result"
+
+        bot._handle_parse_time = slow_parse_time
+        bot._handle_list_schedules = fast_list_schedules
+
+        text, _, is_error, tools_used, _ = await bot._process_with_tools(
+            FakeMessage("do both"), [{"role": "user", "content": "do both"}]
+        )
+
+        assert not is_error
+        assert completion_order == ["list_schedules", "parse_time"], (
+            "test premise broken: the fast tool should complete first"
+        )
+        results = fake.messages_of_call(1)[-1]["content"]
+        assert [r["tool_use_id"] for r in results] == ["call-1", "call-2"], (
+            "tool results must keep call order regardless of completion order"
+        )
+        assert results[0]["content"] == "slow-result"
+        assert results[1]["content"] == "fast-result"
+
+    async def test_op_details_accumulate_in_order_across_iterations(self):
+        """_last_op_details holds ONE list per turn that grows across
+        iterations in execution order (reflection reads the whole turn)."""
+        bot, fake = build(
+            [
+                tool_call_response(("parse_time", {"text": "now"})),
+                tool_call_response(("list_schedules", {})),
+                text_response("done"),
+            ]
+        )
+        msg = FakeMessage("two steps")
+        await bot._process_with_tools(msg, [{"role": "user", "content": "two steps"}])
+
+        details = bot._last_op_details[str(msg.channel.id)]
+        assert [d["tool"] for d in details] == ["parse_time", "list_schedules"], (
+            "op-details must accumulate across iterations in execution order"
+        )
+        # Same object is re-stashed each iteration — not reset between them
+        assert all(set(d) >= {"tool", "input", "result", "error"} for d in details)


### PR DESCRIPTION
## RFC-002 P1 — seam-carve of `tool_loop.py`

`run()` (800 lines) and `run_autonomous()` (348) become orchestrators (75/30 lines) over phase methods carved around per-turn state dataclasses `_ChatTurn`/`_LoopTurn`. **Zero behavior change** — every statement of the old bodies lands verbatim in exactly one phase method, proven mechanically (gate output below). No method exceeds 160 lines. LoopPolicy and every §4.3 chat/loop asymmetry untouched.

Also dissolves the `tool_loop → client` late-import cycle: `ensure_failure_visible`, `_scrub_tool_input_for_storage`, `_EMPTY_RESPONSE_FALLBACK`, and the test-webhook allowlist move to `tool_loop_helpers.py` (the shared leaf module — imports nothing from `src.discord`). The allowlist is now **mutated in place, never rebound**, so every importer's binding stays live; the empty-env no-op semantic is preserved exactly. `client.py` re-exports until P7; `background_task.py` + `intake_pipeline.py` now import the canonical homes.

### Declared mechanical transforms (the AST gate normalizes exactly these)
- **T1** `st.<name>` → `<name>` — turn-state fields keep the closure locals' names 1:1
- **T2** `nonlocal`/`global` dropped (state lives on the turn object)
- **T3** `ImportFrom` dropped (the one late import split across the methods that use each name)
- **T4** outcome protocol: `return ("done", X)` ≡ `return X` · `return ("retry", None)` ≡ `continue` · trailing `("ok", X)` dropped
- **T5** closure calls → method calls (`self._run_one_tool(st, b)` ≡ `_run_tool(b)` etc.)
- **T6** bare-string doc statements dropped
- **T7** declared per-block deltas: 19 closure initializers became dataclass field defaults (values verified); prepare methods end in the state-pack constructor; `_record_loop_iteration` bool protocol ≡ `break`; inline assistant-content block → the byte-identical `build_assistant_content` helper (completing RFC-001 R5 — the loop pipeline already used it); old `_run_tool` audit block → `_audit_tool_outcome` (length gate)

### Block map (old `tool_loop.py` lines → new method)
| Old lines | New method |
|---|---|
| 191–335 | `_prepare_chat_turn` |
| 337–339 / 340–355 | `_clear_active` / `_stopped` |
| 364–381 | `_maybe_compress` |
| 383–443 | `_call_llm` |
| 448–498 | `_check_stuck_and_record` |
| 504–631 | `_finalize_or_retry` |
| 652–814 (minus 759–789) | `_run_one_tool` |
| 759–789 | `_audit_tool_outcome` |
| 819–846 | `_run_one_tool_with_timeout` |
| 816–852 | `_execute_tool_calls` |
| 854–926 | `_post_iteration` |
| 928–937 | `_check_skill_handoff` |
| 939–957 | `_finalize_cap_hit` |
| 978–1075 | `_prepare_loop_turn` |
| 1042–1068 | `_finish_loop` |
| 1077–1093 | `_call_loop_llm` |
| 1095–1114 | `_record_loop_iteration` |
| 1122–1214 | `_run_one_loop_tool` |
| 1216–1256 | `_execute_loop_tools` |
| 1258–1306 | `_finalize_loop` |

Straight-line statements between blocks (cancel checks, assistant-content append, `tools_used` extend, loop increments) live verbatim in the orchestrators; `dispatch_loop_tool`/`dispatch_loop_tool_inner` untouched.

### Gates (all green)
- **AST carve gate: CLEAN — 22/22 blocks statement-identical** modulo the transforms above; the 19 dropped initializers match their dataclass defaults (full output + script below)
- Characterization: **130 passed** (127 existing + 3 new mutation-semantics pins: caller history-list immutability, gather call-order under reversed completion, op-details accumulation order — one-shot retry flags, cascade order, cancel placement, and validation transitions were already pinned)
- Full suite: **6,062 passed, 4 skipped**
- Lint: **zero new findings** (content-normalized diff vs the campaign baseline of 1,481)
- The gate caught one real slip during development (`_clear_active` spelled `self.host.` instead of the closure's `bot.`) — which is the point of it.

<details><summary>Carve-gate output</summary>

```
PASS  _prepare_chat_turn  (30 stmts)  state-pack return dropped (T7)
PASS  _clear_active  (1 stmts)  closure def body
PASS  _stopped  (6 stmts)  closure def body
PASS  _maybe_compress  (1 stmts)  
PASS  _call_llm  (4 stmts)  trailing ok-return dropped
PASS  _check_stuck_and_record  (4 stmts)  nudge continue -> retry
PASS  _finalize_or_retry  (13 stmts)  continues -> retry
PASS  _run_one_tool  (21 stmts)  closure def body; nonlocal dropped; audit block -> _audit_tool_outcome
PASS  _audit_tool_outcome  (1 stmts)  inline audit block of old _run_tool
PASS  _run_one_tool_with_timeout  (2 stmts)  closure def body
PASS  _execute_tool_calls  (3 stmts)  timeout read + gather + append
PASS  _post_iteration  (8 stmts)  
PASS  _check_skill_handoff  (2 stmts)  
PASS  _finalize_cap_hit  (5 stmts)  
PASS  _prepare_loop_turn  (20 stmts)  final_text/completed_naturally/tool_calls_made -> dataclass defaults; _finish def filtered
PASS  _finish_loop  (3 stmts)  closure def body
PASS  _call_loop_llm  (1 stmts)  trailing ok-return dropped
PASS  _record_loop_iteration  (3 stmts)  break/bool protocol
PASS  _run_one_loop_tool  (13 stmts)  closure def body; nonlocal dropped
PASS  _execute_loop_tools  (5 stmts)  trailing return dropped
PASS  _finalize_loop  (3 stmts)  
PASS  dataclass defaults match the 19 dropped initializers

CLEAN — all blocks statement-identical modulo declared transforms
```
</details>

<details><summary>Checker script (carve_check_p1.py)</summary>

```python
#!/usr/bin/env python3
"""RFC-002 P1 carve gate: prove each carved phase body of tool_loop.py is
statement-identical (AST level) to its pre-carve block, modulo the declared
mechanical transforms:

  T1  st.<name>            -> <name>        (turn-state fields keep local names)
  T2  `nonlocal`/`global`  -> dropped       (state lives on the turn object)
  T3  ImportFrom           -> dropped       (late imports split across methods)
  T4  return ("done", X)   -> return X      (outcome protocol)
      return ("retry", None) -> continue
      trailing return ("ok", X) -> dropped
  T5  self._carved(st, ..) -> _old_closure(..)   (closure->method call shape)
  T6  bare-string Expr     -> dropped       (doc/comment strings)
  T7  method-specific declared deltas (listed per block below)

Usage: carve_check_p1.py <old_file> <new_file>
"""

from __future__ import annotations

import ast
import sys

OLD_PATH, NEW_PATH = sys.argv[1], sys.argv[2]

# Locals that became dataclass-field DEFAULTS on _ChatTurn/_LoopTurn (T7).
# Dropped from the old blocks; their default VALUES are verified against the
# dataclass definitions below.
DEFAULT_PACKED = {
    "tools_used_in_loop", "continuation_count", "max_continuations",
    "fabrication_retried", "promise_retried", "unavail_retried",
    "hedging_retried", "code_hedging_retried", "premature_failure_retried",
    "pending_image_blocks", "_pending_validations", "_validation_required",
    "_validation_retries", "_max_validation_retries", "_op_tool_details",
    "_loop_details", "final_text", "completed_naturally", "tool_calls_made",
}

# closure-name mapping for T5 (new method -> old closure/local-fn name)
CALL_MAP = {
    "_run_one_tool": "_run_tool",
    "_run_one_tool_with_timeout": "_run_tool_with_timeout",
    "_run_one_loop_tool": "_run_loop_tool",
    "_stopped": "_stopped",
    "_clear_active": "_clear_active",
    "_finish_loop": "_finish",
}


class Normalize(ast.NodeTransformer):
    def __init__(self, method: str):
        self.method = method

    # T1: st.X -> X ; also msg_proxy etc live on st in loop methods
    def visit_Attribute(self, node):
        self.generic_visit(node)
        if isinstance(node.value, ast.Name) and node.value.id == "st":
            return ast.copy_location(ast.Name(id=node.attr, ctx=node.ctx), node)
        return node

    # T5: self._carved(st, ...) -> _old(...)
    def visit_Call(self, node):
        self.generic_visit(node)
        f = node.func
        if (
            isinstance(f, ast.Attribute)
            and isinstance(f.value, ast.Name)
            and f.value.id == "self"
            and f.attr in CALL_MAP
        ):
            args = node.args
            if args and isinstance(args[0], ast.Name) and args[0].id == "st":
                args = args[1:]
            # _run_one_tool_with_timeout gained explicit tool_timeout arg (was
            # a closure capture): drop it to match the old call shape.
            if f.attr == "_run_one_tool_with_timeout" and len(args) > 1:
                args = args[:1]
            return ast.copy_location(
                ast.Call(func=ast.Name(id=CALL_MAP[f.attr], ctx=ast.Load()), args=args, keywords=node.keywords),
                node,
            )
        return node

    # T2 / T3 / T6
    def visit_Nonlocal(self, node):
        return None

    def visit_Global(self, node):
        return None

    def visit_ImportFrom(self, node):
        return None

    def visit_Expr(self, node):
        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
            return None
        # T7: the audit block of the old _run_tool became a method; the call
        # statement replacing it is dropped, the method body is its own block.
        v = node.value
        if isinstance(v, ast.Await):
            v = v.value
        if (
            isinstance(v, ast.Call)
            and isinstance(v.func, ast.Attribute)
            and isinstance(v.func.value, ast.Name)
            and v.func.value.id == "self"
            and v.func.attr == "_audit_tool_outcome"
        ):
            return None
        self.generic_visit(node)
        return node

    # T4: outcome-protocol returns
    def visit_Return(self, node):
        self.generic_visit(node)
        v = node.value
        if isinstance(v, ast.Tuple) and len(v.elts) == 2 and isinstance(v.elts[0], ast.Constant):
            tag = v.elts[0].value
            if tag == "done":
                return ast.copy_location(ast.Return(value=v.elts[1]), node)
            if tag == "retry":
                return ast.copy_location(ast.Continue(), node)
            if tag == "ok":
                return None  # trailing success-return, dropped
        # method-specific (T7): _record_loop_iteration bool protocol
        if self.method == "_record_loop_iteration":
            if isinstance(v, ast.Constant) and v.value is True:
                return ast.copy_location(ast.Break(), node)
            if isinstance(v, ast.Constant) and v.value is False:
                return None
        # T7: _execute_tool_calls/_execute_loop_tools trailing return of results
        if self.method in ("_execute_tool_calls", "_execute_loop_tools"):
            if isinstance(v, ast.Name) and v.id == "tool_results":
                return None
        # T7: _prepare_* trailing state-pack constructor
        if self.method.startswith("_prepare") and isinstance(v, ast.Call):
            return None
        return node


DROPPED_DEFAULTS: dict[str, str] = {}  # name -> value dump, for verification


def _is_default_packed(s):
    t = None
    if isinstance(s, ast.Assign) and len(s.targets) == 1 and isinstance(s.targets[0], ast.Name):
        t = s.targets[0].id
    elif isinstance(s, ast.AnnAssign) and isinstance(s.target, ast.Name):
        t = s.target.id
    if t in DEFAULT_PACKED and s.value is not None:
        DROPPED_DEFAULTS[t] = ast.dump(s.value, include_attributes=False)
        return True
    return False


def norm_stmts(stmts, method):
    out = []
    tf = Normalize(method)
    for s in stmts:
        if method.startswith("_prepare") and _is_default_packed(s):
            continue  # T7: became a dataclass field default (verified below)
        r = tf.visit(s)
        if r is None:
            continue
        if isinstance(r, list):
            out.extend(r)
        else:
            out.append(r)
    dumps = [ast.dump(ast.fix_missing_locations(s), include_attributes=False) for s in out]
    # T4/T7: an explicit trailing `return None` marks fall-through in the
    # outcome-protocol methods; old blocks simply fell off the end.
    if dumps and dumps[-1] == "Return(value=Constant(value=None))":
        dumps.pop()
    return dumps


def verify_dataclass_defaults(new_tree):
    """Every dropped old initializer must match its dataclass field default."""
    fields = {}
    for node in ast.walk(new_tree):
        if isinstance(node, ast.ClassDef) and node.name in ("_ChatTurn", "_LoopTurn"):
            for item in node.body:
                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name) and item.value is not None:
                    fields[item.target.id] = ast.dump(item.value, include_attributes=False)
    bad = []
    for name, old_val in DROPPED_DEFAULTS.items():
        fv = fields.get(name)
        if fv is None:
            bad.append(f"{name}: not a defaulted dataclass field")
            continue
        # field(default_factory=list) ≡ [] ; plain constants must match exactly
        if "default_factory" in fv:
            ok = old_val in ("List(elts=[], ctx=Load())",) and "Name(id='list'" in fv
        else:
            ok = fv.startswith("Constant") and old_val == fv
        if not ok:
            bad.append(f"{name}: old init {old_val[:60]} vs field default {fv[:80]}")
    return bad


def parse(path):
    return ast.parse(open(path).read())


def find_func(tree, name, cls=None):
    for node in ast.walk(tree):
        if isinstance(node, ast.ClassDef) and (cls is None or node.name == cls):
            for item in node.body:
                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == name:
                    return item
    for node in ast.walk(tree):
        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
            return node
    raise SystemExit(f"function {name} not found")


def stmts_in_range(func, lo, hi):
    """Top-level-of-function statements fully within [lo, hi], recursing is NOT
    done — a range that starts inside a compound stmt must align to it."""
    picked = []
    def walk(body):
        for s in body:
            if s.lineno >= lo and s.end_lineno <= hi:
                picked.append(s)
            elif s.lineno <= hi and s.end_lineno >= lo:
                # partial overlap: descend (incl. closure defs) to find the
                # aligned statements inside
                walk(getattr(s, "body", []) or [])
                for h in getattr(s, "handlers", []) or []:
                    walk(h.body)
                walk(getattr(s, "orelse", []) or [])
                walk(getattr(s, "finalbody", []) or [])
    walk(func.body)
    return picked


old = parse(OLD_PATH)
new = parse(NEW_PATH)

old_run = find_func(old, "run", "ToolLoopRunner")
old_auto = find_func(old, "run_autonomous", "ToolLoopRunner")

# (new_method, old_container, old_line_range, note)
BLOCKS = [
    ("_prepare_chat_turn",        old_run,  (191, 335), "state-pack return dropped (T7)"),
    ("_clear_active",             old_run,  (337, 339), "closure def body"),
    ("_stopped",                  old_run,  (340, 355), "closure def body"),
    ("_maybe_compress",           old_run,  (364, 381), ""),
    ("_call_llm",                 old_run,  (383, 443), "trailing ok-return dropped"),
    ("_check_stuck_and_record",   old_run,  (448, 498), "nudge continue -> retry"),
    ("_finalize_or_retry",        old_run,  (504, 631), "continues -> retry"),
    ("_run_one_tool",             old_run,  (652, 814), "closure def body; nonlocal dropped; audit block -> _audit_tool_outcome"),
    ("_audit_tool_outcome",       old_run,  (759, 789), "inline audit block of old _run_tool"),
    ("_run_one_tool_with_timeout", old_run, (819, 846), "closure def body"),
    ("_execute_tool_calls",       old_run,  (816, 852), "timeout read + gather + append"),
    ("_post_iteration",           old_run,  (854, 926), ""),
    ("_check_skill_handoff",      old_run,  (928, 937), ""),
    ("_finalize_cap_hit",         old_run,  (939, 957), ""),
    ("_prepare_loop_turn",        old_auto, (978, 1075), "final_text/completed_naturally/tool_calls_made -> dataclass defaults; _finish def filtered"),
    ("_finish_loop",              old_auto, (1042, 1068), "closure def body"),
    ("_call_loop_llm",            old_auto, (1077, 1093), "trailing ok-return dropped"),
    ("_record_loop_iteration",    old_auto, (1095, 1114), "break/bool protocol"),
    ("_run_one_loop_tool",        old_auto, (1122, 1214), "closure def body; nonlocal dropped"),
    ("_execute_loop_tools",       old_auto, (1216, 1256), "trailing return dropped"),
    ("_finalize_loop",            old_auto, (1258, 1306), ""),
]

failures = 0
for new_name, container, (lo, hi), note in BLOCKS:
    old_sts = stmts_in_range(container, lo, hi)
    # closure bodies: if range picked exactly one FunctionDef, use ITS body
    if len(old_sts) == 1 and isinstance(old_sts[0], (ast.FunctionDef, ast.AsyncFunctionDef)):
        old_sts = old_sts[0].body
    else:
        old_sts = [s for s in old_sts if not isinstance(s, (ast.FunctionDef, ast.AsyncFunctionDef))]
    if new_name == "_run_one_tool":
        # the inline audit Try moved to _audit_tool_outcome (own block below)
        old_sts = [s for s in old_sts if not (759 <= s.lineno and s.end_lineno <= 789)]
    new_fn = find_func(new, new_name, "ToolLoopRunner")
    new_sts = list(new_fn.body)
    # drop leading docstring + `bot = self.host`
    o = norm_stmts(old_sts, new_name)
    n = []
    for s in new_sts:
        if (isinstance(s, ast.Assign) and len(s.targets) == 1
                and isinstance(s.targets[0], ast.Name) and s.targets[0].id == "bot"
                and isinstance(s.value, ast.Attribute) and s.value.attr == "host"):
            continue
        n.append(s)
    n = norm_stmts(n, new_name)
    if o == n:
        print(f"PASS  {new_name}  ({len(n)} stmts)  {note}")
    else:
        failures += 1
        print(f"FAIL  {new_name}: old={len(o)} new={len(n)} stmts")
        for i, (a, b) in enumerate(zip(o, n)):
            if a != b:
                print(f"  first divergence at stmt {i}:")
                print(f"   OLD: {a[:220]}")
                print(f"   NEW: {b[:220]}")
                break
        else:
            longer = o if len(o) > len(n) else n
            which = "OLD" if len(o) > len(n) else "NEW"
            print(f"  extra stmts in {which}: {[s[:120] for s in longer[min(len(o), len(n)):]]}")

default_problems = verify_dataclass_defaults(new)
if default_problems:
    failures += 1
    print("FAIL  dataclass-default verification:")
    for p in default_problems:
        print(f"  {p}")
else:
    print(f"PASS  dataclass defaults match the {len(DROPPED_DEFAULTS)} dropped initializers")

print(f"\n{'CLEAN — all blocks statement-identical modulo declared transforms' if not failures else str(failures) + ' BLOCK(S) DIVERGE'}")
sys.exit(1 if failures else 0)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3
