### PR TITLE
refactor(wiring): P2 — build_components stage + public component names

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -16,10 +16,8 @@ from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
 from ..tools import ToolResult, get_tool_definitions
 from ..async_utils import fire_and_forget
-from .channel_state import ChannelStateRegistry
 from .completion import CLASSIFIER_SYSTEM_PROMPT, CompletionClassifier
-from .intake_pipeline import MessageIntake, MessagePipeline
-from .tool_loop import ToolLoopRunner, ensure_failure_visible
+from .tool_loop import ensure_failure_visible
 from .tool_loop import _LoopAuthorProxy, _LoopMessageProxy  # noqa: F401 — re-export (tests, proxies)
 
 # Canonical homes moved to tool_loop_helpers (RFC-002 P1) — re-exported here
@@ -32,23 +30,12 @@ from .tool_loop_helpers import (
     _scrub_tool_input_for_storage,
     init_allowed_webhook_ids as _init_allowed_webhook_ids_impl,
 )
-from .delivery import ResponseDelivery
 from .delivery import DISCORD_MAX_LEN  # noqa: F401 — module re-export contract
 from .delivery import SEND_MAX_RETRIES  # noqa: F401 — module re-export contract
-from .llm_gateway import LLMGateway
-from .native_tools import NativeToolDispatcher, register_native_handlers
-from .native_tools.agents_tasks import AgentTaskTools
-from .scheduled_events import ScheduledEventHandlers
 from .slash_commands import register_commands
-from .turn_recorder import TurnRecorder
-from .native_tools.channel_ops import ChannelOpsTools
 from .native_tools.media import MediaTools
-from .native_tools.knowledge import KnowledgeTools
-from .native_tools.scheduling import SchedulingTools
-from .prompts import PromptBuilder
-from .tool_catalog import ToolCatalog
 from .voice import VoiceManager, VoiceMessageProxy
-from .wiring import build_services, shutdown_services
+from .wiring import build_components, build_services, shutdown_services
 
 log = get_logger("discord")
 
@@ -182,11 +169,20 @@ class OdinBot(commands.Bot):
         # commands.Bot already initializes self.tree (app_commands.CommandTree); do not overwrite
         self._start_time = time.monotonic()
 
-        # Per-channel mutable state — owned by ChannelStateRegistry (RFC-001
-        # P2). The dict attributes below are facade ALIASES to the registry's
-        # dicts (same objects): external readers (web layer, tests) keep
-        # working, and mutations through either name stay in sync.
-        self._channel_state = ChannelStateRegistry()
+        # ------------------------------------------------------------------
+        # Subsystem construction lives in the composition root (wiring.py,
+        # RFC-001 P1). Attributes are attached flat so the external facade
+        # (web/api.py, health checks, tests) is unchanged.
+        # ------------------------------------------------------------------
+        services = build_services(config)
+        self.services = services
+
+        # Per-channel mutable state — owned by ChannelStateRegistry
+        # (constructed in build_services since RFC-002 P2). The dict
+        # attributes below are facade ALIASES to the registry's dicts (same
+        # objects): external readers (web layer, tests) keep working, and
+        # mutations through either name stay in sync.
+        self.channel_state = self._channel_state = services.channel_state
         self._channel_locks = self._channel_state.channel_locks
         self._cancel_events = self._channel_state.cancel_events
         self._pending_files = self._channel_state.pending_files
@@ -194,12 +190,6 @@ class OdinBot(commands.Bot):
         self._last_op_details = self._channel_state.last_op_details
         self._background_tasks = self._channel_state.background_tasks
 
-        # ------------------------------------------------------------------
-        # Subsystem construction lives in the composition root (wiring.py,
-        # RFC-001 P1). Attributes are attached flat so the external facade
-        # (web/api.py, health checks, tests) is unchanged.
-        # ------------------------------------------------------------------
-        services = build_services(config)
         self.context_loader = services.context_loader
         self.reflector = services.reflector
         self._embedder = services.embedder
@@ -241,106 +231,50 @@ class OdinBot(commands.Bot):
         # constructor arg; signing happens automatically inside log_execution.
         self.audit_signer = self.audit._signer
 
-        # LLM provider management (RFC-001 P4) — the gateway owns the
-        # provider clients and switch state; codex_client/ollama_client/
-        # kimi_client on the bot are property shims over it.
-        self._llm_gateway = LLMGateway(
-            get_config=lambda: self.config,
-            codex_client=services.codex_client,
-            ollama_client=services.ollama_client,
-            kimi_client=services.kimi_client,
-            subsystem_guard=services.subsystem_guard,
-            model_router=services.model_router,
-            auxiliary_llm_client=services.auxiliary_llm_client,
-            cost_tracker=services.cost_tracker,
-            sessions=services.sessions,
-            reflector=services.reflector,
-        )
-
-        # Wire LLM callbacks to whichever provider is active
-        if self.llm_client is not None:
-            self._wire_llm_callbacks()
-
         # Voice support — VoiceManager takes the live bot, so it stays here
+        # (and must exist before build_components: PromptBuilder consumes it).
         self.voice_manager: VoiceManager | None = None
         if config.voice.enabled:
             self.voice_manager = VoiceManager(config.voice, self)
             self.voice_manager.on_transcription = self._on_voice_transcription
 
-        # Proactive infrastructure monitoring — alert callback needs the bot
+        # ------------------------------------------------------------------
+        # Bot-coupled component assembly (RFC-002 P2) — construction moved to
+        # wiring.build_components. Components carry PUBLIC names; the old
+        # underscore spellings remain as aliases to the same objects until P7
+        # retires the facade.
+        # ------------------------------------------------------------------
+        components = build_components(self, services)
+        self.components = components
+        self.llm_gateway = self._llm_gateway = components.llm_gateway
+        self.prompt_builder = self._prompt_builder = components.prompt_builder
+        self.tool_catalog = self._tool_catalog = components.tool_catalog
+        self.native_tools = self._native_tools = components.native_tools
+        self.scheduling_tools = self._scheduling_tools = components.scheduling_tools
+        self.knowledge_tools = self._knowledge_tools = components.knowledge_tools
+        self.channel_ops_tools = self._channel_ops_tools = components.channel_ops_tools
+        self.media_tools = self._media_tools = components.media_tools
+        self.delivery = self._delivery = components.delivery
+        self.completion_classifier = self._completion_classifier = (
+            components.completion_classifier
+        )
+        self.tool_loop = self._tool_loop_runner = components.tool_loop
+        self.turn_recorder = self._turn_recorder = components.turn_recorder
+        self.scheduled_events = self._scheduled_events = components.scheduled_events
+        self.agent_task_tools = self._agent_task_tools = components.agent_task_tools
+        self.intake = self._message_intake = components.intake
+        self.pipeline = self._message_pipeline = components.pipeline
+
+        # Proactive infrastructure monitoring — constructed AFTER the
+        # components so the alert callback wires directly to the
+        # scheduled-events component (RFC-002 R1; no bot delegate).
         self.infra_watcher: InfraWatcher | None = None
         if config.monitoring.enabled and config.monitoring.checks:
             self.infra_watcher = InfraWatcher(
                 config=config.monitoring,
                 executor=self.tool_executor,
-                alert_callback=self._on_monitor_alert,
+                alert_callback=self.scheduled_events._on_monitor_alert,
             )
-
-        # Prompt assembly + tool catalog (RFC-001 P3). Bot-coupled because
-        # they must read LIVE hot-reloadable state: bot.config is replaced by
-        # the web API's config hot-reload and bot.codex_client by live auth
-        # reloads — hence provider callables, not captured references.
-        self._prompt_builder = PromptBuilder(
-            get_config=lambda: self.config,
-            context_loader=self.context_loader,
-            reflector=self.reflector,
-            skill_manager=self.skill_manager,
-            tool_executor=self.tool_executor,
-            channel_state=self._channel_state,
-            voice_manager=self.voice_manager,
-            get_codex_client=lambda: self.codex_client,
-        )
-        self._tool_catalog = ToolCatalog(
-            get_config=lambda: self.config,
-            skill_manager=self.skill_manager,
-        )
-
-        # One Discord-native dispatch table for both pipelines (RFC-001 P5a);
-        # handler bodies stay as bot methods until P5b moves them to domain
-        # modules. Constructed after the catalog/builder it invalidates.
-        self._native_tools = NativeToolDispatcher(
-            handler_host=self,
-            skill_manager=self.skill_manager,
-            tool_catalog=self._tool_catalog,
-            prompt_builder=self._prompt_builder,
-            channel_state=self._channel_state,
-            invoke_skill_missing_required=self._invoke_skill_missing_required,
-        )
-        register_native_handlers(self._native_tools)
-
-        # Domain handler bundles (P5b) — bodies moved out of the bot; the
-        # delegate methods below keep the dispatch host + test seam stable.
-        self._scheduling_tools = SchedulingTools(scheduler=self.scheduler)
-        self._knowledge_tools = KnowledgeTools(
-            sessions=self.sessions,
-            get_knowledge_store=lambda: self._knowledge_store,
-            embedder=self._embedder,
-            audit=self.audit,
-        )
-        self._channel_ops_tools = ChannelOpsTools(
-            sessions=self.sessions,
-            permissions=self.permissions,
-            get_channel=self.get_channel,
-        )
-        self._media_tools = MediaTools(
-            get_config=lambda: self.config,
-            browser_manager=self.browser_manager,
-            tool_executor=self.tool_executor,
-        )
-        self._delivery = ResponseDelivery(
-            channel_state=self._channel_state,
-            change_presence=self.change_presence,
-        )
-        self._completion_classifier = CompletionClassifier(
-            get_llm_client=lambda: self.llm_client,
-        )
-        self._tool_loop_runner = ToolLoopRunner(self)
-        self._turn_recorder = TurnRecorder(self)
-        self._scheduled_events = ScheduledEventHandlers(self)
-        self._agent_task_tools = AgentTaskTools(self)
-        self._message_intake = MessageIntake(self)
-        self._message_pipeline = MessagePipeline(self)
-
 
         # Public `codex` / `knowledge` attributes are exposed as dynamic
         # properties defined below on the class — see the @property blocks.
@@ -848,7 +782,10 @@ class OdinBot(commands.Bot):
             self.tree.copy_global_to(guild=guild)
             await self.tree.sync(guild=guild)
             log.info("Slash commands synced to guild: %s", guild.name)
-        self.scheduler.start(self._on_scheduled_task, self._on_schedule_failure)
+        self.scheduler.start(
+            self.scheduled_events._on_scheduled_task,
+            self.scheduled_events._on_schedule_failure,
+        )
         if self._vector_store:
             fire_and_forget(self._backfill_archives(), name="backfill_archives")
         # Start proactive monitoring if configured

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -48,6 +48,22 @@ from ..tools.autonomous_loop import LoopManager
 from ..trajectories.saver import TrajectorySaver
 from .channel_config import ChannelConfigManager
 from .channel_logger import ChannelLogger
+from .channel_state import ChannelStateRegistry
+from .completion import CompletionClassifier
+from .delivery import ResponseDelivery
+from .intake_pipeline import MessageIntake, MessagePipeline
+from .llm_gateway import LLMGateway
+from .native_tools import NativeToolDispatcher, register_native_handlers
+from .native_tools.agents_tasks import AgentTaskTools
+from .native_tools.channel_ops import ChannelOpsTools
+from .native_tools.knowledge import KnowledgeTools
+from .native_tools.media import MediaTools
+from .native_tools.scheduling import SchedulingTools
+from .prompts import PromptBuilder
+from .scheduled_events import ScheduledEventHandlers
+from .tool_catalog import ToolCatalog
+from .tool_loop import ToolLoopRunner
+from .turn_recorder import TurnRecorder
 
 log = get_logger("discord")
 
@@ -56,6 +72,7 @@ log = get_logger("discord")
 class BotServices:
     """Every bot-independent subsystem, constructed in dependency order."""
 
+    channel_state: ChannelStateRegistry
     context_loader: ContextLoader
     reflector: ConversationReflector
     embedder: LocalEmbedder | None
@@ -102,6 +119,10 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
     from ..tools.time_parser import set_default_timezone
 
     set_default_timezone(config.timezone)
+
+    # Per-channel mutable state — bot-independent, so it belongs here
+    # (RFC-002 P2; the bot keeps facade aliases to its dicts until P7).
+    channel_state = ChannelStateRegistry()
 
     # Multi-agent orchestration
     agent_manager = AgentManager()
@@ -441,6 +462,7 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
         )
 
     return BotServices(
+        channel_state=channel_state,
         context_loader=context_loader,
         reflector=reflector,
         embedder=embedder,
@@ -480,6 +502,143 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
         stuck_loop_tracker_cls=StuckLoopTracker,
         classify_command_risk=classify_command,
         classify_tool_risk=classify_tool,
+    )
+
+
+@dataclass
+class BotComponents:
+    """Every bot-coupled component, constructed in dependency order (RFC-002 P2)."""
+
+    llm_gateway: LLMGateway
+    prompt_builder: PromptBuilder
+    tool_catalog: ToolCatalog
+    native_tools: NativeToolDispatcher
+    scheduling_tools: SchedulingTools
+    knowledge_tools: KnowledgeTools
+    channel_ops_tools: ChannelOpsTools
+    media_tools: MediaTools
+    delivery: ResponseDelivery
+    completion_classifier: CompletionClassifier
+    tool_loop: ToolLoopRunner
+    turn_recorder: TurnRecorder
+    scheduled_events: ScheduledEventHandlers
+    agent_task_tools: AgentTaskTools
+    intake: MessageIntake
+    pipeline: MessagePipeline
+
+
+def build_components(bot, services: BotServices) -> BotComponents:
+    """Bot-coupled component assembly — moved verbatim from ``OdinBot.__init__``
+    (RFC-002 P2), in the exact construction order it used.
+
+    "Bot-coupled" means exactly: live hot-reloadable roots read via provider
+    callables (``bot.config`` is replaced by config hot-reload, the provider
+    clients by live auth reloads), Discord-client operations
+    (``change_presence``, ``get_channel``), the voice manager (constructed on
+    the bot before this runs), and — until P3/P4 narrow them — the classes
+    that still take the bot as ``host``.
+    """
+    # LLM provider management (RFC-001 P4) — the gateway owns the provider
+    # clients and switch state; codex_client/ollama_client/kimi_client on
+    # the bot are property shims over it.
+    llm_gateway = LLMGateway(
+        get_config=lambda: bot.config,
+        codex_client=services.codex_client,
+        ollama_client=services.ollama_client,
+        kimi_client=services.kimi_client,
+        subsystem_guard=services.subsystem_guard,
+        model_router=services.model_router,
+        auxiliary_llm_client=services.auxiliary_llm_client,
+        cost_tracker=services.cost_tracker,
+        sessions=services.sessions,
+        reflector=services.reflector,
+    )
+
+    # Wire LLM callbacks to whichever provider is active
+    if llm_gateway.active_client is not None:
+        llm_gateway.wire_callbacks()
+
+    # Prompt assembly + tool catalog (RFC-001 P3). Bot-coupled because they
+    # must read LIVE hot-reloadable state: bot.config is replaced by the web
+    # API's config hot-reload and the codex client by live auth reloads —
+    # hence provider callables, not captured references.
+    prompt_builder = PromptBuilder(
+        get_config=lambda: bot.config,
+        context_loader=services.context_loader,
+        reflector=services.reflector,
+        skill_manager=services.skill_manager,
+        tool_executor=services.tool_executor,
+        channel_state=services.channel_state,
+        voice_manager=bot.voice_manager,
+        get_codex_client=lambda: llm_gateway.codex_client,
+    )
+    tool_catalog = ToolCatalog(
+        get_config=lambda: bot.config,
+        skill_manager=services.skill_manager,
+    )
+
+    # One Discord-native dispatch table for both pipelines (RFC-001 P5a);
+    # handler bodies live in the domain modules, dispatched late through the
+    # host until P5 binds owners directly.
+    native_tools = NativeToolDispatcher(
+        handler_host=bot,
+        skill_manager=services.skill_manager,
+        tool_catalog=tool_catalog,
+        prompt_builder=prompt_builder,
+        channel_state=services.channel_state,
+        invoke_skill_missing_required=bot._invoke_skill_missing_required,
+    )
+    register_native_handlers(native_tools)
+
+    # Domain handler bundles (P5b)
+    scheduling_tools = SchedulingTools(scheduler=services.scheduler)
+    knowledge_tools = KnowledgeTools(
+        sessions=services.sessions,
+        get_knowledge_store=lambda: bot._knowledge_store,
+        embedder=services.embedder,
+        audit=services.audit,
+    )
+    channel_ops_tools = ChannelOpsTools(
+        sessions=services.sessions,
+        permissions=services.permissions,
+        get_channel=bot.get_channel,
+    )
+    media_tools = MediaTools(
+        get_config=lambda: bot.config,
+        browser_manager=services.browser_manager,
+        tool_executor=services.tool_executor,
+    )
+    delivery = ResponseDelivery(
+        channel_state=services.channel_state,
+        change_presence=bot.change_presence,
+    )
+    completion_classifier = CompletionClassifier(
+        get_llm_client=lambda: bot.llm_client,
+    )
+    tool_loop = ToolLoopRunner(bot)
+    turn_recorder = TurnRecorder(bot)
+    scheduled_events = ScheduledEventHandlers(bot)
+    agent_task_tools = AgentTaskTools(bot)
+    intake = MessageIntake(bot)
+    pipeline = MessagePipeline(bot)
+
+    return BotComponents(
+        llm_gateway=llm_gateway,
+        prompt_builder=prompt_builder,
+        tool_catalog=tool_catalog,
+        native_tools=native_tools,
+        scheduling_tools=scheduling_tools,
+        knowledge_tools=knowledge_tools,
+        channel_ops_tools=channel_ops_tools,
+        media_tools=media_tools,
+        delivery=delivery,
+        completion_classifier=completion_classifier,
+        tool_loop=tool_loop,
+        turn_recorder=turn_recorder,
+        scheduled_events=scheduled_events,
+        agent_task_tools=agent_task_tools,
+        intake=intake,
+        pipeline=pipeline,
     )
 
 

--- a/tests/characterization/test_p2_composition.py
+++ b/tests/characterization/test_p2_composition.py
@@ -1,0 +1,105 @@
+"""Characterization: two-stage composition (RFC-002 P2).
+
+Pins the build_services → build_components assembly: public component
+names and their campaign-era underscore aliases are the SAME objects,
+the channel-state registry lives in services, and the R1 rewiring holds
+(infra-watcher alert callback and scheduler callbacks bind the
+scheduled-events component directly — no bot delegate in the path).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from src.discord.wiring import BotComponents, BotServices
+from tests.fakes import FakeLLM, make_bot
+
+# (public name, campaign alias, BotComponents field)
+COMPONENT_TRIPLES = [
+    ("llm_gateway", "_llm_gateway", "llm_gateway"),
+    ("prompt_builder", "_prompt_builder", "prompt_builder"),
+    ("tool_catalog", "_tool_catalog", "tool_catalog"),
+    ("native_tools", "_native_tools", "native_tools"),
+    ("scheduling_tools", "_scheduling_tools", "scheduling_tools"),
+    ("knowledge_tools", "_knowledge_tools", "knowledge_tools"),
+    ("channel_ops_tools", "_channel_ops_tools", "channel_ops_tools"),
+    ("media_tools", "_media_tools", "media_tools"),
+    ("delivery", "_delivery", "delivery"),
+    ("completion_classifier", "_completion_classifier", "completion_classifier"),
+    ("tool_loop", "_tool_loop_runner", "tool_loop"),
+    ("turn_recorder", "_turn_recorder", "turn_recorder"),
+    ("scheduled_events", "_scheduled_events", "scheduled_events"),
+    ("agent_task_tools", "_agent_task_tools", "agent_task_tools"),
+    ("intake", "_message_intake", "intake"),
+    ("pipeline", "_message_pipeline", "pipeline"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def bot():
+    return make_bot(fake_llm=FakeLLM([]))
+
+
+class TestTwoStageComposition:
+    def test_services_and_components_handles(self, bot):
+        assert isinstance(bot.services, BotServices)
+        assert isinstance(bot.components, BotComponents)
+
+    def test_public_names_alias_underscore_names_and_component_fields(self, bot):
+        for public, alias, fieldname in COMPONENT_TRIPLES:
+            pub = getattr(bot, public)
+            assert pub is getattr(bot, alias), f"{public} is not {alias}"
+            assert pub is getattr(bot.components, fieldname), (
+                f"bot.{public} is not components.{fieldname}"
+            )
+
+    def test_channel_state_lives_in_services(self, bot):
+        assert bot.channel_state is bot.services.channel_state
+        assert bot.channel_state is bot._channel_state
+        # The six facade dict aliases still point INTO the registry
+        assert bot._channel_locks is bot.channel_state.channel_locks
+        assert bot._cancel_events is bot.channel_state.cancel_events
+        assert bot._pending_files is bot.channel_state.pending_files
+        assert bot._recent_actions is bot.channel_state.recent_actions
+        assert bot._last_op_details is bot.channel_state.last_op_details
+        assert bot._background_tasks is bot.channel_state.background_tasks
+
+    def test_gateway_owns_the_llm_surface(self, bot):
+        # The bot property shims read the gateway (unchanged by P2)
+        assert bot.codex_client is bot.llm_gateway.codex_client
+        assert bot.llm_client is bot.llm_gateway.active_client
+
+    def test_infra_watcher_alert_callback_binds_scheduled_events(self, tmp_path):
+        bot = make_bot(
+            fake_llm=FakeLLM([]),
+            config_overrides={
+                "monitoring": {
+                    "enabled": True,
+                    "checks": [{"name": "disk", "type": "disk", "threshold": 95}],
+                }
+            },
+        )
+        assert bot.infra_watcher is not None
+        cb = bot.infra_watcher._alert_callback
+        assert getattr(cb, "__self__", None) is bot.scheduled_events, (
+            "R1: the alert callback must bind the scheduled-events component "
+            "directly, not a bot delegate"
+        )
+
+    def test_infra_watcher_absent_but_attribute_none_by_default(self, bot):
+        assert bot.infra_watcher is None  # attribute exists, None when disabled
+
+    def test_scheduler_start_wires_scheduled_events_methods(self):
+        # on_ready is too heavy to drive here (guild sync); pin the spelling.
+        from src.discord.client import OdinBot
+
+        src = inspect.getsource(OdinBot.on_ready)
+        assert "self.scheduled_events._on_scheduled_task" in src
+        assert "self.scheduled_events._on_schedule_failure" in src


### PR DESCRIPTION
## RFC-002 P2 — two-stage composition

`OdinBot.__init__` no longer constructs components inline: `wiring.build_components(bot, services) -> BotComponents` does, **verbatim and in the exact original order**. `ChannelStateRegistry` moves into `build_services` (bot-independent). `__init__` shrinks to: services attach → voice manager → `build_components` → public-name/alias attach → infra watcher → prompt build + command registration.

### Public surface (the P6 migration target)
`bot.services`, `bot.components`, and public names for all 16 components + `channel_state`. **Every underscore spelling stays as an alias to the same object** until P7 — nothing existing breaks, which the new identity contract test proves pairwise.

### R1 rewiring (from your plan review)
- `InfraWatcher` now constructs AFTER components; `alert_callback` binds `scheduled_events._on_monitor_alert` **directly** (asserted via `__self__` in the new test).
- `on_ready` passes `scheduled_events._on_scheduled_task/_on_schedule_failure` to `scheduler.start` — no bot delegate in the callback path.

### Notes for review
- `build_components` spells gateway wiring as `llm_gateway.active_client`/`wire_callbacks()` and the prompt builder's codex provider as `lambda: llm_gateway.codex_client` — same objects the old `self.llm_client`/`self.codex_client` properties resolved to (the properties forward to this gateway).
- `client.py` sheds the 15 construction imports (kept: `CompletionClassifier` + `CLASSIFIER_SYSTEM_PROMPT` and `MediaTools` for the class-level shims, proxies/re-exports).

### Gates
- Characterization: **137 passed** (130 + 7 new composition pins)
- Full suite: **6,069 passed, 4 skipped**
- Lint: **zero new findings** (content-normalized diff vs baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3