### PR TITLE
refactor: P3 — narrow deps for turn_recorder, scheduled_events, agents_tasks

### DIFF
--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -1,15 +1,21 @@
-"""Agents/tasks/loops native tool handlers (RFC-001 Phase 5c).
+"""Agents/tasks/loops native tool handlers (RFC-001 P5c, RFC-002 P3).
 
-The deferred fifth handler domain (RFC R4), moved after P8 settled the
-loop terrain. Verbatim host-based moves: these handlers orchestrate the
-loop pipeline itself (start_loop closes over bot._run_loop_iteration),
-background tasks, and the agent manager — dependencies route through the
-bot's late-bound delegates on purpose.
+The fifth handler domain: background-task delegation, autonomous-loop
+start/stop, agent spawn/collect, and the loop-agent bridge. These
+handlers orchestrate the loop pipeline itself, so they take the
+ToolLoopRunner directly (constructed before them in
+``wiring.build_components``). Narrow-deps since RFC-002 P3: ``get_config``
+and ``get_knowledge_store`` are provider callables (config is hot-reload
+replaced; the knowledge store is swappable via reload), the LLM surface
+is the gateway, and the compression config object is read live through
+``get_context_compressor`` (the chat pipeline reads it the same way).
 """
 
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
 
 import discord
 
@@ -22,15 +28,53 @@ from ..tool_loop import _LoopMessageProxy
 log = get_logger("discord")
 
 
+@dataclass(frozen=True)
+class AgentTaskDeps:
+    """The true dependency surface of the agents/tasks/loops handlers."""
+
+    get_config: Callable  # live root — replaced by config hot-reload
+    llm_gateway: object  # owns the swappable provider clients
+    channel_state: object  # background-task registry + caps
+    tool_executor: object
+    skill_manager: object
+    get_knowledge_store: Callable  # swappable via bot.knowledge reloads
+    embedder: object
+    audit: object
+    agent_manager: object
+    loop_manager: object
+    loop_agent_bridge: object
+    agent_trajectory_saver: object
+    get_context_compressor: Callable  # live read — tests swap it on the bot
+    tool_loop: object  # ToolLoopRunner — loop iterations + tool dispatch
+    turn_recorder: object  # lifecycle webhook emission
+    prompt_builder: object
+    tool_catalog: object
+
+
 class AgentTaskTools:
-    def __init__(self, host) -> None:
-        self.host = host
+    def __init__(self, deps: AgentTaskDeps) -> None:
+        self._get_config = deps.get_config
+        self._llm_gateway = deps.llm_gateway
+        self._channel_state = deps.channel_state
+        self._tool_executor = deps.tool_executor
+        self._skill_manager = deps.skill_manager
+        self._get_knowledge_store = deps.get_knowledge_store
+        self._embedder = deps.embedder
+        self._audit = deps.audit
+        self._agent_manager = deps.agent_manager
+        self._loop_manager = deps.loop_manager
+        self._loop_agent_bridge = deps.loop_agent_bridge
+        self._agent_trajectory_saver = deps.agent_trajectory_saver
+        self._get_context_compressor = deps.get_context_compressor
+        self._tool_loop = deps.tool_loop
+        self._turn_recorder = deps.turn_recorder
+        self._prompt_builder = deps.prompt_builder
+        self._tool_catalog = deps.tool_catalog
 
     # --- Background task delegation ---
 
     async def _handle_delegate_task(self, message: discord.Message, inp: dict) -> str:
         """Create and start a background task."""
-        bot = self.host
         description = inp.get("description", "Background task")
         steps = inp.get("steps", [])
 
@@ -71,21 +115,21 @@ class AgentTaskTools:
         # Prune old completed tasks
         completed = [
             tid
-            for tid, t in bot._background_tasks.items()
+            for tid, t in self._channel_state.background_tasks.items()
             if t.status in ("completed", "failed", "cancelled")
         ]
-        while len(completed) > bot._channel_state.background_tasks_max:
+        while len(completed) > self._channel_state.background_tasks_max:
             old = completed.pop(0)
-            del bot._background_tasks[old]
+            del self._channel_state.background_tasks[old]
 
-        bot._background_tasks[task.task_id] = task
+        self._channel_state.background_tasks[task.task_id] = task
 
         # Build Codex callback for conversational follow-up
         codex_cb = None
-        if bot.llm_client:
+        if self._llm_gateway.active_client:
 
             async def _codex_followup(messages: list[dict], system: str, max_tokens: int) -> str:
-                return await bot.llm_client.chat(
+                return await self._llm_gateway.active_client.chat(
                     messages=messages,
                     system=system,
                     max_tokens=max_tokens,
@@ -98,11 +142,11 @@ class AgentTaskTools:
             try:
                 await run_background_task(
                     task,
-                    bot.tool_executor,
-                    bot.skill_manager,
-                    knowledge_store=bot._knowledge_store,
-                    embedder=bot._embedder,
-                    audit_logger=bot.audit,
+                    self._tool_executor,
+                    self._skill_manager,
+                    knowledge_store=self._get_knowledge_store(),
+                    embedder=self._embedder,
+                    audit_logger=self._audit,
                     codex_callback=codex_cb,
                 )
             except Exception as e:
@@ -118,15 +162,14 @@ class AgentTaskTools:
 
     def _handle_list_tasks(self, inp: dict | None = None) -> str:
         """List background tasks, or get detailed results for a specific task."""
-        bot = self.host
-        if not bot._background_tasks:
+        if not self._channel_state.background_tasks:
             return "No background tasks."
 
         task_id = (inp or {}).get("task_id")
 
         # Detailed view for a specific task
         if task_id:
-            task = bot._background_tasks.get(task_id)
+            task = self._channel_state.background_tasks.get(task_id)
             if not task:
                 return f"No task found with ID `{task_id}`."
             lines = [
@@ -153,7 +196,7 @@ class AgentTaskTools:
 
         # Overview of all tasks
         lines = []
-        for tid, t in bot._background_tasks.items():
+        for tid, t in self._channel_state.background_tasks.items():
             done = len(t.results)
             total = len(t.steps)
             ok = sum(1 for r in t.results if r.status == "ok")
@@ -166,9 +209,8 @@ class AgentTaskTools:
 
     def _handle_cancel_task(self, inp: dict) -> str:
         """Cancel a running background task."""
-        bot = self.host
         task_id = inp.get("task_id", "")
-        task = bot._background_tasks.get(task_id)
+        task = self._channel_state.background_tasks.get(task_id)
         if not task:
             return f"No task found with ID `{task_id}`."
         if task.status != "running":
@@ -178,7 +220,6 @@ class AgentTaskTools:
 
     def _handle_start_loop(self, message: discord.Message, inp: dict) -> str:
         """Start an autonomous loop."""
-        bot = self.host
         goal = inp.get("goal", "")
         if not goal:
             return "A 'goal' is required to start a loop."
@@ -194,14 +235,14 @@ class AgentTaskTools:
             channel: object,
             prev_context: str | None,
         ) -> str:
-            return await bot._run_loop_iteration(
+            return await self._tool_loop.run_autonomous(
                 prompt,
                 channel,
                 prev_context,
                 str(message.author.id),
             )
 
-        result = bot.loop_manager.start_loop(
+        result = self._loop_manager.start_loop(
             goal=goal,
             channel=message.channel,
             requester_id=str(message.author.id),
@@ -218,7 +259,7 @@ class AgentTaskTools:
             return result
         # Lifecycle webhook: loop.started
         fire_and_forget(
-            bot._emit_lifecycle_event(
+            self._turn_recorder._emit_lifecycle_event(
                 "loop.started",
                 {
                     "loop_id": result,
@@ -239,14 +280,13 @@ class AgentTaskTools:
 
     def _handle_stop_loop(self, inp: dict) -> str:
         """Stop an autonomous loop."""
-        bot = self.host
         loop_id = inp.get("loop_id", "")
         if not loop_id:
             return "A 'loop_id' is required."
-        result = bot.loop_manager.stop_loop(loop_id)
+        result = self._loop_manager.stop_loop(loop_id)
         # Lifecycle webhook: loop.stopped
         fire_and_forget(
-            bot._emit_lifecycle_event(
+            self._turn_recorder._emit_lifecycle_event(
                 "loop.stopped",
                 {
                     "loop_id": loop_id,
@@ -259,8 +299,7 @@ class AgentTaskTools:
 
     def _handle_list_loops(self) -> str:
         """List all autonomous loops."""
-        bot = self.host
-        return bot.loop_manager.list_loops()
+        return self._loop_manager.list_loops()
 
     # --- Agent tool handlers ---
 
@@ -274,14 +313,13 @@ class AgentTaskTools:
         captures the agent's own id, so if the child itself calls spawn_agent
         the grandchild is correctly nested.
         """
-        bot = self.host
         label = inp.get("label", "")
         goal = inp.get("goal", "")
         parent_id_arg = inp.get("parent_id")
         if not label or not goal:
             return "Both 'label' and 'goal' are required."
 
-        if not bot.llm_client:
+        if not self._llm_gateway.active_client:
             return "Error: LLM provider not available."
 
         channel = getattr(message, "channel", message)
@@ -289,18 +327,20 @@ class AgentTaskTools:
         user_id = str(getattr(author, "id", "0"))
         user_name = str(author) if author else "agent"
 
-        system_prompt = bot._build_system_prompt(channel=channel, user_id=user_id)
-        all_tools = bot._merged_tool_definitions() if bot.config.tools.enabled else []
+        system_prompt = self._prompt_builder.build_full_prompt(channel=channel, user_id=user_id)
+        all_tools = (
+            self._tool_catalog.merged_definitions() if self._get_config().tools.enabled else []
+        )
         # Depth-aware filter: root spawn uses depth 0; nested spawns compute
         # the expected child depth from the parent so terminal children don't
         # even see spawn_agent in their tool list.
         parent_depth = 0
         if parent_id_arg:
-            parent = bot.agent_manager._agents.get(parent_id_arg)
+            parent = self._agent_manager._agents.get(parent_id_arg)
             if parent is not None:
                 parent_depth = parent.depth + 1
         max_depth = getattr(
-            getattr(bot.config, "agents", None),
+            getattr(self._get_config(), "agents", None),
             "max_nesting_depth",
             2,
         )
@@ -312,7 +352,7 @@ class AgentTaskTools:
             sys_prompt: str,
             tool_defs: list[dict],
         ) -> dict:
-            resp = await bot.llm_client.chat_with_tools(
+            resp = await self._llm_gateway.active_client.chat_with_tools(
                 messages=messages,
                 system=sys_prompt,
                 tools=tool_defs,
@@ -342,7 +382,7 @@ class AgentTaskTools:
                 # operate on already-spawned agents and aren't the same as
                 # spawning new ones.
                 pass
-            result = await bot._dispatch_loop_tool(
+            result = await self._tool_loop.dispatch_loop_tool(
                 tool_name,
                 tool_input,
                 msg_proxy,
@@ -351,7 +391,7 @@ class AgentTaskTools:
             return str(result) if result is not None else ""
 
         # Determine iteration cap from config — scheduled spawns get a higher budget
-        agents_cfg = getattr(bot.config, "agents", None)
+        agents_cfg = getattr(self._get_config(), "agents", None)
         hard_max = getattr(agents_cfg, "hard_max_iterations", 300) if agents_cfg else 300
         if inp.get("_scheduled"):
             iter_cap = min(
@@ -368,7 +408,7 @@ class AgentTaskTools:
             else [20, 10, 5, 1]
         )
 
-        agent_id = bot.agent_manager.spawn(
+        agent_id = self._agent_manager.spawn(
             label=label,
             goal=goal,
             channel_id=str(getattr(channel, "id", "0")),
@@ -380,16 +420,16 @@ class AgentTaskTools:
             system_prompt=system_prompt,
             parent_id=parent_id_arg,
             max_depth=max_depth,
-            tool_timeouts=bot.config.tools.tool_timeouts,
-            trajectory_saver=bot.agent_trajectory_saver,
+            tool_timeouts=self._get_config().tools.tool_timeouts,
+            trajectory_saver=self._agent_trajectory_saver,
             max_iterations=iter_cap,
             budget_warnings=warnings,
-            context_compression_enabled=bool(bot.context_compressor),
-            max_context_chars=bot.context_compressor.max_context_chars
-            if bot.context_compressor
+            context_compression_enabled=bool(self._get_context_compressor()),
+            max_context_chars=self._get_context_compressor().max_context_chars
+            if self._get_context_compressor()
             else 750000,
-            keep_recent_iterations=bot.context_compressor.keep_recent_iterations
-            if bot.context_compressor
+            keep_recent_iterations=self._get_context_compressor().keep_recent_iterations
+            if self._get_context_compressor()
             else 30,
         )
 
@@ -410,8 +450,7 @@ class AgentTaskTools:
         so callers can make ok/fail decisions based on structured state
         rather than parsing markdown.
         """
-        bot = self.host
-        results = await bot.agent_manager.wait_for_agents([agent_id], timeout=timeout)
+        results = await self._agent_manager.wait_for_agents([agent_id], timeout=timeout)
         r = results.get(agent_id, {})
         status = r.get("status", "unknown")
         label = r.get("label", agent_id)
@@ -441,21 +480,19 @@ class AgentTaskTools:
 
     def _handle_send_to_agent(self, inp: dict) -> str:
         """Send a message to a running agent."""
-        bot = self.host
         agent_id = inp.get("agent_id", "")
         message = inp.get("message", "")
         if not agent_id:
             return "'agent_id' is required."
         if not message:
             return "'message' is required."
-        return bot.agent_manager.send(agent_id, message)
+        return self._agent_manager.send(agent_id, message)
 
     def _handle_list_agents(self, message: object) -> str:
         """List all agents, optionally filtered by channel."""
-        bot = self.host
         channel = getattr(message, "channel", message)
         channel_id = str(getattr(channel, "id", "0"))
-        agents = bot.agent_manager.list(channel_id)
+        agents = self._agent_manager.list(channel_id)
         if not agents:
             return "No agents running."
         lines = []
@@ -468,19 +505,17 @@ class AgentTaskTools:
 
     def _handle_kill_agent(self, inp: dict) -> str:
         """Kill a running agent."""
-        bot = self.host
         agent_id = inp.get("agent_id", "")
         if not agent_id:
             return "'agent_id' is required."
-        return bot.agent_manager.kill(agent_id)
+        return self._agent_manager.kill(agent_id)
 
     def _handle_get_agent_results(self, inp: dict) -> str:
         """Get results of a completed agent."""
-        bot = self.host
         agent_id = inp.get("agent_id", "")
         if not agent_id:
             return "'agent_id' is required."
-        results = bot.agent_manager.get_results(agent_id)
+        results = self._agent_manager.get_results(agent_id)
         if results is None:
             return f"Agent '{agent_id}' not found."
         if results["status"] == "running":
@@ -506,7 +541,6 @@ class AgentTaskTools:
 
     async def _handle_wait_for_agents(self, inp: dict) -> str:
         """Wait for agents to complete and return collected results."""
-        bot = self.host
         agent_ids = inp.get("agent_ids", [])
         timeout = inp.get("timeout", 300)
         if not agent_ids:
@@ -514,7 +548,7 @@ class AgentTaskTools:
         if not isinstance(agent_ids, list):
             return "'agent_ids' must be a list of agent ID strings."
 
-        results = await bot.agent_manager.wait_for_agents(
+        results = await self._agent_manager.wait_for_agents(
             agent_ids,
             timeout=float(timeout),
         )
@@ -537,7 +571,6 @@ class AgentTaskTools:
 
     async def _handle_spawn_loop_agents(self, message: object, inp: dict) -> str:
         """Spawn agents from within a loop iteration via the loop-agent bridge."""
-        bot = self.host
         loop_id = inp.get("loop_id", "")
         tasks = inp.get("tasks", [])
         if not loop_id:
@@ -546,29 +579,31 @@ class AgentTaskTools:
             return "A 'tasks' list is required."
 
         # Validate the loop exists
-        loop_info = bot.loop_manager._loops.get(loop_id)
+        loop_info = self._loop_manager._loops.get(loop_id)
         if not loop_info:
             return f"Error: Loop '{loop_id}' not found."
         if loop_info.status != "running":
             return f"Error: Loop '{loop_id}' is not running (status: {loop_info.status})."
 
-        if not bot.llm_client:
+        if not self._llm_gateway.active_client:
             return "Error: LLM provider not available."
 
         channel = getattr(message, "channel", message)
         channel_id = str(getattr(channel, "id", "0"))
 
         # Build system prompt and tools for the agents (no agent tools — prevents nesting)
-        system_prompt = bot._build_system_prompt(
+        system_prompt = self._prompt_builder.build_full_prompt(
             channel=channel,
             user_id=loop_info.requester_id,
         )
-        all_tools = bot._merged_tool_definitions() if bot.config.tools.enabled else []
+        all_tools = (
+            self._tool_catalog.merged_definitions() if self._get_config().tools.enabled else []
+        )
         tools = filter_agent_tools(all_tools)
 
         # Build iteration/tool callbacks (same pattern as _handle_spawn_agent)
         async def _iteration_cb(messages, sys, tool_defs):
-            resp = await bot.llm_client.chat_with_tools(
+            resp = await self._llm_gateway.active_client.chat_with_tools(
                 messages=messages,
                 system=sys,
                 tools=tool_defs,
@@ -582,20 +617,20 @@ class AgentTaskTools:
             }
 
         async def _tool_cb(tool_name, tool_input):
-            return await bot._dispatch_loop_tool(
+            return await self._tool_loop.dispatch_loop_tool(
                 tool_name,
                 tool_input,
                 _LoopMessageProxy(channel, loop_info.requester_id, loop_info.requester_name),
                 loop_info.requester_id,
             )
 
-        # bot.context_compressor is the wiring-built compression config object
-        # (None when disabled) — config.context_compression never existed; the
-        # old attribute access raised AttributeError on EVERY spawn_loop_agents
+        # The compression config object (None when disabled) — read live via
+        # the provider; config.context_compression never existed, and the old
+        # attribute access raised AttributeError on EVERY spawn_loop_agents
         # call since the tool shipped (soak round-2 finding, 2026-07-05). Same
         # pattern as _handle_spawn_agent above.
-        cc = bot.context_compressor
-        agent_ids = bot.loop_agent_bridge.spawn_agents_for_loop(
+        cc = self._get_context_compressor()
+        agent_ids = self._loop_agent_bridge.spawn_agents_for_loop(
             loop_id=loop_id,
             iteration=loop_info.iteration_count,
             loop_goal=loop_info.goal,
@@ -607,11 +642,11 @@ class AgentTaskTools:
             tool_executor_callback=_tool_cb,
             tools=tools,
             system_prompt=system_prompt,
-            tool_timeouts=bot.config.tools.tool_timeouts,
+            tool_timeouts=self._get_config().tools.tool_timeouts,
             # Honor the configured agent iteration cap; without this the
             # bridge passed None and agents fell back to the module default,
             # ignoring agents.max_iterations.
-            max_iterations=bot.config.agents.max_iterations,
+            max_iterations=self._get_config().agents.max_iterations,
             context_compression_enabled=bool(cc),
             max_context_chars=cc.max_context_chars if cc else 750000,
             keep_recent_iterations=cc.keep_recent_iterations if cc else 30,
@@ -630,7 +665,6 @@ class AgentTaskTools:
 
     async def _handle_collect_loop_agents(self, inp: dict) -> str:
         """Collect results from agents spawned by a loop."""
-        bot = self.host
         loop_id = inp.get("loop_id", "")
         agent_ids = inp.get("agent_ids", None)
         timeout = inp.get("timeout", 300)
@@ -638,10 +672,10 @@ class AgentTaskTools:
             return "A 'loop_id' is required."
 
         # Validate the loop exists
-        if loop_id not in bot.loop_manager._loops:
+        if loop_id not in self._loop_manager._loops:
             return f"Error: Loop '{loop_id}' not found."
 
-        results = await bot.loop_agent_bridge.wait_and_collect(
+        results = await self._loop_agent_bridge.wait_and_collect(
             loop_id=loop_id,
             agent_ids=agent_ids if isinstance(agent_ids, list) else None,
             timeout=float(timeout),
@@ -650,4 +684,4 @@ class AgentTaskTools:
         if not results:
             return "No agents to collect for this loop."
 
-        return bot.loop_agent_bridge.format_agent_results_for_context(results)
+        return self._loop_agent_bridge.format_agent_results_for_context(results)

--- a/src/discord/scheduled_events.py
+++ b/src/discord/scheduled_events.py
@@ -1,17 +1,22 @@
-"""Scheduler, digest, and monitoring callbacks (RFC-001 Phase 10).
+"""Scheduler, digest, and monitoring callbacks (RFC-001 P10, RFC-002 P3).
 
-Verbatim host-based moves from OdinBot: the scheduled-task action router
-(reminder/check/workflow/digest), workflow step execution with condition
-and on_failure semantics, the structured-RBAC scheduled dispatch, the
-infrastructure digest, mention resolution, and the monitor/failure alert
-callbacks. The bot keeps delegates — the scheduler is started with bot
-methods (on_ready) and tests drive them there.
+The scheduled-task action router (reminder/check/workflow/digest),
+workflow step execution with condition and on_failure semantics, the
+structured-RBAC scheduled dispatch, the infrastructure digest, mention
+resolution, and the monitor/failure alert callbacks. Narrow-deps since
+RFC-002 P3: live roots (``config``, the guild list) come in as provider
+callables; the LLM surface comes in as the gateway (which owns the
+swappable provider clients); cross-component calls (loop dispatch, agent
+collection) take the components directly — construction order in
+``wiring.build_components`` guarantees they exist.
 """
 
 from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Callable
+from dataclasses import dataclass
 
 import discord
 
@@ -23,26 +28,46 @@ from .tool_loop import _LoopMessageProxy
 log = get_logger("discord")
 
 
+@dataclass(frozen=True)
+class ScheduledEventsDeps:
+    """The true dependency surface of the scheduled-events handlers."""
+
+    get_config: Callable  # live root — replaced by config hot-reload
+    get_channel: Callable  # discord.Client.get_channel (bound method)
+    get_guilds: Callable  # live — the guild list changes at runtime
+    tool_executor: object
+    audit: object
+    llm_gateway: object  # owns the swappable provider clients
+    tool_loop: object  # ToolLoopRunner — shared dispatch path
+    agent_task_tools: object  # agent result collection in workflows
+
+
 class ScheduledEventHandlers:
-    def __init__(self, host) -> None:
-        self.host = host
+    def __init__(self, deps: ScheduledEventsDeps) -> None:
+        self._get_config = deps.get_config
+        self._get_channel = deps.get_channel
+        self._get_guilds = deps.get_guilds
+        self._tool_executor = deps.tool_executor
+        self._audit = deps.audit
+        self._llm_gateway = deps.llm_gateway
+        self._tool_loop = deps.tool_loop
+        self._agent_task_tools = deps.agent_task_tools
 
     async def _on_scheduled_digest(self, schedule: dict) -> None:
         """Run the daily infrastructure digest and post results."""
-        bot = self.host
         channel_id = schedule.get("channel_id")
         if not channel_id:
             log.warning("Digest has no channel_id: %s", schedule["id"])
             return
 
-        channel = bot.get_channel(int(channel_id))
+        channel = self._get_channel(int(channel_id))
         if not channel:
             log.warning("Digest channel %s not found", channel_id)
             return
 
         log.info("Running daily digest for channel %s", channel_id)
         try:
-            raw = await bot._format_digest_raw()
+            raw = await self._format_digest_raw()
         except Exception as e:
             log.error("Digest data collection failed: %s", e)
             await channel.send(
@@ -61,8 +86,8 @@ class ScheduledEventHandlers:
         ]
         digest_system = "You are a concise infrastructure report summarizer. Output a short summary with key findings."  # noqa: E501
         try:
-            if bot.llm_client:
-                summary = await bot.llm_client.chat(
+            if self._llm_gateway.active_client:
+                summary = await self._llm_gateway.active_client.chat(
                     messages=digest_messages,
                     system=digest_system,
                     max_tokens=500,
@@ -77,7 +102,7 @@ class ScheduledEventHandlers:
         await channel.send(scrub_response_secrets(f"**Daily Infrastructure Digest**\n\n{summary}"))
 
         # Audit log the digest
-        await bot.audit.log_execution(
+        await self._audit.log_execution(
             user_id="system",
             user_name="scheduler",
             channel_id=channel_id,
@@ -90,14 +115,13 @@ class ScheduledEventHandlers:
 
     async def _format_digest_raw(self) -> str:
         """Collect raw infrastructure data for the digest."""
-        bot = self.host
         tasks = []
         labels = []
 
         # Disk + memory checks on all hosts via run_command
-        for host_alias in bot.config.tools.hosts:
+        for host_alias in self._get_config().tools.hosts:
             tasks.append(
-                bot.tool_executor.execute(
+                self._tool_executor.execute(
                     "run_command",
                     {
                         "host": host_alias,
@@ -107,7 +131,7 @@ class ScheduledEventHandlers:
             )
             labels.append(f"Disk ({host_alias})")
             tasks.append(
-                bot.tool_executor.execute(
+                self._tool_executor.execute(
                     "run_command",
                     {"host": host_alias, "command": "free -h"},
                 )
@@ -127,11 +151,10 @@ class ScheduledEventHandlers:
 
     def _resolve_mentions(self, text: str) -> str:
         """Replace @username with proper Discord <@ID> mentions."""
-        bot = self.host
 
         def _replace(match: re.Match) -> str:
             name = match.group(1).lower()
-            for guild in bot.guilds:
+            for guild in self._get_guilds():
                 for member in guild.members:
                     if member.name.lower() == name or (member.nick and member.nick.lower() == name):
                         return f"<@{member.id}>"
@@ -141,17 +164,16 @@ class ScheduledEventHandlers:
 
     async def _on_monitor_alert(self, message: str) -> None:
         """Callback fired by the infrastructure watcher when a threshold is crossed."""
-        bot = self.host
-        channel_id = bot.config.monitoring.alert_channel_id
+        channel_id = self._get_config().monitoring.alert_channel_id
         if not channel_id:
             # Fall back to first configured channel
-            if bot.config.discord.channels:
-                channel_id = bot.config.discord.channels[0]
+            if self._get_config().discord.channels:
+                channel_id = self._get_config().discord.channels[0]
             else:
                 log.warning("Monitor alert has no channel to send to: %s", message[:100])
                 return
 
-        channel = bot.get_channel(int(channel_id))
+        channel = self._get_channel(int(channel_id))
         if not channel:
             log.warning("Monitor alert channel %s not found", channel_id)
             return
@@ -175,11 +197,10 @@ class ScheduledEventHandlers:
         Routes through the same client-level dispatch as live messages and
         autonomous loops, so scheduled tasks have full tool parity.
         """
-        bot = self.host
         # Pre-check RBAC so we can return a structured failure — the dispatch
         # also checks, but returns a plain denial string we'd have to guess at.
         if requester_id:
-            denial = bot.tool_executor.check_permission(tool_name, requester_id)
+            denial = self._tool_executor.check_permission(tool_name, requester_id)
             if isinstance(denial, str) and denial:
                 return ToolResult(
                     output=denial, ok=False, error="permission_denied", tool_name=tool_name
@@ -187,7 +208,7 @@ class ScheduledEventHandlers:
 
         msg_proxy = _LoopMessageProxy(channel, requester_id or "0", requester_name)
         try:
-            result = await bot._dispatch_loop_tool_inner(
+            result = await self._tool_loop.dispatch_loop_tool_inner(
                 tool_name,
                 tool_input,
                 msg_proxy,
@@ -214,7 +235,6 @@ class ScheduledEventHandlers:
 
         Returns True if all steps succeeded, False if any step failed.
         """
-        bot = self.host
         steps = schedule.get("steps", [])
         desc = schedule.get("description", "Workflow")
         results: list[str] = []
@@ -253,7 +273,7 @@ class ScheduledEventHandlers:
                 if tool_name == "spawn_agent":
                     tool_input = {**tool_input, "_scheduled": True}
 
-                result = await bot._execute_scheduled_tool(
+                result = await self._execute_scheduled_tool(
                     tool_name,
                     tool_input,
                     channel,
@@ -271,7 +291,7 @@ class ScheduledEventHandlers:
                     if id_match:
                         agent_id = id_match.group(1)
                         timeout = float(step.get("timeout", 3660))
-                        agent_text, agent_data = await bot._collect_agent_result(
+                        agent_text, agent_data = await self._agent_task_tools._collect_agent_result(
                             agent_id,
                             timeout=min(timeout, 3660),
                         )
@@ -325,7 +345,6 @@ class ScheduledEventHandlers:
     async def _on_schedule_failure(self, schedule: dict, consecutive: int) -> None:
         """Alert callback fired when a schedule crosses the consecutive-failure
         threshold. Previously never wired, so the alerting path was dead."""
-        bot = self.host
         channel_id = schedule.get("channel_id")
         last_error = schedule.get("last_error", "unknown error")
         text = (
@@ -334,7 +353,7 @@ class ScheduledEventHandlers:
             f"```\n{str(last_error)[:1000]}\n```"
         )
         try:
-            channel = bot.get_channel(int(channel_id)) if channel_id else None
+            channel = self._get_channel(int(channel_id)) if channel_id else None
             if channel:
                 await channel.send(scrub_response_secrets(text))
             else:
@@ -349,9 +368,8 @@ class ScheduledEventHandlers:
 
     async def _on_scheduled_task(self, schedule: dict) -> None:
         """Callback fired by the scheduler when a task is due."""
-        bot = self.host
         try:
-            await bot.audit.log_event(
+            await self._audit.log_event(
                 event_type="schedule_execution",
                 action=schedule.get("action", "unknown"),
                 actor="scheduler",
@@ -366,19 +384,19 @@ class ScheduledEventHandlers:
             log.warning("Scheduled task has no channel_id: %s", schedule["id"])
             return
 
-        channel = bot.get_channel(int(channel_id))
+        channel = self._get_channel(int(channel_id))
         if not channel:
             log.warning("Scheduled task channel %s not found", channel_id)
             return
 
         if schedule["action"] == "digest":
-            await bot._on_scheduled_digest(schedule)
+            await self._on_scheduled_digest(schedule)
             return
 
         if schedule["action"] == "reminder":
             msg = schedule.get("message", schedule["description"])
             # Resolve @username mentions to proper Discord <@ID> mentions
-            msg = bot._resolve_mentions(msg)
+            msg = self._resolve_mentions(msg)
             try:
                 await channel.send(f"**Scheduled reminder:** {msg}")
             except Exception as e:
@@ -390,7 +408,7 @@ class ScheduledEventHandlers:
             req_id = schedule.get("requester_id") or None
             req_name = schedule.get("requester") or schedule.get("created_by") or "scheduler"
             try:
-                result = await bot._execute_scheduled_tool(
+                result = await self._execute_scheduled_tool(
                     tool_name,
                     tool_input,
                     channel,
@@ -424,7 +442,7 @@ class ScheduledEventHandlers:
                 raise
 
         elif schedule["action"] == "workflow":
-            ok = await bot._run_scheduled_workflow(channel, schedule)
+            ok = await self._run_scheduled_workflow(channel, schedule)
             if not ok:
                 raise RuntimeError(
                     f"Scheduled workflow failed: {schedule.get('description', '')[:200]}"

--- a/src/discord/turn_recorder.py
+++ b/src/discord/turn_recorder.py
@@ -1,13 +1,16 @@
-"""Turn observability + reflection dispatch (RFC-001 Phase 10).
+"""Turn observability + reflection dispatch (RFC-001 P10, RFC-002 P3).
 
-Verbatim host-based moves from OdinBot: trajectory user-content recording,
-context-trace creation, turn-trajectory persistence, lifecycle webhook
-emission, and the reflection triggers (chat post-operation + gated loop
-reflection).
+Trajectory user-content recording, context-trace creation, turn-trajectory
+persistence, lifecycle webhook emission, and the reflection triggers (chat
+post-operation + gated loop reflection). Narrow-deps since RFC-002 P3:
+``get_config`` is a provider callable because ``bot.config`` is replaced
+wholesale by the web API's config hot-reload; the remaining collaborators
+are stable service objects (never reassigned after boot).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC
 
 from ..async_utils import fire_and_forget
@@ -18,15 +21,26 @@ log = get_logger("discord")
 
 
 class TurnRecorder:
-    def __init__(self, host) -> None:
-        self.host = host
+    def __init__(
+        self,
+        *,
+        get_config: Callable,
+        trajectory_saver,
+        reflector,
+        outbound_webhook_dispatcher,
+        loop_reflection_gate,
+    ) -> None:
+        self._get_config = get_config
+        self._trajectory_saver = trajectory_saver
+        self._reflector = reflector
+        self._outbound_webhook_dispatcher = outbound_webhook_dispatcher
+        self._loop_reflection_gate = loop_reflection_gate
 
     def _record_user_content(self, trajectory, content: str) -> None:
         """Store the request on the trajectory turn — capped, secret-scrubbed,
         with explicit truncation metadata. Config-gated; never raises."""
-        bot = self.host
         try:
-            obs = getattr(bot.config, "observability", None)
+            obs = getattr(self._get_config(), "observability", None)
             if obs is not None and not obs.trajectory_user_content:
                 return
             cap = getattr(obs, "max_user_content_chars", 4000) if obs else 4000
@@ -45,9 +59,8 @@ class TurnRecorder:
         Returns None when disabled — every consumer treats None as
         "record nothing", leaving the request path byte-identical.
         """
-        bot = self.host
         try:
-            obs = getattr(bot.config, "observability", None)
+            obs = getattr(self._get_config(), "observability", None)
             ct = getattr(obs, "context_trace", None)
             if ct is None or not ct.enabled:
                 return None
@@ -109,14 +122,12 @@ class TurnRecorder:
         user_id: str | None,
     ) -> None:
         """Gated reflection for loop iterations (fire-and-forget)."""
-        bot = self.host
         try:
-            if not getattr(bot.config.learning, "loop_reflection_enabled", True):
+            if not getattr(self._get_config().learning, "loop_reflection_enabled", True):
                 return
-            # The P10 move kept `hasattr(self, ...)` from the bot-method era;
-            # on the recorder that was always False, silently suppressing all
-            # loop reflection. The reflector lives on the bot.
-            if getattr(bot, "reflector", None) is None or not tool_details:
+            # Guard kept from the bot-method era (PR #148 fixed its silent
+            # always-False form); with narrow deps the reflector is injected.
+            if self._reflector is None or not tool_details:
                 return
             if is_error or any(d.get("error") for d in tool_details):
                 effective_error = error_text or next(
@@ -127,14 +138,14 @@ class TurnRecorder:
                     from ..observability.failure_classes import classify_failure
 
                     failure_class = classify_failure(effective_error)["class"]
-                should, reason = bot._loop_reflection_gate.evaluate(
+                should, reason = self._loop_reflection_gate.evaluate(
                     loop_id,
                     is_error=True,
                     failure_class=failure_class,
                     error_text=effective_error,
                 )
             else:
-                should, reason = bot._loop_reflection_gate.evaluate(
+                should, reason = self._loop_reflection_gate.evaluate(
                     loop_id,
                     is_error=False,
                 )
@@ -143,7 +154,7 @@ class TurnRecorder:
                 return
             log.info("Loop reflection triggered (%s) for %s", reason, loop_id)
             fire_and_forget(
-                bot.reflector.reflect_on_operation(
+                self._reflector.reflect_on_operation(
                     user_request=f"[autonomous loop {loop_id}] {prompt[:300]}",
                     tools_used=[d["tool"] for d in tool_details][:20],
                     tool_details=tool_details,
@@ -167,11 +178,10 @@ class TurnRecorder:
     ) -> None:
         """Fire-and-forget post-operation reflection — selective, with real
         tool inputs/results from the operation instead of bare tool names."""
-        bot = self.host
         try:
             if not tool_details:
                 tool_details = [{"tool": t} for t in tools_used[:20]]
-            if not bot._should_reflect_on_operation(
+            if not self._should_reflect_on_operation(
                 user_request,
                 tools_used,
                 is_error,
@@ -182,7 +192,7 @@ class TurnRecorder:
                     len(tools_used),
                 )
                 return
-            await bot.reflector.reflect_on_operation(
+            await self._reflector.reflect_on_operation(
                 user_request=user_request,
                 tools_used=tools_used,
                 tool_details=tool_details,
@@ -203,8 +213,7 @@ class TurnRecorder:
         trace=None,
     ) -> None:
         """Persist the turn trajectory as JSONL. Non-fatal on error."""
-        bot = self.host
-        if bot.trajectory_saver is None:
+        if self._trajectory_saver is None:
             return
         try:
             if trace is not None:
@@ -222,20 +231,19 @@ class TurnRecorder:
             # Aggregate token counts from iterations
             trajectory.total_input_tokens = sum(it.input_tokens for it in trajectory.iterations)
             trajectory.total_output_tokens = sum(it.output_tokens for it in trajectory.iterations)
-            await bot.trajectory_saver.save(trajectory)
+            await self._trajectory_saver.save(trajectory)
         except Exception:
             log.exception("TrajectorySaver.save failed (non-fatal)")
 
     async def _emit_lifecycle_event(self, event_type: str, payload: dict) -> None:
         """Emit a lifecycle event to registered outbound webhooks (no-op if disabled)."""
-        bot = self.host
-        if bot.outbound_webhook_dispatcher is None:
+        if self._outbound_webhook_dispatcher is None:
             return
         try:
             from ..notifications.outbound_webhooks import build_event_payload
 
             full_payload = build_event_payload(event_type=event_type, data=payload)
-            await bot.outbound_webhook_dispatcher.dispatch_fire_and_forget(
+            await self._outbound_webhook_dispatcher.dispatch_fire_and_forget(
                 event_type=event_type,
                 payload=full_payload,
             )

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -54,13 +54,13 @@ from .delivery import ResponseDelivery
 from .intake_pipeline import MessageIntake, MessagePipeline
 from .llm_gateway import LLMGateway
 from .native_tools import NativeToolDispatcher, register_native_handlers
-from .native_tools.agents_tasks import AgentTaskTools
+from .native_tools.agents_tasks import AgentTaskDeps, AgentTaskTools
 from .native_tools.channel_ops import ChannelOpsTools
 from .native_tools.knowledge import KnowledgeTools
 from .native_tools.media import MediaTools
 from .native_tools.scheduling import SchedulingTools
 from .prompts import PromptBuilder
-from .scheduled_events import ScheduledEventHandlers
+from .scheduled_events import ScheduledEventHandlers, ScheduledEventsDeps
 from .tool_catalog import ToolCatalog
 from .tool_loop import ToolLoopRunner
 from .turn_recorder import TurnRecorder
@@ -616,9 +616,55 @@ def build_components(bot, services: BotServices) -> BotComponents:
         get_llm_client=lambda: bot.llm_client,
     )
     tool_loop = ToolLoopRunner(bot)
-    turn_recorder = TurnRecorder(bot)
-    scheduled_events = ScheduledEventHandlers(bot)
-    agent_task_tools = AgentTaskTools(bot)
+    # Narrow-deps components (RFC-002 P3). Construction order note: the
+    # agents/tasks domain now builds BEFORE scheduled events (its consumer)
+    # — a declared deviation from the old inline order, where both were
+    # inert `host` captures.
+    turn_recorder = TurnRecorder(
+        get_config=lambda: bot.config,
+        trajectory_saver=services.trajectory_saver,
+        reflector=services.reflector,
+        outbound_webhook_dispatcher=services.outbound_webhook_dispatcher,
+        loop_reflection_gate=services.loop_reflection_gate,
+    )
+    agent_task_tools = AgentTaskTools(
+        AgentTaskDeps(
+            get_config=lambda: bot.config,
+            llm_gateway=llm_gateway,
+            channel_state=services.channel_state,
+            tool_executor=services.tool_executor,
+            skill_manager=services.skill_manager,
+            get_knowledge_store=lambda: bot._knowledge_store,
+            embedder=services.embedder,
+            audit=services.audit,
+            agent_manager=services.agent_manager,
+            loop_manager=services.loop_manager,
+            loop_agent_bridge=services.loop_agent_bridge,
+            agent_trajectory_saver=services.agent_trajectory_saver,
+            # live read through the bot: never reassigned in production today,
+            # but the chat pipeline reads it the same way and tests swap it
+            get_context_compressor=lambda: bot.context_compressor,
+            tool_loop=tool_loop,
+            turn_recorder=turn_recorder,
+            prompt_builder=prompt_builder,
+            tool_catalog=tool_catalog,
+        )
+    )
+    scheduled_events = ScheduledEventHandlers(
+        ScheduledEventsDeps(
+            get_config=lambda: bot.config,
+            # late-bound through the bot: tests (and any future hot swap)
+            # replace bot.get_channel per-instance — a captured bound method
+            # would go stale (caught by characterization when first captured)
+            get_channel=lambda cid: bot.get_channel(cid),
+            get_guilds=lambda: bot.guilds,
+            tool_executor=services.tool_executor,
+            audit=services.audit,
+            llm_gateway=llm_gateway,
+            tool_loop=tool_loop,
+            agent_task_tools=agent_task_tools,
+        )
+    )
     intake = MessageIntake(bot)
     pipeline = MessagePipeline(bot)
 

--- a/tests/test_scheduled_workflow.py
+++ b/tests/test_scheduled_workflow.py
@@ -67,15 +67,19 @@ class TestCollectAgentResult:
     """_collect_agent_result must return (text, raw_data) with structured status."""
 
     @staticmethod
-    def _make_bot_with_agent_manager(wait_result: dict):
-        """Create a minimal mock bot with agent_manager.wait_for_agents."""
-        bot = MagicMock()
-        bot.agent_manager = MagicMock()
-        bot.agent_manager.wait_for_agents = AsyncMock(return_value=wait_result)
-        return bot
+    def _make_tools_with_agent_manager(wait_result: dict):
+        """AgentTaskTools over a mock agent manager (narrow-deps, RFC-002 P3)."""
+        import dataclasses
+
+        from src.discord.native_tools.agents_tasks import AgentTaskDeps, AgentTaskTools
+
+        am = MagicMock()
+        am.wait_for_agents = AsyncMock(return_value=wait_result)
+        fields = {f.name: MagicMock() for f in dataclasses.fields(AgentTaskDeps)}
+        fields["agent_manager"] = am
+        return AgentTaskTools(AgentTaskDeps(**fields))
 
     async def test_completed_agent_returns_ok(self):
-        from src.discord.native_tools.agents_tasks import AgentTaskTools
         wait_result = {
             "abc123": {
                 "status": "completed",
@@ -87,14 +91,13 @@ class TestCollectAgentResult:
                 "error": "",
             }
         }
-        bot = self._make_bot_with_agent_manager(wait_result)
-        text, raw = await AgentTaskTools(bot)._collect_agent_result("abc123", timeout=10)
+        tools = self._make_tools_with_agent_manager(wait_result)
+        text, raw = await tools._collect_agent_result("abc123", timeout=10)
         assert raw["status"] == "completed"
         assert raw["empty_result"] is False
         assert "All checks passed" in text
 
     async def test_failed_agent_returns_failure_data(self):
-        from src.discord.native_tools.agents_tasks import AgentTaskTools
 
         wait_result = {
             "def456": {
@@ -107,14 +110,13 @@ class TestCollectAgentResult:
                 "error": "All 3 Codex accounts failed",
             }
         }
-        bot = self._make_bot_with_agent_manager(wait_result)
-        text, raw = await AgentTaskTools(bot)._collect_agent_result("def456", timeout=10)
+        tools = self._make_tools_with_agent_manager(wait_result)
+        text, raw = await tools._collect_agent_result("def456", timeout=10)
         assert raw["status"] == "failed"
         assert raw["error"] == "All 3 Codex accounts failed"
         assert raw["empty_result"] is True
 
     async def test_completed_empty_result_flagged(self):
-        from src.discord.native_tools.agents_tasks import AgentTaskTools
 
         wait_result = {
             "ghi789": {
@@ -127,13 +129,12 @@ class TestCollectAgentResult:
                 "error": "",
             }
         }
-        bot = self._make_bot_with_agent_manager(wait_result)
-        text, raw = await AgentTaskTools(bot)._collect_agent_result("ghi789", timeout=10)
+        tools = self._make_tools_with_agent_manager(wait_result)
+        text, raw = await tools._collect_agent_result("ghi789", timeout=10)
         assert raw["status"] == "completed"
         assert raw["empty_result"] is True
 
     async def test_timed_out_agent(self):
-        from src.discord.native_tools.agents_tasks import AgentTaskTools
 
         wait_result = {
             "timeout1": {
@@ -146,8 +147,8 @@ class TestCollectAgentResult:
                 "error": "",
             }
         }
-        bot = self._make_bot_with_agent_manager(wait_result)
-        text, raw = await AgentTaskTools(bot)._collect_agent_result("timeout1", timeout=1)
+        tools = self._make_tools_with_agent_manager(wait_result)
+        text, raw = await tools._collect_agent_result("timeout1", timeout=1)
         assert raw["status"] == "running"
 
 

--- a/tests/test_trajectory_completeness.py
+++ b/tests/test_trajectory_completeness.py
@@ -175,14 +175,21 @@ class _FakeClient:
     def __init__(self, enabled=True, cap=4000):
         from src.discord.turn_recorder import TurnRecorder
 
-        # P10 migration: _record_user_content now delegates to TurnRecorder
-        self._turn_recorder = TurnRecorder(self)
         class _Obs:
             trajectory_user_content = enabled
             max_user_content_chars = cap
         class _Cfg:
             observability = _Obs()
         self.config = _Cfg()
+        # P10 migration: _record_user_content delegates to TurnRecorder
+        # (narrow-deps since RFC-002 P3)
+        self._turn_recorder = TurnRecorder(
+            get_config=lambda: self.config,
+            trajectory_saver=None,
+            reflector=None,
+            outbound_webhook_dispatcher=None,
+            loop_reflection_gate=None,
+        )
 
 
 class TestUserContentRecording:
@@ -263,9 +270,6 @@ class _LoopIterClient:
         from src.discord.tool_loop import ToolLoopRunner
 
         self._tool_loop_runner = ToolLoopRunner(self)
-        from src.discord.turn_recorder import TurnRecorder
-
-        self._turn_recorder = TurnRecorder(self)
 
         class _Obs:
             loop_trace = True
@@ -283,6 +287,16 @@ class _LoopIterClient:
             tools = _Tools()
 
         self.config = _Cfg()
+        from src.discord.turn_recorder import TurnRecorder
+
+        # narrow-deps recorder (RFC-002 P3) — only _record_user_content is used
+        self._turn_recorder = TurnRecorder(
+            get_config=lambda: self.config,
+            trajectory_saver=None,
+            reflector=None,
+            outbound_webhook_dispatcher=None,
+            loop_reflection_gate=None,
+        )
         self.loop_manager = SimpleNamespace(_loops={})
         self._responses = list(responses)
         self._tool_output = tool_output
@@ -465,4 +479,4 @@ class TestAgentSaverWiring:
         from src.discord.native_tools.agents_tasks import AgentTaskTools
 
         src = inspect.getsource(AgentTaskTools._handle_spawn_agent)
-        assert "trajectory_saver=bot.agent_trajectory_saver" in src
+        assert "trajectory_saver=self._agent_trajectory_saver" in src

--- a/tests/test_turn_recorder_loop_reflection.py
+++ b/tests/test_turn_recorder_loop_reflection.py
@@ -20,6 +20,7 @@ ERROR_DETAILS = [{"tool": "run_command", "input": {}, "result": "Error: boom", "
 
 
 def _bot(*, reflection_enabled: bool = True, gate_verdict=(True, "test")):
+    """A namespace carrying the recorder's collaborators (narrow-deps, P3)."""
     gate = Mock()
     gate.evaluate = Mock(return_value=gate_verdict)
     reflector = Mock()
@@ -30,6 +31,16 @@ def _bot(*, reflection_enabled: bool = True, gate_verdict=(True, "test")):
         ),
         reflector=reflector,
         _loop_reflection_gate=gate,
+    )
+
+
+def _recorder(bot) -> TurnRecorder:
+    return TurnRecorder(
+        get_config=lambda: bot.config,
+        trajectory_saver=None,
+        reflector=getattr(bot, "reflector", None),
+        outbound_webhook_dispatcher=None,
+        loop_reflection_gate=bot._loop_reflection_gate,
     )
 
 
@@ -54,7 +65,7 @@ def _reflect(bot, **overrides):
         user_id="u1",
     )
     kwargs.update(overrides)
-    TurnRecorder(bot)._maybe_loop_reflect(**kwargs)
+    _recorder(bot)._maybe_loop_reflect(**kwargs)
 
 
 async def test_success_path_consults_gate_and_fires_reflection(monkeypatch):


### PR DESCRIPTION
## RFC-002 P3 — first narrow-deps wave

The three smallest host-based classes now name their true dependencies. `grep 'self.host\|bot\.'` over all three files returns only a docstring mention.

| Class | Before | After |
|---|---|---|
| `TurnRecorder` | `host` (6 attrs) | 5 kwargs: `get_config` + trajectory_saver, reflector, outbound_webhook_dispatcher, loop_reflection_gate |
| `ScheduledEventHandlers` | `host` (13 attrs) | frozen `ScheduledEventsDeps` (8): `get_config`/`get_channel`/`get_guilds` providers, tool_executor, audit, `llm_gateway`, `tool_loop`, `agent_task_tools` |
| `AgentTaskTools` | `host` (19 attrs) | frozen `AgentTaskDeps` (17): same provider rules; `get_context_compressor` live |

Bot-delegate round-trips inside the classes (`bot._execute_scheduled_tool` → itself, etc.) become plain self calls. Construction order note: agents/tasks now builds **before** scheduled events (its consumer) — declared deviation; both were inert `host` captures before.

### The interesting part — two captured-vs-live traps caught in-flight
Exactly the failure mode the R1 provider rule exists for, and both were caught by existing suites before commit:
1. `get_channel=bot.get_channel` (captured bound method) went stale under the characterization fixture's per-instance `bot.get_channel = lambda ...` patch → wired as `lambda cid: bot.get_channel(cid)`.
2. A captured compression-config object missed `bot.context_compressor` swaps in the spawn-loop config tests → wired as `get_context_compressor=lambda: bot.context_compressor` (matches how the chat pipeline reads it per-iteration).

### Test migrations
Direct constructions only: `test_turn_recorder_loop_reflection` (kwargs helper), `test_trajectory_completeness` (2 fake hosts), `test_scheduled_workflow` (deps helper over MagicMocks), one `getsource` pin updated (`trajectory_saver=self._agent_trajectory_saver`). Characterization drives everything else through the bot delegates, which forward to the wiring-built components unchanged.

### Gates
- Full suite: **6,069 passed, 4 skipped**
- Characterization: 137 passed
- Zero `host`/`bot.` refs in the three classes (grep gate)
- Lint: **zero new findings** (content-normalized vs baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3