### PR TITLE
refactor(web): P6 — web/slash layers consume components directly

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -161,7 +161,7 @@ class OdinBot(commands.Bot):
 
         self.config = config
         # commands.Bot already initializes self.tree (app_commands.CommandTree); do not overwrite
-        self._start_time = time.monotonic()
+        self.start_time = self._start_time = time.monotonic()
 
         # ------------------------------------------------------------------
         # Subsystem construction lives in the composition root (wiring.py,
@@ -185,6 +185,7 @@ class OdinBot(commands.Bot):
         self._background_tasks = self._channel_state.background_tasks
 
         self.context_loader = services.context_loader
+        self.embedder = services.embedder  # public; _embedder alias below
         self.reflector = services.reflector
         self._embedder = services.embedder
         self._fts_index = services.fts_index
@@ -277,7 +278,7 @@ class OdinBot(commands.Bot):
         # health checker always reads the live value, even if the underlying
         # attribute gets reassigned during a reload or reinit.
 
-        self._system_prompt = self._build_system_prompt()
+        self.prompt_builder.rebuild_default()
         self._register_commands()
         self._init_allowed_webhook_ids()
         self._log_startup_config()
@@ -376,6 +377,16 @@ class OdinBot(commands.Bot):
     @property
     def _llm_provider_lock(self):
         return self._llm_gateway.provider_lock
+
+    # Default-prompt storage moved to PromptBuilder (RFC-002 P6); the old
+    # spelling stays live in BOTH directions until P7.
+    @property
+    def _system_prompt(self):
+        return self.prompt_builder.default_prompt
+
+    @_system_prompt.setter
+    def _system_prompt(self, value) -> None:
+        self.prompt_builder.default_prompt = value
 
 
     # Prompt/catalog cache shims — web/api.py reads AND writes these names

--- a/src/discord/prompts.py
+++ b/src/discord/prompts.py
@@ -53,6 +53,8 @@ class PromptBuilder:
         self.cached_hosts: dict[str, str] | None = None
         # Cached skills list text — invalidated on skill create/edit/delete
         self.cached_skills_text: str | None = None
+        # The default (no-channel) system prompt — set by rebuild_default()
+        self.default_prompt: str = ""
         # TTL cache for per-user memory (avoids file I/O per message)
         self.memory_cache: dict[str | None, tuple[float, dict[str, str]]] = {}
         self.memory_cache_ttl: float = 60.0  # seconds
@@ -110,6 +112,17 @@ class PromptBuilder:
         self.memory_cache.clear()
         if self.reflector is not None:
             self.reflector.invalidate_cache()
+
+    def rebuild_default(self) -> str:
+        """Rebuild and store the default (no-channel) system prompt.
+
+        The stored value is the fallback the tool loop uses when a turn has
+        no channel-specific override; the web layer rebuilds it after
+        config/context/personality changes (RFC-002 P6 — this replaces the
+        old ``bot._system_prompt = bot._build_system_prompt()`` dance).
+        """
+        self.default_prompt = self.build_full_prompt()
+        return self.default_prompt
 
     def prune_expired_memory(self, now: float) -> None:
         """Drop expired per-user memory entries (periodic housekeeping)."""

--- a/src/discord/slash_commands.py
+++ b/src/discord/slash_commands.py
@@ -19,7 +19,7 @@ log = get_logger("discord")
 def register_commands(bot) -> None:
     @bot.tree.command(name="status", description="Show Odin bot status")
     async def cmd_status(interaction: discord.Interaction) -> None:
-        if not bot._is_allowed_user(interaction.user):
+        if not bot.intake.is_allowed_user(interaction.user):
             await interaction.response.send_message("Access denied.", ephemeral=True)
             return
         voice_status = ""
@@ -33,15 +33,15 @@ def register_commands(bot) -> None:
                 voice_status = "\nVoice: Not connected"
         provider_cfg = getattr(bot.config, "llm_provider", None)
         active = provider_cfg.active_provider if provider_cfg else "codex"
-        client = bot.llm_client
+        client = bot.llm_gateway.active_client
         if client:
             model = getattr(client, "model", "unknown")
             llm_status = f"LLM: **{active}** ({model})"
         else:
             llm_status = "LLM: not configured"
-        codex_configured = "yes" if bot.codex_client else "no"
-        ollama_configured = "yes" if bot.ollama_client else "no"
-        kimi_configured = "yes" if bot.kimi_client else "no"
+        codex_configured = "yes" if bot.llm_gateway.codex_client else "no"
+        ollama_configured = "yes" if bot.llm_gateway.ollama_client else "no"
+        kimi_configured = "yes" if bot.llm_gateway.kimi_client else "no"
         await interaction.response.send_message(
             f"**Odin Status**\n"
             f"{llm_status}\n"
@@ -51,7 +51,7 @@ def register_commands(bot) -> None:
 
     @bot.tree.command(name="reset", description="Reset conversation history")
     async def cmd_reset(interaction: discord.Interaction) -> None:
-        if not bot._is_allowed_user(interaction.user):
+        if not bot.intake.is_allowed_user(interaction.user):
             await interaction.response.send_message("Access denied.", ephemeral=True)
             return
         bot.sessions.reset(str(interaction.channel_id))
@@ -59,18 +59,19 @@ def register_commands(bot) -> None:
 
     @bot.tree.command(name="reload", description="Reload context files")
     async def cmd_reload(interaction: discord.Interaction) -> None:
-        if not bot._is_allowed_user(interaction.user):
+        if not bot.intake.is_allowed_user(interaction.user):
             await interaction.response.send_message("Access denied.", ephemeral=True)
             return
         bot.context_loader.reload()
-        bot._invalidate_prompt_caches()
-        bot._system_prompt = bot._build_system_prompt()
+        bot.prompt_builder.invalidate()
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.rebuild_default()
         await interaction.response.send_message("Context files reloaded.")
 
     @bot.tree.command(name="purge", description="Delete recent messages in this channel")
     @app_commands.describe(count="Number of messages to delete (default 100, max 500)")
     async def cmd_purge(interaction: discord.Interaction, count: int = 100) -> None:
-        if not bot._is_allowed_user(interaction.user):
+        if not bot.intake.is_allowed_user(interaction.user):
             await interaction.response.send_message("Access denied.", ephemeral=True)
             return
         count = min(count, 500)
@@ -84,7 +85,7 @@ def register_commands(bot) -> None:
 
     @bot.tree.command(name="usage", description="Show token usage details")
     async def cmd_usage(interaction: discord.Interaction) -> None:
-        if not bot._is_allowed_user(interaction.user):
+        if not bot.intake.is_allowed_user(interaction.user):
             await interaction.response.send_message("Access denied.", ephemeral=True)
             return
         await interaction.response.send_message(
@@ -96,12 +97,12 @@ def register_commands(bot) -> None:
 
     @bot.tree.command(name="stop", description="Stop Odin's current task in this channel")
     async def cmd_stop(interaction: discord.Interaction) -> None:
-        if not bot._is_allowed_user(interaction.user):
+        if not bot.intake.is_allowed_user(interaction.user):
             await interaction.response.send_message("Access denied.", ephemeral=True)
             return
         channel_id = str(interaction.channel_id)
-        event = bot._cancel_events.setdefault(channel_id, asyncio.Event())
-        active = bot._channel_state.active_requests.get(channel_id)
+        event = bot.channel_state.cancel_events.setdefault(channel_id, asyncio.Event())
+        active = bot.channel_state.active_requests.get(channel_id)
         if active:
             event.set()
             await interaction.response.send_message("Stopping current task...", ephemeral=True)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -400,8 +400,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             for g in bot.guilds
         ]
         user_count = sum(g.member_count or 0 for g in bot.guilds)
-        tools = bot._merged_tool_definitions()
-        uptime = time.monotonic() - bot._start_time if hasattr(bot, "_start_time") else 0
+        tools = bot.tool_catalog.merged_definitions()
+        uptime = time.monotonic() - bot.start_time if hasattr(bot, "_start_time") else 0
 
         # Agent counts
         try:
@@ -649,8 +649,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     @routes.post("/api/reload")
     async def reload_config(_request: web.Request) -> web.Response:
         bot.context_loader.reload()
-        bot._invalidate_prompt_caches()
-        bot._system_prompt = bot._build_system_prompt()
+        bot.prompt_builder.invalidate()
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.rebuild_default()
         return web.json_response({"status": "reloaded"})
 
     # ------------------------------------------------------------------
@@ -695,8 +696,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         current = bot.config.model_dump()
         config_path = getattr(request.app, "_config_path", "config.yml")
         await asyncio.to_thread(_write_config, config_path, current)
-        bot._invalidate_prompt_caches()
-        bot._system_prompt = bot._build_system_prompt()
+        bot.prompt_builder.invalidate()
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.rebuild_default()
         return web.json_response({"status": "updated", "preset": preset})
 
     @routes.post("/api/personality/presets")
@@ -741,8 +743,9 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         register_user_presets({k: {"name": v.name, "identity": v.identity, "voice": v.voice} for k, v in bot.config.personality.user_presets.items()})
         if bot.config.personality.preset == name:
             bot.config.personality.preset = "odin"
-            bot._invalidate_prompt_caches()
-            bot._system_prompt = bot._build_system_prompt()
+            bot.prompt_builder.invalidate()
+            bot.tool_catalog.invalidate()
+            bot.prompt_builder.rebuild_default()
         current = bot.config.model_dump()
         config_path = getattr(request.app, "_config_path", "config.yml")
         await asyncio.to_thread(_write_config, config_path, current)
@@ -1483,8 +1486,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             if err:
                 return web.json_response({"error": err}, status=400)
         result = bot.skill_manager.create_skill(name, code)
-        bot._cached_merged_tools = None
-        bot._cached_skills_text = None
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.cached_skills_text = None
         is_error = "error" in result.lower() or "failed" in result.lower()
         return web.json_response(
             {"result": result},
@@ -1505,8 +1508,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if err:
             return web.json_response({"error": err}, status=400)
         result = bot.skill_manager.edit_skill(name, code)
-        bot._cached_merged_tools = None
-        bot._cached_skills_text = None
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.cached_skills_text = None
         is_error = "error" in result.lower() or "failed" in result.lower()
         return web.json_response(
             {"result": result},
@@ -1532,8 +1535,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     async def delete_skill(request: web.Request) -> web.Response:
         name = request.match_info["name"]
         result = bot.skill_manager.delete_skill(name)
-        bot._cached_merged_tools = None
-        bot._cached_skills_text = None
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.cached_skills_text = None
         is_error = "error" in result.lower() or "not found" in result.lower()
         return web.json_response(
             {"result": result},
@@ -1569,8 +1572,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         result = bot.skill_manager.enable_skill(name)
         if "not found" in result.lower():
             return web.json_response({"result": result}, status=404)
-        bot._cached_merged_tools = None
-        bot._cached_skills_text = None
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.cached_skills_text = None
         return web.json_response({"result": result})
 
     @routes.post("/api/skills/{name}/disable")
@@ -1579,8 +1582,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         result = bot.skill_manager.disable_skill(name)
         if "not found" in result.lower():
             return web.json_response({"result": result}, status=404)
-        bot._cached_merged_tools = None
-        bot._cached_skills_text = None
+        bot.tool_catalog.invalidate()
+        bot.prompt_builder.cached_skills_text = None
         return web.json_response({"result": result})
 
     @routes.get("/api/skills/{name}/config")
@@ -1659,7 +1662,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 env=data.get("env", {}),
                 timeout=data.get("timeout"),
             )
-            bot._cached_merged_tools = None
+            bot.tool_catalog.invalidate()
             return web.json_response(info, status=201)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=400)
@@ -1672,7 +1675,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         name = request.match_info["name"]
         try:
             await mgr.remove_server(name)
-            bot._cached_merged_tools = None
+            bot.tool_catalog.invalidate()
             return web.json_response({"status": "removed", "server": name})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=404)
@@ -1868,14 +1871,14 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/knowledge")
     async def list_knowledge(_request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         return web.json_response(await asyncio.to_thread(store.list_sources))
 
     @routes.post("/api/knowledge")
     async def ingest_knowledge(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         data = await request.json()
@@ -1891,12 +1894,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         ):
             if err:
                 return web.json_response({"error": err}, status=400)
-        chunks = await store.ingest(content, source, embedder=bot._embedder, uploader="web-api")
+        chunks = await store.ingest(content, source, embedder=bot.embedder, uploader="web-api")
         return web.json_response({"source": source, "chunks": chunks}, status=201)
 
     @routes.delete("/api/knowledge/{source}")
     async def delete_knowledge(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
@@ -1907,19 +1910,19 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/knowledge/{source}/reingest")
     async def reingest_knowledge(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
         content = await asyncio.to_thread(store.get_source_content, source)
         if content is None:
             return web.json_response({"error": "source not found"}, status=404)
-        chunks = await store.ingest(content, source, embedder=bot._embedder, uploader="web-reingest")
+        chunks = await store.ingest(content, source, embedder=bot.embedder, uploader="web-reingest")
         return web.json_response({"source": source, "chunks": chunks})
 
     @routes.get("/api/knowledge/search")
     async def search_knowledge(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         query = request.query.get("q", "").strip()
@@ -1929,12 +1932,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             limit = _safe_int_param(request, "limit", 10, hi=50)
         except ValueError:
             return web.json_response({"error": "limit must be an integer"}, status=400)
-        results = await store.search_hybrid(query, embedder=bot._embedder, limit=limit)
+        results = await store.search_hybrid(query, embedder=bot.embedder, limit=limit)
         return web.json_response(results)
 
     @routes.get("/api/knowledge/{source}/chunks")
     async def list_knowledge_chunks(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
@@ -1948,7 +1951,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/knowledge/duplicates")
     async def list_knowledge_duplicates(_request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         exact = await asyncio.to_thread(store.find_duplicates)
@@ -1962,7 +1965,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/knowledge/merge")
     async def merge_knowledge(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         try:
@@ -1989,7 +1992,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/knowledge/{source}/versions")
     async def list_knowledge_versions(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
@@ -1998,7 +2001,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/knowledge/{source}/versions/{version:\\d+}")
     async def get_knowledge_version(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
@@ -2010,7 +2013,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/knowledge/{source}/versions/{version:\\d+}/restore")
     async def restore_knowledge_version(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
@@ -2022,14 +2025,14 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             return web.json_response(
                 {"error": "version has no content snapshot (delete version)"}, status=400
             )
-        chunks = await store.restore_version(source, version, embedder=bot._embedder)
+        chunks = await store.restore_version(source, version, embedder=bot.embedder)
         return web.json_response(
             {"status": "restored", "source": source, "version": version, "chunks": chunks}
         )
 
     @routes.get("/api/knowledge/{source}/versions/{v1:\\d+}/diff/{v2:\\d+}")
     async def diff_knowledge_versions(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         source = request.match_info["source"]
@@ -2045,7 +2048,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/knowledge/import")
     async def import_knowledge(request: web.Request) -> web.Response:
-        store = bot._knowledge_store
+        store = bot.knowledge
         if not store or not store.available:
             return web.json_response({"error": "knowledge store not available"}, status=503)
         try:
@@ -2056,7 +2059,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not items or not isinstance(items, list):
             return web.json_response({"error": "items (array) is required"}, status=400)
         from ..knowledge.importer import BulkImporter
-        importer = BulkImporter(store, bot._embedder)
+        importer = BulkImporter(store, bot.embedder)
         batch = await importer.import_batch(items, uploader="web-api")
         return web.json_response({
             "total": batch.total,
@@ -2283,7 +2286,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         async def _iteration_cb(
             prompt: str, ch: object, prev_context: str | None,
         ) -> str:
-            return await bot._run_loop_iteration(
+            return await bot.tool_loop.run_autonomous(
                 prompt, ch, prev_context, requester_id,
             )
 
@@ -2344,7 +2347,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         async def _iteration_cb(
             prompt: str, ch: object, prev_context: str | None,
         ) -> str:
-            return await bot._run_loop_iteration(
+            return await bot.tool_loop.run_autonomous(
                 prompt, ch, prev_context, requester_id,
             )
 
@@ -2911,7 +2914,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 _atomic_write_secure(path, _json.dumps([creds], indent=2))
                 log.warning("Failed to merge credentials (backup at %s), wrote fresh: %s", bak, e)
 
-        await bot.reload_codex_auth()
+        await bot.llm_gateway.reload_codex()
 
         return web.json_response({
             "status": "authenticated",
@@ -2978,7 +2981,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/codex/reload")
     async def codex_reload(_request: web.Request) -> web.Response:
-        result = await bot.reload_codex_auth()
+        result = await bot.llm_gateway.reload_codex()
         status = 200 if result.get("configured") else 503
         return web.json_response(result, status=status)
 
@@ -3093,8 +3096,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         provider_cfg = getattr(bot.config, "llm_provider", None)
         active = provider_cfg.active_provider if provider_cfg else "codex"
 
-        codex_configured = bot.codex_client is not None
-        ollama_configured = bot.ollama_client is not None
+        codex_configured = bot.llm_gateway.codex_client is not None
+        ollama_configured = bot.llm_gateway.ollama_client is not None
 
         ollama_cfg = getattr(bot.config, "ollama", None)
         kimi_cfg = getattr(bot.config, "kimi", None)
@@ -3118,7 +3121,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                 "has_api_key": bool(ollama_cfg and ollama_cfg.api_key),
             },
             "kimi": {
-                "configured": bot.kimi_client is not None,
+                "configured": bot.llm_gateway.kimi_client is not None,
                 "enabled": kimi_cfg.enabled if kimi_cfg else False,
                 "model": kimi_cfg.model if kimi_cfg else "",
                 "max_tokens": kimi_cfg.max_tokens if kimi_cfg else 4096,
@@ -3126,7 +3129,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             },
         }
 
-        client = bot.llm_client
+        client = bot.llm_gateway.active_client
         if client:
             result["active_model"] = getattr(client, "model", "unknown")
             result["active_provider_name"] = getattr(client, "provider_name", active)
@@ -3144,7 +3147,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if provider not in ("codex", "ollama", "kimi"):
             return web.json_response({"error": "provider must be 'codex', 'ollama', or 'kimi'"}, status=400)
 
-        result = await bot.switch_llm_provider(provider)
+        result = await bot.llm_gateway.switch_provider(provider)
         if "error" in result:
             return web.json_response(result, status=400)
         await _persist_config()
@@ -3298,7 +3301,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                     cfg.max_tokens = _parse_int(body["max_tokens"], "max_tokens", 1, 128000)
                     changed = True
                 if changed:
-                    await bot._reload_codex_inner()
+                    await bot.llm_gateway.reload_codex_inner()
                     await _persist_config()
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
@@ -3307,7 +3310,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "status": "updated",
             "enabled": cfg.enabled,
             "model": cfg.model,
-            "configured": bot.codex_client is not None,
+            "configured": bot.llm_gateway.codex_client is not None,
         })
 
     @routes.put("/api/llm/ollama/config")
@@ -3345,7 +3348,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                     cfg.timeout = _parse_int(body["timeout"], "timeout", 10, 3600)
                     changed = True
                 if changed:
-                    await bot._reload_ollama_inner()
+                    await bot.llm_gateway.reload_ollama_inner()
                     await _persist_config()
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
@@ -3355,7 +3358,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "enabled": cfg.enabled,
             "model": cfg.model,
             "base_url": cfg.base_url,
-            "configured": bot.ollama_client is not None,
+            "configured": bot.llm_gateway.ollama_client is not None,
         })
 
     @routes.put("/api/llm/kimi/config")
@@ -3390,7 +3393,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
                     cfg.timeout = _parse_int(body["timeout"], "timeout", 10, 3600)
                     changed = True
                 if changed:
-                    await bot._reload_kimi_inner()
+                    await bot.llm_gateway.reload_kimi_inner()
                     await _persist_config()
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
@@ -3399,7 +3402,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             "status": "updated",
             "enabled": cfg.enabled,
             "model": cfg.model,
-            "configured": bot.kimi_client is not None,
+            "configured": bot.llm_gateway.kimi_client is not None,
         })
 
     # ------------------------------------------------------------------
@@ -3424,7 +3427,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/ollama/reload")
     async def ollama_reload(_request: web.Request) -> web.Response:
-        result = await bot.reload_ollama()
+        result = await bot.llm_gateway.reload_ollama()
         status = 200 if result.get("configured") else 503
         return web.json_response(result, status=status)
 
@@ -3533,7 +3536,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.post("/api/kimi/reload")
     async def kimi_reload(_request: web.Request) -> web.Response:
-        result = await bot.reload_kimi()
+        result = await bot.llm_gateway.reload_kimi()
         status = 200 if result.get("configured") else 503
         return web.json_response(result, status=status)
 

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 
 log = get_logger("web.chat")
 
+# Per-channel serialization for persistent web-chat channels — WEB-OWNED
+# state (RFC-002 P6: previously parked on the bot as _web_channel_locks).
+# One bot per process, so module scope ≡ the old bot scope.
+WEB_CHANNEL_LOCKS: dict[str, asyncio.Lock] = {}
+
 # Atomic monotonic counter for virtual message IDs (thread-safe via C impl)
 _msg_id_counter = itertools.count(int(time.time() * 1000))
 
@@ -170,9 +175,11 @@ async def process_web_chat(
 
     persist_channel_lock: when True (default), concurrent calls sharing this
         channel_id are serialized via a per-channel asyncio.Lock cached in
-        bot._web_channel_locks. Used by /api/chat and the WebSocket chat, where
-        channel_id == user_id and a user's overlapping requests must run one at
-        a time. Set False for single-use/ephemeral channels — e.g.
+        this module's WEB_CHANNEL_LOCKS (web-owned state — RFC-002 P6 moved
+        it off the bot; one app per bot per process makes the scopes
+        equivalent). Used by /api/chat and the WebSocket chat, where
+        channel_id == user_id and a user's overlapping requests must run one
+        at a time. Set False for single-use/ephemeral channels — e.g.
         /api/execute's per-request UUID channels — which no other caller can
         share: caching a lock there is pointless and leaks one permanent dict
         entry per request, since the channel is reset and never reused.
@@ -191,9 +198,7 @@ async def process_web_chat(
 
     try:
         if persist_channel_lock:
-            if not hasattr(bot, "_web_channel_locks"):
-                bot._web_channel_locks = {}
-            lock = bot._web_channel_locks.setdefault(channel_id, asyncio.Lock())
+            lock = WEB_CHANNEL_LOCKS.setdefault(channel_id, asyncio.Lock())
             async with lock:
                 return await _do_process_web_chat(bot, content, channel_id, user_id, username, allowed_tools)
         else:
@@ -221,7 +226,7 @@ async def _do_process_web_chat(
     tagged = f"[{username}]: {content}"
     bot.sessions.add_message(channel_id, "user", tagged, user_id=user_id)
 
-    if not bot.codex_client:
+    if not bot.llm_gateway.codex_client:
         bot.sessions.remove_last_message(channel_id, "user")
         return {
             "response": "No LLM backend available.",
@@ -230,8 +235,8 @@ async def _do_process_web_chat(
         }
 
     try:
-        trace = bot._new_context_trace()
-        sp = bot._build_system_prompt(
+        trace = bot.turn_recorder._new_context_trace()
+        sp = bot.prompt_builder.build_full_prompt(
             channel=None, user_id=user_id, query=content, trace=trace,
         )
         history = await bot.sessions.get_task_history(
@@ -240,12 +245,12 @@ async def _do_process_web_chat(
 
         try:
             response, _already_sent, is_error, tools_used, handoff = (
-                await bot._process_with_tools(
+                await bot.tool_loop.run(
                     msg, history, system_prompt_override=sp, trace=trace,
                 )
             )
         finally:
-            await bot._set_status(None, task_end=True)
+            await bot.delivery.set_status(None, task_end=True)
 
         response = _scrub(response)
 

--- a/tests/characterization/test_facade_contract.py
+++ b/tests/characterization/test_facade_contract.py
@@ -108,7 +108,6 @@ FACADE_METHODS = [
 
 LATE_BOUND_ABSENT = [
     "startup_report",
-    "_web_channel_locks",
     "mcp_manager",
     "_codex_auth_pool",
     "_issue_tracker_client",
@@ -172,9 +171,8 @@ class TestPositiveSurface:
         assert bot.codex_client == "sentinel"
         bot.knowledge = "kstore"
         assert bot._knowledge_store == "kstore"
-        # web/chat.py lazily creates this:
-        bot._web_channel_locks = {}
-        assert bot._web_channel_locks == {}
+        # (the web-chat lock cache moved to src.web.chat.WEB_CHANNEL_LOCKS
+        # in RFC-002 P6 — web-owned state no longer parked on the bot)
 
     def test_classifier_prompt_class_attr_exists(self, bot):
         assert isinstance(type(bot)._CLASSIFIER_SYSTEM_PROMPT, str)
@@ -251,6 +249,8 @@ class TestWebChatRoute:
         assert result["is_error"] is False
         assert result["response"] == "web answer"
         assert result["tools_used"] == []
-        assert len(fake.calls) == 1  # went through the REAL _process_with_tools
-        # And the lazily-created lock cache now exists (late-bound behavior)
-        assert hasattr(bot, "_web_channel_locks")
+        assert len(fake.calls) == 1  # went through the REAL tool loop
+        # The lock cache is web-owned module state now (RFC-002 P6)
+        from src.web.chat import WEB_CHANNEL_LOCKS
+
+        assert "web-42" in WEB_CHANNEL_LOCKS

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -160,7 +160,8 @@ async def test_same_session_serializes_concurrent_requests():
     from src.web.chat import process_web_chat
 
     bot = _make_bot()
-    bot._web_channel_locks = {}          # real dict -> a real asyncio.Lock is used
+    from src.web import chat as web_chat
+    web_chat.WEB_CHANNEL_LOCKS.clear()   # module cache -> a real asyncio.Lock is used
     state = {"now": 0, "max": 0}
 
     async def slow_do(*args, **kwargs):

--- a/tests/test_execute_api.py
+++ b/tests/test_execute_api.py
@@ -266,7 +266,7 @@ class TestRealHandler:
     @pytest.mark.asyncio
     async def test_execute_opts_out_of_channel_lock(self):
         """/api/execute must pass persist_channel_lock=False so it does not
-        cache (and leak) a per-request lock in bot._web_channel_locks."""
+        cache (and leak) a per-request lock in the module WEB_CHANNEL_LOCKS cache."""
         bot = _make_bot()
         bot.config = MagicMock()
         bot.config.web.api_token = ""

--- a/tests/test_knowledge_dedup.py
+++ b/tests/test_knowledge_dedup.py
@@ -560,8 +560,8 @@ class TestModuleImports:
 
 def _make_bot_with_store(store=None):
     bot = MagicMock()
-    bot._knowledge_store = store
-    bot._embedder = None
+    bot.knowledge = store
+    bot.embedder = None
     bot.config = MagicMock()
     bot.config.web = MagicMock()
     bot.config.web.api_token = ""

--- a/tests/test_knowledge_versions.py
+++ b/tests/test_knowledge_versions.py
@@ -688,8 +688,8 @@ class TestVersioningEdgeCases:
 
 def _make_bot_with_store(store=None):
     bot = MagicMock()
-    bot._knowledge_store = store
-    bot._embedder = None
+    bot.knowledge = store
+    bot.embedder = None
     bot.config = MagicMock()
     bot.config.web = MagicMock()
     bot.config.web.api_token = ""

--- a/tests/test_web_chat.py
+++ b/tests/test_web_chat.py
@@ -215,13 +215,14 @@ class TestProcessWebChat:
         bot.sessions.get_task_history = AsyncMock(return_value=[])
 
         if has_codex:
-            bot.codex_client = MagicMock()
+            bot.llm_gateway.codex_client = MagicMock()
         else:
-            bot.codex_client = None
+            bot.llm_gateway.codex_client = None
 
-        bot._build_system_prompt = MagicMock(return_value="system prompt")
-        bot._set_status = AsyncMock()
-        bot._process_with_tools = AsyncMock(return_value=(
+        bot.prompt_builder.build_full_prompt = MagicMock(return_value="system prompt")
+        bot.delivery.set_status = AsyncMock()
+        bot.turn_recorder._new_context_trace = MagicMock(return_value=None)
+        bot.tool_loop.run = AsyncMock(return_value=(
             response,
             False,  # already_sent
             is_error,
@@ -249,7 +250,7 @@ class TestProcessWebChat:
     @pytest.mark.asyncio
     async def test_chat_no_tools_no_save(self):
         bot = self._make_bot(response="Just chat", tools=[])
-        bot._process_with_tools = AsyncMock(return_value=(
+        bot.tool_loop.run = AsyncMock(return_value=(
             "Just chat", False, False, [], False,
         ))
         result = await process_web_chat(bot, "hello", "ch-1")
@@ -266,7 +267,7 @@ class TestProcessWebChat:
     @pytest.mark.asyncio
     async def test_exception_handling(self):
         bot = self._make_bot()
-        bot._process_with_tools = AsyncMock(side_effect=RuntimeError("boom"))
+        bot.tool_loop.run = AsyncMock(side_effect=RuntimeError("boom"))
         result = await process_web_chat(bot, "hello", "ch-1")
         assert result["is_error"] is True
         # User-facing error is intentionally generic (no internal details leaked)
@@ -278,15 +279,15 @@ class TestProcessWebChat:
         bot = self._make_bot(response="done")
         result = await process_web_chat(bot, "hello", "ch-1")
         assert result["is_error"] is False
-        bot._set_status.assert_awaited_once_with(None, task_end=True)
+        bot.delivery.set_status.assert_awaited_once_with(None, task_end=True)
 
     @pytest.mark.asyncio
     async def test_web_chat_ends_status_when_tool_processing_raises(self):
         bot = self._make_bot()
-        bot._process_with_tools = AsyncMock(side_effect=RuntimeError("boom"))
+        bot.tool_loop.run = AsyncMock(side_effect=RuntimeError("boom"))
         result = await process_web_chat(bot, "hello", "ch-1")
         assert result["is_error"] is True
-        bot._set_status.assert_awaited_once_with(None, task_end=True)
+        bot.delivery.set_status.assert_awaited_once_with(None, task_end=True)
 
     @pytest.mark.asyncio
     async def test_files_returned(self):
@@ -299,23 +300,25 @@ class TestProcessWebChat:
     async def test_single_use_channel_does_not_register_lock(self):
         """persist_channel_lock=False (e.g. /api/execute) must not cache a
         per-channel lock; otherwise each ephemeral UUID channel leaks one
-        permanent entry in bot._web_channel_locks."""
+        permanent entry in the module's WEB_CHANNEL_LOCKS cache."""
         bot = self._make_bot()
-        bot._web_channel_locks = {}  # real dict so growth is observable
+        from src.web import chat as web_chat
+        web_chat.WEB_CHANNEL_LOCKS.clear()  # module cache — observable growth
         for i in range(5):
             await process_web_chat(bot, "hi", f"api-{i}", persist_channel_lock=False)
-        assert bot._web_channel_locks == {}
+        assert web_chat.WEB_CHANNEL_LOCKS == {}
 
     @pytest.mark.asyncio
     async def test_stateful_channel_registers_one_lock_per_channel(self):
         """The default path (/api/chat, WebSocket) still caches exactly one
         lock per channel_id so a user's overlapping requests serialize."""
         bot = self._make_bot()
-        bot._web_channel_locks = {}
+        from src.web import chat as web_chat
+        web_chat.WEB_CHANNEL_LOCKS.clear()
         await process_web_chat(bot, "hi", "user-1")
         await process_web_chat(bot, "again", "user-1")
-        assert set(bot._web_channel_locks) == {"user-1"}
-        assert isinstance(bot._web_channel_locks["user-1"], asyncio.Lock)
+        assert set(web_chat.WEB_CHANNEL_LOCKS) == {"user-1"}
+        assert isinstance(web_chat.WEB_CHANNEL_LOCKS["user-1"], asyncio.Lock)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## RFC-002 P6 — the web layer stops speaking facade

`grep -rnE 'bot\._[a-zA-Z]' src/web src/health` → **empty**. Public handles (config, sessions, audit, guilds, is_ready…) unchanged — they were never the disease.

### Respellings
- **api.py** — LLM ops → `bot.llm_gateway` (clients, `reload_*`, `switch_provider`, `active_client`); prompt/catalog → `bot.prompt_builder` + `bot.tool_catalog` (the 13 cache-null sites become `invalidate()`/attr writes); loop-iterate endpoint → `bot.tool_loop.run_autonomous`; traces → `bot.turn_recorder`; presence → `bot.delivery`; `bot.knowledge`/`bot.embedder`/`bot.start_time` public names.
- **Default prompt** gets a real home: `PromptBuilder.default_prompt` + `rebuild_default()` (seeded in `__init__`, called by the 3 api rebuild sites + slash reload). `bot._system_prompt` stays a two-way property alias until P7 (the tool loop's provider reads through it unchanged).
- **chat.py** — `_web_channel_locks` leaves the bot: module-owned `WEB_CHANNEL_LOCKS` (web state was never the bot's to hold; one bot per process ⇒ same scope). The existing `test_same_session_serializes_concurrent_requests` now exercises the module cache — the R1 serialization gate.
- **slash_commands.py** — channel_state / gateway / prompt_builder / `intake.is_allowed_user`.
- **__main__.py** — untouched (already public-flat, getattr-guarded).

### Test migrations
Fixture respellings only: web-chat/execute/chat-session component seams; knowledge dedup/versions set `bot.knowledge`/`bot.embedder` (their MagicMock `_knowledge_store` attr was invisible to the new spelling — the auto-attr truthiness broke the 503 path, caught immediately); facade contract drops `_web_channel_locks` from the bot surface.

### Gates
- Full suite: **6,069 passed, 4 skipped** · 169 web-focused tests green
- `bot._` in src/web + src/health: **zero** · `ui/` untouched
- Lint: **zero new findings** (content-normalized vs baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3