### PR TITLE
refactor(client)!: P7 — retire the facade; OdinBot is composition + lifecycle only

### DIFF
--- a/docs/plans/facade-retirement-plan.md
+++ b/docs/plans/facade-retirement-plan.md
@@ -138,7 +138,17 @@ Rollback: every phase is a merge commit on the campaign branch; `git revert -m1`
 5. Full suite green (≥6,056 tests), characterization green throughout, ruff finding-set diff vs baseline = zero new.
 6. Soak on /opt/odin: healthy chat + loop + web traffic, no new log errors attributable to the campaign.
 
+## 6.1 Results (P7 complete, 2026-07-05)
+
+- `client.py`: **1,267 → 361 lines**, 13 methods, all real logic — zero delegates, zero property shims (one deliberate property survives: `knowledge`, see R2). Cumulative across both campaigns: 5,790 → 361.
+- `grep "def __init__(self, host)" src/discord` → empty; `grep "bot\._" src/web src/health` → empty.
+- `tool_loop.run()`: 800 → 75-line orchestrator; no method > 160 lines; AST carve gate CLEAN (22/22 blocks).
+- Dispatch: 36 entries bound to 5 domain owners; the bot is out of the dispatch path.
+- New negative contract: ~110 retired `bot.<name>` spellings scanned to zero across src/ AND tests/; broad `bot._` scan over src/ (composition files excepted).
+- Suite: 6,067 passed / 4 skipped; lint finding-set vs baseline: **zero new, 11 resolved**.
+
 ## 7. Revision log
 
 - R0 (2026-07-05): initial draft for Odin review.
+- R2 (2026-07-05, during P6/P7): two declared deviations from the §3.2 table. (1) The web-chat lock cache landed as **module-owned** `src.web.chat.WEB_CHANNEL_LOCKS`, not aiohttp app state — one bot/app per process makes them equivalent, and it keeps `process_web_chat()` request-agnostic (Odin's P6 review note). (2) The knowledge store's public name stays the established **`knowledge` property pair** (live, settable — the dominant spelling in tests and the P6 web migration) instead of a `knowledge_store` rename; `_knowledge_store` is client-internal storage.
 - R1 (2026-07-05, from Odin's review): resolved the `_on_monitor_alert` keeps/deletes contradiction — scheduler + infra-watcher callbacks wire directly to `scheduled_events`, no delegate survives P7 (infra_watcher construction reorders after components in P2). P1 gains an explicit mechanical carve gate (AST-normalized block comparison + mutation-semantics assertions). Live-state grep gate extended to Deps-dataclass field captures. P6 underscore-gate wording made precise (public handles allowed) + app-state lock serialization test. health/checker.py inventory note. Discovery during prep, fixed ahead of P1 as its own PR: `turn_recorder.py:116` kept `hasattr(self, "reflector")` from the P10 verbatim move — always False on the recorder, silently suppressing ALL loop reflection since v3.45.0.

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -102,7 +102,8 @@ def main() -> None:
         load_dotenv(env_path)
 
     from src.config import load_config
-    from src.discord.client import OdinBot, scrub_response_secrets
+    from src.discord.client import OdinBot
+    from src.discord.response_guards import scrub_response_secrets
     from src.health import HealthServer
     from src.odin_log import get_logger
 

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -1,42 +1,30 @@
+"""OdinBot — the Discord client: lifecycle, gating entry points, composition.
+
+Since RFC-002 P7 this module holds ONLY what genuinely belongs to the bot:
+discord.py lifecycle hooks, the composition sequence (services →
+components → watchers), and the handful of real helpers those hooks use.
+Everything else lives in the components (``wiring.build_components``) and
+is reachable through their PUBLIC names on the bot (``bot.tool_loop``,
+``bot.prompt_builder``, ``bot.llm_gateway``, …) plus ``bot.services`` /
+``bot.components``. The old delegate/shim facade is retired — the public
+surface is pinned by tests/characterization/test_facade_contract.py.
+"""
+
 from __future__ import annotations
 
-import asyncio
-import hashlib
 import os
-import re
 import time
-from collections.abc import Callable
 
 import discord
 from discord.ext import commands
 
 from ..config.schema import Config
 from ..monitoring import InfraWatcher
-from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
-from ..tools import ToolResult, get_tool_definitions
+from ..tools import get_tool_definitions
 from ..async_utils import fire_and_forget
-from .completion import CLASSIFIER_SYSTEM_PROMPT, CompletionClassifier
-from .tool_loop import ensure_failure_visible
-from .tool_loop import _LoopAuthorProxy, _LoopMessageProxy  # noqa: F401 — re-export (tests, proxies)
-
-# Canonical homes moved to tool_loop_helpers (RFC-002 P1) — re-exported here
-# until P7 retires the facade spellings. _ALLOWED_WEBHOOK_IDS is the SAME set
-# object (mutated in place), so this binding stays live across env re-reads.
-from .tool_loop_helpers import (
-    _ALLOWED_WEBHOOK_IDS,  # noqa: F401 — re-export
-    _EMAIL_BODY_TOOLS,  # noqa: F401 — re-export
-    _EMPTY_RESPONSE_FALLBACK,  # noqa: F401 — re-export
-    _scrub_tool_input_for_storage,  # noqa: F401 — re-export until P7
-    init_allowed_webhook_ids as _init_allowed_webhook_ids_impl,
-)
-from .delivery import DISCORD_MAX_LEN  # noqa: F401 — module re-export contract
-from .delivery import SEND_MAX_RETRIES  # noqa: F401 — module re-export contract
-from .delivery import TOOL_STATUS_LABELS
-from .intake_pipeline import SECRET_SCRUB_PATTERNS  # noqa: F401 — re-export until P7
-from .intake_pipeline import check_for_secrets as _check_for_secrets_impl
 from .slash_commands import register_commands
-from .native_tools.media import MediaTools
+from .tool_loop_helpers import init_allowed_webhook_ids as _init_allowed_webhook_ids_impl
 from .voice import VoiceManager, VoiceMessageProxy
 from .wiring import build_components, build_services, shutdown_services
 
@@ -56,96 +44,6 @@ INITIAL_EXTENSIONS: tuple[str, ...] = (
 )
 
 
-# Tool-iteration caps are now configurable per path (chat vs loop) via
-# config.tools.max_tool_iterations_chat / _loop. Read fresh each request so
-# config updates via /api/config PUT take effect on the next message/iteration.
-TOOL_OUTPUT_MAX_CHARS = 12000  # ~3000 tokens; cap tool results to prevent context bloat
-_LONG_TIMEOUT_TOOL_SET = frozenset({"claude_code"})  # Tools that get extended timeout (3660s vs config default)
-
-# Pre-compiled regex for merging adjacent code blocks in combine_bot_messages
-_ADJACENT_FENCE_RE = re.compile(r"\n```[ \t]*\n\n```(\w*)[ \t]*\n")
-
-
-
-
-
-# Additional patterns for scrubbing LLM responses before Discord delivery.
-# These extend OUTPUT_SECRET_PATTERNS (applied via scrub_output_secrets) with
-# patterns more likely to appear in natural-language LLM output.
-_RESPONSE_EXTRA_PATTERNS = [
-    re.compile(r"xox[boaprs]-[a-zA-Z0-9-]+"),  # Slack tokens
-    # Natural language: "the password is ...", "my password is hunter2"
-    re.compile(r"(?i)(?:my\s+)?(?:password|passwd|pwd)\s+(?:\S+\s+){0,4}(?:is|was)\s+\S{6,}"),
-]
-
-
-def scrub_response_secrets(text: str) -> str:
-    """Scrub potential secrets from LLM responses before sending to Discord.
-
-    Applies the tool-output patterns (passwords, API keys, private keys,
-    database URLs) plus additional patterns for secrets that LLMs might
-    express in natural language.
-    """
-    text = scrub_output_secrets(text)
-    for pattern in _RESPONSE_EXTRA_PATTERNS:
-        text = pattern.sub("[REDACTED]", text)
-    return text
-
-
-
-
-def truncate_tool_output(text: str, max_chars: int = TOOL_OUTPUT_MAX_CHARS) -> str:
-    """Truncate large tool output, preserving the start and end for context.
-
-    Tool results stay in the messages list and are re-sent as input tokens
-    on every subsequent iteration of the tool loop.  Capping output prevents
-    a single large result (Prometheus JSON, file contents, long command output)
-    from ballooning costs across iterations.
-    """
-    if len(text) <= max_chars:
-        return text
-    half = max_chars // 2
-    omitted = len(text) - max_chars
-    return (
-        text[:half]
-        + f"\n\n[... {omitted} characters omitted ...]\n\n"
-        + text[-half:]
-    )
-
-
-def combine_bot_messages(parts: list[str]) -> str:
-    """Combine buffered bot messages, intelligently merging code blocks.
-
-    Handles:
-    - Split code blocks (open in one message, close in later one) — joined
-      with a single newline so no extra blank lines appear inside the block.
-    - Adjacent code blocks (close fence then immediately open fence) — merged
-      into one continuous block by removing the redundant fence pair.
-    - Regular text between code blocks — joined with double newline as usual.
-    """
-    if len(parts) <= 1:
-        return parts[0] if parts else ""
-
-    # Join parts, using \n (not \n\n) when the previous part has an unclosed
-    # code block — meaning the next part is a continuation of the same block.
-    # Track fence count incrementally to avoid O(n²) rescanning.
-    result = parts[0]
-    fence_count = result.count("```")
-    for i in range(1, len(parts)):
-        if fence_count % 2 == 1:
-            # Inside an unclosed code block — continuation, single newline
-            result += "\n" + parts[i]
-        else:
-            result += "\n\n" + parts[i]
-        fence_count += parts[i].count("```")
-
-    # Merge adjacent code blocks: \n```<ws>\n\n```<lang>\n → \n
-    # This collapses e.g. "\n```\n\n```bash\n" into a single block.
-    result = _ADJACENT_FENCE_RE.sub("\n", result)
-
-    return result
-
-
 class OdinBot(commands.Bot):
     def __init__(self, config: Config) -> None:
         intents = discord.Intents.default()
@@ -161,38 +59,22 @@ class OdinBot(commands.Bot):
 
         self.config = config
         # commands.Bot already initializes self.tree (app_commands.CommandTree); do not overwrite
-        self.start_time = self._start_time = time.monotonic()
+        self.start_time = time.monotonic()
 
         # ------------------------------------------------------------------
-        # Subsystem construction lives in the composition root (wiring.py,
-        # RFC-001 P1). Attributes are attached flat so the external facade
-        # (web/api.py, health checks, tests) is unchanged.
+        # Stage 1: bot-independent services (wiring.build_services).
+        # Flat handles are the documented public composition surface.
         # ------------------------------------------------------------------
         services = build_services(config)
         self.services = services
 
-        # Per-channel mutable state — owned by ChannelStateRegistry
-        # (constructed in build_services since RFC-002 P2). The dict
-        # attributes below are facade ALIASES to the registry's dicts (same
-        # objects): external readers (web layer, tests) keep working, and
-        # mutations through either name stay in sync.
-        self.channel_state = self._channel_state = services.channel_state
-        self._channel_locks = self._channel_state.channel_locks
-        self._cancel_events = self._channel_state.cancel_events
-        self._pending_files = self._channel_state.pending_files
-        self._recent_actions = self._channel_state.recent_actions
-        self._last_op_details = self._channel_state.last_op_details
-        self._background_tasks = self._channel_state.background_tasks
+        # Per-channel mutable state — owned by ChannelStateRegistry.
+        self.channel_state = services.channel_state
 
         self.context_loader = services.context_loader
-        self.embedder = services.embedder  # public; _embedder alias below
         self.reflector = services.reflector
-        self._embedder = services.embedder
-        self._fts_index = services.fts_index
-        self._vector_store = services.vector_store
-        self._knowledge_store = services.knowledge_store
+        self.embedder = services.embedder
         self.sessions = services.sessions
-        self._memory_path = services.memory_path
         self.channel_config = services.channel_config
         self.channel_logger = services.channel_logger
         self.browser_manager = services.browser_manager
@@ -208,7 +90,7 @@ class OdinBot(commands.Bot):
         self.trajectory_saver = services.trajectory_saver
         self.agent_trajectory_saver = services.agent_trajectory_saver
         self.loop_agent_bridge = services.loop_agent_bridge
-        self._loop_reflection_gate = services.loop_reflection_gate
+        self.loop_reflection_gate = services.loop_reflection_gate
         self.cost_tracker = services.cost_tracker
         self.subsystem_guard = services.subsystem_guard
         self.diff_tracker = services.diff_tracker
@@ -217,10 +99,18 @@ class OdinBot(commands.Bot):
         self.prefix_tracker = services.prefix_tracker
         self.auxiliary_llm_client = services.auxiliary_llm_client
         self.outbound_webhook_dispatcher = services.outbound_webhook_dispatcher
-        self._run_startup_diagnostics = services.run_startup_diagnostics
         self.stuck_loop_tracker_cls = services.stuck_loop_tracker_cls
         self.classify_command_risk = services.classify_command_risk
         self.classify_tool_risk = services.classify_tool_risk
+        # Internal storage (client-owned): search stores + memory path. The
+        # knowledge store is swappable at runtime via the `knowledge`
+        # property; the others feed the archive backfill below.
+        self._embedder = services.embedder
+        self._fts_index = services.fts_index
+        self._vector_store = services.vector_store
+        self._knowledge_store = services.knowledge_store
+        self._memory_path = services.memory_path
+        self._run_startup_diagnostics = services.run_startup_diagnostics
         # Audit signer — exposed as bot.audit_signer for tests/introspection.
         # The actual chain signing is wired into AuditLogger via the hmac_key
         # constructor arg; signing happens automatically inside log_execution.
@@ -234,31 +124,27 @@ class OdinBot(commands.Bot):
             self.voice_manager.on_transcription = self._on_voice_transcription
 
         # ------------------------------------------------------------------
-        # Bot-coupled component assembly (RFC-002 P2) — construction moved to
-        # wiring.build_components. Components carry PUBLIC names; the old
-        # underscore spellings remain as aliases to the same objects until P7
-        # retires the facade.
+        # Stage 2: bot-coupled components (wiring.build_components), exposed
+        # under their public names — the real successor of the old facade.
         # ------------------------------------------------------------------
         components = build_components(self, services)
         self.components = components
-        self.llm_gateway = self._llm_gateway = components.llm_gateway
-        self.prompt_builder = self._prompt_builder = components.prompt_builder
-        self.tool_catalog = self._tool_catalog = components.tool_catalog
-        self.native_tools = self._native_tools = components.native_tools
-        self.scheduling_tools = self._scheduling_tools = components.scheduling_tools
-        self.knowledge_tools = self._knowledge_tools = components.knowledge_tools
-        self.channel_ops_tools = self._channel_ops_tools = components.channel_ops_tools
-        self.media_tools = self._media_tools = components.media_tools
-        self.delivery = self._delivery = components.delivery
-        self.completion_classifier = self._completion_classifier = (
-            components.completion_classifier
-        )
-        self.tool_loop = self._tool_loop_runner = components.tool_loop
-        self.turn_recorder = self._turn_recorder = components.turn_recorder
-        self.scheduled_events = self._scheduled_events = components.scheduled_events
-        self.agent_task_tools = self._agent_task_tools = components.agent_task_tools
-        self.intake = self._message_intake = components.intake
-        self.pipeline = self._message_pipeline = components.pipeline
+        self.llm_gateway = components.llm_gateway
+        self.prompt_builder = components.prompt_builder
+        self.tool_catalog = components.tool_catalog
+        self.native_tools = components.native_tools
+        self.scheduling_tools = components.scheduling_tools
+        self.knowledge_tools = components.knowledge_tools
+        self.channel_ops_tools = components.channel_ops_tools
+        self.media_tools = components.media_tools
+        self.delivery = components.delivery
+        self.completion_classifier = components.completion_classifier
+        self.tool_loop = components.tool_loop
+        self.turn_recorder = components.turn_recorder
+        self.scheduled_events = components.scheduled_events
+        self.agent_task_tools = components.agent_task_tools
+        self.intake = components.intake
+        self.pipeline = components.pipeline
         self.housekeeping = components.housekeeping
 
         # Proactive infrastructure monitoring — constructed AFTER the
@@ -272,141 +158,23 @@ class OdinBot(commands.Bot):
                 alert_callback=self.scheduled_events._on_monitor_alert,
             )
 
-        # Public `codex` / `knowledge` attributes are exposed as dynamic
-        # properties defined below on the class — see the @property blocks.
-        # Using properties (instead of one-time aliases) means the web UI /
-        # health checker always reads the live value, even if the underlying
-        # attribute gets reassigned during a reload or reinit.
-
         self.prompt_builder.rebuild_default()
-        self._register_commands()
+        register_commands(self)
         self._init_allowed_webhook_ids()
         self._log_startup_config()
 
-    # ---------- LLM provider abstraction ------------------------------------
-
-    @property
-    def llm_client(self):
-        """Return whichever LLM provider is currently active (gateway-owned)."""
-        return self._llm_gateway.active_client
-
-    def _wire_llm_callbacks(self) -> None:
-        """Attach LLM-backed compaction/reflection callbacks (gateway-owned)."""
-        self._llm_gateway.wire_callbacks()
-
-    def _wire_codex_callbacks(self) -> None:
-        """Legacy alias — routes through provider abstraction."""
-        self._llm_gateway.wire_callbacks()
-
-    # ---------- Live provider reloads (gateway-owned, facade retained) ------
-
-    async def _reload_codex_inner(self) -> dict:
-        """Inner reload — caller must hold _llm_provider_lock."""
-        return await self._llm_gateway.reload_codex_inner()
-
-    async def reload_codex_auth(self) -> dict:
-        """Reload Codex credentials and create the client if it was missing at boot."""
-        return await self._llm_gateway.reload_codex()
-
-    async def _reload_ollama_inner(self) -> dict:
-        """Inner reload — caller must hold _llm_provider_lock."""
-        return await self._llm_gateway.reload_ollama_inner()
-
-    async def reload_ollama(self) -> dict:
-        """Reload Ollama client from current config."""
-        return await self._llm_gateway.reload_ollama()
-
-    async def _reload_kimi_inner(self) -> dict:
-        """Inner reload — caller must hold _llm_provider_lock."""
-        return await self._llm_gateway.reload_kimi_inner()
-
-    async def reload_kimi(self) -> dict:
-        """Reload Kimi client from current config."""
-        return await self._llm_gateway.reload_kimi()
-
-    async def switch_llm_provider(self, provider: str) -> dict:
-        """Switch the active LLM provider at runtime."""
-        return await self._llm_gateway.switch_provider(provider)
-
-
-    @property
-    def codex(self):
-        return self.codex_client
-
-    @codex.setter
-    def codex(self, value) -> None:
-        """Allow tests and reloads to swap the Codex client via the public name."""
-        self.codex_client = value
+    # ---------- Runtime-swappable stores ------------------------------------
 
     @property
     def knowledge(self):
+        """The knowledge store — live: reloads and tests swap it at runtime."""
         return self._knowledge_store
 
     @knowledge.setter
     def knowledge(self, value) -> None:
-        """Allow tests and reloads to swap the knowledge store via the public name."""
         self._knowledge_store = value
 
-    # LLM provider client shims — storage moved to LLMGateway (P4); the
-    # attribute spellings stay because the web layer reads them, live
-    # reloads replace them, and tests inject fakes via bot.codex_client.
-    @property
-    def codex_client(self):
-        return self._llm_gateway.codex_client
-
-    @codex_client.setter
-    def codex_client(self, value) -> None:
-        self._llm_gateway.codex_client = value
-
-    @property
-    def ollama_client(self):
-        return self._llm_gateway.ollama_client
-
-    @ollama_client.setter
-    def ollama_client(self, value) -> None:
-        self._llm_gateway.ollama_client = value
-
-    @property
-    def kimi_client(self):
-        return self._llm_gateway.kimi_client
-
-    @kimi_client.setter
-    def kimi_client(self, value) -> None:
-        self._llm_gateway.kimi_client = value
-
-    @property
-    def _llm_provider_lock(self):
-        return self._llm_gateway.provider_lock
-
-    # Default-prompt storage moved to PromptBuilder (RFC-002 P6); the old
-    # spelling stays live in BOTH directions until P7.
-    @property
-    def _system_prompt(self):
-        return self.prompt_builder.default_prompt
-
-    @_system_prompt.setter
-    def _system_prompt(self, value) -> None:
-        self.prompt_builder.default_prompt = value
-
-
-    # Prompt/catalog cache shims — web/api.py reads AND writes these names
-    # (Appendix B starred entries); storage moved to PromptBuilder/ToolCatalog
-    # in P3, the facade spelling stays.
-    @property
-    def _cached_merged_tools(self):
-        return self._tool_catalog.cached
-
-    @_cached_merged_tools.setter
-    def _cached_merged_tools(self, value) -> None:
-        self._tool_catalog.cached = value
-
-    @property
-    def _cached_skills_text(self):
-        return self._prompt_builder.cached_skills_text
-
-    @_cached_skills_text.setter
-    def _cached_skills_text(self, value) -> None:
-        self._prompt_builder.cached_skills_text = value
+    # ---------- Startup helpers ----------------------------------------------
 
     def _init_allowed_webhook_ids(self) -> None:
         """Populate the test-webhook allowlist from the ALLOWED_WEBHOOK_IDS env var."""
@@ -421,107 +189,12 @@ class OdinBot(commands.Bot):
             log.info("Configured hosts: %s", ", ".join(cfg.tools.hosts.keys()))
         if not cfg.tools.claude_code_host:
             log.info("claude_code_host not set — claude -p code generation requires a configured host")
-        if cfg.openai_codex.enabled and not self.codex_client:
+        if cfg.openai_codex.enabled and not self.llm_gateway.codex_client:
             log.warning("Codex enabled but not configured — session compaction and learning reflection disabled")
         if cfg.discord.respond_to_bots:
             log.info("Bot interaction enabled — will respond to other bots")
         if cfg.discord.require_mention:
             log.info("Mention-only mode — will only respond when @mentioned")
-
-    # -- turn observability: bodies in turn_recorder.py (P10) --
-
-    def _record_user_content(self, trajectory, content: str) -> None:
-        self._turn_recorder._record_user_content(trajectory, content)
-
-    def _new_context_trace(self):
-        return self._turn_recorder._new_context_trace()
-
-
-    def _invalidate_prompt_caches(self) -> None:
-        """Invalidate all prompt-related caches. Called on config/context reload."""
-        self._prompt_builder.invalidate()
-        self._tool_catalog.invalidate()
-
-
-    def _invoke_skill_missing_required(self, name: str, payload: dict) -> list[str]:
-        """Return required input fields the payload omits, or [] if complete.
-
-        Used by invoke_skill to fail loudly when the LLM omits the input
-        object — otherwise the skill silently runs with empty params and
-        returns a degenerate result that looks like a tool bug.
-        """
-        try:
-            skill = self.skill_manager._skills.get(name)
-            if skill is None:
-                return []
-            schema = skill.definition.get("input_schema") or {}
-            required = schema.get("required") or []
-            return [f for f in required if f not in payload]
-        except Exception:
-            return []
-
-    def _build_system_prompt(
-        self, channel: discord.abc.GuildChannel | None = None,
-        user_id: str | None = None,
-        query: str | None = None,
-        trace=None,
-    ) -> str:
-        """Full system prompt — owned by PromptBuilder (P3)."""
-        return self._prompt_builder.build_full_prompt(
-            channel=channel, user_id=user_id, query=query, trace=trace,
-        )
-
-
-    def _build_chat_system_prompt(
-        self, channel: discord.abc.GuildChannel | None = None,
-        user_id: str | None = None,
-        query: str | None = None,
-    ) -> str:
-        """Lightweight chat prompt — owned by PromptBuilder (P3)."""
-        return self._prompt_builder.build_chat_prompt(
-            channel=channel, user_id=user_id, query=query,
-        )
-
-
-    def _merged_tool_definitions(self) -> list[dict]:
-        """Merged builtin+skill tool definitions — owned by ToolCatalog (P3)."""
-        return self._tool_catalog.merged_definitions()
-
-
-    def _cleanup_stale_caches(self) -> None:
-        """Cache housekeeping — owned by Housekeeping (P4)."""
-        self.housekeeping.cleanup_stale()
-
-    def _maybe_cleanup_caches(self) -> None:
-        """Throttled cache housekeeping — owned by Housekeeping (P4)."""
-        self.housekeeping.maybe_cleanup()
-
-    def _track_recent_action(
-        self, tool_name: str, tool_input: dict, result_preview: str,
-        elapsed_ms: int, channel_id: str | None = None,
-    ) -> None:
-        """Recent-action tracking — owned by ChannelStateRegistry (P4)."""
-        self.channel_state.track_action(
-            tool_name, tool_input, result_preview, elapsed_ms, channel_id=channel_id,
-        )
-
-    def _register_commands(self) -> None:
-        """Slash commands — owned by slash_commands.register_commands (P10)."""
-        register_commands(self)
-
-
-    def _is_cancelled(self, channel_id: str) -> bool:
-        ev = self._cancel_events.get(channel_id)
-        return bool(ev and ev.is_set())
-
-    def _is_allowed_user(self, user: discord.User | discord.Member) -> bool:
-        return self.intake.is_allowed_user(user)
-
-    def _is_allowed_channel(self, channel_id: int) -> bool:
-        return self.intake.is_allowed_channel(channel_id)
-
-    def _check_for_secrets(self, content: str) -> bool:
-        return _check_for_secrets_impl(content)
 
     # ------------------------------------------------------------------
     # commands.Bot lifecycle hooks (cog loading + prefix)
@@ -533,51 +206,6 @@ class OdinBot(commands.Bot):
         """Return applicable prefixes; mention also accepted."""
         base = ["!"]  # OdinBot's default prefix; can be made config-driven later
         return commands.when_mentioned_or(*base)(bot, message)
-
-    async def _codex_call(
-        self, *, messages: list, system: str, tools: list,
-        user_message: str = "",
-        user_id: str = "", channel_id: str = "", tools_used: list[str] | None = None,
-        **kwargs,
-    ):
-        """Guarded LLM call — owned by LLMGateway (P4)."""
-        return await self._llm_gateway.call_with_tools(
-            messages=messages, system=system, tools=tools,
-            user_message=user_message, user_id=user_id, channel_id=channel_id,
-            tools_used=tools_used, **kwargs,
-        )
-
-
-    async def _operational_reflection(
-        self, user_request: str, tools_used: list[str], response: str,
-        is_error: bool, user_id: str | None, tool_details: list[dict] | None = None,
-    ) -> None:
-        await self._turn_recorder._operational_reflection(
-            user_request, tools_used, response, is_error, user_id, tool_details=tool_details,
-        )
-
-    def _should_reflect_on_operation(
-        self, user_request: str, tools_used: list[str], is_error: bool, tool_details: list[dict],
-    ) -> bool:
-        return self._turn_recorder._should_reflect_on_operation(
-            user_request, tools_used, is_error, tool_details,
-        )
-
-    def _maybe_loop_reflect(self, **kwargs) -> None:
-        self._turn_recorder._maybe_loop_reflect(**kwargs)
-
-    async def _save_turn_trajectory(
-        self, trajectory, *, error: str = "", final_response: str = "",
-        tools_used: list[str] | None = None, trace=None,
-    ) -> None:
-        await self._turn_recorder._save_turn_trajectory(
-            trajectory, error=error, final_response=final_response,
-            tools_used=tools_used, trace=trace,
-        )
-
-    async def _emit_lifecycle_event(self, event_type: str, payload: dict) -> None:
-        await self._turn_recorder._emit_lifecycle_event(event_type, payload)
-
 
     async def setup_hook(self) -> None:
         """Called once before connecting to the gateway.
@@ -631,14 +259,6 @@ class OdinBot(commands.Bot):
         await super().close()
         log.info("OdinBot shutdown complete")
 
-    # Moved to delivery.TOOL_STATUS_LABELS (P4); alias kept until P7.
-    _TOOL_STATUS_LABELS = TOOL_STATUS_LABELS
-
-    async def _set_status(self, text: str | None = None, task_start: bool = False, task_end: bool = False) -> None:
-        """Presence updates — owned by ResponseDelivery (P6)."""
-        await self._delivery.set_status(text, task_start=task_start, task_end=task_end)
-
-
     async def on_ready(self) -> None:
         log.info("Logged in as %s (ID: %s)", self.user, self.user.id)
         log.info("Tools loaded: %d definitions", len(get_tool_definitions()))
@@ -662,7 +282,7 @@ class OdinBot(commands.Bot):
         # Start proactive monitoring if configured
         if hasattr(self, "infra_watcher") and self.infra_watcher:
             self.infra_watcher.start()
-        await self._set_status(None, task_end=True)
+        await self.delivery.set_status(None, task_end=True)
 
     async def _backfill_archives(self) -> None:
         """Backfill semantic search index and FTS5 with existing archive files."""
@@ -675,6 +295,8 @@ class OdinBot(commands.Bot):
                 log.info("Vector store up to date")
             # Backfill knowledge FTS from existing data
             if self._knowledge_store and self._fts_index:
+                import asyncio
+
                 kb_count = await asyncio.to_thread(self._knowledge_store.backfill_fts)
                 if kb_count:
                     log.info("Backfilled %d knowledge chunks into FTS index", kb_count)
@@ -692,7 +314,7 @@ class OdinBot(commands.Bot):
             return
         if member.bot:
             return
-        if not self._is_allowed_user(member):
+        if not self.intake.is_allowed_user(member):
             return
         # User joined a voice channel (was not in one before)
         if before.channel is None and after.channel is not None:
@@ -708,13 +330,8 @@ class OdinBot(commands.Bot):
                     await self.voice_manager.leave_channel()
 
     async def on_message(self, message: discord.Message) -> None:
-        """Intake gating chain — owned by intake_pipeline.MessageIntake (P9)."""
-        await self._message_intake.handle(message)
-
-
-    async def _process_attachments(self, message: discord.Message, content: str = "") -> tuple[str, list[dict]]:
-        """Attachment processing — owned by MessageIntake (P4)."""
-        return await self.intake._process_attachments(message, content)
+        """Intake gating chain — owned by intake_pipeline.MessageIntake."""
+        await self.intake.handle(message)
 
     async def _on_voice_transcription(
         self, text: str, member: discord.Member, transcript_channel: discord.TextChannel,
@@ -738,278 +355,7 @@ class OdinBot(commands.Bot):
             if self.voice_manager:
                 await self.voice_manager.speak(response)
 
-        await self._handle_message(
+        await self.pipeline.run(
             proxy, text,
             voice_callback=voice_callback,
         )
-
-    async def _handle_message(
-        self, message: discord.Message, content: str, *, image_blocks: list[dict] | None = None,
-        voice_callback: Callable | None = None,
-    ) -> None:
-        """Pipeline orchestration — owned by intake_pipeline.MessagePipeline (P9)."""
-        await self._message_pipeline.run(
-            message, content, image_blocks=image_blocks, voice_callback=voice_callback,
-        )
-
-    async def _handle_message_inner(
-        self, message: discord.Message, content: str, channel_id: str,
-        *, image_blocks: list[dict] | None = None,
-        voice_callback: Callable | None = None,
-    ) -> None:
-        await self._message_pipeline._run_inner(
-            message, content, channel_id,
-            image_blocks=image_blocks, voice_callback=voice_callback,
-        )
-
-
-    # Completion classification — owned by completion.CompletionClassifier
-    # (P7). The class attr + method delegates keep the facade/test seams.
-    _CLASSIFIER_SYSTEM_PROMPT = CLASSIFIER_SYSTEM_PROMPT
-
-    async def _classify_completion(
-        self,
-        user_message: str,
-        response_text: str,
-        tools_used: list[str],
-    ) -> tuple[bool, str]:
-        return await self._completion_classifier.classify(
-            user_message, response_text, tools_used,
-        )
-
-    @staticmethod
-    def _parse_classifier_response(raw: str) -> tuple[bool, str]:
-        return CompletionClassifier.parse_response(raw)
-
-
-    async def _process_with_tools(
-        self,
-        message: discord.Message,
-        history: list[dict],
-        system_prompt_override: str | None = None,
-        trace=None,
-    ) -> tuple[str, bool, bool, list[str], bool]:
-        """Chat tool loop — owned by tool_loop.ToolLoopRunner (P7).
-
-        Returns (text, already_sent, is_error, tools_used, handoff).
-        """
-        return await self._tool_loop_runner.run(
-            message, history, system_prompt_override=system_prompt_override, trace=trace,
-        )
-
-    _ensure_failure_visible = staticmethod(ensure_failure_visible)
-
-
-    _detect_image_type = staticmethod(MediaTools._detect_image_type)
-
-    async def _handle_purge(self, message: discord.Message, inp: dict) -> str:
-        return await self._channel_ops_tools._handle_purge(message, inp)
-
-
-    # -- media handlers: bodies in native_tools/media.py (P5b) --
-
-    async def _handle_browser_screenshot(self, message: discord.Message, inp: dict) -> str:
-        return await self._media_tools._handle_browser_screenshot(message, inp)
-
-    async def _handle_generate_file(self, message: discord.Message, inp: dict) -> str:
-        return await self._media_tools._handle_generate_file(message, inp)
-
-    async def _handle_post_file(self, message: discord.Message, inp: dict) -> str:
-        return await self._media_tools._handle_post_file(message, inp)
-
-
-    def _validate_schedule_payload(self, inp: dict) -> str | None:
-        return self._scheduling_tools._validate_schedule_payload(inp)
-
-    async def _handle_schedule_task(self, message: discord.Message, inp: dict) -> str:
-        return await self._scheduling_tools._handle_schedule_task(message, inp)
-
-    def _handle_list_schedules(self) -> str:
-        return self._scheduling_tools._handle_list_schedules()
-
-    async def _handle_update_schedule(self, inp: dict) -> str:
-        return await self._scheduling_tools._handle_update_schedule(inp)
-
-    async def _handle_delete_schedule(self, inp: dict) -> str:
-        return await self._scheduling_tools._handle_delete_schedule(inp)
-
-    def _handle_parse_time(self, inp: dict) -> str:
-        return self._scheduling_tools._handle_parse_time(inp)
-
-
-    # -- knowledge/history handlers: bodies in native_tools/knowledge.py (P5b) --
-
-    async def _handle_search_history(self, inp: dict) -> str:
-        return await self._knowledge_tools._handle_search_history(inp)
-
-    async def _handle_search_knowledge(self, inp: dict) -> str:
-        return await self._knowledge_tools._handle_search_knowledge(inp)
-
-    async def _handle_ingest_document(self, inp: dict, uploader: str) -> str:
-        return await self._knowledge_tools._handle_ingest_document(inp, uploader)
-
-    async def _handle_bulk_ingest(self, inp: dict, uploader: str) -> str:
-        return await self._knowledge_tools._handle_bulk_ingest(inp, uploader)
-
-    def _handle_list_knowledge(self) -> str:
-        return self._knowledge_tools._handle_list_knowledge()
-
-    async def _handle_delete_knowledge(self, inp: dict) -> str:
-        return await self._knowledge_tools._handle_delete_knowledge(inp)
-
-
-    async def _handle_set_permission(self, caller_id: str, inp: dict) -> str:
-        return await self._channel_ops_tools._handle_set_permission(caller_id, inp)
-
-
-    async def _handle_search_audit(self, inp: dict) -> str:
-        return await self._knowledge_tools._handle_search_audit(inp)
-
-
-    # -- scheduler/digest/monitor callbacks: bodies in scheduled_events.py (P10) --
-
-    async def _on_scheduled_digest(self, schedule: dict) -> None:
-        await self._scheduled_events._on_scheduled_digest(schedule)
-
-    async def _format_digest_raw(self) -> str:
-        return await self._scheduled_events._format_digest_raw()
-
-    def _resolve_mentions(self, text: str) -> str:
-        return self._scheduled_events._resolve_mentions(text)
-
-    async def _on_monitor_alert(self, message: str) -> None:
-        await self._scheduled_events._on_monitor_alert(message)
-
-
-    # -- agents/tasks/loops handlers: bodies in native_tools/agents_tasks.py (P5c) --
-
-    async def _handle_delegate_task(self, message: discord.Message, inp: dict) -> str:
-        return await self._agent_task_tools._handle_delegate_task(message, inp)
-
-    def _handle_list_tasks(self, inp: dict | None = None) -> str:
-        return self._agent_task_tools._handle_list_tasks(inp)
-
-    def _handle_cancel_task(self, inp: dict) -> str:
-        return self._agent_task_tools._handle_cancel_task(inp)
-
-    def _handle_start_loop(self, message: discord.Message, inp: dict) -> str:
-        return self._agent_task_tools._handle_start_loop(message, inp)
-
-    def _handle_stop_loop(self, inp: dict) -> str:
-        return self._agent_task_tools._handle_stop_loop(inp)
-
-    def _handle_list_loops(self) -> str:
-        return self._agent_task_tools._handle_list_loops()
-
-    async def _handle_spawn_agent(self, message: object, inp: dict) -> str:
-        return await self._agent_task_tools._handle_spawn_agent(message, inp)
-
-    async def _collect_agent_result(self, agent_id: str, timeout: float = 3660.0):
-        return await self._agent_task_tools._collect_agent_result(agent_id, timeout=timeout)
-
-    def _handle_send_to_agent(self, inp: dict) -> str:
-        return self._agent_task_tools._handle_send_to_agent(inp)
-
-    def _handle_list_agents(self, message: object) -> str:
-        return self._agent_task_tools._handle_list_agents(message)
-
-    def _handle_kill_agent(self, inp: dict) -> str:
-        return self._agent_task_tools._handle_kill_agent(inp)
-
-    def _handle_get_agent_results(self, inp: dict) -> str:
-        return self._agent_task_tools._handle_get_agent_results(inp)
-
-    async def _handle_wait_for_agents(self, inp: dict) -> str:
-        return await self._agent_task_tools._handle_wait_for_agents(inp)
-
-    async def _handle_spawn_loop_agents(self, message: object, inp: dict) -> str:
-        return await self._agent_task_tools._handle_spawn_loop_agents(message, inp)
-
-    async def _handle_collect_loop_agents(self, inp: dict) -> str:
-        return await self._agent_task_tools._handle_collect_loop_agents(inp)
-
-
-    async def _run_loop_iteration(
-        self,
-        prompt: str,
-        channel: object,
-        prev_context: str | None,
-        user_id: str,
-    ) -> str:
-        """Autonomous-loop iteration — owned by tool_loop.ToolLoopRunner (P8)."""
-        return await self._tool_loop_runner.run_autonomous(prompt, channel, prev_context, user_id)
-
-    async def _dispatch_loop_tool(
-        self,
-        tool_name: str,
-        tool_input: dict,
-        msg_proxy: _LoopMessageProxy,
-        user_id: str,
-    ) -> str | dict:
-        """Loop tool dispatch — owned by tool_loop.ToolLoopRunner (P8)."""
-        return await self._tool_loop_runner.dispatch_loop_tool(
-            tool_name, tool_input, msg_proxy, user_id,
-        )
-
-    async def _dispatch_loop_tool_inner(
-        self,
-        tool_name: str,
-        tool_input: dict,
-        msg_proxy: _LoopMessageProxy,
-        user_id: str,
-    ) -> str | dict:
-        return await self._tool_loop_runner.dispatch_loop_tool_inner(
-            tool_name, tool_input, msg_proxy, user_id,
-        )
-
-
-    # -- channel-ops handlers: bodies in native_tools/channel_ops.py (P5b) --
-
-    async def _handle_read_channel(self, message: discord.Message, inp: dict) -> str:
-        return await self._channel_ops_tools._handle_read_channel(message, inp)
-
-    async def _handle_add_reaction(self, message: discord.Message, inp: dict) -> str:
-        return await self._channel_ops_tools._handle_add_reaction(message, inp)
-
-    async def _handle_create_poll(self, message: discord.Message, inp: dict) -> str:
-        return await self._channel_ops_tools._handle_create_poll(message, inp)
-
-
-    async def _handle_analyze_image(self, message: discord.Message, inp: dict) -> str | dict:
-        return await self._media_tools._handle_analyze_image(message, inp)
-
-    async def _handle_generate_image(self, message: discord.Message, inp: dict) -> str:
-        return await self._media_tools._handle_generate_image(message, inp)
-
-
-    async def _execute_scheduled_tool(
-        self, tool_name: str, tool_input: dict, channel: discord.abc.Messageable,
-        requester_id: str | None, requester_name: str = "scheduler",
-    ) -> ToolResult:
-        return await self._scheduled_events._execute_scheduled_tool(
-            tool_name, tool_input, channel, requester_id, requester_name,
-        )
-
-    async def _run_scheduled_workflow(self, channel: discord.abc.Messageable, schedule: dict) -> bool:
-        return await self._scheduled_events._run_scheduled_workflow(channel, schedule)
-
-    async def _on_schedule_failure(self, schedule: dict, consecutive: int) -> None:
-        await self._scheduled_events._on_schedule_failure(schedule, consecutive)
-
-    async def _on_scheduled_task(self, schedule: dict) -> None:
-        await self._scheduled_events._on_scheduled_task(schedule)
-
-
-    async def _send_with_retry(
-        self,
-        message: discord.Message,
-        text: str,
-        as_reply: bool = True,
-        files: list[discord.File] | None = None,
-    ) -> discord.Message | None:
-        """Send with retry — owned by ResponseDelivery (P6)."""
-        return await self._delivery.send_with_retry(message, text, as_reply=as_reply, files=files)
-
-    async def _send_chunked(self, message: discord.Message, text: str) -> None:
-        """Chunked send — owned by ResponseDelivery (P6)."""
-        await self._delivery.send_chunked(message, text)

--- a/src/discord/llm_gateway.py
+++ b/src/discord/llm_gateway.py
@@ -6,10 +6,10 @@ the guarded ``call_with_tools`` path (provider lock, subsystem-guard
 health, model routing to the auxiliary cheap client, cost tracking).
 Bodies are verbatim moves from ``OdinBot``.
 
-The bot keeps ``codex_client``/``ollama_client``/``kimi_client`` and
-``_llm_provider_lock`` as property shims over this gateway, because the
-web layer reads them, live reloads replace them, and tests inject fakes
-through ``bot.codex_client`` (RFC-001 Appendix B).
+Since RFC-002 P7 the gateway IS the public LLM surface: the web layer,
+tests, and every component read/replace the provider clients here
+(``bot.llm_gateway.codex_client`` …) — the old bot property shims are
+retired.
 
 Deliberately NOT routed through here: the autonomous loop's LLM calls —
 it calls ``active_client.chat_with_tools`` directly, bypassing cost

--- a/src/discord/prompts.py
+++ b/src/discord/prompts.py
@@ -5,9 +5,9 @@ the prompt-layer caches (hosts, skills text, per-user memory TTL cache).
 Bodies are verbatim moves from ``OdinBot`` with dependency access adjusted.
 
 Two dependencies are provider callables rather than captured references,
-because the bot attributes they read are REPLACED at runtime:
-``bot.config`` by the web API's config hot-reload and ``bot.codex_client``
-by live auth reloads / the ``codex`` property setter. ``voice_manager`` is
+because the underlying objects are REPLACED at runtime: the config by
+the web API's config hot-reload and the codex client by live auth
+reloads (both live on the gateway/bot as live roots). ``voice_manager`` is
 constructed once and never reassigned, so it is captured directly.
 
 Cache-name note: the fields here deliberately carry no leading underscore
@@ -118,8 +118,8 @@ class PromptBuilder:
 
         The stored value is the fallback the tool loop uses when a turn has
         no channel-specific override; the web layer rebuilds it after
-        config/context/personality changes (RFC-002 P6 — this replaces the
-        old ``bot._system_prompt = bot._build_system_prompt()`` dance).
+        config/context/personality changes (RFC-002 P6 — this replaced the
+        old rebuild-and-reassign dance on the bot).
         """
         self.default_prompt = self.build_full_prompt()
         return self.default_prompt

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -589,7 +589,8 @@ def build_components(bot, services: BotServices) -> BotComponents:
     scheduling_tools = SchedulingTools(scheduler=services.scheduler)
     knowledge_tools = KnowledgeTools(
         sessions=services.sessions,
-        get_knowledge_store=lambda: bot._knowledge_store,
+        # live: swappable at runtime via the bot's `knowledge` property
+        get_knowledge_store=lambda: bot.knowledge,
         embedder=services.embedder,
         audit=services.audit,
     )
@@ -626,7 +627,7 @@ def build_components(bot, services: BotServices) -> BotComponents:
         change_presence=bot.change_presence,
     )
     completion_classifier = CompletionClassifier(
-        get_llm_client=lambda: bot.llm_client,
+        get_llm_client=lambda: llm_gateway.active_client,
     )
     # Narrow-deps components (RFC-002 P3/P4). Construction order notes:
     # the turn recorder builds BEFORE the tool loop (its consumer), and the
@@ -643,8 +644,8 @@ def build_components(bot, services: BotServices) -> BotComponents:
     tool_loop = ToolLoopRunner(
         ToolLoopDeps(
             get_config=lambda: bot.config,
-            # live: the web layer rebuilds + reassigns the default prompt
-            get_default_system_prompt=lambda: bot._system_prompt,
+            # live: the web layer rebuilds it via prompt_builder.rebuild_default()
+            get_default_system_prompt=lambda: prompt_builder.default_prompt,
             get_context_compressor=lambda: bot.context_compressor,
             llm_gateway=llm_gateway,
             prompt_builder=prompt_builder,
@@ -669,7 +670,8 @@ def build_components(bot, services: BotServices) -> BotComponents:
             channel_state=services.channel_state,
             tool_executor=services.tool_executor,
             skill_manager=services.skill_manager,
-            get_knowledge_store=lambda: bot._knowledge_store,
+            # live: swappable at runtime via the bot's `knowledge` property
+        get_knowledge_store=lambda: bot.knowledge,
             embedder=services.embedder,
             audit=services.audit,
             agent_manager=services.agent_manager,
@@ -875,22 +877,25 @@ async def shutdown_services(bot) -> None:
         except Exception:
             log.exception("Error closing auxiliary LLM client")
 
-    # Close LLM HTTP client sessions
-    codex = getattr(bot, "codex_client", None)
+    # Close LLM HTTP client sessions — read through the gateway: the
+    # per-provider bot properties were retired in RFC-002 P7, and the
+    # gateway holds the LIVE clients (reloads replace them there).
+    gateway = getattr(bot, "llm_gateway", None)
+    codex = getattr(gateway, "codex_client", None)
     if codex is not None:
         try:
             await codex.close()
         except Exception:
             log.exception("Error closing Codex client")
 
-    ollama = getattr(bot, "ollama_client", None)
+    ollama = getattr(gateway, "ollama_client", None)
     if ollama is not None:
         try:
             await ollama.close()
         except Exception:
             log.exception("Error closing Ollama client")
 
-    kimi = getattr(bot, "kimi_client", None)
+    kimi = getattr(gateway, "kimi_client", None)
     if kimi is not None:
         try:
             await kimi.close()

--- a/src/health/checker.py
+++ b/src/health/checker.py
@@ -64,7 +64,7 @@ def check_discord(bot: OdinBot) -> ComponentStatus:
 
 
 def check_codex(bot: OdinBot) -> ComponentStatus:
-    codex = getattr(bot, "codex", None)
+    codex = getattr(getattr(bot, "llm_gateway", None), "codex_client", None)
     if codex is None:
         cfg = getattr(bot, "config", None)
         codex_cfg = getattr(cfg, "openai_codex", None) if cfg else None

--- a/src/health/checker.py
+++ b/src/health/checker.py
@@ -401,7 +401,7 @@ def check_agents(bot: OdinBot) -> ComponentStatus:
 
 def check_ollama(bot: OdinBot) -> ComponentStatus:
     from ..llm.ollama import OllamaClient
-    ollama = getattr(bot, "ollama_client", None)
+    ollama = getattr(getattr(bot, "llm_gateway", None), "ollama_client", None)
     if not isinstance(ollama, OllamaClient):
         return ComponentStatus(
             name="ollama", healthy=True, status="unconfigured",
@@ -440,7 +440,7 @@ def check_ollama(bot: OdinBot) -> ComponentStatus:
 
 def check_kimi(bot: OdinBot) -> ComponentStatus:
     from ..llm.kimi import KimiClient
-    kimi = getattr(bot, "kimi_client", None)
+    kimi = getattr(getattr(bot, "llm_gateway", None), "kimi_client", None)
     if not isinstance(kimi, KimiClient):
         return ComponentStatus(
             name="kimi", healthy=True, status="unconfigured",

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3283,7 +3283,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except Exception:
             return web.json_response({"error": "invalid JSON body"}, status=400)
 
-        lock = getattr(bot, "_llm_provider_lock", None)
+        lock = getattr(getattr(bot, "llm_gateway", None), "provider_lock", None)
         if lock is None:
             return web.json_response({"error": "provider lock not available"}, status=503)
 
@@ -3320,7 +3320,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except Exception:
             return web.json_response({"error": "invalid JSON body"}, status=400)
 
-        lock = getattr(bot, "_llm_provider_lock", None)
+        lock = getattr(getattr(bot, "llm_gateway", None), "provider_lock", None)
         if lock is None:
             return web.json_response({"error": "provider lock not available"}, status=503)
 
@@ -3368,7 +3368,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except Exception:
             return web.json_response({"error": "invalid JSON body"}, status=400)
 
-        lock = getattr(bot, "_llm_provider_lock", None)
+        lock = getattr(getattr(bot, "llm_gateway", None), "provider_lock", None)
         if lock is None:
             return web.json_response({"error": "provider lock not available"}, status=503)
 
@@ -3411,7 +3411,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/ollama/status")
     async def ollama_status(_request: web.Request) -> web.Response:
-        client = getattr(bot, "ollama_client", None)
+        client = getattr(getattr(bot, "llm_gateway", None), "ollama_client", None)
         if client is None:
             return web.json_response({"configured": False, "enabled": False})
 
@@ -3458,7 +3458,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/ollama/models")
     async def ollama_models(_request: web.Request) -> web.Response:
-        client = getattr(bot, "ollama_client", None)
+        client = getattr(getattr(bot, "llm_gateway", None), "ollama_client", None)
         if client is None:
             return web.json_response({"error": "Ollama not configured"}, status=503)
 
@@ -3491,12 +3491,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not model:
             return web.json_response({"error": "model is required"}, status=400)
 
-        lock = getattr(bot, "_llm_provider_lock", None)
+        lock = getattr(getattr(bot, "llm_gateway", None), "provider_lock", None)
         if lock is None:
             return web.json_response({"error": "provider lock not available"}, status=503)
 
         async with lock:
-            client = getattr(bot, "ollama_client", None)
+            client = getattr(getattr(bot, "llm_gateway", None), "ollama_client", None)
             if client is None:
                 return web.json_response({"error": "Ollama not configured"}, status=503)
 
@@ -3520,7 +3520,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/kimi/status")
     async def kimi_status(_request: web.Request) -> web.Response:
-        client = getattr(bot, "kimi_client", None)
+        client = getattr(getattr(bot, "llm_gateway", None), "kimi_client", None)
         if client is None:
             return web.json_response({"configured": False, "enabled": False})
 
@@ -3542,7 +3542,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/kimi/models")
     async def kimi_models(_request: web.Request) -> web.Response:
-        client = getattr(bot, "kimi_client", None)
+        client = getattr(getattr(bot, "llm_gateway", None), "kimi_client", None)
         if client is None:
             return web.json_response({"error": "Kimi not configured"}, status=503)
 
@@ -3565,12 +3565,12 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         if not model:
             return web.json_response({"error": "model is required"}, status=400)
 
-        lock = getattr(bot, "_llm_provider_lock", None)
+        lock = getattr(getattr(bot, "llm_gateway", None), "provider_lock", None)
         if lock is None:
             return web.json_response({"error": "provider lock not available"}, status=503)
 
         async with lock:
-            client = getattr(bot, "kimi_client", None)
+            client = getattr(getattr(bot, "llm_gateway", None), "kimi_client", None)
             if client is None:
                 return web.json_response({"error": "Kimi not configured"}, status=503)
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -1309,13 +1309,13 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     @routes.get("/api/pools/http")
     async def get_http_pool(_request: web.Request) -> web.Response:
         result = {}
-        codex = getattr(bot, "codex", None)
+        codex = getattr(bot.llm_gateway, "codex_client", None)
         if codex is not None and hasattr(codex, "get_pool_metrics"):
             result["codex"] = codex.get_pool_metrics()
-        ollama = getattr(bot, "ollama_client", None)
+        ollama = getattr(bot.llm_gateway, "ollama_client", None)
         if ollama is not None:
             result["ollama"] = ollama.pool_stats()
-        kimi = getattr(bot, "kimi_client", None)
+        kimi = getattr(bot.llm_gateway, "kimi_client", None)
         if kimi is not None:
             result["kimi"] = kimi.pool_stats()
         if not result:
@@ -2801,7 +2801,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
 
     @routes.get("/api/codex/status")
     async def codex_status(_request: web.Request) -> web.Response:
-        pool = getattr(bot, "codex_client", None)
+        pool = getattr(bot.llm_gateway, "codex_client", None)
         pool = getattr(pool, "auth", None) if pool else None
         if pool is None:
             pool = getattr(bot, "_codex_auth_pool", None)
@@ -2929,7 +2929,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except ValueError:
             return web.json_response({"error": "index must be an integer"}, status=400)
 
-        pool = getattr(bot, "codex_client", None)
+        pool = getattr(bot.llm_gateway, "codex_client", None)
         pool = getattr(pool, "auth", None) if pool else None
         if pool is None:
             return web.json_response({"error": "codex not configured"}, status=503)
@@ -2969,7 +2969,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
         except ValueError:
             return web.json_response({"error": "index must be an integer"}, status=400)
 
-        pool = getattr(bot, "codex_client", None)
+        pool = getattr(bot.llm_gateway, "codex_client", None)
         pool = getattr(pool, "auth", None) if pool else None
         if pool is None:
             return web.json_response({"error": "codex not configured"}, status=503)
@@ -3026,7 +3026,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             _atomic_write_secure(path, _json.dumps(raw, indent=2))
 
         # Also update the in-memory shadow file so status reflects immediately
-        pool = getattr(bot, "codex_client", None)
+        pool = getattr(bot.llm_gateway, "codex_client", None)
         pool = getattr(pool, "auth", None) if pool else None
         if pool and index < len(pool._accounts):
             try:
@@ -3071,7 +3071,7 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
             else:
                 return web.json_response({"error": "invalid index"}, status=400)
 
-        pool = getattr(bot, "codex_client", None)
+        pool = getattr(bot.llm_gateway, "codex_client", None)
         pool = getattr(pool, "auth", None) if pool else None
         if pool:
             # reload() ignores the pool lock and can race in-flight token

--- a/tests/characterization/test_autonomous_loop.py
+++ b/tests/characterization/test_autonomous_loop.py
@@ -45,7 +45,7 @@ class _ReflectRecorder:
 
 
 async def run_iteration(bot, prompt="do the loop work", prev=None, user_id="4242"):
-    return await bot._run_loop_iteration(prompt, FakeChannel(id=777), prev, user_id)
+    return await bot.tool_loop.run_autonomous(prompt, FakeChannel(id=777), prev, user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +82,7 @@ class TestLoopFlow:
         assert msgs == [{"role": "user", "content": "just this"}]
 
     async def test_long_final_text_truncated_to_discord_limit(self):
-        from src.discord.client import DISCORD_MAX_LEN
+        from src.discord.delivery import DISCORD_MAX_LEN
 
         bot, fake = build([text_response("x" * (DISCORD_MAX_LEN + 500))])
         result = await run_iteration(bot)
@@ -277,11 +277,11 @@ class TestLoopDispatchParity:
             ]
         )
         bot.skill_manager.create_skill = lambda name, code: f"Skill '{name}' created."
-        bot._cached_skills_text = "stale"
-        bot._cached_merged_tools = [{"name": "stale"}]
+        bot.prompt_builder.cached_skills_text = "stale"
+        bot.tool_catalog.cached = [{"name": "stale"}]
         await run_iteration(bot)
-        assert bot._cached_merged_tools is None
-        assert bot._cached_skills_text != "stale"
+        assert bot.tool_catalog.cached is None
+        assert bot.prompt_builder.cached_skills_text != "stale"
 
     async def test_export_skill_stages_pending_file_in_loop(self):
         """Loop-path skill files are STAGED to _pending_files, not sent
@@ -289,12 +289,14 @@ class TestLoopDispatchParity:
         parity subtlety worth its own tripwire."""
         bot, _ = build([text_response("unused")])
         bot.skill_manager.export_skill = lambda name: (b"zipbytes", "s1_skill.zip")
-        from src.discord.client import _LoopMessageProxy
+        from src.discord.tool_loop import _LoopMessageProxy
 
         proxy = _LoopMessageProxy(FakeChannel(id=777), "4242", "loop")
-        result = await bot._dispatch_loop_tool("export_skill", {"name": "s1"}, proxy, "4242")
+        result = await bot.tool_loop.dispatch_loop_tool(
+            "export_skill", {"name": "s1"}, proxy, "4242"
+        )
         assert "exported as s1_skill.zip" in result
-        assert bot._pending_files["777"] == [(b"zipbytes", "s1_skill.zip")]
+        assert bot.channel_state.pending_files["777"] == [(b"zipbytes", "s1_skill.zip")]
 
     async def test_invoke_skill_missing_required_fields_errors(self):
         bot, _ = build([text_response("unused")])
@@ -304,10 +306,10 @@ class TestLoopDispatchParity:
         bot.skill_manager._skills = {
             "needy": SimpleNamespace(definition={"input_schema": {"required": ["q", "depth"]}}),
         }
-        from src.discord.client import _LoopMessageProxy
+        from src.discord.tool_loop import _LoopMessageProxy
 
         proxy = _LoopMessageProxy(FakeChannel(id=777), "4242", "loop")
-        result = await bot._dispatch_loop_tool(
+        result = await bot.tool_loop.dispatch_loop_tool(
             "invoke_skill",
             {"name": "needy", "input": {"q": "x"}},
             proxy,
@@ -321,10 +323,10 @@ class TestLoopDispatchParity:
         bot.tool_executor.execute = AsyncMock(
             return_value=ToolResult(output="ran", tool_name="run_command")
         )
-        from src.discord.client import _LoopMessageProxy
+        from src.discord.tool_loop import _LoopMessageProxy
 
         proxy = _LoopMessageProxy(FakeChannel(id=777), "4242", "loop")
-        result = await bot._dispatch_loop_tool(
+        result = await bot.tool_loop.dispatch_loop_tool(
             "run_command", {"host": "h", "command": "x"}, proxy, "4242"
         )
         bot.tool_executor.execute.assert_awaited_once()

--- a/tests/characterization/test_chat_tool_loop.py
+++ b/tests/characterization/test_chat_tool_loop.py
@@ -56,7 +56,7 @@ def build(script, chat=None, **overrides):
 
 
 async def run_loop(bot, msg, history=None):
-    return await bot._process_with_tools(
+    return await bot.tool_loop.run(
         msg,
         history if history is not None else [{"role": "user", "content": msg.content}],
     )
@@ -402,22 +402,22 @@ class TestCompletionClassifier:
 
     async def test_start_loop_short_circuits_classifier(self):
         bot, fake = build([])
-        is_complete, reason = await bot._classify_completion(
+        is_complete, reason = await bot.completion_classifier.classify(
             "run 50 iterations", "started", ["start_loop"]
         )
         assert is_complete is True and reason == ""
         assert fake.chat_calls == []
 
     def test_parse_classifier_response_variants(self):
-        from src.discord.client import OdinBot
+        from src.discord.completion import CompletionClassifier
 
-        assert OdinBot._parse_classifier_response("COMPLETE") == (True, "")
-        ok, reason = OdinBot._parse_classifier_response("INCOMPLETE: missing deploy")
+        assert CompletionClassifier.parse_response("COMPLETE") == (True, "")
+        ok, reason = CompletionClassifier.parse_response("INCOMPLETE: missing deploy")
         assert ok is False and reason == "missing deploy"
-        ok, reason = OdinBot._parse_classifier_response("INCOMPLETE - no artifact")
+        ok, reason = CompletionClassifier.parse_response("INCOMPLETE - no artifact")
         assert ok is False and reason == "no artifact"
-        assert OdinBot._parse_classifier_response("¯\\_(ツ)_/¯") == (True, "")
-        assert OdinBot._parse_classifier_response("") == (True, "")
+        assert CompletionClassifier.parse_response("¯\\_(ツ)_/¯") == (True, "")
+        assert CompletionClassifier.parse_response("") == (True, "")
 
 
 # ---------------------------------------------------------------------------
@@ -509,7 +509,7 @@ class TestLoopTermination:
         bot = None  # placeholder for closure
 
         def cancel_then_tool():
-            bot._cancel_events["99"].set()
+            bot.channel_state.cancel_events["99"].set()
             return tool_call_response(("parse_time", {"text": "now"}))
 
         fake = FakeLLM([cancel_then_tool])
@@ -523,8 +523,8 @@ class TestLoopTermination:
         assert tools_used == []
         bot.tool_executor.execute.assert_not_awaited()
         # Active-request bookkeeping cleaned up
-        assert "99" not in bot._channel_state.active_requests
-        assert not bot._cancel_events["99"].is_set()
+        assert "99" not in bot.channel_state.active_requests
+        assert not bot.channel_state.cancel_events["99"].is_set()
 
     async def test_stop_during_tool_execution_reports_tools_used(self):
         """Cancel set while a tool executes → the after_tools checkpoint
@@ -532,7 +532,7 @@ class TestLoopTermination:
         bot = None  # placeholder for closure
 
         async def tool_sets_cancel(name, tool_input, user_id=None):
-            bot._cancel_events["99"].set()
+            bot.channel_state.cancel_events["99"].set()
             return ToolResult(output="partial work", tool_name=name)
 
         fake = FakeLLM([tool_call_response(("run_command", {"host": "h", "command": "x"}))])
@@ -544,7 +544,7 @@ class TestLoopTermination:
         assert "run_command" in text  # tools note
         assert is_error is False
         assert tools_used == ["run_command"]
-        assert "99" not in bot._channel_state.active_requests
+        assert "99" not in bot.channel_state.active_requests
 
     async def test_iteration_cap_exit_is_error(self):
         bot, fake = build(
@@ -563,7 +563,7 @@ class TestLoopTermination:
         bot, fake = build([text_response("done")])
         msg = FakeMessage("go")
         await run_loop(bot, msg)
-        assert str(msg.channel.id) not in bot._channel_state.active_requests
+        assert str(msg.channel.id) not in bot.channel_state.active_requests
 
 
 # ---------------------------------------------------------------------------
@@ -599,8 +599,8 @@ class TestToolSurfaceAndSkills:
             ],
         )
         bot.skill_manager.create_skill = lambda name, code: f"Skill '{name}' created."
-        bot._cached_skills_text = "stale-skills-text"
-        bot._cached_merged_tools = [{"name": "stale"}]
+        bot.prompt_builder.cached_skills_text = "stale-skills-text"
+        bot.tool_catalog.cached = [{"name": "stale"}]
         rebuild_calls = []
         orig_build = bot.prompt_builder.build_full_prompt
 
@@ -612,8 +612,8 @@ class TestToolSurfaceAndSkills:
         await run_loop(bot, FakeMessage("make a skill"))
         # CRUD invalidated both caches and rebuilt the prompt mid-loop
         assert rebuild_calls, "system prompt was not rebuilt after skill CRUD"
-        assert bot._cached_skills_text != "stale-skills-text"
-        assert bot._cached_merged_tools is None
+        assert bot.prompt_builder.cached_skills_text != "stale-skills-text"
+        assert bot.tool_catalog.cached is None
 
     async def test_analyze_image_block_injected_for_next_iteration(self):
         bot, fake = build(

--- a/tests/characterization/test_delivery.py
+++ b/tests/characterization/test_delivery.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.discord.client import DISCORD_MAX_LEN
+from src.discord.delivery import DISCORD_MAX_LEN
 from tests.fakes import FakeLLM, FakeMessage, make_bot
 
 
@@ -26,14 +26,14 @@ def bot():
 class TestSendChunked:
     async def test_short_text_single_reply(self, bot):
         msg = FakeMessage("q")
-        await bot._send_chunked(msg, "short answer")
+        await bot.delivery.send_chunked(msg, "short answer")
         assert msg.reply_texts == ["short answer"]
         assert msg.channel.sent == []
 
     async def test_chunked_first_is_reply_rest_are_sends(self, bot):
         msg = FakeMessage("q")
         text = "\n".join(f"line {i} " + "x" * 40 for i in range(90))  # ~4.3K chars
-        await bot._send_chunked(msg, text)
+        await bot.delivery.send_chunked(msg, text)
         assert len(msg.replies) == 1  # first chunk replies to the message
         assert len(msg.channel.sent) >= 1  # later chunks are plain sends
         rejoined = "\n".join(t.rstrip("\n") for t in msg.all_delivered_texts())
@@ -45,7 +45,7 @@ class TestSendChunked:
         msg = FakeMessage("q")
         body = "\n".join("x = 1  # padding padding padding" for _ in range(90))
         text = f"```python\n{body}\n```"
-        await bot._send_chunked(msg, text)
+        await bot.delivery.send_chunked(msg, text)
         chunks = msg.all_delivered_texts()
         assert len(chunks) >= 2
         # Every chunk that opens a block closes it, and continuation chunks
@@ -57,7 +57,7 @@ class TestSendChunked:
     async def test_single_overlong_line_is_presplit(self, bot):
         msg = FakeMessage("q")
         text = "y" * 5000  # one line, no newlines, still under the 4x file threshold
-        await bot._send_chunked(msg, text)
+        await bot.delivery.send_chunked(msg, text)
         chunks = msg.all_delivered_texts()
         assert len(chunks) >= 3
         for t in chunks:
@@ -66,7 +66,7 @@ class TestSendChunked:
 
     async def test_very_long_response_becomes_file(self, bot):
         msg = FakeMessage("q")
-        await bot._send_chunked(msg, "z" * (DISCORD_MAX_LEN * 4 + 1))
+        await bot.delivery.send_chunked(msg, "z" * (DISCORD_MAX_LEN * 4 + 1))
         assert len(msg.replies) == 1
         entry = msg.replies[0]
         assert entry["content"] == "Response too long for chat, attached as file:"
@@ -75,17 +75,17 @@ class TestSendChunked:
 
     async def test_pending_files_attach_to_first_message_and_are_popped(self, bot):
         msg = FakeMessage("q")
-        bot._pending_files[str(msg.channel.id)] = [(b"data", "report.txt")]
-        await bot._send_chunked(msg, "here is your file")
+        bot.channel_state.pending_files[str(msg.channel.id)] = [(b"data", "report.txt")]
+        await bot.delivery.send_chunked(msg, "here is your file")
         entry = msg.replies[0]
         assert entry["content"] == "here is your file"
         assert [f.filename for f in entry["files"]] == ["report.txt"]
-        assert str(msg.channel.id) not in bot._pending_files
+        assert str(msg.channel.id) not in bot.channel_state.pending_files
 
     async def test_pending_files_ride_along_with_file_fallback(self, bot):
         msg = FakeMessage("q")
-        bot._pending_files[str(msg.channel.id)] = [(b"data", "extra.bin")]
-        await bot._send_chunked(msg, "z" * (DISCORD_MAX_LEN * 4 + 1))
+        bot.channel_state.pending_files[str(msg.channel.id)] = [(b"data", "extra.bin")]
+        await bot.delivery.send_chunked(msg, "z" * (DISCORD_MAX_LEN * 4 + 1))
         names = [f.filename for f in msg.replies[0]["files"]]
         assert names == ["extra.bin", "response.md"]
 
@@ -100,7 +100,7 @@ class TestSendWithRetry:
         monkeypatch.setattr("asyncio.sleep", fake_sleep)
         msg = FakeMessage("q")
         msg.reply_error = ConnectionError("blip")  # first attempt fails
-        sent = await bot._send_with_retry(msg, "eventually delivered")
+        sent = await bot.delivery.send_with_retry(msg, "eventually delivered")
         assert sent is not None
         assert msg.reply_texts == ["eventually delivered"]
         assert sleeps == [1]  # backoff is 1 + attempt
@@ -118,12 +118,12 @@ class TestSendWithRetry:
             raise ConnectionError("still down")
 
         msg.reply = always_fail
-        sent = await bot._send_with_retry(msg, "never arrives")
+        sent = await bot.delivery.send_with_retry(msg, "never arrives")
         assert sent is None
         assert sleeps == [1, 2]  # two backoffs between three attempts
 
     async def test_as_reply_false_uses_channel_send(self, bot):
         msg = FakeMessage("q")
-        await bot._send_with_retry(msg, "broadcast", as_reply=False)
+        await bot.delivery.send_with_retry(msg, "broadcast", as_reply=False)
         assert msg.replies == []
         assert msg.channel.sent_texts == ["broadcast"]

--- a/tests/characterization/test_facade_contract.py
+++ b/tests/characterization/test_facade_contract.py
@@ -1,20 +1,22 @@
-"""Characterization: the OdinBot facade contract (RFC-001 Appendix B).
+"""The OdinBot PUBLIC surface contract (RFC-002 P7).
 
-Three enforcement layers:
-1. POSITIVE — every externally-consumed attribute/property/method exists on
-   a constructed bot (and stays settable where external code writes it).
-2. LATE-BOUND — names set after construction must be ABSENT on a fresh bot
+The RFC-001 compatibility facade is retired. This contract replaces the
+old Appendix B pins with three enforcement layers:
+
+1. POSITIVE — the documented public surface exists on a constructed bot:
+   flat service handles, the component handles, the two composition
+   handles (services/components), the live `knowledge` property, and the
+   lifecycle attributes.
+2. LATE-BOUND — names set after construction stay ABSENT on a fresh bot
    (hasattr/getattr semantics are load-bearing for health checks).
-3. NEGATIVE — the 12 internal-only names must have zero references outside
-   src/discord/client.py (and outside this campaign's own test infra),
-   enforced by source scan so nothing starts reaching in mid-campaign.
-
-Plus: the web-chat route (the facade's highest-value consumer) driven
-end-to-end through the real _process_with_tools.
+3. NEGATIVE — retired facade spellings have ZERO references anywhere in
+   src/ and tests/, and no code outside the composition files reaches
+   into `bot._underscore` state at all. The facade stays dead.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -23,9 +25,9 @@ from tests.fakes import FakeLLM, make_bot, text_response
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# --- Appendix B: positive surface -------------------------------------------
+# --- positive surface -------------------------------------------------------
 
-SUBSYSTEM_ATTRS = [
+SERVICE_HANDLES = [
     "config",
     "sessions",
     "scheduler",
@@ -56,54 +58,35 @@ SUBSYSTEM_ATTRS = [
     "trajectory_saver",
     "agent_trajectory_saver",
     "loop_agent_bridge",
-    "codex_client",
-    "ollama_client",
-    "kimi_client",
+    "loop_reflection_gate",
     "stuck_loop_tracker_cls",
     "classify_command_risk",
     "classify_tool_risk",
+    "embedder",
+    "start_time",
 ]
 
-PROPERTIES = ["llm_client", "codex", "knowledge"]
-
-PRIVATE_READ_ATTRS = [
-    "_system_prompt",
-    "_cached_merged_tools",
-    "_cached_skills_text",
-    "_embedder",
-    "_knowledge_store",
-    "_start_time",
-    "_llm_provider_lock",
-    "_memory_path",
-    "_recent_actions",
-    "_pending_files",
-    "_channel_locks",
-    "_cancel_events",
-    "_last_op_details",
-]
-
-FACADE_METHODS = [
-    "reload_codex_auth",
-    "reload_ollama",
-    "reload_kimi",
-    "switch_llm_provider",
-    "_reload_codex_inner",
-    "_reload_ollama_inner",
-    "_reload_kimi_inner",
-    "_build_system_prompt",
-    "_build_chat_system_prompt",
-    "_invalidate_prompt_caches",
-    "_merged_tool_definitions",
-    "_new_context_trace",
-    "_set_status",
-    "_process_with_tools",
-    "_run_loop_iteration",
-    "_codex_call",
-    "_dispatch_loop_tool",
-    "_emit_lifecycle_event",
-    "_classify_completion",
-    "_is_allowed_user",
-    "_is_cancelled",
+COMPONENT_HANDLES = [
+    "services",
+    "components",
+    "channel_state",
+    "llm_gateway",
+    "prompt_builder",
+    "tool_catalog",
+    "native_tools",
+    "scheduling_tools",
+    "knowledge_tools",
+    "channel_ops_tools",
+    "media_tools",
+    "delivery",
+    "completion_classifier",
+    "tool_loop",
+    "turn_recorder",
+    "scheduled_events",
+    "agent_task_tools",
+    "intake",
+    "pipeline",
+    "housekeeping",
 ]
 
 LATE_BOUND_ABSENT = [
@@ -113,23 +96,70 @@ LATE_BOUND_ABSENT = [
     "_issue_tracker_client",
     "compression_stats",
     "health_server",
+    "process_registry",
 ]
 
-# RFC-001 Appendix B negative contract: internal-only, zero external refs.
-INTERNAL_ONLY = [
-    "_active_request_by_channel",
-    "_processed_messages",
-    "_processed_messages_max",
-    "_bot_msg_buffer",
-    "_bot_msg_tasks",
-    "_bot_msg_buffer_delay",
-    "_bot_msg_buffer_max",
-    "_cached_hosts",
-    "_memory_cache",
-    "_memory_cache_ttl",
-    "_llm_active_requests",
-    "_llm_switching",
+# --- negative contract: retired facade spellings ----------------------------
+# Every name deleted from OdinBot in RFC-002 P7. The scan matches the
+# ATTRIBUTE ACCESS form (`bot.<name>`), so component methods that
+# legitimately share a suffix (e.g. turn_recorder's _save_turn_trajectory,
+# reached as bot.turn_recorder._save_turn_trajectory) never false-positive.
+
+RETIRED_BOT_ATTRS = [
+    # LLM facade
+    "llm_client", "codex_client", "ollama_client", "kimi_client", "codex",
+    "_llm_provider_lock", "_codex_call", "_wire_llm_callbacks",
+    "_wire_codex_callbacks", "reload_codex_auth", "reload_ollama",
+    "reload_kimi", "switch_llm_provider", "_reload_codex_inner",
+    "_reload_ollama_inner", "_reload_kimi_inner",
+    # prompt/catalog facade
+    "_system_prompt", "_build_system_prompt", "_build_chat_system_prompt",
+    "_invalidate_prompt_caches", "_merged_tool_definitions",
+    "_cached_merged_tools", "_cached_skills_text",
+    # pipeline/delivery/observability delegates
+    "_process_with_tools", "_run_loop_iteration", "_dispatch_loop_tool",
+    "_dispatch_loop_tool_inner", "_handle_message", "_handle_message_inner",
+    "_process_attachments", "_set_status", "_send_with_retry",
+    "_send_chunked", "_record_user_content", "_new_context_trace",
+    "_save_turn_trajectory", "_emit_lifecycle_event",
+    "_operational_reflection", "_should_reflect_on_operation",
+    "_maybe_loop_reflect", "_classify_completion",
+    "_parse_classifier_response", "_CLASSIFIER_SYSTEM_PROMPT",
+    "_ensure_failure_visible", "_TOOL_STATUS_LABELS",
+    # gating/housekeeping delegates
+    "_check_for_secrets", "_is_allowed_user", "_is_allowed_channel",
+    "_is_cancelled", "_maybe_cleanup_caches", "_cleanup_stale_caches",
+    "_track_recent_action", "_invoke_skill_missing_required",
+    # channel-state aliases
+    "_channel_state", "_channel_locks", "_cancel_events", "_pending_files",
+    "_recent_actions", "_last_op_details", "_background_tasks",
+    # scheduled-events delegates
+    "_on_scheduled_task", "_on_schedule_failure", "_on_scheduled_digest",
+    "_on_monitor_alert", "_execute_scheduled_tool", "_run_scheduled_workflow",
+    "_format_digest_raw", "_resolve_mentions",
+    # web-owned state formerly parked on the bot
+    "_web_channel_locks",
+    # native-tool handler delegates (owner-dispatched since P5)
+    "_handle_purge", "_handle_browser_screenshot", "_handle_generate_file",
+    "_handle_post_file", "_handle_schedule_task", "_handle_delegate_task",
+    "_handle_start_loop", "_handle_read_channel", "_handle_add_reaction",
+    "_handle_create_poll", "_handle_analyze_image", "_handle_generate_image",
+    "_handle_spawn_agent", "_handle_spawn_loop_agents",
+    "_handle_update_schedule", "_handle_delete_schedule", "_handle_parse_time",
+    "_handle_search_history", "_handle_list_tasks", "_handle_cancel_task",
+    "_handle_stop_loop", "_handle_search_knowledge", "_handle_delete_knowledge",
+    "_handle_search_audit", "_handle_send_to_agent", "_handle_kill_agent",
+    "_handle_get_agent_results", "_handle_wait_for_agents",
+    "_handle_collect_loop_agents", "_handle_list_schedules",
+    "_handle_list_loops", "_handle_list_knowledge", "_handle_list_agents",
+    "_handle_ingest_document", "_handle_bulk_ingest", "_handle_set_permission",
+    "_validate_schedule_payload", "_collect_agent_result",
 ]
+
+_RETIRED_RE = re.compile(r"\bbot\.(" + "|".join(map(re.escape, RETIRED_BOT_ATTRS)) + r")\b")
+
+# Files allowed to mention retired spellings (this contract itself)
+_SCAN_EXCLUDE = {"test_facade_contract.py"}
 
 
 @pytest.fixture(autouse=True)
@@ -143,53 +173,24 @@ def bot():
 
 
 class TestPositiveSurface:
-    def test_subsystem_attributes_exist(self, bot):
-        missing = [a for a in SUBSYSTEM_ATTRS if not hasattr(bot, a)]
-        assert missing == [], f"facade attributes missing: {missing}"
+    def test_service_handles_exist(self, bot):
+        missing = [a for a in SERVICE_HANDLES if not hasattr(bot, a)]
+        assert missing == [], f"public service handles missing: {missing}"
 
-    def test_properties_exist(self, bot):
-        missing = [p for p in PROPERTIES if not hasattr(type(bot), p)]
-        assert missing == [], f"facade properties missing: {missing}"
+    def test_component_handles_exist(self, bot):
+        missing = [a for a in COMPONENT_HANDLES if not hasattr(bot, a)]
+        assert missing == [], f"public component handles missing: {missing}"
 
-    def test_private_read_attrs_exist(self, bot):
-        missing = [a for a in PRIVATE_READ_ATTRS if not hasattr(bot, a)]
-        assert missing == [], f"externally-read private attrs missing: {missing}"
+    def test_knowledge_property_is_live_and_settable(self, bot):
+        sentinel = object()
+        bot.knowledge = sentinel
+        assert bot.knowledge is sentinel
+        assert type(bot).knowledge.fset is not None
 
-    def test_facade_methods_exist_and_callable(self, bot):
-        missing = [m for m in FACADE_METHODS if not callable(getattr(bot, m, None))]
-        assert missing == [], f"facade methods missing: {missing}"
-
-    def test_externally_written_names_are_settable(self, bot):
-        # web/api.py writes these on live config/skill changes:
-        bot._system_prompt = "replaced"
-        assert bot._system_prompt == "replaced"
-        bot._cached_merged_tools = None
-        bot._cached_skills_text = None
-        bot.config = bot.config  # hot-reload assigns a fresh Config
-        # property setters used by tests/reloads:
-        bot.codex = "sentinel"
-        assert bot.codex_client == "sentinel"
-        bot.knowledge = "kstore"
-        assert bot._knowledge_store == "kstore"
-        # (the web-chat lock cache moved to src.web.chat.WEB_CHANNEL_LOCKS
-        # in RFC-002 P6 — web-owned state no longer parked on the bot)
-
-    def test_classifier_prompt_class_attr_exists(self, bot):
-        assert isinstance(type(bot)._CLASSIFIER_SYSTEM_PROMPT, str)
-        assert "COMPLETE" in type(bot)._CLASSIFIER_SYSTEM_PROMPT
-
-    def test_module_level_reexports(self):
-        from src.discord.client import (  # noqa: F401
-            DISCORD_MAX_LEN,
-            INITIAL_EXTENSIONS,
-            OdinBot,
-            combine_bot_messages,
-            scrub_response_secrets,
-            truncate_tool_output,
-        )
-
-        assert DISCORD_MAX_LEN == 2000
-        assert isinstance(INITIAL_EXTENSIONS, tuple)
+    def test_config_is_replaceable(self, bot):
+        # config hot-reload assigns a fresh Config object
+        bot.config = bot.config
+        assert bot.config is not None
 
 
 class TestLateBoundAbsent:
@@ -202,46 +203,42 @@ class TestLateBoundAbsent:
 
 
 class TestNegativeContract:
-    """No code outside client.py (and this campaign's test infra) may
-    reference the internal-only names. Keeps the corpse closed while the
-    decomposition operates on it."""
+    """The retired facade stays dead: no `bot.<retired>` spelling anywhere,
+    and nothing outside the composition files touches `bot._` state."""
 
-    def _scan(self, root: Path, exclude: set[Path]) -> list[str]:
+    def _scan(self, root: Path, regex: re.Pattern, exclude_names: set[str]) -> list[str]:
         offenders = []
         for py in sorted(root.rglob("*.py")):
-            if py in exclude or "__pycache__" in py.parts:
+            if py.name in exclude_names or "__pycache__" in py.parts:
                 continue
             text = py.read_text(encoding="utf-8", errors="replace")
-            for name in INTERNAL_ONLY:
-                if name in text:
-                    offenders.append(f"{py.relative_to(REPO_ROOT)}: {name}")
+            for m in regex.finditer(text):
+                line = text.count("\n", 0, m.start()) + 1
+                offenders.append(f"{py.relative_to(REPO_ROOT)}:{line}: {m.group(0)}")
         return offenders
 
-    def test_no_src_references_outside_client(self):
-        offenders = self._scan(
-            REPO_ROOT / "src",
-            exclude={REPO_ROOT / "src" / "discord" / "client.py"},
-        )
-        assert offenders == [], (
-            "internal-only OdinBot state referenced outside client.py:\n" + "\n".join(offenders)
-        )
+    def test_no_retired_spellings_in_src(self):
+        offenders = self._scan(REPO_ROOT / "src", _RETIRED_RE, _SCAN_EXCLUDE)
+        assert offenders == [], "retired facade spellings in src:\n" + "\n".join(offenders)
 
-    def test_no_test_references_outside_campaign_infra(self):
-        campaign_dirs = (
-            REPO_ROOT / "tests" / "characterization",
-            REPO_ROOT / "tests" / "fakes",
-        )
-        exclude = {p for d in campaign_dirs for p in d.rglob("*.py")}
-        offenders = self._scan(REPO_ROOT / "tests", exclude=exclude)
-        assert offenders == [], (
-            "internal-only OdinBot state referenced by tests outside the "
-            "campaign infra:\n" + "\n".join(offenders)
-        )
+    def test_no_retired_spellings_in_tests(self):
+        offenders = self._scan(REPO_ROOT / "tests", _RETIRED_RE, _SCAN_EXCLUDE)
+        assert offenders == [], "retired facade spellings in tests:\n" + "\n".join(offenders)
+
+    def test_no_bot_private_access_in_src(self):
+        """Outside the bot's own module and the composition root, no src
+        code reaches into bot._underscore state (the god-interface is gone;
+        the private storage that remains — search stores, memory path — is
+        client/wiring-internal)."""
+        broad = re.compile(r"\bbot\._[a-zA-Z]")
+        allowed = {"client.py", "wiring.py"}
+        offenders = self._scan(REPO_ROOT / "src", broad, allowed | _SCAN_EXCLUDE)
+        assert offenders == [], "bot._ access outside composition files:\n" + "\n".join(offenders)
 
 
 class TestWebChatRoute:
     async def test_process_web_chat_drives_real_tool_loop(self):
-        from src.web.chat import process_web_chat
+        from src.web.chat import WEB_CHANNEL_LOCKS, process_web_chat
 
         fake = FakeLLM([text_response("web answer")])
         bot = make_bot(fake_llm=fake)
@@ -251,6 +248,4 @@ class TestWebChatRoute:
         assert result["tools_used"] == []
         assert len(fake.calls) == 1  # went through the REAL tool loop
         # The lock cache is web-owned module state now (RFC-002 P6)
-        from src.web.chat import WEB_CHANNEL_LOCKS
-
         assert "web-42" in WEB_CHANNEL_LOCKS

--- a/tests/characterization/test_facade_contract.py
+++ b/tests/characterization/test_facade_contract.py
@@ -158,6 +158,14 @@ RETIRED_BOT_ATTRS = [
 
 _RETIRED_RE = re.compile(r"\bbot\.(" + "|".join(map(re.escape, RETIRED_BOT_ATTRS)) + r")\b")
 
+# String-based lookups dodge the attribute regex — exactly how the last
+# offenders survived the P7 sweep (Odin's #155 review). Scan them too.
+_RETIRED_STR_RE = re.compile(
+    r"(?:getattr|hasattr|setattr)\(\s*bot\s*,\s*['\"](?:"
+    + "|".join(map(re.escape, RETIRED_BOT_ATTRS))
+    + r")['\"]"
+)
+
 # Files allowed to mention retired spellings (this contract itself)
 _SCAN_EXCLUDE = {"test_facade_contract.py"}
 
@@ -220,6 +228,15 @@ class TestNegativeContract:
     def test_no_retired_spellings_in_src(self):
         offenders = self._scan(REPO_ROOT / "src", _RETIRED_RE, _SCAN_EXCLUDE)
         assert offenders == [], "retired facade spellings in src:\n" + "\n".join(offenders)
+
+    def test_no_string_based_retired_lookups_in_src(self):
+        """getattr/hasattr/setattr(bot, "<retired>") — the dark-corner form."""
+        offenders = self._scan(REPO_ROOT / "src", _RETIRED_STR_RE, _SCAN_EXCLUDE)
+        assert offenders == [], "string-based retired lookups in src:\n" + "\n".join(offenders)
+
+    def test_no_string_based_retired_lookups_in_tests(self):
+        offenders = self._scan(REPO_ROOT / "tests", _RETIRED_STR_RE, _SCAN_EXCLUDE)
+        assert offenders == [], "string-based retired lookups in tests:\n" + "\n".join(offenders)
 
     def test_no_retired_spellings_in_tests(self):
         offenders = self._scan(REPO_ROOT / "tests", _RETIRED_RE, _SCAN_EXCLUDE)

--- a/tests/characterization/test_intake_gating.py
+++ b/tests/characterization/test_intake_gating.py
@@ -178,7 +178,7 @@ class TestGatingChain:
 class TestBotMessageBuffering:
     async def test_rapid_bot_messages_buffered_and_combined(self):
         bot = build(discord={"respond_to_bots": True})
-        bot._channel_state.bot_msg_buffer_delay = 0.02
+        bot.channel_state.bot_msg_buffer_delay = 0.02
         other_bot = FakeAuthor(id=555, name="otherbot", bot=True)
         ch = FakeChannel(id=99)
         await bot.on_message(FakeMessage("part one", author=other_bot, channel=ch))
@@ -189,7 +189,7 @@ class TestBotMessageBuffering:
 
     async def test_split_code_block_joined_across_bot_messages(self):
         bot = build(discord={"respond_to_bots": True})
-        bot._channel_state.bot_msg_buffer_delay = 0.02
+        bot.channel_state.bot_msg_buffer_delay = 0.02
         other_bot = FakeAuthor(id=555, name="otherbot", bot=True)
         ch = FakeChannel(id=99)
         await bot.on_message(FakeMessage("```python\nx = 1", author=other_bot, channel=ch))
@@ -200,7 +200,7 @@ class TestBotMessageBuffering:
 
     async def test_buffered_bot_messages_dropped_without_mention_when_required(self):
         bot = build(discord={"respond_to_bots": True, "require_mention": True})
-        bot._channel_state.bot_msg_buffer_delay = 0.02
+        bot.channel_state.bot_msg_buffer_delay = 0.02
         other_bot = FakeAuthor(id=555, name="otherbot", bot=True)
         guild = _FakeGuild()
         ch = FakeChannel(id=99)

--- a/tests/characterization/test_p1_carve_semantics.py
+++ b/tests/characterization/test_p1_carve_semantics.py
@@ -56,7 +56,7 @@ class TestCarveMutationSemantics:
         snapshot = copy.deepcopy(history)
         history_id = id(history)
 
-        await bot._process_with_tools(FakeMessage("parse the time"), history)
+        await bot.tool_loop.run(FakeMessage("parse the time"), history)
 
         assert id(history) == history_id
         assert history == snapshot, "caller's history list was mutated by the turn"
@@ -90,7 +90,7 @@ class TestCarveMutationSemantics:
         bot.scheduling_tools._handle_parse_time = slow_parse_time
         bot.scheduling_tools._handle_list_schedules = fast_list_schedules
 
-        text, _, is_error, tools_used, _ = await bot._process_with_tools(
+        text, _, is_error, tools_used, _ = await bot.tool_loop.run(
             FakeMessage("do both"), [{"role": "user", "content": "do both"}]
         )
 
@@ -116,9 +116,9 @@ class TestCarveMutationSemantics:
             ]
         )
         msg = FakeMessage("two steps")
-        await bot._process_with_tools(msg, [{"role": "user", "content": "two steps"}])
+        await bot.tool_loop.run(msg, [{"role": "user", "content": "two steps"}])
 
-        details = bot._last_op_details[str(msg.channel.id)]
+        details = bot.channel_state.last_op_details[str(msg.channel.id)]
         assert [d["tool"] for d in details] == ["parse_time", "list_schedules"], (
             "op-details must accumulate across iterations in execution order"
         )

--- a/tests/characterization/test_p2_composition.py
+++ b/tests/characterization/test_p2_composition.py
@@ -16,24 +16,26 @@ import pytest
 from src.discord.wiring import BotComponents, BotServices
 from tests.fakes import FakeLLM, make_bot
 
-# (public name, campaign alias, BotComponents field)
-COMPONENT_TRIPLES = [
-    ("llm_gateway", "_llm_gateway", "llm_gateway"),
-    ("prompt_builder", "_prompt_builder", "prompt_builder"),
-    ("tool_catalog", "_tool_catalog", "tool_catalog"),
-    ("native_tools", "_native_tools", "native_tools"),
-    ("scheduling_tools", "_scheduling_tools", "scheduling_tools"),
-    ("knowledge_tools", "_knowledge_tools", "knowledge_tools"),
-    ("channel_ops_tools", "_channel_ops_tools", "channel_ops_tools"),
-    ("media_tools", "_media_tools", "media_tools"),
-    ("delivery", "_delivery", "delivery"),
-    ("completion_classifier", "_completion_classifier", "completion_classifier"),
-    ("tool_loop", "_tool_loop_runner", "tool_loop"),
-    ("turn_recorder", "_turn_recorder", "turn_recorder"),
-    ("scheduled_events", "_scheduled_events", "scheduled_events"),
-    ("agent_task_tools", "_agent_task_tools", "agent_task_tools"),
-    ("intake", "_message_intake", "intake"),
-    ("pipeline", "_message_pipeline", "pipeline"),
+# (public name, BotComponents field) — the campaign-era underscore aliases
+# were retired in P7; public names are the only spelling.
+COMPONENT_PAIRS = [
+    ("llm_gateway", "llm_gateway"),
+    ("prompt_builder", "prompt_builder"),
+    ("tool_catalog", "tool_catalog"),
+    ("native_tools", "native_tools"),
+    ("scheduling_tools", "scheduling_tools"),
+    ("knowledge_tools", "knowledge_tools"),
+    ("channel_ops_tools", "channel_ops_tools"),
+    ("media_tools", "media_tools"),
+    ("delivery", "delivery"),
+    ("completion_classifier", "completion_classifier"),
+    ("tool_loop", "tool_loop"),
+    ("turn_recorder", "turn_recorder"),
+    ("scheduled_events", "scheduled_events"),
+    ("agent_task_tools", "agent_task_tools"),
+    ("intake", "intake"),
+    ("pipeline", "pipeline"),
+    ("housekeeping", "housekeeping"),
 ]
 
 
@@ -52,29 +54,26 @@ class TestTwoStageComposition:
         assert isinstance(bot.services, BotServices)
         assert isinstance(bot.components, BotComponents)
 
-    def test_public_names_alias_underscore_names_and_component_fields(self, bot):
-        for public, alias, fieldname in COMPONENT_TRIPLES:
+    def test_public_names_are_the_component_fields(self, bot):
+        for public, fieldname in COMPONENT_PAIRS:
             pub = getattr(bot, public)
-            assert pub is getattr(bot, alias), f"{public} is not {alias}"
             assert pub is getattr(bot.components, fieldname), (
                 f"bot.{public} is not components.{fieldname}"
             )
 
     def test_channel_state_lives_in_services(self, bot):
         assert bot.channel_state is bot.services.channel_state
-        assert bot.channel_state is bot._channel_state
+        assert bot.channel_state is bot.channel_state
         # The six facade dict aliases still point INTO the registry
-        assert bot._channel_locks is bot.channel_state.channel_locks
-        assert bot._cancel_events is bot.channel_state.cancel_events
-        assert bot._pending_files is bot.channel_state.pending_files
-        assert bot._recent_actions is bot.channel_state.recent_actions
-        assert bot._last_op_details is bot.channel_state.last_op_details
-        assert bot._background_tasks is bot.channel_state.background_tasks
+        assert bot.channel_state.channel_locks is bot.channel_state.channel_locks
+        assert bot.channel_state.cancel_events is bot.channel_state.cancel_events
+        assert bot.channel_state.pending_files is bot.channel_state.pending_files
+        assert bot.channel_state.recent_actions is bot.channel_state.recent_actions
+        assert bot.channel_state.last_op_details is bot.channel_state.last_op_details
+        assert bot.channel_state.background_tasks is bot.channel_state.background_tasks
 
     def test_gateway_owns_the_llm_surface(self, bot):
-        # The bot property shims read the gateway (unchanged by P2)
-        assert bot.codex_client is bot.llm_gateway.codex_client
-        assert bot.llm_client is bot.llm_gateway.active_client
+        assert bot.llm_gateway is bot.components.llm_gateway
 
     def test_infra_watcher_alert_callback_binds_scheduled_events(self, tmp_path):
         bot = make_bot(

--- a/tests/characterization/test_pipeline_persistence.py
+++ b/tests/characterization/test_pipeline_persistence.py
@@ -43,7 +43,7 @@ class TestPersistence:
     async def test_success_persists_tagged_user_and_assistant_turns(self):
         bot, fake = build([text_response("the answer")])
         msg = FakeMessage("what is it?")
-        await bot._handle_message(msg, "what is it?")
+        await bot.pipeline.run(msg, "what is it?")
         hist = history_of(bot, str(msg.channel.id))
         assert hist[0] == ("user", "[tester]: what is it?")
         assert hist[1] == ("assistant", "the answer")
@@ -57,7 +57,7 @@ class TestPersistence:
             ]
         )
         msg = FakeMessage("do it")
-        await bot._handle_message(msg, "do it")
+        await bot.pipeline.run(msg, "do it")
         hist = history_of(bot, str(msg.channel.id))
         expected = summarize_tool_response(
             "Detailed multi-tool response " + "x" * 400,
@@ -68,7 +68,7 @@ class TestPersistence:
     async def test_error_persists_sanitized_marker_not_raw_error(self):
         bot, fake = build([RuntimeError("provider meltdown")])
         msg = FakeMessage("do it")
-        await bot._handle_message(msg, "do it")
+        await bot.pipeline.run(msg, "do it")
         hist = history_of(bot, str(msg.channel.id))
         assert hist[-1][0] == "assistant"
         assert hist[-1][1] == "[Previous request encountered an error before tool execution.]"
@@ -84,7 +84,7 @@ class TestPersistence:
             ]
         )
         msg = FakeMessage("do it")
-        await bot._handle_message(msg, "do it")
+        await bot.pipeline.run(msg, "do it")
         hist = history_of(bot, str(msg.channel.id))
         assert "[Previous request used tools (parse_time)" in hist[-1][1]
 
@@ -92,11 +92,11 @@ class TestPersistence:
         bot, fake = build()
         bot.tool_loop.run = AsyncMock(side_effect=asyncio.CancelledError())
         msg = FakeMessage("interrupted")
-        bot._pending_files[str(msg.channel.id)] = [(b"x", "leak.txt")]
+        bot.channel_state.pending_files[str(msg.channel.id)] = [(b"x", "leak.txt")]
         with pytest.raises(asyncio.CancelledError):
-            await bot._handle_message(msg, "interrupted")
+            await bot.pipeline.run(msg, "interrupted")
         assert history_of(bot, str(msg.channel.id)) == []
-        assert str(msg.channel.id) not in bot._pending_files
+        assert str(msg.channel.id) not in bot.channel_state.pending_files
 
     async def test_reflection_receives_popped_op_details(self):
         bot, fake = build(
@@ -115,12 +115,12 @@ class TestPersistence:
 
         bot.turn_recorder._operational_reflection = spy_reflection
         msg = FakeMessage("do it")
-        await bot._handle_message(msg, "do it")
+        await bot.pipeline.run(msg, "do it")
         await asyncio.sleep(0.05)  # fire_and_forget task
         assert seen["tools_used"] == ["parse_time"]
         assert seen["tool_details"] and seen["tool_details"][0]["tool"] == "parse_time"
         # And the per-channel stash was consumed
-        assert str(msg.channel.id) not in bot._last_op_details
+        assert str(msg.channel.id) not in bot.channel_state.last_op_details
 
 
 class TestRouting:
@@ -128,16 +128,16 @@ class TestRouting:
         bot, fake = build(chat=["guest-tier answer"])
         bot.permissions.is_guest = lambda uid: True
         msg = FakeMessage("hello")
-        await bot._handle_message(msg, "hello")
+        await bot.pipeline.run(msg, "hello")
         assert fake.calls == []  # no tool loop
         assert len(fake.chat_calls) == 1  # chat route
         assert msg.reply_texts == ["guest-tier answer"]
 
     async def test_no_llm_provider_notifies_and_removes_user_turn(self):
         bot, fake = build()
-        bot.codex_client = None  # llm_client property now resolves to None
+        bot.llm_gateway.codex_client = None  # llm_client property now resolves to None
         msg = FakeMessage("hello")
-        await bot._handle_message(msg, "hello")
+        await bot.pipeline.run(msg, "hello")
         assert any("No LLM provider available" in t for t in msg.reply_texts)
         assert history_of(bot, str(msg.channel.id)) == []
 
@@ -147,7 +147,7 @@ class TestRouting:
             return_value=("raw skill output", False, False, ["myskill"], True),
         )
         msg = FakeMessage("use the skill")
-        await bot._handle_message(msg, "use the skill")
+        await bot.pipeline.run(msg, "use the skill")
         assert msg.reply_texts == ["conversational wrap-up"]
         # The handoff chat saw the tool result as an assistant message
         handoff_msgs = fake.chat_calls[0]["messages"]
@@ -159,7 +159,7 @@ class TestRouting:
             return_value=("raw skill output", False, False, ["myskill"], True),
         )
         msg = FakeMessage("use the skill")
-        await bot._handle_message(msg, "use the skill")
+        await bot.pipeline.run(msg, "use the skill")
         assert msg.reply_texts == ["raw skill output"]
 
     async def test_voice_callback_receives_response(self):
@@ -170,7 +170,7 @@ class TestRouting:
             spoken.append(text)
 
         msg = FakeMessage("say it")
-        await bot._handle_message(msg, "say it", voice_callback=voice_cb)
+        await bot.pipeline.run(msg, "say it", voice_callback=voice_cb)
         assert spoken == ["spoken words"]
         assert msg.reply_texts == ["spoken words"]
 
@@ -194,7 +194,7 @@ class TestThreadInheritance:
         thread.typing = real.typing
 
         msg = FakeMessage("continue here", channel=thread)
-        await bot._handle_message(msg, "continue here")
+        await bot.pipeline.run(msg, "continue here")
 
         thread_session = bot.sessions.get("200")
         assert thread_session.summary.startswith("[INHERITED FROM #general]")
@@ -216,7 +216,7 @@ class TestThreadInheritance:
         thread.typing = real.typing
 
         msg = FakeMessage("more", channel=thread)
-        await bot._handle_message(msg, "more")
+        await bot.pipeline.run(msg, "more")
         assert not (bot.sessions.get("200").summary or "").startswith("[INHERITED")
 
 
@@ -224,8 +224,8 @@ class TestDeliveryHandoff:
     async def test_pending_files_delivered_with_response(self):
         bot, fake = build([text_response("here you go")])
         msg = FakeMessage("give me the file")
-        bot._pending_files[str(msg.channel.id)] = [(b"bytes", "gift.txt")]
-        await bot._handle_message(msg, "give me the file")
+        bot.channel_state.pending_files[str(msg.channel.id)] = [(b"bytes", "gift.txt")]
+        await bot.pipeline.run(msg, "give me the file")
         entry = msg.replies[0]
         assert entry["content"] == "here you go"
         assert [f.filename for f in entry["files"]] == ["gift.txt"]
@@ -236,8 +236,8 @@ class TestDeliveryHandoff:
             return_value=("streamed already", True, False, ["some_tool"], False),
         )
         msg = FakeMessage("stream it")
-        bot._pending_files[str(msg.channel.id)] = [(b"bytes", "late.txt")]
-        await bot._handle_message(msg, "stream it")
+        bot.channel_state.pending_files[str(msg.channel.id)] = [(b"bytes", "late.txt")]
+        await bot.pipeline.run(msg, "stream it")
         assert msg.replies == []  # not re-sent
         assert msg.channel.sent  # files posted on their own
         assert [f.filename for f in msg.channel.sent[0]["files"]] == ["late.txt"]

--- a/tests/characterization/test_scheduled_events.py
+++ b/tests/characterization/test_scheduled_events.py
@@ -39,17 +39,21 @@ def schedule(**kw) -> dict:
 class TestScheduledTaskRouting:
     async def test_reminder_posts_to_channel(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot._on_scheduled_task(schedule(action="reminder", message="water the servers"))
+        await bot.scheduled_events._on_scheduled_task(
+            schedule(action="reminder", message="water the servers")
+        )
         assert channel.sent_texts == ["**Scheduled reminder:** water the servers"]
 
     async def test_missing_channel_id_is_silently_skipped(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot._on_scheduled_task(schedule(action="reminder", channel_id="", message="x"))
+        await bot.scheduled_events._on_scheduled_task(
+            schedule(action="reminder", channel_id="", message="x")
+        )
         assert channel.sent == []
 
     async def test_unknown_action_is_ignored_without_raise(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot._on_scheduled_task(schedule(action="mystery"))
+        await bot.scheduled_events._on_scheduled_task(schedule(action="mystery"))
         assert channel.sent == []
 
     async def test_check_success_posts_result(self, bot_and_channel):
@@ -57,7 +61,7 @@ class TestScheduledTaskRouting:
         bot.tool_executor.execute = AsyncMock(
             return_value=ToolResult(output="disk 42% used", tool_name="run_command"),
         )
-        await bot._on_scheduled_task(
+        await bot.scheduled_events._on_scheduled_task(
             schedule(
                 action="check",
                 tool_name="run_command",
@@ -76,7 +80,7 @@ class TestScheduledTaskRouting:
             return_value=ToolResult(output="host unreachable", ok=False, tool_name="run_command"),
         )
         with pytest.raises(RuntimeError, match="Scheduled check failed"):
-            await bot._on_scheduled_task(
+            await bot.scheduled_events._on_scheduled_task(
                 schedule(
                     action="check",
                     tool_name="run_command",
@@ -103,7 +107,7 @@ class TestScheduledWorkflow:
             ],
         )
         with pytest.raises(RuntimeError, match="Scheduled workflow failed"):
-            await bot._on_scheduled_task(sched)
+            await bot.scheduled_events._on_scheduled_task(sched)
         assert bot.tool_executor.execute.await_count == 1
         summary = channel.sent_texts[0]
         assert "FAILED" in summary
@@ -130,7 +134,7 @@ class TestScheduledWorkflow:
                 {"tool_name": "run_command", "tool_input": {"host": "h", "command": "b"}},
             ],
         )
-        await bot._on_scheduled_task(sched)  # no raise
+        await bot.scheduled_events._on_scheduled_task(sched)  # no raise
         assert bot.tool_executor.execute.await_count == 2
         summary = channel.sent_texts[0]
         assert "FAILED" in summary and "second ran fine" in summary
@@ -156,7 +160,7 @@ class TestScheduledWorkflow:
                 },
             ],
         )
-        await bot._on_scheduled_task(sched)
+        await bot.scheduled_events._on_scheduled_task(sched)
         assert bot.tool_executor.execute.await_count == 1
         assert "skipped" in channel.sent_texts[0]
 
@@ -179,7 +183,7 @@ class TestScheduledWorkflow:
                 },
             ],
         )
-        await bot._on_scheduled_task(sched)
+        await bot.scheduled_events._on_scheduled_task(sched)
         assert bot.tool_executor.execute.await_count == 1
         assert "skipped" in channel.sent_texts[0]
 
@@ -188,7 +192,7 @@ class TestExecuteScheduledTool:
     async def test_rbac_denial_returns_structured_failure(self, bot_and_channel):
         bot, channel = bot_and_channel
         bot.tool_executor.check_permission = lambda tool, uid: "RBAC denied: nope"
-        result = await bot._execute_scheduled_tool(
+        result = await bot.scheduled_events._execute_scheduled_tool(
             "run_command",
             {"host": "h", "command": "x"},
             channel,
@@ -202,7 +206,7 @@ class TestExecuteScheduledTool:
     async def test_dispatch_exception_wrapped_as_execution_error(self, bot_and_channel):
         bot, channel = bot_and_channel
         bot.tool_executor.execute = AsyncMock(side_effect=RuntimeError("ssh exploded"))
-        result = await bot._execute_scheduled_tool(
+        result = await bot.scheduled_events._execute_scheduled_tool(
             "run_command",
             {"host": "h", "command": "x"},
             channel,
@@ -214,7 +218,7 @@ class TestExecuteScheduledTool:
 
     async def test_string_result_wrapped_ok(self, bot_and_channel):
         bot, channel = bot_and_channel
-        result = await bot._execute_scheduled_tool(
+        result = await bot.scheduled_events._execute_scheduled_tool(
             "parse_time",
             {"text": "tomorrow 3pm"},
             channel,
@@ -234,17 +238,17 @@ class TestAlerts:
         )
         channel = FakeChannel(id=777)
         bot.get_channel = lambda cid: channel if int(cid) == 777 else None
-        await bot._on_monitor_alert("CPU at 99% on desktop")
+        await bot.scheduled_events._on_monitor_alert("CPU at 99% on desktop")
         assert channel.sent_texts == ["CPU at 99% on desktop"]
 
     async def test_monitor_alert_with_no_channel_is_dropped(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot._on_monitor_alert("nowhere to go")
+        await bot.scheduled_events._on_monitor_alert("nowhere to go")
         assert channel.sent == []
 
     async def test_schedule_failure_alert_posts_threshold_message(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot._on_schedule_failure(
+        await bot.scheduled_events._on_schedule_failure(
             schedule(last_error="timeout talking to host"),
             consecutive=3,
         )

--- a/tests/fakes/bot_factory.py
+++ b/tests/fakes/bot_factory.py
@@ -46,7 +46,7 @@ def make_bot(*, config_overrides: dict | None = None, fake_llm=None):
     - openai_codex stays disabled (schema default) → codex_client is None
       until a FakeLLM is installed.
 
-    If ``fake_llm`` is given it is installed at ``bot.codex_client`` — the
+    If ``fake_llm`` is given it is installed at ``bot.llm_gateway.codex_client`` — the
     single attribute BOTH pipelines resolve their provider from (the chat
     loop via the llm_client property inside _codex_call, the autonomous
     loop via self.llm_client directly).
@@ -73,5 +73,5 @@ def make_bot(*, config_overrides: dict | None = None, fake_llm=None):
     cfg = Config(**_deep_merge(base, config_overrides or {}))
     bot = OdinBot(cfg)
     if fake_llm is not None:
-        bot.codex_client = fake_llm
+        bot.llm_gateway.codex_client = fake_llm
     return bot

--- a/tests/fakes/llm.py
+++ b/tests/fakes/llm.py
@@ -7,7 +7,7 @@ exact message-list shape the tool loop constructs per iteration.
 
 Installable at BOTH seams the client currently uses:
 
-- ``bot.codex_client = FakeLLM(...)`` — the chat tool loop reaches the LLM
+- ``bot.llm_gateway.codex_client = FakeLLM(...)`` — the chat tool loop reaches the LLM
   via ``_codex_call`` → the ``llm_client`` property, which resolves to
   ``codex_client`` under the default ``active_provider: codex``.
 - The autonomous loop (``_run_loop_iteration``) calls

--- a/tests/test_connection_pools.py
+++ b/tests/test_connection_pools.py
@@ -640,9 +640,10 @@ class TestPoolAPI:
             "http_pool_active_connections": 1,
             "http_pool_total_requests": 42,
         }
-        bot = _make_bot(codex=codex)
-        bot.ollama_client = None
-        bot.kimi_client = None
+        bot = _make_bot()
+        bot.llm_gateway.codex_client = codex
+        bot.llm_gateway.ollama_client = None
+        bot.llm_gateway.kimi_client = None
         async with TestClient(TestServer(_make_app(bot))) as client:
             resp = await client.get("/api/pools/http")
             assert resp.status == 200
@@ -651,10 +652,10 @@ class TestPoolAPI:
 
     async def test_http_pool_unavailable(self):
         from aiohttp.test_utils import TestClient, TestServer
-        bot = MagicMock(spec=[])
-        bot.config = MagicMock()
-        bot.config.web = MagicMock()
-        bot.config.web.api_token = ""
+        bot = _make_bot()
+        bot.llm_gateway.codex_client = None
+        bot.llm_gateway.ollama_client = None
+        bot.llm_gateway.kimi_client = None
         async with TestClient(TestServer(_make_app(bot))) as client:
             resp = await client.get("/api/pools/http")
             assert resp.status == 503

--- a/tests/test_evaluative_discipline_prompt.py
+++ b/tests/test_evaluative_discipline_prompt.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from src.llm.system_prompt import build_system_prompt
-from src.discord.client import OdinBot
+from src.discord.completion import CLASSIFIER_SYSTEM_PROMPT
 
 
 class TestSystemPromptRule12:
@@ -47,14 +47,14 @@ class TestCompletionClassifierPrompt:
     def test_classifier_rejects_plausible_substitute(self):
         """The classifier prompt now explicitly teaches it to flag
         INCOMPLETE when the artifact doesn't match the request shape."""
-        prompt = OdinBot._CLASSIFIER_SYSTEM_PROMPT
+        prompt = CLASSIFIER_SYSTEM_PROMPT
         assert "plausible-shaped substitute" in prompt
         assert "artifact asked for was produced" in prompt
 
     def test_classifier_rejects_offering_more_work(self):
         """The classifier learns to flag 'I could also' as INCOMPLETE
         rather than closure."""
-        prompt = OdinBot._CLASSIFIER_SYSTEM_PROMPT
+        prompt = CLASSIFIER_SYSTEM_PROMPT
         assert "I could also" in prompt or "would you like" in prompt
         # Example of this class of incompletion must be present so the
         # classifier has a concrete target.
@@ -65,5 +65,5 @@ class TestCompletionClassifierPrompt:
         runbook without including its source."""
         assert (
             "described the synthesized runbook but did not include its source"
-            in OdinBot._CLASSIFIER_SYSTEM_PROMPT
+            in CLASSIFIER_SYSTEM_PROMPT
         )

--- a/tests/test_executor_integration_smoke.py
+++ b/tests/test_executor_integration_smoke.py
@@ -24,7 +24,7 @@ from src.discord.client import OdinBot
 def _make_bot() -> OdinBot:
     """Build a bot from a minimal pydantic Config — Codex disabled.
 
-    Codex disabled means bot.codex_client is None; the executor surface
+    Codex disabled means bot.llm_gateway.codex_client is None; the executor surface
     still gets wired (tool_executor, sessions, scheduler, agents, etc.),
     which is what we want to validate.
     """
@@ -96,7 +96,8 @@ class TestExecutorSurface:
         # When credentials are absent, codex_client must be None (not crash).
         bot = _make_bot()
         # Either disabled in config or no credentials → None is the only sane outcome
-        assert bot.codex_client is None or bot.codex_client is not None  # type only
+        gw = bot.llm_gateway
+        assert gw.codex_client is None or gw.codex_client is not None  # type only
 
 
 # ---------------------------------------------------------------------------
@@ -105,23 +106,23 @@ class TestExecutorSurface:
 
 
 class TestHelperMethods:
-    """The methods src/web/chat.py and the message handler depend on exist."""
+    """The component surfaces src/web/chat.py and the pipeline depend on exist."""
 
-    def test_process_with_tools_callable(self):
+    def test_tool_loop_run_callable(self):
         bot = _make_bot()
-        assert callable(bot._process_with_tools)
+        assert callable(bot.tool_loop.run)
 
-    def test_build_system_prompt_callable(self):
+    def test_prompt_builder_callable(self):
         bot = _make_bot()
-        assert callable(bot._build_system_prompt)
+        assert callable(bot.prompt_builder.build_full_prompt)
 
-    def test_classify_completion_callable(self):
+    def test_completion_classifier_callable(self):
         bot = _make_bot()
-        assert callable(bot._classify_completion)
+        assert callable(bot.completion_classifier.classify)
 
     def test_handle_start_loop_callable(self):
         bot = _make_bot()
-        assert callable(bot._handle_start_loop)
+        assert callable(bot.agent_task_tools._handle_start_loop)
 
 
 # ---------------------------------------------------------------------------
@@ -222,22 +223,20 @@ class TestOnMessageWiring:
 
 
 class TestWebChatContract:
-    """src/web/chat.py calls bot._process_with_tools(...) — the contract must hold."""
+    """src/web/chat.py calls bot.tool_loop.run(...) — the contract must hold."""
 
     def test_web_chat_module_imports(self):
         from src.web import chat
         assert hasattr(chat, "process_web_chat")
 
     def test_web_chat_signatures_compatible(self):
-        # The web chat endpoint expects bot.sessions.add_message,
-        # bot.sessions.remove_last_message, bot.sessions.get_task_history,
-        # bot.codex_client (may be None), bot._build_system_prompt,
-        # bot._process_with_tools.
+        # The web chat endpoint expects bot.sessions (add/remove/history),
+        # bot.llm_gateway.codex_client (may be None), and the prompt/tool-loop
+        # /delivery/turn-recorder components.
         bot = _make_bot()
         for attr in (
-            "sessions", "codex_client",
-            "_build_system_prompt",
-            "_process_with_tools",
+            "sessions", "llm_gateway", "prompt_builder",
+            "tool_loop", "delivery", "turn_recorder",
         ):
             assert hasattr(bot, attr), f"web/chat.py needs bot.{attr}"
         for method in ("add_message", "remove_last_message", "get_task_history"):
@@ -307,7 +306,7 @@ class TestProcessWithToolsEndToEnd:
 
         bot = _make_bot()
         # Inject a mock codex client (real wiring path; only the network call is faked)
-        bot.codex_client = MagicMock()
+        bot.llm_gateway.codex_client = MagicMock()
 
         # Codex returns a single tool call on iter 1, then a text response on iter 2.
         async def fake_chat_with_tools(messages, system, tools):
@@ -330,9 +329,11 @@ class TestProcessWithToolsEndToEnd:
                 stop_reason="tool_use",
             )
 
-        bot.codex_client.chat_with_tools = fake_chat_with_tools
+        bot.llm_gateway.codex_client.chat_with_tools = fake_chat_with_tools
         from src.tools.result_validator import ToolResult
-        bot.tool_executor.execute = AsyncMock(return_value=ToolResult(output="Filesystem 42% used", tool_name="check_disk"))
+        bot.tool_executor.execute = AsyncMock(
+            return_value=ToolResult(output="Filesystem 42% used", tool_name="check_disk")
+        )
         bot.audit.log_execution = AsyncMock()
 
         # Build a fake Discord message
@@ -361,10 +362,10 @@ class TestProcessWithToolsEndToEnd:
         msg.attachments = []
         msg.webhook_id = None
 
-        with patch("src.discord.client.scrub_output_secrets", side_effect=lambda x: x), \
-             patch("src.discord.client.truncate_tool_output", side_effect=lambda x: x):
+        with patch("src.discord.tool_loop.scrub_output_secrets", side_effect=lambda x: x), \
+             patch("src.discord.tool_loop.truncate_tool_output", side_effect=lambda x: x):
             text, _already_sent, is_error, tools_used, _handoff = (
-                await bot._process_with_tools(
+                await bot.tool_loop.run(
                     msg,
                     [{"role": "user", "content": "check disk"}],
                 )
@@ -485,32 +486,32 @@ class TestExecutorHelpers:
 
     def test_codex_call_helper_exists(self):
         bot = _make_bot()
-        assert callable(bot._codex_call)
+        assert callable(bot.llm_gateway.call_with_tools)
 
     def test_save_turn_trajectory_helper_exists(self):
         bot = _make_bot()
-        assert callable(bot._save_turn_trajectory)
+        assert callable(bot.turn_recorder._save_turn_trajectory)
 
     def test_emit_lifecycle_event_helper_exists(self):
         bot = _make_bot()
-        assert callable(bot._emit_lifecycle_event)
+        assert callable(bot.turn_recorder._emit_lifecycle_event)
 
     @pytest.mark.asyncio
     async def test_codex_call_records_cost_and_subsystem(self):
         from src.llm.types import LLMResponse
         bot = _make_bot()
-        bot.codex_client = MagicMock()
+        bot.llm_gateway.codex_client = MagicMock()
 
         async def fake_chat(messages, system, tools, **kw):
             return LLMResponse(
                 text="ok", tool_calls=[], stop_reason="stop",
                 input_tokens=100, output_tokens=50,
             )
-        bot.codex_client.chat_with_tools = fake_chat
+        bot.llm_gateway.codex_client.chat_with_tools = fake_chat
 
         before_in = bot.cost_tracker._total_input_tokens
         before_out = bot.cost_tracker._total_output_tokens
-        resp = await bot._codex_call(messages=[], system="s", tools=[])
+        resp = await bot.llm_gateway.call_with_tools(messages=[], system="s", tools=[])
         assert resp.text == "ok"
         assert bot.cost_tracker._total_input_tokens == before_in + 100
         assert bot.cost_tracker._total_output_tokens == before_out + 50
@@ -518,14 +519,14 @@ class TestExecutorHelpers:
     @pytest.mark.asyncio
     async def test_codex_call_records_subsystem_failure_on_exception(self):
         bot = _make_bot()
-        bot.codex_client = MagicMock()
+        bot.llm_gateway.codex_client = MagicMock()
 
         async def fake_chat(messages, system, tools, **kw):
             raise RuntimeError("boom")
-        bot.codex_client.chat_with_tools = fake_chat
+        bot.llm_gateway.codex_client.chat_with_tools = fake_chat
 
         with pytest.raises(RuntimeError, match="boom"):
-            await bot._codex_call(messages=[], system="s", tools=[])
+            await bot.llm_gateway.call_with_tools(messages=[], system="s", tools=[])
         # Failure was recorded against the llm subsystem
         info = bot.subsystem_guard._subsystems["llm_codex"]
         assert info.consecutive_failures >= 1
@@ -536,7 +537,7 @@ class TestExecutorHelpers:
         # dispatcher is None when outbound_webhooks.enabled is False
         assert bot.outbound_webhook_dispatcher is None
         # Must not raise
-        await bot._emit_lifecycle_event("test.event", {"foo": "bar"})
+        await bot.turn_recorder._emit_lifecycle_event("test.event", {"foo": "bar"})
 
 
 # ---------------------------------------------------------------------------
@@ -592,7 +593,7 @@ class TestInvokeSkillTool:
         msg_proxy.channel = MagicMock()
         msg_proxy.channel.id = 123
         msg_proxy.channel.send = AsyncMock()
-        out = await bot._dispatch_loop_tool(
+        out = await bot.tool_loop.dispatch_loop_tool(
             "invoke_skill",
             {"name": "my_skill", "input": {"x": 1}},
             msg_proxy,
@@ -608,7 +609,7 @@ class TestInvokeSkillTool:
     async def test_dispatch_loop_tool_invoke_skill_missing_name(self):
         bot = _make_bot()
         msg_proxy = MagicMock()
-        out = await bot._dispatch_loop_tool(
+        out = await bot.tool_loop.dispatch_loop_tool(
             "invoke_skill",
             {},
             msg_proxy,
@@ -621,7 +622,7 @@ class TestInvokeSkillTool:
         bot = _make_bot()
         bot.skill_manager.has_skill = MagicMock(return_value=False)
         msg_proxy = MagicMock()
-        out = await bot._dispatch_loop_tool(
+        out = await bot.tool_loop.dispatch_loop_tool(
             "invoke_skill",
             {"name": "nope"},
             msg_proxy,
@@ -633,7 +634,7 @@ class TestInvokeSkillTool:
         """Odin queued a check-action schedule without tool_input; it fired 90s
         later and crashed. Validation now rejects at creation time."""
         bot = _make_bot()
-        err = bot._validate_schedule_payload({
+        err = bot.scheduling_tools._validate_schedule_payload({
             "description": "x",
             "action": "check",
             "tool_name": "run_command",
@@ -649,9 +650,14 @@ class TestInvokeSkillTool:
             "description": "x",
             "action": "check",
             "tool_name": "run_command",
-            "steps": [{"tool_name": "run_command", "tool_input": {"host": "localhost", "command": "uname"}}],
+            "steps": [
+                {
+                    "tool_name": "run_command",
+                    "tool_input": {"host": "localhost", "command": "uname"},
+                }
+            ],
         }
-        err = bot._validate_schedule_payload(inp)
+        err = bot.scheduling_tools._validate_schedule_payload(inp)
         assert err is None
         assert inp["tool_input"] == {"host": "localhost", "command": "uname"}
 
@@ -663,7 +669,7 @@ class TestInvokeSkillTool:
             "action": "check",
             "command": "uname -r",
         }
-        err = bot._validate_schedule_payload(inp)
+        err = bot.scheduling_tools._validate_schedule_payload(inp)
         assert err is None
         assert inp["tool_name"] == "run_command"
         assert inp["tool_input"] == {"host": "localhost", "command": "uname -r"}
@@ -676,13 +682,13 @@ class TestInvokeSkillTool:
             "command": "uname",
             "host": "myhost",
         }
-        err = bot._validate_schedule_payload(inp)
+        err = bot.scheduling_tools._validate_schedule_payload(inp)
         assert err is None
         assert inp["tool_input"]["host"] == "myhost"
 
     def test_validate_schedule_rejects_workflow_step_missing_tool_input(self):
         bot = _make_bot()
-        err = bot._validate_schedule_payload({
+        err = bot.scheduling_tools._validate_schedule_payload({
             "description": "x",
             "action": "workflow",
             "steps": [{"tool_name": "run_command", "description": "doit"}],
@@ -692,7 +698,7 @@ class TestInvokeSkillTool:
 
     def test_validate_schedule_accepts_complete_check(self):
         bot = _make_bot()
-        err = bot._validate_schedule_payload({
+        err = bot.scheduling_tools._validate_schedule_payload({
             "description": "x",
             "action": "check",
             "tool_name": "run_command",
@@ -702,8 +708,10 @@ class TestInvokeSkillTool:
 
     def test_validate_schedule_reminder_needs_message(self):
         bot = _make_bot()
-        assert bot._validate_schedule_payload({"description": "x", "action": "reminder"}) is not None
-        assert bot._validate_schedule_payload(
+        assert bot.scheduling_tools._validate_schedule_payload(
+            {"description": "x", "action": "reminder"}
+        ) is not None
+        assert bot.scheduling_tools._validate_schedule_payload(
             {"description": "x", "action": "reminder", "message": "hi"}
         ) is None
 
@@ -871,11 +879,13 @@ class TestInvokeSkillTool:
         bot.skill_manager.execute = AsyncMock(return_value="should-not-run")
         fake_skill = MagicMock()
         fake_skill.definition = {
-            "input_schema": {"type": "object", "required": ["msg"], "properties": {"msg": {"type": "string"}}},
+            "input_schema": {
+                "type": "object", "required": ["msg"], "properties": {"msg": {"type": "string"}}
+            },
         }
         bot.skill_manager._skills = {"echo_test": fake_skill}
         msg_proxy = MagicMock()
-        out = await bot._dispatch_loop_tool(
+        out = await bot.tool_loop.dispatch_loop_tool(
             "invoke_skill",
             {"name": "echo_test"},
             msg_proxy,

--- a/tests/test_health_checker.py
+++ b/tests/test_health_checker.py
@@ -125,7 +125,7 @@ class TestCheckCodex:
         session = MagicMock()
         session.closed = not session_ok
         codex._session = session
-        bot.codex = codex
+        bot.llm_gateway.codex_client = codex
         return bot
 
     def test_healthy(self):
@@ -159,24 +159,25 @@ class TestCheckCodex:
         assert "session" in result.detail.lower()
 
     def test_no_codex_disabled(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
+        bot.llm_gateway.codex_client = None
         result = check_codex(bot)
         assert result.healthy is True
         assert result.status == "unconfigured"
 
     def test_no_codex_enabled_no_creds(self):
-        bot = MagicMock(spec=["config"])
+        bot = MagicMock(spec=["config", "llm_gateway"])
         bot.config.openai_codex.enabled = True
-        bot.codex = None
+        bot.llm_gateway.codex_client = None
         result = check_codex(bot)
         assert result.healthy is False
         assert result.status == "down"
 
     def test_exception(self):
         bot = MagicMock()
-        bot.codex = MagicMock()
-        bot.codex.breaker = MagicMock()
-        bot.codex.get_pool_metrics.side_effect = RuntimeError("fail")
+        bot.llm_gateway.codex_client = MagicMock()
+        bot.llm_gateway.codex_client.breaker = MagicMock()
+        bot.llm_gateway.codex_client.get_pool_metrics.side_effect = RuntimeError("fail")
         result = check_codex(bot)
         assert result.healthy is False
         assert result.status == "down"
@@ -214,7 +215,7 @@ class TestCheckSessions:
         assert "over token budget" in result.detail
 
     def test_no_sessions_manager(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_sessions(bot)
         assert result.healthy is False
         assert "not initialised" in result.detail
@@ -271,7 +272,7 @@ class TestCheckKnowledge:
         assert result.status == "down"
 
     def test_no_knowledge(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_knowledge(bot)
         assert result.status == "unconfigured"
 
@@ -353,7 +354,7 @@ class TestCheckSSHHosts:
         assert "No SSH hosts" in result.detail
 
     def test_no_executor(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_ssh_hosts(bot)
         assert result.status == "unconfigured"
 
@@ -410,7 +411,7 @@ class TestCheckVoice:
         assert result.status == "degraded"
 
     def test_unconfigured(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_voice(bot)
         assert result.status == "unconfigured"
 
@@ -447,7 +448,7 @@ class TestCheckMonitoring:
         assert "2 active alert" in result.detail
 
     def test_unconfigured(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_monitoring(bot)
         assert result.status == "unconfigured"
 
@@ -490,7 +491,7 @@ class TestCheckBrowser:
         assert result.status == "unconfigured"
 
     def test_no_executor(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_browser(bot)
         assert result.status == "unconfigured"
 
@@ -515,7 +516,7 @@ class TestCheckScheduler:
         assert "0 scheduled" in result.detail
 
     def test_unconfigured(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_scheduler(bot)
         assert result.status == "unconfigured"
 
@@ -545,7 +546,7 @@ class TestCheckLoops:
         assert "0 active" in result.detail
 
     def test_unconfigured(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_loops(bot)
         assert result.status == "unconfigured"
 
@@ -575,7 +576,7 @@ class TestCheckAgents:
         assert result.metadata["total"] == 0
 
     def test_unconfigured(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_agents(bot)
         assert result.status == "unconfigured"
 
@@ -592,10 +593,10 @@ class TestCheckAll:
         guild.member_count = 10
         bot.guilds = [guild]
         # codex
-        bot.codex.model = "gpt-4o"
-        bot.codex.breaker = MagicMock()
-        type(bot.codex.breaker).state = PropertyMock(return_value="closed")
-        bot.codex.get_pool_metrics.return_value = {
+        bot.llm_gateway.codex_client.model = "gpt-4o"
+        bot.llm_gateway.codex_client.breaker = MagicMock()
+        type(bot.llm_gateway.codex_client.breaker).state = PropertyMock(return_value="closed")
+        bot.llm_gateway.codex_client.get_pool_metrics.return_value = {
             "http_pool_max_connections": 10,
             "http_pool_keepalive_timeout": 30,
             "http_pool_active_connections": 0,
@@ -603,7 +604,7 @@ class TestCheckAll:
         }
         session = MagicMock()
         session.closed = False
-        bot.codex._session = session
+        bot.llm_gateway.codex_client._session = session
         # sessions
         bot.sessions._sessions = {}
         bot.sessions.count.return_value = 0
@@ -657,10 +658,10 @@ class TestCheckAll:
 
     def test_unhealthy_overall(self):
         bot = self._make_healthy_bot()
-        bot.codex.breaker = MagicMock()
-        type(bot.codex.breaker).state = PropertyMock(return_value="open")
-        bot.codex._session = MagicMock()
-        bot.codex._session.closed = False
+        bot.llm_gateway.codex_client.breaker = MagicMock()
+        type(bot.llm_gateway.codex_client.breaker).state = PropertyMock(return_value="open")
+        bot.llm_gateway.codex_client._session = MagicMock()
+        bot.llm_gateway.codex_client._session.closed = False
         result = check_all(bot)
         assert result["overall"] == "unhealthy"
         assert result["down_count"] >= 1
@@ -746,10 +747,10 @@ class TestHealthAPI:
         guild = MagicMock()
         guild.member_count = 5
         bot.guilds = [guild]
-        bot.codex.model = "gpt-4o"
-        bot.codex.breaker = MagicMock()
-        type(bot.codex.breaker).state = PropertyMock(return_value="closed")
-        bot.codex.get_pool_metrics.return_value = {
+        bot.llm_gateway.codex_client.model = "gpt-4o"
+        bot.llm_gateway.codex_client.breaker = MagicMock()
+        type(bot.llm_gateway.codex_client.breaker).state = PropertyMock(return_value="closed")
+        bot.llm_gateway.codex_client.get_pool_metrics.return_value = {
             "http_pool_max_connections": 10,
             "http_pool_keepalive_timeout": 30,
             "http_pool_active_connections": 0,
@@ -757,7 +758,7 @@ class TestHealthAPI:
         }
         session = MagicMock()
         session.closed = False
-        bot.codex._session = session
+        bot.llm_gateway.codex_client._session = session
         bot.sessions._sessions = {}
         bot.sessions.count.return_value = 0
         bot.sessions.get_token_metrics.return_value = {"total_tokens": 0, "over_budget_count": 0}
@@ -774,7 +775,7 @@ class TestHealthAPI:
         bot.agent_manager._agents = {}
         bot.config.model_dump.return_value = {}
         bot.skill_manager.list_skills.return_value = []
-        bot._merged_tool_definitions.return_value = []
+        bot.tool_catalog.merged_definitions.return_value = []
         return bot
 
     @pytest.mark.asyncio
@@ -832,15 +833,15 @@ class TestEdgeCases:
 
     def test_codex_no_breaker(self):
         bot = MagicMock()
-        bot.codex.breaker = None
-        bot.codex.get_pool_metrics.return_value = {
+        bot.llm_gateway.codex_client.breaker = None
+        bot.llm_gateway.codex_client.get_pool_metrics.return_value = {
             "http_pool_max_connections": 10,
             "http_pool_keepalive_timeout": 30,
             "http_pool_active_connections": 0,
             "http_pool_total_requests": 0,
         }
-        bot.codex._session = MagicMock()
-        bot.codex._session.closed = False
+        bot.llm_gateway.codex_client._session = MagicMock()
+        bot.llm_gateway.codex_client._session.closed = False
         result = check_codex(bot)
         assert result.metadata["circuit_breaker"] == "unknown"
 
@@ -866,7 +867,7 @@ class TestEdgeCases:
         assert result.status == "down"
 
     def test_check_all_returns_iso_timestamp(self):
-        bot = MagicMock(spec=[])
+        bot = MagicMock(spec=["llm_gateway"])
         result = check_all(bot)
         assert "T" in result["checked_at"]
         assert result["total"] == 13

--- a/tests/test_resource_usage.py
+++ b/tests/test_resource_usage.py
@@ -718,8 +718,8 @@ class TestResourceUsageAPI:
         bot.config.web.session_timeout_minutes = 30
         bot.config.model_dump.return_value = {}
         bot.skill_manager.list_skills.return_value = []
-        bot._merged_tool_definitions.return_value = []
-        bot._start_time = 0
+        bot.tool_catalog.merged_definitions.return_value = []
+        bot.start_time = 0
         return bot
 
     @pytest.mark.asyncio

--- a/tests/test_round30_reviewer.py
+++ b/tests/test_round30_reviewer.py
@@ -46,8 +46,8 @@ def _make_bot(tmp_path=None, knowledge_store=None, permission_manager=None):
     bot = MagicMock()
     bot.config = MagicMock()
     bot.config.web.api_token = ""
-    bot._knowledge_store = knowledge_store
-    bot._embedder = None
+    bot.knowledge = knowledge_store
+    bot.embedder = None
     bot.permission_manager = permission_manager
     if tmp_path:
         bot.audit = AuditLogger(path=str(tmp_path / "audit.jsonl"))

--- a/tests/test_session_search.py
+++ b/tests/test_session_search.py
@@ -501,8 +501,8 @@ def _make_bot(tmp_path):
     bot = MagicMock()
     mgr = _manager(tmp_path)
     bot.sessions = mgr
-    bot._knowledge_store = None
-    bot._embedder = None
+    bot.knowledge = None
+    bot.embedder = None
     bot.config = MagicMock()
     bot.config.web = MagicMock()
     bot.config.web.api_token = ""

--- a/tests/test_spawn_loop_agents_config.py
+++ b/tests/test_spawn_loop_agents_config.py
@@ -51,7 +51,7 @@ class TestSpawnLoopAgentsConfigPath:
         values are forwarded (the old code raised AttributeError here)."""
         bot, captured = _bot_with_running_loop()
         assert bot.context_compressor is not None  # schema default: enabled
-        result = await bot._handle_spawn_loop_agents(
+        result = await bot.agent_task_tools._handle_spawn_loop_agents(
             FakeMessage("go", channel=FakeChannel(id=777)),
             {"loop_id": "loop-1", "tasks": [{"goal": "trivial"}]},
         )
@@ -64,7 +64,7 @@ class TestSpawnLoopAgentsConfigPath:
     async def test_defaults_used_when_compression_disabled(self):
         bot, captured = _bot_with_running_loop()
         bot.context_compressor = None  # config-disabled wiring outcome
-        await bot._handle_spawn_loop_agents(
+        await bot.agent_task_tools._handle_spawn_loop_agents(
             FakeMessage("go", channel=FakeChannel(id=777)),
             {"loop_id": "loop-1", "tasks": [{"goal": "trivial"}]},
         )
@@ -77,7 +77,7 @@ class TestSpawnLoopAgentsConfigPath:
         bot.context_compressor = SimpleNamespace(
             enabled=True, max_context_chars=123456, keep_recent_iterations=7
         )
-        await bot._handle_spawn_loop_agents(
+        await bot.agent_task_tools._handle_spawn_loop_agents(
             FakeMessage("go", channel=FakeChannel(id=777)),
             {"loop_id": "loop-1", "tasks": [{"goal": "trivial"}]},
         )
@@ -88,8 +88,9 @@ class TestSpawnLoopAgentsConfigPath:
     async def test_validation_paths_unchanged(self):
         bot, _ = _bot_with_running_loop()
         msg = FakeMessage("go", channel=FakeChannel(id=777))
-        assert "loop_id" in await bot._handle_spawn_loop_agents(msg, {"tasks": [{}]})
-        assert "tasks" in await bot._handle_spawn_loop_agents(msg, {"loop_id": "loop-1"})
-        assert "not found" in await bot._handle_spawn_loop_agents(
+        spawn = bot.agent_task_tools._handle_spawn_loop_agents
+        assert "loop_id" in await spawn(msg, {"tasks": [{}]})
+        assert "tasks" in await spawn(msg, {"loop_id": "loop-1"})
+        assert "not found" in await bot.agent_task_tools._handle_spawn_loop_agents(
             msg, {"loop_id": "nope", "tasks": [{}]}
         )

--- a/tests/test_tool_failure_visibility.py
+++ b/tests/test_tool_failure_visibility.py
@@ -13,6 +13,7 @@ import pytest
 
 from src.config.schema import Config
 from src.discord.client import OdinBot
+from src.discord.tool_loop_helpers import ensure_failure_visible
 
 
 def _make_bot() -> OdinBot:
@@ -29,12 +30,12 @@ def _make_bot() -> OdinBot:
 
 def test_ok_result_untouched():
     text = "### host\n```\nall good\n```"
-    assert OdinBot._ensure_failure_visible(text, True) == text
+    assert ensure_failure_visible(text, True) == text
 
 
 def test_failed_result_without_marker_gets_prefixed():
     text = "### definitely-not-a-host\n```\nHost access denied: definitely-not-a-host\n```"
-    out = OdinBot._ensure_failure_visible(text, False)
+    out = ensure_failure_visible(text, False)
     assert out.startswith("Error (tool reported failure):")
     assert "Host access denied" in out
 
@@ -46,7 +47,7 @@ def test_failed_result_with_existing_marker_not_double_prefixed():
         "Blocked [critical]: nope",
         "Unknown or disallowed host: x",
     ):
-        assert OdinBot._ensure_failure_visible(text, False) == text
+        assert ensure_failure_visible(text, False) == text
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +65,6 @@ async def test_multi_host_denial_visible_through_executor():
     # Structured layer: classified as failure (PR#128 fix).
     assert result.ok is False
     # Model layer: after the visibility wrapper, the text carries an error marker.
-    rendered = OdinBot._ensure_failure_visible(str(result), result.ok)
+    rendered = ensure_failure_visible(str(result), result.ok)
     assert rendered.startswith("Error")
     assert "Unknown or disallowed host" in rendered or "Host access denied" in rendered

--- a/tests/test_trajectory_completeness.py
+++ b/tests/test_trajectory_completeness.py
@@ -169,8 +169,10 @@ class TestCommandFailedClass:
 
 class _FakeClient:
     """Just enough client surface for _record_user_content."""
-    from src.discord.client import OdinBot as _C  # noqa: N814
-    _record_user_content = _C._record_user_content
+
+    def _record_user_content(self, trajectory, content):
+        # P7: the bot delegate is retired — forward like it used to
+        return self._turn_recorder._record_user_content(trajectory, content)
 
     def __init__(self, enabled=True, cap=4000):
         from src.discord.turn_recorder import TurnRecorder
@@ -256,10 +258,14 @@ class TestStoredToolResults:
 
 
 class _LoopIterClient:
-    """Fake client binding the REAL _run_loop_iteration + _record_user_content."""
-    from src.discord.client import OdinBot as _C  # noqa: N814
-    _run_loop_iteration = _C._run_loop_iteration
-    _record_user_content = _C._record_user_content
+    """Fake client driving the REAL loop body + user-content recording."""
+
+    async def _run_loop_iteration(self, prompt, channel, prev_context, user_id):
+        # P7: the bot delegate is retired — drive the runner directly
+        return await self._tool_loop_runner.run_autonomous(prompt, channel, prev_context, user_id)
+
+    def _record_user_content(self, trajectory, content):
+        return self._turn_recorder._record_user_content(trajectory, content)
 
     def __init__(self, responses, tool_output="hi out", result_cap=2000):
         from types import SimpleNamespace


### PR DESCRIPTION
## RFC-002 P7 — the deletion

**`client.py`: 1,267 → 361 lines, 13 methods, zero delegates.** Cumulative: 5,790 → 361. What remains is exactly what a Discord bot class should be: intents + two-stage composition, lifecycle hooks (`setup_hook`/`on_ready`/`on_message`/`on_voice_state_update`/`close`), the archive backfill, voice transcription routing, startup logging, and the one live `knowledge` property (R2).

### Deleted (~110 names)
LLM facade (client properties + reload/switch/wire delegates + `_codex_call`) · prompt/catalog facade (`_build_system_prompt`, `_system_prompt` property, `_cached_*` pairs) · pipeline/delivery/observability delegates · gating + housekeeping delegates · 6 channel-state dict aliases · scheduled-events delegates · all ~40 `_handle_*` dispatch fossils · duplicate module functions (canonical homes: `response_guards`/`tool_loop_helpers`/`intake_pipeline`/`delivery`).

### Consumers respelled
- wiring providers read components directly (`get_default_system_prompt=lambda: prompt_builder.default_prompt`; classifier via the gateway; `get_knowledge_store=lambda: bot.knowledge`)
- `shutdown_services` closes the **live** provider clients through the gateway (bot properties are gone; services refs would be stale)
- `health/checker.py` + two api.py `getattr(bot, "codex_client")` **string** spellings (invisible to the P6 attr regexes) → gateway
- `__main__` imports `scrub_response_secrets` from `response_guards`

### The new contract (rewritten `test_facade_contract.py`)
- **Positive**: 36 service handles + 20 component handles + `knowledge` property (live/settable) + late-bound-absent set
- **Negative**: every retired `bot.<name>` spelling = ZERO across **src/ and tests/** (attribute-access regex — component methods sharing a suffix can't false-positive), plus a broad `bot._` scan over src/ with only client.py/wiring.py excepted
- The negative scan caught its first offenders during development (docstrings, two MagicMock fixture primes, getattr-string spellings) — working as intended.

### Test sweep
~120 spellings across 17 files migrated to component seams; fixtures rebuilt where MagicMock auto-attrs would have silently lied (gateway clients, knowledge store).

### R2 (declared deviations, recorded in the plan)
1. `WEB_CHANNEL_LOCKS` is module-owned, not aiohttp app state (your P6 note — plan updated so P7 doesn't chase a ghost).
2. `knowledge` property kept as the public name instead of a `knowledge_store` rename (dominant existing spelling; live semantics identical).

### Gates
- Full suite: **6,067 passed, 4 skipped**
- Lint: **zero new findings; 11 pre-existing resolved**
- Negative scans: green · `ui/` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3
