### PR TITLE
ci: PR test gate — pytest + no-new-lint-findings diff (RFC-003 P0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Run the suite
+        run: pytest -q
+
+  lint-no-new:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # full history: the gate merge-bases against the PR base ref
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # The gate diffs findings from the SAME ruff binary on both trees, so
+      # it is self-consistent across ruff releases; no version pin needed.
+      - name: Install ruff
+        run: pip install ruff
+      - name: No new lint findings vs base
+        run: python scripts/ci/lint_gate.py

--- a/scripts/ci/lint_gate.py
+++ b/scripts/ci/lint_gate.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Lint gate: fail on NEW ruff findings versus a base commit (RFC-003 P0).
+
+The repo carries pre-existing lint debt, so a plain ``ruff check`` cannot
+gate. This gate compares the FINDING SETS of the base commit and HEAD,
+normalized to ``(file, code, stripped-source-line-text)`` so pure line-number
+shifts (insertions above old debt) never false-positive — the comparator
+shape proven during the RFC-002 campaign.
+
+Usage:
+    python scripts/ci/lint_gate.py [--base-ref origin/master] [--base <sha>]
+
+Resolution order for the base commit:
+  1. --base <sha> if given
+  2. merge-base of HEAD and --base-ref (default: origin/$GITHUB_BASE_REF
+     when set, else origin/master)
+
+Exit codes: 0 = no new findings, 1 = new findings (printed), 2 = setup error.
+Requires: git history deep enough for merge-base (checkout fetch-depth: 0)
+and ``ruff`` on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+RUFF_ARGS = ["check", "src/", "tests/", "--output-format", "concise", "--no-cache"]
+
+
+def run(cmd: list[str], cwd: str | None = None, check: bool = True) -> str:
+    res = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check and res.returncode not in (0, 1):  # ruff exits 1 when findings exist
+        sys.stderr.write(res.stderr)
+        raise SystemExit(2)
+    return res.stdout
+
+
+def findings(tree: str) -> Counter:
+    """Normalized finding multiset for a checked-out tree."""
+    out = run(["ruff", *RUFF_ARGS], cwd=tree)
+    sources: dict[str, list[str]] = {}
+    normalized: Counter = Counter()
+    for line in out.splitlines():
+        parts = line.split(":", 3)
+        if len(parts) != 4 or not parts[1].isdigit():
+            continue
+        fname, lineno, _col, rest = parts[0], int(parts[1]), parts[2], parts[3]
+        code = rest.strip().split()[0] if rest.strip() else "?"
+        if fname not in sources:
+            try:
+                sources[fname] = (Path(tree) / fname).read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+            except OSError:
+                sources[fname] = []
+        lines = sources[fname]
+        src = lines[lineno - 1].strip() if 0 < lineno <= len(lines) else "?"
+        normalized[(fname, code, src)] += 1
+    return normalized
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", help="explicit base commit sha")
+    ap.add_argument("--base-ref", default=None, help="ref to merge-base against")
+    args = ap.parse_args()
+
+    if args.base:
+        base = args.base
+    else:
+        ref = args.base_ref or (
+            f"origin/{os.environ['GITHUB_BASE_REF']}"
+            if os.environ.get("GITHUB_BASE_REF")
+            else "origin/master"
+        )
+        base = run(["git", "merge-base", ref, "HEAD"], check=False).strip()
+        if not base:
+            print(f"lint-gate: cannot resolve merge-base against {ref} "
+                  "(need fetch-depth: 0)", file=sys.stderr)
+            return 2
+
+    head_findings = findings(".")
+
+    with tempfile.TemporaryDirectory(prefix="lint-gate-base-") as tmp:
+        wt = str(Path(tmp) / "base")
+        res = subprocess.run(
+            ["git", "worktree", "add", "--detach", wt, base],
+            capture_output=True, text=True,
+        )
+        if res.returncode != 0:
+            sys.stderr.write(res.stderr)
+            return 2
+        try:
+            base_findings = findings(wt)
+        finally:
+            subprocess.run(["git", "worktree", "remove", "--force", wt],
+                           capture_output=True)
+
+    new = head_findings - base_findings
+    resolved = base_findings - head_findings
+
+    print(f"lint-gate: base={base[:10]} "
+          f"base-findings={sum(base_findings.values())} "
+          f"head-findings={sum(head_findings.values())} "
+          f"new={sum(new.values())} resolved={sum(resolved.values())}")
+    if resolved:
+        print(f"resolved {sum(resolved.values())} pre-existing finding(s) — thank you.")
+    if new:
+        print("\nNEW findings (fix these — the debt may not grow):")
+        for (fname, code, src), n in sorted(new.items()):
+            suffix = f"  (x{n})" if n > 1 else ""
+            print(f"  {fname}  {code}  {src[:100]}{suffix}")
+        return 1
+    print("no new findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/health/grafana_alerts.py
+++ b/src/health/grafana_alerts.py
@@ -363,7 +363,14 @@ class GrafanaAlertHandler:
                 rec.status = "completed"
 
     def _is_on_cooldown(self, key: str, cooldown_seconds: int) -> bool:
-        last = self._cooldowns.get(key, 0)
+        last = self._cooldowns.get(key)
+        if last is None:
+            # Never remediated. A `0` sentinel here reads as "on cooldown
+            # since boot" on the monotonic clock, silently dropping every
+            # alert for the first cooldown_seconds after a host reboot —
+            # exactly the window when alerts fire (caught by the first CI
+            # run on a fresh runner, RFC-003 P0).
+            return False
         return (time.monotonic() - last) < cooldown_seconds
 
     def _count_active(self) -> int:

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -170,10 +170,12 @@ class LoopManager:
         for lid, info in self._loops.items():
             if info.status != "running":
                 # A loop stopped before its first iteration has no
-                # last_trigger — treat it as immediately stale.
-                ref = info.last_trigger or 0
-                if now - ref > 3600:  # 1 hour after finish
-                    to_remove.append(lid)
+                # last_trigger — treat it as immediately stale. (An `or 0`
+                # sentinel on the monotonic clock only looked stale on
+                # machines up longer than an hour; on a freshly booted host
+                # such loops lingered.)
+                if info.last_trigger is None or now - info.last_trigger > 3600:
+                    to_remove.append(lid)  # 1 hour after finish
         for lid in to_remove:
             del self._loops[lid]
 

--- a/tests/test_grafana_alerts.py
+++ b/tests/test_grafana_alerts.py
@@ -1508,3 +1508,46 @@ class TestModuleImports:
         from src.config.schema import GrafanaAlertConfig, GrafanaRemediationRuleConfig
         assert GrafanaAlertConfig is not None
         assert GrafanaRemediationRuleConfig is not None
+
+
+class TestFreshBootClock:
+    """Regression: a `0` cooldown sentinel on the monotonic clock read as
+    "on cooldown since boot" — every alert was silently dropped for the
+    first cooldown window after a host reboot. Caught by the first CI run
+    on a fresh runner (uptime < cooldown), invisible on long-uptime dev
+    machines (RFC-003 P0)."""
+
+    def test_never_remediated_alert_matches_on_fresh_boot(self, monkeypatch):
+        import time as _time
+
+        monkeypatch.setattr(_time, "monotonic", lambda: 10.0)  # 10s uptime
+        handler = GrafanaAlertHandler(auto_remediate=True, cooldown_seconds=300)
+        handler.add_rule(RemediationRule(id="r1", name_pattern="High*", cooldown_seconds=300))
+        alert = GrafanaAlert(
+            fingerprint="fb1", status="firing", alert_name="HighCPU",
+            labels={"severity": "critical"}, annotations={}, starts_at="",
+            ends_at="", generator_url="", silence_url="", dashboard_url="",
+            panel_url="", values={}, severity="critical", instance="",
+            summary="", description="",
+        )
+        matches = handler.process_alerts([alert])
+        assert len(matches) == 1, "fresh-boot clock must not fake a cooldown"
+
+    def test_real_cooldown_still_enforced_on_fresh_boot(self, monkeypatch):
+        import time as _time
+
+        clock = {"now": 10.0}
+        monkeypatch.setattr(_time, "monotonic", lambda: clock["now"])
+        handler = GrafanaAlertHandler(auto_remediate=True, cooldown_seconds=300)
+        handler.add_rule(RemediationRule(id="r1", name_pattern="*", cooldown_seconds=300))
+        handler._cooldowns["fb2:r1"] = 5.0  # remediated 5s after boot
+        alert = GrafanaAlert(
+            fingerprint="fb2", status="firing", alert_name="Anything",
+            labels={}, annotations={}, starts_at="", ends_at="",
+            generator_url="", silence_url="", dashboard_url="", panel_url="",
+            values={}, severity="unknown", instance="", summary="",
+            description="",
+        )
+        assert handler.process_alerts([alert]) == []  # genuinely on cooldown
+        clock["now"] = 320.0  # past the window
+        assert len(handler.process_alerts([alert])) == 1

--- a/tests/test_scheduler_agents_reliability.py
+++ b/tests/test_scheduler_agents_reliability.py
@@ -342,3 +342,20 @@ def test_plans_file_is_not_world_readable(tmp_path):
     store.create(user_id="u", channel_id="c", original_request="secret request", summary="s")
     mode = stat.S_IMODE(os.stat(path).st_mode)
     assert mode == 0o600
+
+
+def test_cleanup_removes_untriggered_loop_even_on_fresh_boot(monkeypatch):
+    """Regression: `last_trigger or 0` on the monotonic clock kept
+    never-triggered stopped loops alive for an hour after a fresh boot
+    (monotonic < 3600); the intent was "immediately stale" (RFC-003 P0)."""
+    import time as _time
+
+    monkeypatch.setattr(_time, "monotonic", lambda: 42.0)  # young machine
+    manager = LoopManager()
+    info = _loop_info()
+    info.status = "stopped"
+    info.last_trigger = None
+    manager._loops[info.id] = info
+
+    manager.cleanup_finished()
+    assert info.id not in manager._loops


### PR DESCRIPTION
## RFC-003 P0 — the safety net becomes law

Two jobs on every PR (+ report-style on master pushes):

- **tests** — `pip install -e ".[dev]"` → `pytest -q`, Python 3.12, pip cached. The 4 standing skips are version-conditional and identical on a bare runner (verified).
- **lint-no-new** — `scripts/ci/lint_gate.py` (committed, stdlib-only): same-binary ruff over merge-base and HEAD via `git worktree`, findings normalized to (file, code, source-line-text) so pure line shifts can't false-positive, **fail only on NEW findings** (resolved ones get thanked). `fetch-depth: 0` per R1 so merge-base has history. Self-consistent across ruff releases: both sides of the diff always run the same binary.

### Local validation (real history, not synthetic only)
- base = v3.45.0 tag vs HEAD → `new=0, resolved=11` — reproduces the RFC-002 lint ledger exactly.
- synthetic `import os, sys` appended to a src file → exit 1 with all 5 findings printed.
- auto-merge-base path (no args) resolves against `origin/master` → clean.

### The proof is this PR itself
Both jobs run on this very PR (pull_request workflows execute from the PR merge ref) — check the checks tab: green here means the gate gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3