### PR TITLE
RFC-004 P0: plan of record + tools-layer characterization contracts

### DIFF
--- a/docs/plans/tools-decomposition-plan.md
+++ b/docs/plans/tools-decomposition-plan.md
@@ -1,0 +1,81 @@
+# RFC-004: Tools Layer Decomposition (registry.py + executor.py)
+
+Status: R1 — APPROVED (Odin re-review LGTM, no remaining blockers; live inventory independently verified against master @ 7263c03).
+Campaign branch: `refactor/tools-decomposition` (created after plan approval).
+Predecessors: RFC-001 (client.py), RFC-002 (facade retirement, native_tools domains), RFC-003 (api.py + CI gate). This is the first campaign gated by CI from its first PR.
+
+## 1. Motivation
+
+`src/tools/registry.py` (1,978 lines) and `src/tools/executor.py` (1,893 lines) are now the two largest files in the codebase and form one system split across two monoliths. Every tool call from every pipeline funnels through `ToolExecutor.execute()`; the three most recent production bugs found in soak (spawn_loop_agents AttributeError, background-task failure visibility, RBAC wiring) lived in or around this layer. Adding a tool today means coordinated edits to a 1,978-line literal list and a 1,893-line class.
+
+## 2. Inventory (verified against master @ 7263c03)
+
+- **74 tools** in the `TOOLS` list (exact ordered names captured in the P0 contract). **Order is behavior**: `get_tool_definitions()` feeds the tool catalog → prompt assembly; reordering changes prompts.
+- **Two-tier dispatch** (`tool_loop.py:871`): `native_tools.handles(name)` → native table in `src/discord/native_tools/registry.py` (36 registered natives + 10 skill tools special-cased + user skills by name), else → `ToolExecutor.execute()`.
+- **28 executor-routed tools**, dispatched via `getattr(self, f"_handle_{tool_name}")` — string reflection, the pattern RFC-002 banned on the Discord side.
+- `execute()` is a **middleware pipeline** around the handlers: contextvars → RBAC `check_permission` → risk classification → timeout → `_try_tool` → recovery (hint/skip/retry, `UNSAFE_TO_RETRY`) → mutation annotation → result validation → `ToolResult` assembly. This pipeline is NOT moving.
+- **Narrow external surface**: `tools/__init__.py` re-exports `TOOLS`/`get_tool_definitions`; `skill_manager.py` reads `TOOLS` (read-only, `BUILTIN_TOOL_NAMES`); `web/api/observability.py` reads `get_tool_definitions`; `wiring.py` constructs `ToolExecutor` once. `invalidate_tool_defs_cache()` called by skill CRUD.
+- **Native side residue**: skill CRUD dispatch is inline `if/elif` inside `native_tools/registry.py` (lines ~155–230) — a hidden domain living in the dispatch-table file.
+
+## 3. Deliverables
+
+1. `registry.py` → `src/tools/defs/` package: section modules each owning a **contiguous slice** of the original TOOLS order (same model as api.py's section carve — sections are positional, not semantic, so concatenation reproduces exact order). `registry.py` becomes a composition root (< 250 lines): concatenates section lists, builds `TOOL_MAP`, keeps `get_tool_definitions()` + cache + invalidation with identical semantics.
+2. `executor.py` → middleware core + `src/tools/handlers/` domain modules. Core keeps: `execute()` pipeline, `_try_tool`, recovery, metrics, RBAC/governor/host-access wiring, SSH plumbing (`_exec_command`, `_run_on_host`, `_govern_command`, `_resolve_host`), contextvars, bulkheads. Handlers move to domain owners reached through an **explicit dispatch table of the native_tools shape** — `name → (owner_key, attr)` — with the handler **resolved via `getattr(owner, attr)` at CALL time, never pre-bound at `__init__`** (R1 blocker #1: pre-binding captures originals and breaks the `executor._handle_x = fake` patch seam — the RFC-003 `process_web_chat` failure mode). During migration waves an assertion verifies `getattr(self, f"_handle_{name}")` resolves to the same function the table resolves. The f-string `getattr` dispatch is retired and contract-banned only in the final phase.
+3. Handler domains (verbatim moves; ~28 handlers + their private helpers):
+   - `system.py`: run_command, run_script, run_command_multi, manage_process
+   - `files_docs.py`: read_file, write_file, analyze_pdf
+   - `browser_web.py`: browser_read_page/read_table/click/fill/evaluate, web_search, fetch_url, http_probe
+   - `coding.py`: claude_code (+ stream-JSON parser)
+   - `state.py`: memory_manage, manage_list (+ their persistence helpers)
+   - `devops.py`: git_ops, kubectl, docker_ops, terraform_ops
+   - `comms.py`: email_send/search/read/list_recent, issue_tracker
+   - `validation.py`: validate_action
+   Shared access via a frozen `HandlerDeps` — the ToolLoopDeps pattern; no `__init__(self, executor)` back-references. **R1 blocker #3 — explicit stateful inventory, identity-preserved:** exactly ONE `HandlerDeps` instance per executor, carrying the existing singletons by reference: `_memory_path` + `_memory_lock`, `_lists_lock`, browser manager, email config accessor, output streamer, `command_governor`, `host_access_manager`, `freshness_stats`/`risk_stats`/`recovery_stats`/`validation_stats`, current-tool-timeout accessor, user/tier contextvar accessors, `_resolve_host`/`_resolve_default_host`/`_run_on_host`/`_exec_command`/`_govern_command` as callables, ssh pool, bulkheads. Domain modules MUST NOT instantiate their own locks or stats objects — a P0 identity contract asserts the shared objects are the same `id()` before and after each wave (separate instances pass happy-path tests but ship deadlocks, races, and observability lies).
+4. Native residue cleanup: skill CRUD if/elif → `native_tools/skills_tools.py` domain module registered like the other five (scope-fenced: mechanical move of existing blocks, no behavior change).
+5. `src/tools/` package at **zero ruff findings** (absorbed per-wave, P6-style).
+
+## 4. Contracts (P0, before any carve)
+
+- **Tool-parity contract** (`tests/characterization/test_tool_parity.py`): exact ordered 74-name list; per-tool schema deep-equality against a pinned snapshot; `TOOL_MAP` completeness; `get_tool_definitions()` output identity + cache invalidation behavior.
+- **Registry mutability pins** (R1 advisory #3): `TOOLS` is module-level mutable and `TOOL_MAP` builds ONCE from it; `invalidate_tool_defs_cache()` clears the defs cache but does NOT rebuild `TOOL_MAP`. Pin these semantics exactly as they are — no accidental "improvement" during the carve.
+- **Dispatch-parity contract**: the executor-routed set (74 − native − skills = 28) each resolves to a handler; `handles()`/executor split pinned exactly; unknown-tool → `ok=False, error="unknown_tool"` preserved AND pinned to bypass RBAC/risk/timeout (handler-lookup failure returns before the middleware runs, as today); explicit table == legacy getattr resolution for every name.
+- **Patch-seam contract** (R1 blocker #2): a P0 test monkeypatches `executor._handle_run_command = fake` and asserts `execute("run_command", ...)` calls the fake — proving execution-time resolution. This test is re-pointed at the new owner attribute as each handler migrates and must pass in every phase; the invariant "handler resolved at execution time, not construction" holds campaign-wide.
+- **Native skill-dispatch pins** (R1 blocker #4, before the extraction phase): `handles()` truth table (registered natives, `SKILL_CRUD_TOOLS`, `list_skills`/`export_skill`/`skill_status`/`invoke_skill`, dynamic user-skill names); skill CRUD sets `effects.rebuild_system_prompt=True` and invalidates the tool catalog + skills-text cache; `invoke_skill` with missing required input fails loudly; file-delivery modes pinned (chat sends, loop stages, `export_skill` always stages).
+- **Middleware pins**: existing test_executor/test_tool_rbac/test_tool_timeouts suites stay green untouched (they are the middleware's characterization); add pins for the P0-audit gaps: tuple `(output, exit_code)` returns, `_ERROR_RESULT_PREFIXES` classification, recovery retry-once semantics, **contextvar isolation across concurrent `execute()` calls, permission-denial metrics increment, timeout path preserving `ToolResult.error`** (R1 advisory #6).
+- **HandlerDeps identity contract** (R1 blocker #3): shared singletons (locks, stats, browser manager) are identity-equal (`is`) through the deps object before and after every wave.
+
+## 5. Phases (each = one PR, Odin-reviewed, CI-gated; resequenced per R1 advisories #1–2)
+
+- **P0**: contracts + this plan committed. No production-code changes.
+- **P1**: registry carve (defs/ sections + composition root). Parity green.
+- **P2**: executor dispatch table introduced over UNMOVED handlers — `name → (owner_key, attr)` entries all pointing at the core owner, resolved by `getattr` at call time; f-string fallback retained + logged-if-hit; table-vs-getattr identity assertion. Behavior-identical wave.
+- **P3**: native skill-CRUD extraction to `native_tools/skills_tools.py` (moved earlier: independent of executor waves, and late skill regressions would churn — pinned by the P0 skill-dispatch contracts).
+- **P4**: handler wave 1 — `system.py` + `files_docs.py` (SSH plumbing seam proven first).
+- **P5**: handler wave 2 — `browser_web.py` + `coding.py` + `devops.py`.
+- **P6**: handler wave 3 — `state.py` (memory/list locks reviewed in isolation) + `comms.py` + `validation.py`; core slim-down.
+- **P7**: retire the f-string fallback; contract bans `_handle_`-string spellings outside the core — **the ban scan is AST/token-aware, not raw grep** (re-review advisory: must not flag fixture names, comments, or the intentional compat assertion in its removal phase); production startup assertions (R1 advisory #5: `len(TOOLS)==74`, no duplicate names, table keys == expected executor-routed set); final metrics; docs; soak deploy + two-battery protocol — round-2 MUST include the negative-path battery: unknown tool, RBAC-denied, host-access-denied run_command, tiny-timeout, nonzero exit, run_command_multi mixed success/failure, memory round-trip, skill CRUD+invoke, http_probe redirect safety, validate_action (R1 advisory #10). Sign-off report.
+
+## 6. Size targets & quality gates
+
+registry.py < 250 · executor.py **target < 700, hard ceiling 800** — coherence beats line-count theater (R1 advisory #9); middleware and shared plumbing stay core, tool-specific logic moves · each defs/ section < 400 · each handlers/ domain < 450 · native registry.py sheds the ~80-line skill blob. **Lint scope** (R1 blocker #5): `src/tools/` package to ZERO ruff findings; the two files P3 touches outside it (`native_tools/registry.py`, new `skills_tools.py`) also to zero; everything else rides the CI lint-no-new gate. Deliberate non-goals: no semantic regrouping of TOOLS order (sections are positional slices, never hand-curated domains — R1 advisory #4); no changes to middleware behavior, recovery policy, or the native/executor split; no tool additions/removals/renames; `analyze_pdf`'s helpers stay local to `files_docs.py` (advisory #7); browser/static-web stay one module unless size forces a split (advisory #8).
+
+## 7. Risks & mitigations
+
+- **Order sensitivity** → contiguous-slice sections + exact-order contract (the 183-route lesson).
+- **getattr dispatch is load-bearing and invisible to grep** → explicit table built and verified against getattr resolution before any handler moves (P2 gate), fallback retired only in P7.
+- **Handler tuple/str return duality** → middleware pins in P0; handlers move verbatim.
+- **Hidden helper coupling** (memory/list persistence, email cfg, SSH internals) → helpers move WITH their sole consumers; shared plumbing stays in core; import-cycle check per wave.
+- **Skill seam** (`skill_manager` ↔ registry cache) → `BUILTIN_TOOL_NAMES` and `invalidate_tool_defs_cache` semantics pinned in P0.
+- **Registrar-swallow class** (RFC-003 wave-1 near-miss) → executable composition assertions: every section list consumed exactly once, concatenation length == 74, every table entry bound exactly once.
+- **Patch-seam capture** (R1) → call-time getattr resolution + the P0 patch-seam contract re-pointed each wave.
+- **Deps identity drift** (R1) → HandlerDeps identity contract; domains banned from constructing locks/stats.
+- **Native skill side effects** (R1) → P0 pins on effects/cache-invalidation/file-delivery before P3 moves anything.
+- **Registry mutability surprise** (R1) → TOOLS/TOOL_MAP/cache semantics pinned as-is.
+
+## 8. Rollback
+
+Every phase is one revertable merge commit on the campaign branch; campaign→master is a single merge commit (`git revert -m1` path). Live install rides the campaign branch only during soak, master otherwise.
+
+## R1 amendment log (Odin plan review, 2026-07-05)
+
+Blockers, all fixed: **B1** dispatch table is late-bound `name → (owner_key, attr)` resolved at call time, never pre-bound (§3.2); **B2** patch-seam contract added to P0, re-pointed per wave (§4); **B3** HandlerDeps stateful inventory enumerated with identity contract (§3.3, §4); **B4** native skill-dispatch pins added to P0, gating the extraction (§4); **B5** lint scope stated precisely (§6). Advisories, all adopted: **A1** skill extraction resequenced to P3, ahead of handler waves; **A2** `state.py` split out of wave 1 into P6 for isolated lock review; **A3** TOOLS/TOOL_MAP mutability semantics pinned as-is; **A4** positional-slice discipline reaffirmed; **A5** production startup assertions in P7; **A6** middleware pins expanded (contextvars, denial metrics, timeout error, unknown-tool bypass); **A7** analyze_pdf helpers stay local; **A8** browser/static-web stay merged; **A9** executor core soft 700 / hard 800, no line-count theater; **A10** negative-path soak battery specified in P7. Path correction applied (`src/discord/native_tools/registry.py`). Re-review verdict: **LGTM, no remaining blockers**; final advisory adopted — P7 spelling-ban scan is AST/token-aware rather than raw grep.

--- a/tests/characterization/test_executor_dispatch_parity.py
+++ b/tests/characterization/test_executor_dispatch_parity.py
@@ -1,0 +1,266 @@
+"""RFC-004 P0 — executor dispatch-parity + middleware pins.
+
+Pins the three-way dispatch partition (native / skill / executor), the
+execution-time handler resolution (THE patch seam — R1 blocker #2), and
+the execute() middleware behaviors the carve must not disturb:
+unknown-tool short-circuit, RBAC denial shape + metrics, timeout shape
+(no retry), exception shape, tuple exit-code propagation, error-prefix
+classification, contextvar isolation across concurrent calls, and the
+special call shape for memory_manage/manage_list.
+
+The handler table introduced in P2 must resolve handlers via getattr at
+CALL time — every pin here must stay green when the f-string dispatch is
+replaced and when handlers move to domain owners (P4–P6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.config.schema import ToolsConfig
+from src.tools.executor import ToolExecutor, _user_id_ctx
+
+from .test_tool_parity import EXPECTED_TOOL_ORDER
+
+# --- The dispatch partition on master @ 7263c03 -----------------------------
+# 36 tools registered in the native table (src/discord/native_tools/registry.py,
+# register_native_handlers), dispatched Discord-side:
+NATIVE_REGISTERED = frozenset({
+    "add_reaction", "analyze_image", "browser_screenshot", "bulk_ingest_knowledge",
+    "cancel_task", "collect_loop_agents", "create_poll", "delegate_task",
+    "delete_knowledge", "delete_schedule", "generate_file", "generate_image",
+    "get_agent_results", "ingest_document", "kill_agent", "list_agents",
+    "list_knowledge", "list_loops", "list_schedules", "list_tasks",
+    "parse_time", "post_file", "purge_messages", "read_channel",
+    "schedule_task", "search_audit", "search_history", "search_knowledge",
+    "send_to_agent", "set_permission", "spawn_agent", "spawn_loop_agents",
+    "start_loop", "stop_loop", "update_schedule", "wait_for_agents",
+})
+
+# 10 skill tools special-cased by NativeToolDispatcher (CRUD + meta):
+SKILL_TOOLS = frozenset({
+    "create_skill", "edit_skill", "delete_skill", "enable_skill",
+    "disable_skill", "install_skill", "export_skill", "skill_status",
+    "list_skills", "invoke_skill",
+})
+
+# 28 tools that reach ToolExecutor.execute() — the set whose handlers the
+# P4–P6 waves move to domain modules:
+EXECUTOR_ROUTED = frozenset({
+    "run_command", "run_script", "run_command_multi", "read_file", "write_file",
+    "memory_manage", "manage_list", "manage_process",
+    "browser_read_page", "browser_read_table", "browser_click", "browser_fill",
+    "browser_evaluate", "web_search", "fetch_url", "http_probe",
+    "analyze_pdf", "claude_code",
+    "git_ops", "kubectl", "docker_ops", "terraform_ops",
+    "issue_tracker", "validate_action",
+    "email_send", "email_search", "email_read", "email_list_recent",
+})
+
+# Stateful attributes ToolExecutor owns today. The P4–P6 HandlerDeps must
+# carry THESE OBJECTS by reference (identity), never construct fresh ones
+# (R1 blocker #3). This inventory is the baseline the identity contract
+# extends as waves land.
+STATEFUL_ATTRS = [
+    "config", "_email_config", "_memory_path", "_browser_manager",
+    "_permission_manager", "output_streamer", "_host_access", "_metrics",
+    "_memory_lock", "_lists_lock", "risk_stats", "recovery_stats",
+    "validation_stats", "command_governor", "_recovery_enabled",
+    "freshness_stats", "_branch_freshness_enabled", "_current_tool_timeout",
+    "bulkheads", "ssh_pool",
+]
+
+
+def _executor(**kwargs) -> ToolExecutor:
+    return ToolExecutor(config=kwargs.pop("config", ToolsConfig()), **kwargs)
+
+
+class TestDispatchPartition:
+    def test_partition_is_exact(self):
+        all_names = set(EXPECTED_TOOL_ORDER)
+        assert NATIVE_REGISTERED | SKILL_TOOLS | EXECUTOR_ROUTED == all_names
+        assert not (NATIVE_REGISTERED & SKILL_TOOLS)
+        assert not (NATIVE_REGISTERED & EXECUTOR_ROUTED)
+        assert not (SKILL_TOOLS & EXECUTOR_ROUTED)
+        assert (len(NATIVE_REGISTERED), len(SKILL_TOOLS), len(EXECUTOR_ROUTED)) == (36, 10, 28)
+
+    def test_every_executor_tool_resolves_a_handler(self):
+        ex = _executor()
+        for name in sorted(EXECUTOR_ROUTED):
+            handler = getattr(ex, f"_handle_{name}", None)
+            assert callable(handler), f"no handler for executor-routed tool {name}"
+
+    def test_no_orphan_handlers(self):
+        defined = {
+            attr.removeprefix("_handle_")
+            for attr in vars(ToolExecutor)
+            if attr.startswith("_handle_")
+        }
+        assert defined == set(EXECUTOR_ROUTED), (
+            f"handler set drifted: extra={sorted(defined - EXECUTOR_ROUTED)} "
+            f"missing={sorted(EXECUTOR_ROUTED - defined)}"
+        )
+
+    def test_stateful_attr_inventory(self):
+        ex = _executor()
+        for attr in STATEFUL_ATTRS:
+            assert hasattr(ex, attr), f"stateful attr {attr} vanished from ToolExecutor"
+
+
+class TestUnknownTool:
+    async def test_unknown_tool_result_shape(self):
+        ex = _executor()
+        res = await ex.execute("no_such_tool", {})
+        assert res.ok is False
+        assert res.error == "unknown_tool"
+        assert res.output == "Unknown tool: no_such_tool"
+
+    async def test_unknown_tool_bypasses_middleware(self):
+        """Handler lookup happens BEFORE RBAC/risk/timeout — pinned."""
+        ex = _executor()
+
+        def _boom(*a, **k):  # pragma: no cover — must never run
+            raise AssertionError("middleware ran for unknown tool")
+
+        ex.check_permission = _boom
+        res = await ex.execute("no_such_tool", {})
+        assert res.ok is False and res.error == "unknown_tool"
+
+
+class TestPatchSeam:
+    """R1 blocker #2 — THE campaign-critical contract. Handlers must be
+    resolved at execution time so `executor._handle_x = fake` governs the
+    call. Re-point at the new owner attribute as each handler migrates."""
+
+    async def test_instance_patch_governs_execution(self):
+        ex = _executor()
+        calls = []
+
+        async def fake(tool_input):
+            calls.append(tool_input)
+            return "patched-ok"
+
+        ex._handle_run_command = fake
+        res = await ex.execute("run_command", {"command": "whoami"})
+        assert calls == [{"command": "whoami"}]
+        assert res.ok is True
+        assert res.output.strip() == "patched-ok"
+
+    async def test_memory_manage_receives_user_id_kwarg(self):
+        """memory_manage/manage_list get handler(input, user_id=…) — the
+        only special call shape in _try_tool. Pinned so the P2 table and
+        the P6 state.py move preserve it."""
+        ex = _executor()
+        seen = {}
+
+        async def fake(tool_input, *, user_id=None):
+            seen["user_id"] = user_id
+            return "ok"
+
+        ex._handle_memory_manage = fake
+        await ex.execute("memory_manage", {"action": "list"}, user_id="u-42")
+        assert seen["user_id"] == "u-42"
+
+
+class TestMiddlewarePins:
+    async def test_rbac_denial_shape_and_metrics(self):
+        class _Denier:
+            def allowed_tool_names(self, user_id):
+                return {"read_file"}
+
+            def get_tier(self, user_id):
+                return "guest"
+
+        ex = _executor(permission_manager=_Denier())
+        called = []
+
+        async def fake(tool_input):  # pragma: no cover — must never run
+            called.append(1)
+            return "nope"
+
+        ex._handle_run_command = fake
+        res = await ex.execute("run_command", {"command": "x"}, user_id="u1")
+        assert not called, "denied tool must not execute its handler"
+        assert res.ok is False
+        assert res.error == "permission_denied"
+        assert "Permission denied: tool 'run_command'" in res.output
+        assert "tier 'guest'" in res.output
+        assert ex._metrics["run_command"]["errors"] == 1
+
+    async def test_timeout_shape_no_retry(self):
+        ex = _executor(config=ToolsConfig(tool_timeouts={"run_command": 1}))
+        attempts = []
+
+        async def slow(tool_input):
+            attempts.append(1)
+            await asyncio.sleep(5)
+            return "never"
+
+        ex._handle_run_command = slow
+        res = await ex.execute("run_command", {"command": "x"})
+        assert len(attempts) == 1, "TIMEOUT is in _SKIP_RECOVERY — never retried"
+        assert res.ok is False
+        assert res.exit_code == -1
+        assert "timed out after 1s" in res.output
+        assert res.error and "timed out" in res.error
+        assert ex._metrics["run_command"]["timeouts"] == 1
+
+    async def test_exception_shape(self):
+        ex = _executor()
+
+        async def broken(tool_input):
+            raise ValueError("boom")
+
+        ex._handle_run_command = broken
+        res = await ex.execute("run_command", {"command": "x"})
+        assert res.ok is False
+        assert res.exit_code == -1
+        assert "Error executing run_command: boom" in res.output
+        assert ex._metrics["run_command"]["errors"] >= 1
+
+    async def test_tuple_exit_code_propagation(self):
+        ex = _executor()
+
+        async def with_code(tool_input):
+            return ("done (exit 3)", 3)
+
+        ex._handle_run_command = with_code
+        res = await ex.execute("run_command", {"command": "x"})
+        assert res.exit_code == 3
+        assert res.ok is False, "nonzero exit code marks the result as error"
+
+        async def clean(tool_input):
+            return ("fine", 0)
+
+        ex._handle_run_command = clean
+        res2 = await ex.execute("run_command", {"command": "x"})
+        assert res2.exit_code == 0 and res2.ok is True
+
+    async def test_error_prefix_classification(self):
+        ex = _executor()
+
+        async def stringly(tool_input):
+            return "Error: custom-unrecoverable-xyz"
+
+        ex._handle_run_command = stringly
+        res = await ex.execute("run_command", {"command": "x"})
+        assert res.ok is False
+        assert res.error.startswith("Error: custom-unrecoverable-xyz")
+
+    async def test_contextvar_isolation_concurrent(self):
+        """User identity is contextvar-backed and task-isolated: two
+        overlapping execute() calls must each observe their own caller."""
+        ex = _executor()
+
+        async def report_identity(tool_input):
+            await asyncio.sleep(0.05)  # force overlap
+            return f"uid={_user_id_ctx.get()}"
+
+        ex._handle_run_command = report_identity
+        ex._handle_run_script = report_identity
+        res_a, res_b = await asyncio.gather(
+            ex.execute("run_command", {"command": "x"}, user_id="alice"),
+            ex.execute("run_script", {"script": "y"}, user_id="bob"),
+        )
+        assert "uid=alice" in res_a.output
+        assert "uid=bob" in res_b.output

--- a/tests/characterization/test_native_skill_dispatch_pins.py
+++ b/tests/characterization/test_native_skill_dispatch_pins.py
@@ -1,0 +1,225 @@
+"""RFC-004 P0 — native skill-dispatch pins (R1 blocker #4).
+
+Pins the DISPATCH-LAYER behavior of the skill paths inside
+NativeToolDispatcher before P3 extracts them to skills_tools.py:
+
+- handles() truth table (registered natives, skill CRUD + meta, dynamic
+  user skills, and False for executor-routed tools)
+- skill CRUD side effects: tool_catalog.invalidate(), skills-text cache
+  cleared, effects.rebuild_system_prompt=True
+- invoke_skill loud failures (missing name / unknown skill / non-dict
+  input / missing required fields)
+- export_skill ALWAYS stages into channel_state.pending_files
+- file-delivery modes: "send" posts to the channel, "stage" appends to
+  pending_files
+
+These are dispatch pins, not skill_manager pins — the manager is stubbed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.discord.native_tools.registry import (
+    SKILL_CRUD_TOOLS,
+    NativeToolDispatcher,
+)
+
+from .test_executor_dispatch_parity import (
+    EXECUTOR_ROUTED,
+    NATIVE_REGISTERED,
+    SKILL_TOOLS,
+)
+
+
+def _dispatcher(**overrides) -> NativeToolDispatcher:
+    skill_manager = overrides.pop("skill_manager", None) or MagicMock()
+    tool_catalog = overrides.pop("tool_catalog", None) or MagicMock()
+    prompt_builder = overrides.pop("prompt_builder", None) or SimpleNamespace(
+        cached_skills_text="stale"
+    )
+    channel_state = overrides.pop("channel_state", None) or SimpleNamespace(
+        pending_files={}
+    )
+    return NativeToolDispatcher(
+        owners={},
+        skill_manager=skill_manager,
+        tool_catalog=tool_catalog,
+        prompt_builder=prompt_builder,
+        channel_state=channel_state,
+    )
+
+
+def _message(channel_id: int = 123):
+    msg = MagicMock()
+    msg.channel.id = channel_id
+    msg.channel.send = AsyncMock()
+    msg.author = "tester#1"
+    return msg
+
+
+class TestHandlesTruthTable:
+    def test_skill_names_always_handled(self):
+        d = _dispatcher()
+        d.skill_manager.has_skill = lambda name: False
+        for name in sorted(SKILL_TOOLS):
+            assert d.handles(name), f"{name} must be native-handled"
+
+    def test_dynamic_user_skill_names_handled(self):
+        d = _dispatcher()
+        d.skill_manager.has_skill = lambda name: name == "my_custom_skill"
+        assert d.handles("my_custom_skill")
+        assert not d.handles("someone_elses_skill")
+
+    def test_executor_routed_tools_not_handled(self):
+        d = _dispatcher()
+        d.skill_manager.has_skill = lambda name: False
+        for name in sorted(EXECUTOR_ROUTED):
+            assert not d.handles(name), f"{name} must fall through to ToolExecutor"
+
+    def test_wired_bot_handles_all_native_registrations(self):
+        """The fully-wired dispatcher answers True for every registered
+        native — the live half of the truth table."""
+        from src.config.schema import Config
+        from src.discord.client import OdinBot
+
+        bot = OdinBot(
+            Config(discord={"token": "pin-test"}, permissions={"default_tier": "admin"})
+        )
+        bot.native_tools.skill_manager.has_skill = lambda name: False
+        for name in sorted(NATIVE_REGISTERED):
+            assert bot.native_tools.handles(name), f"{name} missing from native table"
+        for name in sorted(EXECUTOR_ROUTED):
+            assert not bot.native_tools.handles(name), f"{name} wrongly native"
+
+
+class TestSkillCrudEffects:
+    CRUD_CALLS = {
+        "create_skill": ({"name": "s", "code": "c"}, "create_skill"),
+        "edit_skill": ({"name": "s", "code": "c"}, "edit_skill"),
+        "delete_skill": ({"name": "s"}, "delete_skill"),
+        "enable_skill": ({"name": "s"}, "enable_skill"),
+        "disable_skill": ({"name": "s"}, "disable_skill"),
+        "install_skill": ({"url": "https://example.com/skill.py"}, "install_from_url"),
+    }
+
+    @pytest.mark.parametrize("tool_name", sorted(SKILL_CRUD_TOOLS))
+    async def test_crud_invalidates_and_signals_rebuild(self, tool_name):
+        assert tool_name in self.CRUD_CALLS, "CRUD set drifted — update the pins"
+        tool_input, manager_method = self.CRUD_CALLS[tool_name]
+
+        sm = MagicMock()
+        sm.install_from_url = AsyncMock(return_value="installed")
+        for m in ("create_skill", "edit_skill", "delete_skill", "enable_skill", "disable_skill"):
+            setattr(sm, m, MagicMock(return_value=f"{m}-done"))
+
+        d = _dispatcher(skill_manager=sm)
+        result, effects = await d.dispatch(
+            tool_name, dict(tool_input), message=_message(), user_id="u",
+            skill_file_delivery="send",
+        )
+        assert getattr(sm, manager_method).called
+        assert effects.rebuild_system_prompt is True, f"{tool_name} must signal prompt rebuild"
+        assert d.tool_catalog.invalidate.called, f"{tool_name} must invalidate the tool catalog"
+        assert d.prompt_builder.cached_skills_text is None, f"{tool_name} must clear skills text"
+        assert result
+
+
+class TestInvokeSkillLoudFailures:
+    async def test_missing_name(self):
+        d = _dispatcher()
+        result, effects = await d.dispatch(
+            "invoke_skill", {}, message=_message(), user_id="u", skill_file_delivery="send",
+        )
+        assert result == "Error: invoke_skill requires 'name'."
+        assert effects.rebuild_system_prompt is False
+
+    async def test_unknown_skill(self):
+        d = _dispatcher()
+        d.skill_manager.has_skill = lambda name: False
+        result, _ = await d.dispatch(
+            "invoke_skill", {"name": "ghost"}, message=_message(), user_id="u",
+            skill_file_delivery="send",
+        )
+        assert "Error: skill 'ghost' not found or disabled" in result
+
+    async def test_non_dict_input(self):
+        d = _dispatcher()
+        d.skill_manager.has_skill = lambda name: True
+        result, _ = await d.dispatch(
+            "invoke_skill", {"name": "s", "input": "oops"}, message=_message(),
+            user_id="u", skill_file_delivery="send",
+        )
+        assert result == "Error: invoke_skill 'input' must be an object."
+
+    async def test_missing_required_fields_fail_loudly(self):
+        skill = SimpleNamespace(definition={"input_schema": {"required": ["target", "mode"]}})
+        sm = MagicMock()
+        sm.has_skill = lambda name: True
+        sm._skills = {"s": skill}
+        d = _dispatcher(skill_manager=sm)
+        result, _ = await d.dispatch(
+            "invoke_skill", {"name": "s", "input": {"target": "x"}},
+            message=_message(), user_id="u", skill_file_delivery="send",
+        )
+        assert "missing required fields" in result
+        assert "'mode'" in result
+        assert not sm.execute.called, "skill must NOT run with incomplete input"
+
+    async def test_complete_input_executes_with_callbacks(self):
+        skill = SimpleNamespace(definition={"input_schema": {"required": ["target"]}})
+        sm = MagicMock()
+        sm.has_skill = lambda name: True
+        sm._skills = {"s": skill}
+        sm.execute = AsyncMock(return_value="skill-ran")
+        d = _dispatcher(skill_manager=sm)
+        result, _ = await d.dispatch(
+            "invoke_skill", {"name": "s", "input": {"target": "x"}},
+            message=_message(), user_id="u", skill_file_delivery="stage",
+        )
+        assert result == "skill-ran"
+        kwargs = sm.execute.call_args.kwargs
+        assert callable(kwargs["message_callback"]) and callable(kwargs["file_callback"])
+
+
+class TestFileDelivery:
+    async def test_export_skill_always_stages(self):
+        sm = MagicMock()
+        sm.export_skill = MagicMock(return_value=(b"payload", "skill.py"))
+        d = _dispatcher(skill_manager=sm)
+        msg = _message(channel_id=777)
+        result, _ = await d.dispatch(
+            "export_skill", {"name": "s"}, message=msg, user_id="u",
+            skill_file_delivery="send",  # even in send mode, export stages
+        )
+        assert "exported as skill.py" in result
+        assert d.channel_state.pending_files["777"] == [(b"payload", "skill.py")]
+        assert not msg.channel.send.called
+
+    async def test_file_cb_stage_mode_appends_pending(self):
+        d = _dispatcher()
+        msg = _message(channel_id=42)
+        cb = d._skill_file_cb(msg, "stage")
+        await cb(b"data", "out.txt")
+        assert d.channel_state.pending_files["42"] == [(b"data", "out.txt")]
+        assert not msg.channel.send.called
+
+    async def test_file_cb_send_mode_posts_to_channel(self):
+        d = _dispatcher()
+        msg = _message(channel_id=42)
+        cb = d._skill_file_cb(msg, "send")
+        await cb(b"data", "out.txt", "caption")
+        assert msg.channel.send.called
+        assert d.channel_state.pending_files == {}
+
+    async def test_list_skills_empty_message(self):
+        sm = MagicMock()
+        sm.list_skills = MagicMock(return_value=[])
+        d = _dispatcher(skill_manager=sm)
+        result, _ = await d.dispatch(
+            "list_skills", {}, message=_message(), user_id="u", skill_file_delivery="send",
+        )
+        assert result == "No user-created skills."

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -1,0 +1,210 @@
+"""RFC-004 P0 — tool-parity contract for src/tools/registry.py.
+
+Pins the EXACT ordered tool list, per-tool schema content, TOOL_MAP
+semantics, and the get_tool_definitions() cache behavior BEFORE the
+registry carve (docs/plans/tools-decomposition-plan.md §4).
+
+ORDER IS BEHAVIOR: get_tool_definitions() feeds the tool catalog, which
+feeds prompt assembly — reordering TOOLS changes prompts. The carve must
+reproduce this list exactly, so sections are positional slices and their
+concatenation is asserted here.
+
+Registry mutability semantics are pinned AS THEY ARE (R1 advisory #3):
+TOOL_MAP builds once at import and is NOT rebuilt by cache invalidation;
+the defs cache re-reads the live TOOLS list after invalidate. Do not
+"fix" either behavior during the carve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from src.tools import registry
+from src.tools.registry import (
+    TOOL_MAP,
+    TOOLS,
+    get_tool_definitions,
+    invalidate_tool_defs_cache,
+)
+
+# The exact TOOLS order on master @ 7263c03 (74 tools). A failure here means
+# a tool was added, removed, renamed, or REORDERED — all of which are
+# out of scope for RFC-004 and must be deliberate, reviewed changes.
+EXPECTED_TOOL_ORDER = [
+    "run_command", "run_script", "run_command_multi", "read_file", "write_file",
+    "purge_messages", "post_file", "generate_file", "schedule_task", "list_schedules",
+    "update_schedule", "delete_schedule", "parse_time", "search_history", "memory_manage",
+    "search_audit", "create_skill", "edit_skill", "delete_skill", "list_skills",
+    "enable_skill", "disable_skill", "install_skill", "export_skill", "skill_status",
+    "invoke_skill", "delegate_task", "list_tasks", "cancel_task", "search_knowledge",
+    "ingest_document", "bulk_ingest_knowledge", "list_knowledge", "delete_knowledge",
+    "browser_screenshot", "browser_read_page", "browser_read_table", "browser_click",
+    "browser_fill", "browser_evaluate",
+    "web_search", "fetch_url", "claude_code", "set_permission", "analyze_pdf",
+    "read_channel", "add_reaction", "create_poll", "manage_process", "manage_list",
+    "analyze_image", "start_loop", "stop_loop", "list_loops", "spawn_agent",
+    "send_to_agent", "list_agents", "kill_agent", "get_agent_results", "wait_for_agents",
+    "spawn_loop_agents", "collect_loop_agents", "git_ops", "kubectl", "docker_ops",
+    "terraform_ops", "http_probe", "issue_tracker", "generate_image", "validate_action",
+    "email_send", "email_search", "email_read", "email_list_recent",
+]
+
+# sha256[:16] of each tool's canonical JSON (sort_keys, compact separators).
+# Deep-equality pin: ANY edit to a tool's schema/description flips its hash.
+EXPECTED_TOOL_HASHES = {
+    "run_command": "2b146575d0ff5c16",
+    "run_script": "61132f018a660518",
+    "run_command_multi": "f4666ed522cdd0b4",
+    "read_file": "fe043b1283771975",
+    "write_file": "8e409827499b2a64",
+    "purge_messages": "db35efc321c205b1",
+    "post_file": "6860faab30251338",
+    "generate_file": "2f4687a63e985fdd",
+    "schedule_task": "8ce8ebd429e7ad19",
+    "list_schedules": "6f72cb95cee9eb6c",
+    "update_schedule": "46f5e367a38afbbc",
+    "delete_schedule": "01e54d37b70471a8",
+    "parse_time": "6ae3f4c04138a2cd",
+    "search_history": "d3d173bfe5262866",
+    "memory_manage": "f7aa460db948c1d5",
+    "search_audit": "6fcb11f91a34bcb6",
+    "create_skill": "9eaddf122cc9c67d",
+    "edit_skill": "f4553310fb4d0d81",
+    "delete_skill": "b9cfb78dd6a38d2a",
+    "list_skills": "7be07140d1e6be5e",
+    "enable_skill": "3cd7bc0e5785ba0f",
+    "disable_skill": "f6183e060f3be137",
+    "install_skill": "98be50df8fb83d61",
+    "export_skill": "d223c6528f2c88bd",
+    "skill_status": "5177be67a7a1ae1e",
+    "invoke_skill": "f80a1610b5a49289",
+    "delegate_task": "05c99b6f11821d1c",
+    "list_tasks": "a81136a21dc48a2b",
+    "cancel_task": "aaffe5a4cdfa32e0",
+    "search_knowledge": "3e5555a61c0509da",
+    "ingest_document": "622541a401f80226",
+    "bulk_ingest_knowledge": "0427db261b28cd7e",
+    "list_knowledge": "4ea7f4f545878fdc",
+    "delete_knowledge": "73268085bef06627",
+    "browser_screenshot": "89e8d695b035d5f2",
+    "browser_read_page": "114732e75e12d257",
+    "browser_read_table": "dab744148b75846c",
+    "browser_click": "836c03f7acbc9f6d",
+    "browser_fill": "6c3832a67ec9f31e",
+    "browser_evaluate": "10ab6fb73e39e4b0",
+    "web_search": "387c3cf486568b5d",
+    "fetch_url": "15aa90cb901577fa",
+    "claude_code": "1b2355262f9db20c",
+    "set_permission": "c12a0a66bb423d59",
+    "analyze_pdf": "7006855cb4bf0b85",
+    "read_channel": "22d87d43b1ac97e2",
+    "add_reaction": "f466eef6573b0166",
+    "create_poll": "6fb64482c930284b",
+    "manage_process": "13de19d29edd55ba",
+    "manage_list": "1fe50a2ac7a59952",
+    "analyze_image": "8680a337769f8d09",
+    "start_loop": "67faa086c9b0987f",
+    "stop_loop": "d098afff69b3da0a",
+    "list_loops": "c811f88df56a3005",
+    "spawn_agent": "ee64e938a2fddccf",
+    "send_to_agent": "90eb251b4ab2f940",
+    "list_agents": "89bed3253e8298d8",
+    "kill_agent": "2543a3eeb5720fdf",
+    "get_agent_results": "82b266fc0e61b299",
+    "wait_for_agents": "b9ad3d97dacf1d46",
+    "spawn_loop_agents": "3168833df916d812",
+    "collect_loop_agents": "b4eddcf0e4e2edca",
+    "git_ops": "e87a7ab5d999cef3",
+    "kubectl": "aac8c396875dbaab",
+    "docker_ops": "7e7b5293a299aa8d",
+    "terraform_ops": "054cd8877208bc7d",
+    "http_probe": "dfc3b04b36c5e7f9",
+    "issue_tracker": "4f0a793414052b40",
+    "generate_image": "3df436d69f3b9169",
+    "validate_action": "199baeb4723517d7",
+    "email_send": "1282279440e34e6f",
+    "email_search": "3a7584b725d1c134",
+    "email_read": "c88d947b915f9cf0",
+    "email_list_recent": "f673907aa8906746",
+}
+
+
+def _canonical_hash(tool_def: dict) -> str:
+    return hashlib.sha256(
+        json.dumps(tool_def, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:16]
+
+
+class TestToolParity:
+    def test_exact_names_and_order(self):
+        actual = [t["name"] for t in TOOLS]
+        assert len(actual) == len(EXPECTED_TOOL_ORDER) == 74
+        missing = set(EXPECTED_TOOL_ORDER) - set(actual)
+        added = set(actual) - set(EXPECTED_TOOL_ORDER)
+        assert not missing and not added, (
+            f"tool set drifted:\nmissing={sorted(missing)}\nadded={sorted(added)}"
+        )
+        assert actual == EXPECTED_TOOL_ORDER, "TOOLS ORDER drifted — order is prompt behavior"
+
+    def test_no_duplicate_names(self):
+        names = [t["name"] for t in TOOLS]
+        assert len(names) == len(set(names))
+
+    def test_schema_deep_equality(self):
+        changed = [
+            t["name"] for t in TOOLS
+            if _canonical_hash(t) != EXPECTED_TOOL_HASHES[t["name"]]
+        ]
+        assert not changed, (
+            f"tool definitions changed content: {changed} — "
+            "schema/description edits are out of scope for the carve"
+        )
+
+    def test_tool_map_completeness_and_identity(self):
+        assert set(TOOL_MAP) == set(EXPECTED_TOOL_ORDER)
+        for t in TOOLS:
+            assert TOOL_MAP[t["name"]] is t, "TOOL_MAP values must BE the TOOLS entries"
+
+
+class TestRegistryMutabilitySemantics:
+    """Current semantics, pinned as-is (R1 advisory #3): TOOL_MAP builds once;
+    the defs cache rebuilds from the live TOOLS list on invalidation."""
+
+    def test_tool_map_static_but_defs_cache_rebuilds(self):
+        fake = {"name": "zz_parity_probe", "description": "probe", "input_schema": {}}
+        invalidate_tool_defs_cache()
+        baseline = get_tool_definitions()
+        assert all(d["name"] != "zz_parity_probe" for d in baseline)
+        TOOLS.append(fake)
+        try:
+            # TOOL_MAP was built at import — mutation does NOT appear there.
+            assert "zz_parity_probe" not in TOOL_MAP
+            # Cached defs also unchanged until invalidated…
+            assert get_tool_definitions() is baseline
+            # …but invalidation re-reads the live TOOLS list.
+            invalidate_tool_defs_cache()
+            rebuilt = get_tool_definitions()
+            assert any(d["name"] == "zz_parity_probe" for d in rebuilt)
+        finally:
+            TOOLS.remove(fake)
+            invalidate_tool_defs_cache()
+
+    def test_defs_cache_identity(self):
+        invalidate_tool_defs_cache()
+        first = get_tool_definitions()
+        assert get_tool_definitions() is first, "cache must return the same object"
+        invalidate_tool_defs_cache()
+        assert registry._tool_defs_cache is None
+
+    def test_defs_shape_and_schema_identity(self):
+        invalidate_tool_defs_cache()
+        defs = get_tool_definitions()
+        assert [d["name"] for d in defs] == EXPECTED_TOOL_ORDER
+        by_name = {t["name"]: t for t in TOOLS}
+        for d in defs:
+            src = by_name[d["name"]]
+            # input_schema passes through by REFERENCE (same object)…
+            assert d["input_schema"] is src["input_schema"]
+            # …while the description is affordance-decorated from the raw one.
+            assert src["description"] in d["description"]


### PR DESCRIPTION
## RFC-004 P0 — contracts only, no production code

Plan of record: `docs/plans/tools-decomposition-plan.md` — **R1, Odin plan-review LGTM** (5 blockers fixed incl. late-bound dispatch + patch-seam contract; all 11 advisories adopted incl. resequencing and the AST-aware ban scan).

**Three characterization contracts (40 tests), all green against unmodified code:**
- `test_tool_parity.py` — exact 74-tool order (order = prompt behavior), per-tool canonical-JSON schema hashes, TOOL_MAP completeness/identity, registry mutability + defs-cache semantics pinned AS-IS (TOOL_MAP builds once; cache rebuilds from live TOOLS on invalidation)
- `test_executor_dispatch_parity.py` — the 36/10/28 native/skill/executor partition; THE patch-seam contract (instance-attr patch governs execution — re-pointed per wave); unknown-tool short-circuits before RBAC/risk/timeout; RBAC denial shape + metrics; timeout no-retry shape; exception/tuple-exit-code/error-prefix shapes; contextvar isolation across concurrent calls; memory_manage user_id call shape; the 20-attr stateful inventory (HandlerDeps identity baseline)
- `test_native_skill_dispatch_pins.py` — handles() truth table (incl. wired-bot half), skill-CRUD invalidation + rebuild_system_prompt effects, invoke_skill loud failures, export always stages, send-vs-stage file callbacks

Full suite: **6,119 passed** (6,079 + 40 new). Lint: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3
