### PR TITLE
RFC-004 P2: explicit late-bound dispatch table over unmoved handlers

### DIFF
--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -106,6 +106,44 @@ def _build_bulkhead_registry(config: ToolsConfig) -> BulkheadRegistry:
     return registry
 
 
+# RFC-004 P2: explicit late-bound dispatch table — tool name -> (owner_key, attr).
+# Handlers are resolved via getattr(owner, attr) at CALL time, never pre-bound,
+# so instance-attribute patches (``executor._handle_x = fake``) keep governing
+# execution (the patch-seam contract in test_executor_dispatch_parity). All
+# entries point at the "core" owner until the P4–P6 waves rebind them to domain
+# owners. The characterization contract pins table keys == executor-routed set.
+EXECUTOR_HANDLERS: dict[str, tuple[str, str]] = {
+    "run_command": ("core", "_handle_run_command"),
+    "run_script": ("core", "_handle_run_script"),
+    "run_command_multi": ("core", "_handle_run_command_multi"),
+    "read_file": ("core", "_handle_read_file"),
+    "write_file": ("core", "_handle_write_file"),
+    "memory_manage": ("core", "_handle_memory_manage"),
+    "manage_list": ("core", "_handle_manage_list"),
+    "manage_process": ("core", "_handle_manage_process"),
+    "browser_read_page": ("core", "_handle_browser_read_page"),
+    "browser_read_table": ("core", "_handle_browser_read_table"),
+    "browser_click": ("core", "_handle_browser_click"),
+    "browser_fill": ("core", "_handle_browser_fill"),
+    "browser_evaluate": ("core", "_handle_browser_evaluate"),
+    "web_search": ("core", "_handle_web_search"),
+    "fetch_url": ("core", "_handle_fetch_url"),
+    "http_probe": ("core", "_handle_http_probe"),
+    "analyze_pdf": ("core", "_handle_analyze_pdf"),
+    "claude_code": ("core", "_handle_claude_code"),
+    "git_ops": ("core", "_handle_git_ops"),
+    "kubectl": ("core", "_handle_kubectl"),
+    "docker_ops": ("core", "_handle_docker_ops"),
+    "terraform_ops": ("core", "_handle_terraform_ops"),
+    "issue_tracker": ("core", "_handle_issue_tracker"),
+    "validate_action": ("core", "_handle_validate_action"),
+    "email_send": ("core", "_handle_email_send"),
+    "email_search": ("core", "_handle_email_search"),
+    "email_read": ("core", "_handle_email_read"),
+    "email_list_recent": ("core", "_handle_email_list_recent"),
+}
+
+
 class ToolExecutor:
     def __init__(
         self, config: ToolsConfig | None = None, memory_path: str | None = None,
@@ -122,6 +160,10 @@ class ToolExecutor:
         self._permission_manager = permission_manager
         self.output_streamer = output_streamer
         self._host_access = host_access_manager
+        # RFC-004 P2: owners for EXECUTOR_HANDLERS resolution. The P4–P6
+        # waves add domain-owner instances here; "core" stays the executor
+        # itself for middleware-adjacent handlers.
+        self._handler_owners: dict[str, object] = {"core": self}
         self._metrics: dict[str, dict[str, int]] = {}
         self._memory_lock = asyncio.Lock()
         self._lists_lock = asyncio.Lock()
@@ -201,8 +243,36 @@ class ToolExecutor:
             )
         return None
 
+    def _resolve_handler(self, tool_name: str):
+        """Resolve a tool handler at CALL time (RFC-004 P2).
+
+        Table-first: EXECUTOR_HANDLERS maps name -> (owner_key, attr) and the
+        handler is fetched with getattr(owner, attr) NOW — never pre-bound —
+        so instance-attribute patches keep governing execution. The legacy
+        f-string lookup remains as a logged fallback until P7 retires it.
+        """
+        entry = EXECUTOR_HANDLERS.get(tool_name)
+        # getattr: tolerate __init__-bypassing construction (ToolExecutor.__new__
+        # in older fixtures) — resolution then falls through to the legacy path,
+        # which is behavior-identical while every entry points at "core".
+        owners = getattr(self, "_handler_owners", None)
+        if entry is not None and owners is not None:
+            owner_key, attr = entry
+            owner = owners.get(owner_key)
+            if owner is not None:
+                handler = getattr(owner, attr, None)
+                if handler is not None:
+                    return handler
+        legacy = getattr(self, f"_handle_{tool_name}", None)
+        if legacy is not None:
+            log.warning(
+                "Tool %s resolved via legacy getattr fallback — missing EXECUTOR_HANDLERS entry",
+                tool_name,
+            )
+        return legacy
+
     async def execute(self, tool_name: str, tool_input: dict, *, user_id: str | None = None) -> ToolResult:
-        handler = getattr(self, f"_handle_{tool_name}", None)
+        handler = self._resolve_handler(tool_name)
         if handler is None:
             return ToolResult(output=f"Unknown tool: {tool_name}", ok=False, error="unknown_tool", tool_name=tool_name)
 

--- a/tests/characterization/test_executor_dispatch_parity.py
+++ b/tests/characterization/test_executor_dispatch_parity.py
@@ -107,6 +107,46 @@ class TestDispatchPartition:
             assert hasattr(ex, attr), f"stateful attr {attr} vanished from ToolExecutor"
 
 
+class TestDispatchTable:
+    """RFC-004 P2 — the explicit late-bound table must mirror the legacy
+    f-string resolution exactly (the migration bridge assertion), stay
+    call-time-resolved, and cover precisely the executor-routed set."""
+
+    def test_table_keys_match_executor_routed(self):
+        from src.tools.executor import EXECUTOR_HANDLERS
+
+        assert set(EXECUTOR_HANDLERS) == set(EXECUTOR_ROUTED)
+
+    def test_every_owner_key_bound(self):
+        from src.tools.executor import EXECUTOR_HANDLERS
+
+        ex = _executor()
+        for name, (owner_key, _attr) in EXECUTOR_HANDLERS.items():
+            assert owner_key in ex._handler_owners, f"{name}: unbound owner {owner_key!r}"
+
+    def test_table_resolution_identical_to_legacy_getattr(self):
+        """Bridge assertion (plan §3.2): for every entry, the table resolves
+        the SAME function the legacy f-string getattr would."""
+        from src.tools.executor import EXECUTOR_HANDLERS
+
+        ex = _executor()
+        for name, (owner_key, attr) in EXECUTOR_HANDLERS.items():
+            table_handler = getattr(ex._handler_owners[owner_key], attr)
+            legacy_handler = getattr(ex, f"_handle_{name}")
+            assert table_handler == legacy_handler, f"{name} diverged from legacy resolution"
+
+    async def test_table_resolves_instance_patch(self):
+        """The seam holds THROUGH the table: an instance-attribute patch on
+        the owner is what resolution returns."""
+        ex = _executor()
+
+        async def fake(tool_input):
+            return "table-seam-ok"
+
+        ex._handle_run_command = fake
+        assert ex._resolve_handler("run_command") is fake
+
+
 class TestUnknownTool:
     async def test_unknown_tool_result_shape(self):
         ex = _executor()


### PR DESCRIPTION
## RFC-004 P2 — late-bound dispatch table (behavior-identical wave)

`EXECUTOR_HANDLERS: dict[str, tuple[str, str]]` — 28 explicit `name → (owner_key, attr)` entries, all pointing at the `"core"` owner until the P4–P6 waves rebind them to domain owners. Resolution is `getattr(owner, attr)` at **call time** in `_resolve_handler`, never pre-bound — the shape your plan-review blocker #1 demanded, mirroring the native dispatcher.

- Legacy f-string getattr retained as a logged fallback (P7 retires it)
- Resolution tolerates `__init__`-bypassing fixtures (`ToolExecutor.__new__` in test_http_probe_ops) by falling through to the legacy path — identical behavior while every entry is core-bound
- **+4 contract tests**: table keys == executor-routed set · every owner_key bound · per-entry table-vs-legacy resolution identity (the migration bridge assertion) · patch-seam THROUGH the table

Full suite: **6,123 passed** · lint gate vs campaign base: **new=0** (the 50 pre-existing executor.py findings are untouched baseline, absorbed when the core slims in P4–P6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3
