### PR TITLE
RFC-004 P5: handler wave 2 — browser_web, coding, devops domains

### DIFF
--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import json
-import shlex
 from pathlib import Path
 
 from ..config.schema import ToolsConfig
@@ -91,20 +90,20 @@ EXECUTOR_HANDLERS: dict[str, tuple[str, str]] = {
     "memory_manage": ("core", "_handle_memory_manage"),
     "manage_list": ("core", "_handle_manage_list"),
     "manage_process": ("system", "_handle_manage_process"),
-    "browser_read_page": ("core", "_handle_browser_read_page"),
-    "browser_read_table": ("core", "_handle_browser_read_table"),
-    "browser_click": ("core", "_handle_browser_click"),
-    "browser_fill": ("core", "_handle_browser_fill"),
-    "browser_evaluate": ("core", "_handle_browser_evaluate"),
-    "web_search": ("core", "_handle_web_search"),
-    "fetch_url": ("core", "_handle_fetch_url"),
-    "http_probe": ("core", "_handle_http_probe"),
+    "browser_read_page": ("browser_web", "_handle_browser_read_page"),
+    "browser_read_table": ("browser_web", "_handle_browser_read_table"),
+    "browser_click": ("browser_web", "_handle_browser_click"),
+    "browser_fill": ("browser_web", "_handle_browser_fill"),
+    "browser_evaluate": ("browser_web", "_handle_browser_evaluate"),
+    "web_search": ("browser_web", "_handle_web_search"),
+    "fetch_url": ("browser_web", "_handle_fetch_url"),
+    "http_probe": ("browser_web", "_handle_http_probe"),
     "analyze_pdf": ("files_docs", "_handle_analyze_pdf"),
-    "claude_code": ("core", "_handle_claude_code"),
-    "git_ops": ("core", "_handle_git_ops"),
-    "kubectl": ("core", "_handle_kubectl"),
-    "docker_ops": ("core", "_handle_docker_ops"),
-    "terraform_ops": ("core", "_handle_terraform_ops"),
+    "claude_code": ("coding", "_handle_claude_code"),
+    "git_ops": ("devops", "_handle_git_ops"),
+    "kubectl": ("devops", "_handle_kubectl"),
+    "docker_ops": ("devops", "_handle_docker_ops"),
+    "terraform_ops": ("devops", "_handle_terraform_ops"),
     "issue_tracker": ("core", "_handle_issue_tracker"),
     "validate_action": ("core", "_handle_validate_action"),
     "email_send": ("core", "_handle_email_send"),
@@ -169,7 +168,10 @@ class ToolExecutor:
         # variable) — attribute lookup happens per call, so instance/class
         # monkeypatches on the executor keep governing domain behavior, and
         # stateful objects are reached by identity (R1 blocker #3).
+        from .handlers.browser_web import BrowserWebTools
+        from .handlers.coding import CodingTools
         from .handlers.deps import HandlerDeps
+        from .handlers.devops import DevOpsTools
         from .handlers.files_docs import FilesDocsTools
         from .handlers.system import SystemTools
 
@@ -180,6 +182,8 @@ class ToolExecutor:
             branch_freshness_enabled=lambda: self._branch_freshness_enabled,
             current_user_id=lambda: self._current_user_id,
             process_registry=lambda: self._ensure_process_registry(),
+            browser_manager=lambda: self._browser_manager,
+            bulkheads=lambda: self.bulkheads,
             resolve_host=lambda alias: self._resolve_host(alias),
             resolve_default_host=lambda user_id: self._resolve_default_host(user_id),
             govern_command=lambda command, host=None: self._govern_command(command, host),
@@ -192,6 +196,9 @@ class ToolExecutor:
         # the domain level, e.g. ``executor.system_tools._handle_run_command``.
         self.system_tools = SystemTools(self._handler_deps)
         self.files_docs_tools = FilesDocsTools(self._handler_deps)
+        self.browser_web_tools = BrowserWebTools(self._handler_deps)
+        self.coding_tools = CodingTools(self._handler_deps)
+        self.devops_tools = DevOpsTools(self._handler_deps)
         # Owners for EXECUTOR_HANDLERS resolution. "core" is the executor
         # itself for not-yet-moved handlers; domain owners are added as the
         # P4–P6 waves land.
@@ -199,6 +206,9 @@ class ToolExecutor:
             "core": self,
             "system": self.system_tools,
             "files_docs": self.files_docs_tools,
+            "browser_web": self.browser_web_tools,
+            "coding": self.coding_tools,
+            "devops": self.devops_tools,
         }
 
     @property
@@ -630,258 +640,13 @@ class ToolExecutor:
 
     # --- Browser tools (text-returning, screenshot handled in client.py) ---
 
-    async def _browser_with_bulkhead(self, coro):
-        """Wrap a browser coroutine with the browser bulkhead."""
-        bh = self.bulkheads.get("browser")
-        if bh:
-            try:
-                async with bh.acquire():
-                    return await coro
-            except BulkheadFullError:
-                return "Error: browser bulkhead full — too many concurrent browser operations"
-        return await coro
-
-    async def _handle_browser_read_page(self, inp: dict) -> str:
-        if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
-        from .browser import handle_browser_read_page
-
-        return await self._browser_with_bulkhead(
-            handle_browser_read_page(self._browser_manager, inp)
-        )
-
-    async def _handle_browser_read_table(self, inp: dict) -> str:
-        if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
-        from .browser import handle_browser_read_table
-
-        return await self._browser_with_bulkhead(
-            handle_browser_read_table(self._browser_manager, inp)
-        )
-
-    async def _handle_browser_click(self, inp: dict) -> str:
-        if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
-        from .browser import handle_browser_click
-
-        return await self._browser_with_bulkhead(handle_browser_click(self._browser_manager, inp))
-
-    async def _handle_browser_fill(self, inp: dict) -> str:
-        if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
-        from .browser import handle_browser_fill
-
-        return await self._browser_with_bulkhead(handle_browser_fill(self._browser_manager, inp))
-
-    async def _handle_browser_evaluate(self, inp: dict) -> str:
-        if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
-        from .browser import handle_browser_evaluate
-
-        return await self._browser_with_bulkhead(
-            handle_browser_evaluate(self._browser_manager, inp)
-        )
-
     # --- Web tools ---
-
-    async def _handle_web_search(self, inp: dict) -> str:
-        from .web import web_search
-
-        max_results = min(inp.get("max_results", 5), 10)
-        return await web_search(inp["query"], max_results=max_results)
-
-    async def _handle_fetch_url(self, inp: dict) -> str:
-        from .web import fetch_url
-
-        return await fetch_url(inp["url"])
 
     # --- PDF analysis ---
 
     # --- Process management ---
 
     # --- Claude Code ---
-
-    async def _handle_claude_code(self, inp: dict) -> str:
-        host = inp.get("host") or self.config.claude_code_host
-        if not host:
-            return "claude_code_host not configured in tools config"
-        working_dir = inp["working_directory"]
-        prompt = inp["prompt"]
-        allowed_tools = inp.get("allowed_tools")
-        allow_edits = inp.get("allow_edits", False)
-
-        resolved = self._resolve_host(host)
-        if not resolved:
-            return f"Unknown or disallowed host: {host}"
-        address, ssh_user, _os = resolved
-
-        claude_user = self.config.claude_code_user
-        import os
-
-        _already_claude_user = (os.getenv("USER", "") == claude_user) if claude_user else False
-        if allow_edits and not claude_user:
-            return "claude_code_user not configured — required for allow_edits=true"
-
-        import base64 as b64mod
-
-        encoded_prompt = b64mod.b64encode(prompt.encode()).decode()
-
-        claude_args = [
-            "claude",
-            "--print",
-            "--output-format stream-json",
-            "--verbose",
-            "--no-session-persistence",
-        ]
-        if allow_edits:
-            claude_args.append("--dangerously-skip-permissions")
-        if allowed_tools:
-            claude_args.append(f"--allowedTools {shlex.quote(allowed_tools)}")
-
-        claude_cmd = " ".join(claude_args)
-        safe_wd = shlex.quote(working_dir)
-
-        if allow_edits:
-            safe_user = shlex.quote(claude_user)
-            inner = (
-                f"cd {safe_wd} && echo '{encoded_prompt}' | base64 -d | timeout 3600 {claude_cmd}"
-            )
-            if _already_claude_user:
-                cmd = inner
-            else:
-                cmd = f"su - {safe_user} -c {shlex.quote(inner)}"
-        else:
-            cmd = f"cd {safe_wd} && echo '{encoded_prompt}' | base64 -d | timeout 3600 {claude_cmd}"
-
-        on_output = None
-        finish_cb = None
-        if self.output_streamer and self.output_streamer.is_enabled("claude_code"):
-            _, on_output, finish_cb = self.output_streamer.create_callback(
-                "claude_code",
-                channel_id=host,
-            )
-
-        code, output = await self._exec_command(
-            address,
-            cmd,
-            ssh_user,
-            timeout=3660,
-            on_output=on_output,
-        )
-        if finish_cb:
-            try:
-                await finish_cb()
-            except Exception:
-                pass
-
-        if code != 0:
-            return f"Claude Code failed (exit {code}):\n{output[-2000:]}"
-
-        response_text, activity = self._parse_claude_stream_json(output)
-
-        max_output = inp.get("max_output_chars", 6000)
-        if len(response_text) > max_output:
-            half = max_output // 2
-            response_text = response_text[:half] + "[... truncated ...]" + response_text[-half:]
-        return response_text + activity
-
-    @staticmethod
-    def _parse_claude_stream_json(raw_output: str) -> tuple[str, str]:
-        """Parse stream-json output into (response_text, activity_summary)."""
-        response_text = ""
-        tool_calls: list[dict] = []
-        cost = 0.0
-        num_turns = 0
-        duration_ms = 0
-
-        for line in raw_output.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                d = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            msg_type = d.get("type", "")
-
-            if msg_type == "assistant":
-                for block in (d.get("message") or {}).get("content", []):
-                    bt = block.get("type", "")
-                    if bt == "tool_use":
-                        inp = block.get("input", {})
-                        entry = {"tool": block.get("name", "?"), "input": inp}
-                        tool_calls.append(entry)
-
-            elif msg_type == "result":
-                response_text = d.get("result", "") or ""
-                cost = d.get("total_cost_usd", 0)
-                num_turns = d.get("num_turns", 0)
-                duration_ms = d.get("duration_ms", 0)
-
-        if not tool_calls and not cost:
-            return raw_output, ""
-
-        lines = ["\n\n--- claude_code activity ---"]
-        lines.append(
-            f"Turns: {num_turns} | Cost: ${cost:.4f} | Duration: {duration_ms / 1000:.1f}s"
-        )
-
-        reads = []
-        edits = []
-        writes = []
-        commands = []
-        other = []
-
-        for tc in tool_calls:
-            tool = tc["tool"]
-            inp = tc["input"]
-            if tool == "Read":
-                path = inp.get("file_path", "?")
-                if path not in reads:
-                    reads.append(path)
-            elif tool == "Edit":
-                path = inp.get("file_path", "?")
-                old = inp.get("old_string", "")
-                new = inp.get("new_string", "")
-                edits.append(f"{path}: '{old[:40]}' → '{new[:40]}'")
-            elif tool == "Write":
-                path = inp.get("file_path", "?")
-                size = len(inp.get("content", ""))
-                writes.append(f"{path} ({size} chars)")
-            elif tool in ("Bash", "bash"):
-                cmd = inp.get("command", "?")
-                commands.append(cmd[:100])
-            else:
-                desc = inp.get("description", "") or inp.get("query", "") or inp.get("pattern", "")
-                other.append(f"{tool}: {desc[:60]}" if desc else tool)
-
-        if reads:
-            shown = reads[:10]
-            extra = f" (+{len(reads) - 10} more)" if len(reads) > 10 else ""
-            lines.append(f"Files read: {', '.join(shown)}{extra}")
-        if edits:
-            lines.append("Files edited:")
-            for e in edits[:8]:
-                lines.append(f"  {e}")
-            if len(edits) > 8:
-                lines.append(f"  (+{len(edits) - 8} more)")
-        if writes:
-            lines.append(f"Files written: {', '.join(writes[:8])}")
-        if commands:
-            lines.append("Commands run:")
-            for c in commands[:8]:
-                lines.append(f"  $ {c}")
-            if len(commands) > 8:
-                lines.append(f"  (+{len(commands) - 8} more)")
-        if other:
-            lines.append(f"Other tools: {', '.join(other[:8])}")
-
-        activity = "\n".join(lines)
-        if len(activity) > 2000:
-            activity = activity[:1997] + "..."
-
-        return response_text, activity
 
     def set_user_context(self, user_id: str | None) -> None:
         """Deprecated: user_id is now passed directly to execute().
@@ -1291,165 +1056,6 @@ class ToolExecutor:
             lines.append(f"{i}. {done_mark}{strike}{suffix}")
         return "\n".join(lines)
 
-    async def _handle_git_ops(self, inp: dict) -> str:
-        from .git_ops import ALLOWED_ACTIONS, build_git_command
-
-        action = inp.get("action", "")
-        if action not in ALLOWED_ACTIONS:
-            return f"Unknown git action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
-
-        host = inp.get("host", "")
-        resolved = self._resolve_host(host)
-        if not resolved:
-            return f"Unknown or disallowed host: {host}"
-        address, ssh_user, _os = resolved
-
-        params = inp.get("params") or {}
-
-        try:
-            cmds = build_git_command(action, params)
-        except ValueError as e:
-            return f"git_ops error: {e}"
-
-        if action == "push":
-            freshness_cmd, push_cmd = cmds
-            allowed, denial, _ = self._govern_command(push_cmd, host)
-            if not allowed:
-                return denial
-            code, output = await self._exec_command(
-                address,
-                freshness_cmd,
-                ssh_user,
-            )
-            if code != 0:
-                return f"Branch freshness check failed (exit {code}):\n{output}", code
-            if output.strip().startswith("STALE:"):
-                return f"Push blocked — {output.strip().split(':', 1)[1].strip()}", 1
-            code, output = await self._exec_command(
-                address,
-                push_cmd,
-                ssh_user,
-            )
-            if code != 0:
-                return f"Push failed (exit {code}):\n{_truncate_lines(output)}", code
-            return (
-                _truncate_lines(output) if output.strip() else "Push completed successfully."
-            ), 0
-        else:
-            cmd = cmds
-            allowed, denial, _ = self._govern_command(cmd, host)
-            if not allowed:
-                return denial
-            code, output = await self._exec_command(address, cmd, ssh_user)
-            if code != 0:
-                return f"git {action} failed (exit {code}):\n{_truncate_lines(output)}", code
-            return (
-                _truncate_lines(output)
-                if output.strip()
-                else f"git {action} completed successfully."
-            ), 0
-
-    async def _handle_kubectl(self, inp: dict) -> str:
-        from .kubectl_ops import ALLOWED_ACTIONS as KUBECTL_ACTIONS, build_kubectl_command
-
-        action = inp.get("action", "")
-        if action not in KUBECTL_ACTIONS:
-            return (
-                f"Unknown kubectl action: {action}. Allowed: {', '.join(sorted(KUBECTL_ACTIONS))}"
-            )
-
-        host = inp.get("host", "")
-        resolved = self._resolve_host(host)
-        if not resolved:
-            return f"Unknown or disallowed host: {host}"
-        address, ssh_user, _os = resolved
-
-        params = inp.get("params") or {}
-
-        try:
-            cmd = build_kubectl_command(action, params)
-        except ValueError as e:
-            return f"kubectl error: {e}"
-
-        allowed, denial, _ = self._govern_command(cmd, host)
-        if not allowed:
-            return denial
-
-        code, output = await self._exec_command(address, cmd, ssh_user)
-        if code != 0:
-            return f"kubectl {action} failed (exit {code}):\n{_truncate_lines(output)}", code
-        return (
-            _truncate_lines(output)
-            if output.strip()
-            else f"kubectl {action} completed successfully."
-        ), 0
-
-    async def _handle_docker_ops(self, inp: dict) -> str:
-        from .docker_ops import ALLOWED_ACTIONS as DOCKER_ACTIONS, build_docker_command
-
-        action = inp.get("action", "")
-        if action not in DOCKER_ACTIONS:
-            return f"Unknown docker action: {action}. Allowed: {', '.join(sorted(DOCKER_ACTIONS))}"
-
-        host = inp.get("host", "")
-        resolved = self._resolve_host(host)
-        if not resolved:
-            return f"Unknown or disallowed host: {host}"
-        address, ssh_user, _os = resolved
-
-        params = inp.get("params") or {}
-
-        try:
-            cmd = build_docker_command(action, params)
-        except ValueError as e:
-            return f"docker_ops error: {e}"
-
-        allowed, denial, _ = self._govern_command(cmd, host)
-        if not allowed:
-            return denial
-
-        code, output = await self._exec_command(address, cmd, ssh_user)
-        if code != 0:
-            return f"docker {action} failed (exit {code}):\n{_truncate_lines(output)}", code
-        return (
-            _truncate_lines(output)
-            if output.strip()
-            else f"docker {action} completed successfully."
-        ), 0
-
-    async def _handle_terraform_ops(self, inp: dict) -> str:
-        from .terraform_ops import ALLOWED_ACTIONS as TF_ACTIONS, build_terraform_command
-
-        action = inp.get("action", "")
-        if action not in TF_ACTIONS:
-            return f"Unknown terraform action: {action}. Allowed: {', '.join(sorted(TF_ACTIONS))}"
-
-        host = inp.get("host", "")
-        resolved = self._resolve_host(host)
-        if not resolved:
-            return f"Unknown or disallowed host: {host}"
-        address, ssh_user, _os = resolved
-
-        params = inp.get("params") or {}
-
-        try:
-            cmd = build_terraform_command(action, params)
-        except ValueError as e:
-            return f"terraform_ops error: {e}"
-
-        allowed, denial, _ = self._govern_command(cmd, host)
-        if not allowed:
-            return denial
-
-        code, output = await self._exec_command(address, cmd, ssh_user)
-        if code != 0:
-            return f"terraform {action} failed (exit {code}):\n{_truncate_lines(output)}", code
-        return (
-            _truncate_lines(output)
-            if output.strip()
-            else f"terraform {action} completed successfully."
-        ), 0
-
     async def _handle_issue_tracker(self, inp: dict) -> str:
         action = inp.get("action", "")
         if not action:
@@ -1474,29 +1080,6 @@ class ToolExecutor:
             from ..llm.secret_scrubber import scrub_output_secrets
 
             return f"issue_tracker error: {scrub_output_secrets(str(e))}"
-
-    async def _handle_http_probe(self, inp: dict) -> str:
-        from .http_probe_ops import build_http_probe_command
-
-        host = inp.get("host", "")
-        if host:
-            resolved = self._resolve_host(host)
-            if not resolved:
-                return f"Unknown or disallowed host: {host}"
-            address, ssh_user, _os = resolved
-        else:
-            address = "127.0.0.1"
-            ssh_user = "root"
-
-        try:
-            cmd = build_http_probe_command(inp)
-        except ValueError as e:
-            return f"http_probe error: {e}"
-
-        code, output = await self._exec_command(address, cmd, ssh_user)
-        if code != 0 and not output.strip():
-            return f"http_probe failed (exit {code}): curl returned no output"
-        return _truncate_lines(output) if output.strip() else "http_probe: no response received"
 
     async def _handle_validate_action(self, inp: dict) -> str:
         from .post_validation import (

--- a/src/tools/handlers/browser_web.py
+++ b/src/tools/handlers/browser_web.py
@@ -1,0 +1,104 @@
+"""Browser & web handler domain — browser_read_page/read_table/click/fill/
+evaluate, web_search, fetch_url, http_probe (RFC-004 P5, wave 2).
+
+Bodies moved VERBATIM from executor.py; the only mechanical adjustment is
+lazy relative imports re-anchored one level (``.browser`` → ``..browser``
+etc.). Browser-session and static-HTTP tools deliberately share one module
+(plan advisory #8 — don't split unless size forces it).
+"""
+
+from __future__ import annotations
+
+from ..bulkhead import BulkheadFullError
+from ..tool_text import _truncate_lines
+from .deps import HandlerBase
+
+
+class BrowserWebTools(HandlerBase):
+    async def _browser_with_bulkhead(self, coro):
+        """Wrap a browser coroutine with the browser bulkhead."""
+        bh = self.bulkheads.get("browser")
+        if bh:
+            try:
+                async with bh.acquire():
+                    return await coro
+            except BulkheadFullError:
+                return "Error: browser bulkhead full — too many concurrent browser operations"
+        return await coro
+
+    async def _handle_browser_read_page(self, inp: dict) -> str:
+        if not self._browser_manager:
+            return "Browser automation is not enabled. Set browser.enabled=true in config."
+        from ..browser import handle_browser_read_page
+
+        return await self._browser_with_bulkhead(
+            handle_browser_read_page(self._browser_manager, inp)
+        )
+
+    async def _handle_browser_read_table(self, inp: dict) -> str:
+        if not self._browser_manager:
+            return "Browser automation is not enabled. Set browser.enabled=true in config."
+        from ..browser import handle_browser_read_table
+
+        return await self._browser_with_bulkhead(
+            handle_browser_read_table(self._browser_manager, inp)
+        )
+
+    async def _handle_browser_click(self, inp: dict) -> str:
+        if not self._browser_manager:
+            return "Browser automation is not enabled. Set browser.enabled=true in config."
+        from ..browser import handle_browser_click
+
+        return await self._browser_with_bulkhead(handle_browser_click(self._browser_manager, inp))
+
+    async def _handle_browser_fill(self, inp: dict) -> str:
+        if not self._browser_manager:
+            return "Browser automation is not enabled. Set browser.enabled=true in config."
+        from ..browser import handle_browser_fill
+
+        return await self._browser_with_bulkhead(handle_browser_fill(self._browser_manager, inp))
+
+    async def _handle_browser_evaluate(self, inp: dict) -> str:
+        if not self._browser_manager:
+            return "Browser automation is not enabled. Set browser.enabled=true in config."
+        from ..browser import handle_browser_evaluate
+
+        return await self._browser_with_bulkhead(
+            handle_browser_evaluate(self._browser_manager, inp)
+        )
+
+    # --- Web tools ---
+
+    async def _handle_web_search(self, inp: dict) -> str:
+        from ..web import web_search
+
+        max_results = min(inp.get("max_results", 5), 10)
+        return await web_search(inp["query"], max_results=max_results)
+
+    async def _handle_fetch_url(self, inp: dict) -> str:
+        from ..web import fetch_url
+
+        return await fetch_url(inp["url"])
+
+    async def _handle_http_probe(self, inp: dict) -> str:
+        from ..http_probe_ops import build_http_probe_command
+
+        host = inp.get("host", "")
+        if host:
+            resolved = self._resolve_host(host)
+            if not resolved:
+                return f"Unknown or disallowed host: {host}"
+            address, ssh_user, _os = resolved
+        else:
+            address = "127.0.0.1"
+            ssh_user = "root"
+
+        try:
+            cmd = build_http_probe_command(inp)
+        except ValueError as e:
+            return f"http_probe error: {e}"
+
+        code, output = await self._exec_command(address, cmd, ssh_user)
+        if code != 0 and not output.strip():
+            return f"http_probe failed (exit {code}): curl returned no output"
+        return _truncate_lines(output) if output.strip() else "http_probe: no response received"

--- a/src/tools/handlers/coding.py
+++ b/src/tools/handlers/coding.py
@@ -1,0 +1,197 @@
+"""Coding-agent handler domain — claude_code (RFC-004 P5, wave 2).
+
+Body moved VERBATIM from executor.py (no adjustments needed — its lazy
+imports are absolute). ``_parse_claude_stream_json`` moves with its sole
+consumer (plan advisory #7).
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+
+from .deps import HandlerBase
+
+
+class CodingTools(HandlerBase):
+    async def _handle_claude_code(self, inp: dict) -> str:
+        host = inp.get("host") or self.config.claude_code_host
+        if not host:
+            return "claude_code_host not configured in tools config"
+        working_dir = inp["working_directory"]
+        prompt = inp["prompt"]
+        allowed_tools = inp.get("allowed_tools")
+        allow_edits = inp.get("allow_edits", False)
+
+        resolved = self._resolve_host(host)
+        if not resolved:
+            return f"Unknown or disallowed host: {host}"
+        address, ssh_user, _os = resolved
+
+        claude_user = self.config.claude_code_user
+        import os
+
+        _already_claude_user = (os.getenv("USER", "") == claude_user) if claude_user else False
+        if allow_edits and not claude_user:
+            return "claude_code_user not configured — required for allow_edits=true"
+
+        import base64 as b64mod
+
+        encoded_prompt = b64mod.b64encode(prompt.encode()).decode()
+
+        claude_args = [
+            "claude",
+            "--print",
+            "--output-format stream-json",
+            "--verbose",
+            "--no-session-persistence",
+        ]
+        if allow_edits:
+            claude_args.append("--dangerously-skip-permissions")
+        if allowed_tools:
+            claude_args.append(f"--allowedTools {shlex.quote(allowed_tools)}")
+
+        claude_cmd = " ".join(claude_args)
+        safe_wd = shlex.quote(working_dir)
+
+        if allow_edits:
+            safe_user = shlex.quote(claude_user)
+            inner = (
+                f"cd {safe_wd} && echo '{encoded_prompt}' | base64 -d | timeout 3600 {claude_cmd}"
+            )
+            if _already_claude_user:
+                cmd = inner
+            else:
+                cmd = f"su - {safe_user} -c {shlex.quote(inner)}"
+        else:
+            cmd = f"cd {safe_wd} && echo '{encoded_prompt}' | base64 -d | timeout 3600 {claude_cmd}"
+
+        on_output = None
+        finish_cb = None
+        if self.output_streamer and self.output_streamer.is_enabled("claude_code"):
+            _, on_output, finish_cb = self.output_streamer.create_callback(
+                "claude_code",
+                channel_id=host,
+            )
+
+        code, output = await self._exec_command(
+            address,
+            cmd,
+            ssh_user,
+            timeout=3660,
+            on_output=on_output,
+        )
+        if finish_cb:
+            try:
+                await finish_cb()
+            except Exception:
+                pass
+
+        if code != 0:
+            return f"Claude Code failed (exit {code}):\n{output[-2000:]}"
+
+        response_text, activity = self._parse_claude_stream_json(output)
+
+        max_output = inp.get("max_output_chars", 6000)
+        if len(response_text) > max_output:
+            half = max_output // 2
+            response_text = response_text[:half] + "[... truncated ...]" + response_text[-half:]
+        return response_text + activity
+
+    @staticmethod
+    def _parse_claude_stream_json(raw_output: str) -> tuple[str, str]:
+        """Parse stream-json output into (response_text, activity_summary)."""
+        response_text = ""
+        tool_calls: list[dict] = []
+        cost = 0.0
+        num_turns = 0
+        duration_ms = 0
+
+        for line in raw_output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            msg_type = d.get("type", "")
+
+            if msg_type == "assistant":
+                for block in (d.get("message") or {}).get("content", []):
+                    bt = block.get("type", "")
+                    if bt == "tool_use":
+                        inp = block.get("input", {})
+                        entry = {"tool": block.get("name", "?"), "input": inp}
+                        tool_calls.append(entry)
+
+            elif msg_type == "result":
+                response_text = d.get("result", "") or ""
+                cost = d.get("total_cost_usd", 0)
+                num_turns = d.get("num_turns", 0)
+                duration_ms = d.get("duration_ms", 0)
+
+        if not tool_calls and not cost:
+            return raw_output, ""
+
+        lines = ["\n\n--- claude_code activity ---"]
+        lines.append(
+            f"Turns: {num_turns} | Cost: ${cost:.4f} | Duration: {duration_ms / 1000:.1f}s"
+        )
+
+        reads = []
+        edits = []
+        writes = []
+        commands = []
+        other = []
+
+        for tc in tool_calls:
+            tool = tc["tool"]
+            inp = tc["input"]
+            if tool == "Read":
+                path = inp.get("file_path", "?")
+                if path not in reads:
+                    reads.append(path)
+            elif tool == "Edit":
+                path = inp.get("file_path", "?")
+                old = inp.get("old_string", "")
+                new = inp.get("new_string", "")
+                edits.append(f"{path}: '{old[:40]}' → '{new[:40]}'")
+            elif tool == "Write":
+                path = inp.get("file_path", "?")
+                size = len(inp.get("content", ""))
+                writes.append(f"{path} ({size} chars)")
+            elif tool in ("Bash", "bash"):
+                cmd = inp.get("command", "?")
+                commands.append(cmd[:100])
+            else:
+                desc = inp.get("description", "") or inp.get("query", "") or inp.get("pattern", "")
+                other.append(f"{tool}: {desc[:60]}" if desc else tool)
+
+        if reads:
+            shown = reads[:10]
+            extra = f" (+{len(reads) - 10} more)" if len(reads) > 10 else ""
+            lines.append(f"Files read: {', '.join(shown)}{extra}")
+        if edits:
+            lines.append("Files edited:")
+            for e in edits[:8]:
+                lines.append(f"  {e}")
+            if len(edits) > 8:
+                lines.append(f"  (+{len(edits) - 8} more)")
+        if writes:
+            lines.append(f"Files written: {', '.join(writes[:8])}")
+        if commands:
+            lines.append("Commands run:")
+            for c in commands[:8]:
+                lines.append(f"  $ {c}")
+            if len(commands) > 8:
+                lines.append(f"  (+{len(commands) - 8} more)")
+        if other:
+            lines.append(f"Other tools: {', '.join(other[:8])}")
+
+        activity = "\n".join(lines)
+        if len(activity) > 2000:
+            activity = activity[:1997] + "..."
+
+        return response_text, activity

--- a/src/tools/handlers/deps.py
+++ b/src/tools/handlers/deps.py
@@ -34,6 +34,8 @@ class HandlerDeps:
     branch_freshness_enabled: Callable[[], bool]
     current_user_id: Callable[[], str | None]
     process_registry: Callable[[], Any]  # lazy-inits ON the executor (web API reads it there)
+    browser_manager: Callable[[], Any]
+    bulkheads: Callable[[], Any]
     # method passthroughs (resolve the executor attr per call)
     resolve_host: Callable[..., Any]
     resolve_default_host: Callable[..., Any]
@@ -78,6 +80,14 @@ class HandlerBase:
     @property
     def _current_user_id(self) -> str | None:
         return self._deps.current_user_id()
+
+    @property
+    def _browser_manager(self):
+        return self._deps.browser_manager()
+
+    @property
+    def bulkheads(self):
+        return self._deps.bulkheads()
 
     def _process_registry(self):
         """The executor-owned ProcessRegistry (lazy-inited there — the web

--- a/src/tools/handlers/devops.py
+++ b/src/tools/handlers/devops.py
@@ -1,0 +1,176 @@
+"""DevOps handler domain — git_ops, kubectl, docker_ops, terraform_ops
+(RFC-004 P5, wave 2).
+
+Bodies moved VERBATIM from executor.py; the only mechanical adjustment is
+lazy relative imports re-anchored one level (``.git_ops`` → ``..git_ops``
+etc.).
+"""
+
+from __future__ import annotations
+
+from ..tool_text import _truncate_lines
+from .deps import HandlerBase
+
+
+class DevOpsTools(HandlerBase):
+    async def _handle_git_ops(self, inp: dict) -> str:
+        from ..git_ops import ALLOWED_ACTIONS, build_git_command
+
+        action = inp.get("action", "")
+        if action not in ALLOWED_ACTIONS:
+            return f"Unknown git action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
+
+        host = inp.get("host", "")
+        resolved = self._resolve_host(host)
+        if not resolved:
+            return f"Unknown or disallowed host: {host}"
+        address, ssh_user, _os = resolved
+
+        params = inp.get("params") or {}
+
+        try:
+            cmds = build_git_command(action, params)
+        except ValueError as e:
+            return f"git_ops error: {e}"
+
+        if action == "push":
+            freshness_cmd, push_cmd = cmds
+            allowed, denial, _ = self._govern_command(push_cmd, host)
+            if not allowed:
+                return denial
+            code, output = await self._exec_command(
+                address,
+                freshness_cmd,
+                ssh_user,
+            )
+            if code != 0:
+                return f"Branch freshness check failed (exit {code}):\n{output}", code
+            if output.strip().startswith("STALE:"):
+                return f"Push blocked — {output.strip().split(':', 1)[1].strip()}", 1
+            code, output = await self._exec_command(
+                address,
+                push_cmd,
+                ssh_user,
+            )
+            if code != 0:
+                return f"Push failed (exit {code}):\n{_truncate_lines(output)}", code
+            return (
+                _truncate_lines(output) if output.strip() else "Push completed successfully."
+            ), 0
+        else:
+            cmd = cmds
+            allowed, denial, _ = self._govern_command(cmd, host)
+            if not allowed:
+                return denial
+            code, output = await self._exec_command(address, cmd, ssh_user)
+            if code != 0:
+                return f"git {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+            return (
+                _truncate_lines(output)
+                if output.strip()
+                else f"git {action} completed successfully."
+            ), 0
+
+    async def _handle_kubectl(self, inp: dict) -> str:
+        from ..kubectl_ops import ALLOWED_ACTIONS as KUBECTL_ACTIONS
+        from ..kubectl_ops import build_kubectl_command
+
+        action = inp.get("action", "")
+        if action not in KUBECTL_ACTIONS:
+            return (
+                f"Unknown kubectl action: {action}. Allowed: {', '.join(sorted(KUBECTL_ACTIONS))}"
+            )
+
+        host = inp.get("host", "")
+        resolved = self._resolve_host(host)
+        if not resolved:
+            return f"Unknown or disallowed host: {host}"
+        address, ssh_user, _os = resolved
+
+        params = inp.get("params") or {}
+
+        try:
+            cmd = build_kubectl_command(action, params)
+        except ValueError as e:
+            return f"kubectl error: {e}"
+
+        allowed, denial, _ = self._govern_command(cmd, host)
+        if not allowed:
+            return denial
+
+        code, output = await self._exec_command(address, cmd, ssh_user)
+        if code != 0:
+            return f"kubectl {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+        return (
+            _truncate_lines(output)
+            if output.strip()
+            else f"kubectl {action} completed successfully."
+        ), 0
+
+    async def _handle_docker_ops(self, inp: dict) -> str:
+        from ..docker_ops import ALLOWED_ACTIONS as DOCKER_ACTIONS
+        from ..docker_ops import build_docker_command
+
+        action = inp.get("action", "")
+        if action not in DOCKER_ACTIONS:
+            return f"Unknown docker action: {action}. Allowed: {', '.join(sorted(DOCKER_ACTIONS))}"
+
+        host = inp.get("host", "")
+        resolved = self._resolve_host(host)
+        if not resolved:
+            return f"Unknown or disallowed host: {host}"
+        address, ssh_user, _os = resolved
+
+        params = inp.get("params") or {}
+
+        try:
+            cmd = build_docker_command(action, params)
+        except ValueError as e:
+            return f"docker_ops error: {e}"
+
+        allowed, denial, _ = self._govern_command(cmd, host)
+        if not allowed:
+            return denial
+
+        code, output = await self._exec_command(address, cmd, ssh_user)
+        if code != 0:
+            return f"docker {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+        return (
+            _truncate_lines(output)
+            if output.strip()
+            else f"docker {action} completed successfully."
+        ), 0
+
+    async def _handle_terraform_ops(self, inp: dict) -> str:
+        from ..terraform_ops import ALLOWED_ACTIONS as TF_ACTIONS
+        from ..terraform_ops import build_terraform_command
+
+        action = inp.get("action", "")
+        if action not in TF_ACTIONS:
+            return f"Unknown terraform action: {action}. Allowed: {', '.join(sorted(TF_ACTIONS))}"
+
+        host = inp.get("host", "")
+        resolved = self._resolve_host(host)
+        if not resolved:
+            return f"Unknown or disallowed host: {host}"
+        address, ssh_user, _os = resolved
+
+        params = inp.get("params") or {}
+
+        try:
+            cmd = build_terraform_command(action, params)
+        except ValueError as e:
+            return f"terraform_ops error: {e}"
+
+        allowed, denial, _ = self._govern_command(cmd, host)
+        if not allowed:
+            return denial
+
+        code, output = await self._exec_command(address, cmd, ssh_user)
+        if code != 0:
+            return f"terraform {action} failed (exit {code}):\n{_truncate_lines(output)}", code
+        return (
+            _truncate_lines(output)
+            if output.strip()
+            else f"terraform {action} completed successfully."
+        ), 0

--- a/tests/test_bulkhead.py
+++ b/tests/test_bulkhead.py
@@ -372,7 +372,7 @@ class TestExecutorBulkheadIntegration:
 
         with patch("src.tools.browser.handle_browser_read_page", new_callable=AsyncMock) as mock_handler:
             mock_handler.return_value = "page content"
-            result = await ex._handle_browser_read_page({"url": "http://example.com"})
+            result = await ex.browser_web_tools._handle_browser_read_page({"url": "http://example.com"})
             assert str(result) == "page content"
             assert browser_bh.total == 1
 

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -718,19 +718,19 @@ class TestHandleDockerOps:
     @pytest.mark.asyncio
     async def test_unknown_host(self):
         ex = _make_executor()
-        result = await ex._handle_docker_ops({"host": "nope", "action": "ps"})
+        result = await ex.devops_tools._handle_docker_ops({"host": "nope", "action": "ps"})
         assert "Unknown or disallowed host" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_unknown_action(self):
         ex = _make_executor()
-        result = await ex._handle_docker_ops({"host": "prod", "action": "nope"})
+        result = await ex.devops_tools._handle_docker_ops({"host": "prod", "action": "nope"})
         assert "Unknown docker action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_missing_action(self):
         ex = _make_executor()
-        result = await ex._handle_docker_ops({"host": "prod"})
+        result = await ex.devops_tools._handle_docker_ops({"host": "prod"})
         assert "Unknown docker action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
@@ -738,7 +738,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "CONTAINER ID  IMAGE  STATUS\nabc  nginx  Up")
-            result = await ex._handle_docker_ops({"host": "prod", "action": "ps"})
+            result = await ex.devops_tools._handle_docker_ops({"host": "prod", "action": "ps"})
         assert "nginx" in (result[0] if isinstance(result, tuple) else result)
         mock_exec.assert_awaited_once()
         cmd_arg = mock_exec.call_args[0][1]
@@ -749,7 +749,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "abc123")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "run",
                 "params": {"image": "nginx", "detach": True},
             })
@@ -760,7 +760,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "file.txt")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "exec",
                 "params": {"container": "web", "command": "ls"},
             })
@@ -771,7 +771,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "log line 1\nlog line 2")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "logs",
                 "params": {"container": "web"},
             })
@@ -782,7 +782,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "Successfully built abc123")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "build",
                 "params": {"tag": "myapp:latest"},
             })
@@ -793,7 +793,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "Status: Downloaded newer image")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "pull",
                 "params": {"image": "nginx:latest"},
             })
@@ -804,7 +804,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "web")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "stop",
                 "params": {"container": "web"},
             })
@@ -815,7 +815,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "web")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "rm",
                 "params": {"container": "web"},
             })
@@ -826,7 +826,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, '{"State": {"Status": "running"}}')
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "inspect",
                 "params": {"target": "web"},
             })
@@ -837,7 +837,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "CONTAINER  CPU%  MEM%")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "stats",
                 "params": {},
             })
@@ -848,7 +848,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "Creating web_1 ... done")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "compose_up",
                 "params": {},
             })
@@ -859,7 +859,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "Stopping web_1 ... done")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "compose_down",
                 "params": {},
             })
@@ -870,7 +870,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "NAME  STATUS\nweb  running")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "compose_ps",
                 "params": {},
             })
@@ -881,7 +881,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "web_1  | Starting server")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "compose_logs",
                 "params": {},
             })
@@ -892,7 +892,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (1, "Error: No such container: web")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "logs",
                 "params": {"container": "web"},
             })
@@ -902,7 +902,7 @@ class TestHandleDockerOps:
     @pytest.mark.asyncio
     async def test_validation_error(self):
         ex = _make_executor()
-        result = await ex._handle_docker_ops({
+        result = await ex.devops_tools._handle_docker_ops({
             "host": "prod", "action": "run", "params": {},
         })
         assert "docker_ops error" in (result[0] if isinstance(result, tuple) else result)
@@ -912,7 +912,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "ps", "params": {},
             })
         assert "completed successfully" in (result[0] if isinstance(result, tuple) else result)
@@ -922,7 +922,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "docker ps output")
-            result = await ex._handle_docker_ops({
+            result = await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "ps",
             })
         assert "docker ps output" in (result[0] if isinstance(result, tuple) else result)
@@ -932,7 +932,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "ok")
-            await ex._handle_docker_ops({
+            await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "ps", "params": {},
             })
         _, kwargs = mock_exec.call_args if mock_exec.call_args.kwargs else (mock_exec.call_args[0], {})
@@ -945,7 +945,7 @@ class TestHandleDockerOps:
         ex = _make_executor()
         with patch.object(ex, "_exec_command", new_callable=AsyncMock) as mock_exec:
             mock_exec.return_value = (0, "ok")
-            await ex._handle_docker_ops({
+            await ex.devops_tools._handle_docker_ops({
                 "host": "prod", "action": "ps", "params": {},
             })
         mock_exec.assert_awaited_once()

--- a/tests/test_http_probe_ops.py
+++ b/tests/test_http_probe_ops.py
@@ -628,7 +628,7 @@ class TestHandleHttpProbe:
         config.tools.tool_timeouts = {}
         config.tools.tool_timeout_seconds = 300
 
-        exec_inst = ToolExecutor.__new__(ToolExecutor)
+        exec_inst = ToolExecutor()
         exec_inst.config = config
         exec_inst._metrics = {}
         exec_inst._permission_manager = None
@@ -648,7 +648,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_local_probe_no_host(self, executor):
-        result = await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         executor._exec_command.assert_called_once()
@@ -657,7 +657,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_remote_probe_with_host(self, executor):
-        result = await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
             "host": "web",
         })
@@ -667,7 +667,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_unknown_host(self, executor):
-        result = await executor._handle_http_probe({
+        result = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
             "host": "nohost",
         })
@@ -675,7 +675,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_correct_ssh_user(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
             "host": "web",
         })
@@ -684,7 +684,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_local_uses_default_ssh_user(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         ssh_user = executor._exec_command.call_args[0][2]
@@ -692,7 +692,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_curl_command_built(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
             "method": "POST",
         })
@@ -702,20 +702,20 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_validation_error_returned(self, executor):
-        result = await executor._handle_http_probe({
+        result = await executor.browser_web_tools._handle_http_probe({
             "url": "ftp://example.com",
         })
         assert "http_probe error" in result
 
     @pytest.mark.asyncio
     async def test_missing_url_error(self, executor):
-        result = await executor._handle_http_probe({})
+        result = await executor.browser_web_tools._handle_http_probe({})
         assert "http_probe error" in result
 
     @pytest.mark.asyncio
     async def test_command_failure_with_output(self, executor):
         executor._exec_command.return_value = (7, "curl: (7) Failed to connect")
-        result = await executor._handle_http_probe({
+        result = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         assert "Failed to connect" in result
@@ -723,7 +723,7 @@ class TestHandleHttpProbe:
     @pytest.mark.asyncio
     async def test_command_failure_no_output(self, executor):
         executor._exec_command.return_value = (1, "")
-        result = await executor._handle_http_probe({
+        result = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         assert "http_probe failed" in result
@@ -732,7 +732,7 @@ class TestHandleHttpProbe:
     @pytest.mark.asyncio
     async def test_empty_success(self, executor):
         executor._exec_command.return_value = (0, "")
-        result = await executor._handle_http_probe({
+        result = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         assert "no response received" in result
@@ -743,7 +743,7 @@ class TestHandleHttpProbe:
             0,
             "HTTP/1.1 200 OK\nContent-Type: text/plain\n\nHello"
         )
-        result = await executor._handle_http_probe({
+        result = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         assert "HTTP/1.1 200 OK" in result
@@ -751,7 +751,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_get_dispatch(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
         cmd = executor._exec_command.call_args[0][1]
@@ -760,7 +760,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_post_with_body_dispatch(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://api.example.com/data",
             "method": "POST",
             "body": '{"key": "val"}',
@@ -773,7 +773,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_retries_dispatch(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
             "retries": 3,
             "retry_delay": 2,
@@ -784,7 +784,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_ssl_off_dispatch(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://self-signed.example.com",
             "verify_ssl": False,
         })
@@ -793,7 +793,7 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_no_redirects_dispatch(self, executor):
-        await executor._handle_http_probe({
+        await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
             "follow_redirects": False,
         })

--- a/tests/test_terraform_ops.py
+++ b/tests/test_terraform_ops.py
@@ -644,7 +644,7 @@ class TestHandleTerraformOps:
         config.tools.tool_timeouts = {}
         config.tools.tool_timeout_seconds = 300
 
-        exec_inst = ToolExecutor.__new__(ToolExecutor)
+        exec_inst = ToolExecutor()
         exec_inst.config = config
         exec_inst._metrics = {}
         exec_inst._permission_manager = None
@@ -660,7 +660,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_unknown_host(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "nohost",
             "action": "plan",
         })
@@ -668,7 +668,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_unknown_action(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "deploy",
         })
@@ -676,14 +676,14 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_missing_action(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
         })
         assert "Unknown terraform action" in (result[0] if isinstance(result, tuple) else result)
 
     @pytest.mark.asyncio
     async def test_init_dispatch(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "init",
         })
@@ -694,7 +694,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_plan_dispatch(self, executor):
-        result = await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "plan",
             "params": {"out": "tf.plan"},
@@ -705,7 +705,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_apply_dispatch(self, executor):
-        result = await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "apply",
             "params": {"plan_file": "tf.plan"},
@@ -716,7 +716,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_apply_validation_error(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "apply",
             "params": {},
@@ -726,7 +726,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_output_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "output",
             "params": {"json": True},
@@ -737,7 +737,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_show_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "show",
             "params": {"plan_file": "tf.plan"},
@@ -747,7 +747,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_validate_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "validate",
         })
@@ -756,7 +756,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_fmt_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "fmt",
             "params": {"check": True},
@@ -767,7 +767,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_state_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "state",
             "params": {"subaction": "list"},
@@ -777,7 +777,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_workspace_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "workspace",
             "params": {"subaction": "select", "name": "prod"},
@@ -787,7 +787,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_import_dispatch(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "import",
             "params": {"address": "aws_instance.web", "id": "i-abc123"},
@@ -800,7 +800,7 @@ class TestHandleTerraformOps:
     @pytest.mark.asyncio
     async def test_command_failure(self, executor):
         executor._exec_command.return_value = (1, "Error: No configuration files")
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "init",
         })
@@ -810,7 +810,7 @@ class TestHandleTerraformOps:
     @pytest.mark.asyncio
     async def test_empty_output(self, executor):
         executor._exec_command.return_value = (0, "")
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "validate",
         })
@@ -818,7 +818,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_no_params_default(self, executor):
-        result = await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "plan",
         })
@@ -827,7 +827,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_correct_ssh_user(self, executor):
-        await executor._handle_terraform_ops({
+        await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "plan",
         })
@@ -837,7 +837,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_state_validation_error(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "state",
             "params": {"subaction": "show"},
@@ -847,7 +847,7 @@ class TestHandleTerraformOps:
 
     @pytest.mark.asyncio
     async def test_import_validation_error(self, executor):
-        result = await executor._handle_terraform_ops({
+        result = await executor.devops_tools._handle_terraform_ops({
             "host": "infra",
             "action": "import",
             "params": {"address": "aws_instance.web"},


### PR DESCRIPTION
## RFC-004 P5 — handler wave 2: browser_web + coding + devops

13 handlers leave `ToolExecutor` behind the same late-resolving `HandlerDeps` seam wave 1 proved:
- `browser_web.py`: the 5 browser handlers + `_browser_with_bulkhead`, `web_search`, `fetch_url`, `http_probe` (browser + static web deliberately share one module — plan advisory #8)
- `coding.py`: `claude_code` + `_parse_claude_stream_json` (sole consumer travels along)
- `devops.py`: `git_ops`, `kubectl`, `docker_ops`, `terraform_ops`

- `HandlerDeps` gains two live accessors (`browser_manager`, `bulkheads`) — same closure-over-executor pattern
- Only declared adjustment: lazy relative imports re-anchored one level (AST-identical otherwise)
- 13 table entries rebound; public owners `browser_web_tools` / `coding_tools` / `devops_tools` per the P4 convention
- Direct-call sites re-pointed in terraform/docker/http_probe/bulkhead tests; the last two `__new__`-bypass fixtures now construct properly; 5 newly-unused `result =` assignments dropped; orphaned `shlex` import removed

`executor.py` 1,530 → **1,298** · Full suite **6,125 passed** · lint gate **new=0** (8 more pre-existing resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3
