### PR TITLE
RFC-004 P7: fallback retirement, AST spelling ban, startup assertions, package zero-lint

### DIFF
--- a/docs/plans/tools-decomposition-plan.md
+++ b/docs/plans/tools-decomposition-plan.md
@@ -76,6 +76,18 @@ registry.py < 250 · executor.py **target < 700, hard ceiling 800** — coherenc
 
 Every phase is one revertable merge commit on the campaign branch; campaign→master is a single merge commit (`git revert -m1` path). Live install rides the campaign branch only during soak, master otherwise.
 
+## R2 — results (code-complete, 2026-07-06)
+
+**Registry**: `registry.py` 1,978 → **84 lines** (composition root + TOOL_MAP + defs cache + startup dup-assertion); 9 positional section modules in `src/tools/defs/` (129–326 lines each). Exact 74-tool order held throughout — every one of the 135 inherited long-line rewraps proven value-identical by the schema-hash contract.
+
+**Executor**: `executor.py` 1,893 → **~730 lines** — the middleware core (execute pipeline, `_try_tool`, recovery, RBAC/risk, SSH plumbing, contextvars, memory persistence primitives) plus the dispatch table. ALL 28 handlers live in 8 domain modules in `src/tools/handlers/` (system, files_docs, browser_web, coding, devops, state, comms, validation — each < 320 lines) behind the late-resolving `HandlerDeps` seam; domain owners are public attributes. The f-string dispatch is retired: the table is the only class-level path, the executor-instance `__dict__` override remains the sanctioned patch seam, and the characterization contract's AST scan permits exactly ONE dynamic `_handle_` spelling in src/ (the resolver's probe).
+
+**Native residue**: skill CRUD/meta/invoke dispatch extracted to `native_tools/skills_tools.py` (registry.py 324 → 193).
+
+**Quality**: `src/tools/` package + touched native files at **ZERO ruff findings** (~230 pre-existing findings resolved campaign-wide, incl. 7 verified StrEnum conversions); suite 6,079 → **6,12x green** throughout (+40 P0 contracts and wave additions); every phase PR CI-gated, new=0 at every step.
+
+**Declared deviations from R1**: (1) the production startup assertion pins INVARIANTS (no duplicate tool names; every table entry resolves on its owner at construction) rather than the literal `len(TOOLS)==74` — a hardcoded count in prod would fail the next legitimate tool addition in the wrong place; the 74-count/order pin lives in the characterization contract where changing it is a reviewed edit. (2) The historical executor-instance patch seam was RETAINED via `__dict__`-override precedence instead of re-pointing the 13+ existing patch sites — strictly better than the planned re-pointing (zero churn on patchers, both seams live).
+
 ## R1 amendment log (Odin plan review, 2026-07-05)
 
 Blockers, all fixed: **B1** dispatch table is late-bound `name → (owner_key, attr)` resolved at call time, never pre-bound (§3.2); **B2** patch-seam contract added to P0, re-pointed per wave (§4); **B3** HandlerDeps stateful inventory enumerated with identity contract (§3.3, §4); **B4** native skill-dispatch pins added to P0, gating the extraction (§4); **B5** lint scope stated precisely (§6). Advisories, all adopted: **A1** skill extraction resequenced to P3, ahead of handler waves; **A2** `state.py` split out of wave 1 into P6 for isolated lock review; **A3** TOOLS/TOOL_MAP mutability semantics pinned as-is; **A4** positional-slice discipline reaffirmed; **A5** production startup assertions in P7; **A6** middleware pins expanded (contextvars, denial metrics, timeout error, unknown-tool bypass); **A7** analyze_pdf helpers stay local; **A8** browser/static-web stay merged; **A9** executor core soft 700 / hard 800, no line-count theater; **A10** negative-path soak battery specified in P7. Path correction applied (`src/discord/native_tools/registry.py`). Re-review verdict: **LGTM, no remaining blockers**; final advisory adopted — P7 spelling-ban scan is AST/token-aware rather than raw grep.

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,12 +1,17 @@
-from .registry import TOOLS, get_tool_definitions
 from .executor import ToolExecutor
+from .mcp_client import MCPManager
 from .output_streamer import StreamChunk, ToolOutputStreamer
+from .registry import TOOLS, get_tool_definitions
 from .result_validator import ToolResult
 from .skill_manager import SkillManager
-from .mcp_client import MCPManager
 
 __all__ = [
-    "TOOLS", "get_tool_definitions", "ToolExecutor", "ToolResult",
-    "StreamChunk", "ToolOutputStreamer",
-    "SkillManager", "MCPManager",
+    "TOOLS",
+    "get_tool_definitions",
+    "ToolExecutor",
+    "ToolResult",
+    "StreamChunk",
+    "ToolOutputStreamer",
+    "SkillManager",
+    "MCPManager",
 ]

--- a/src/tools/affordances.py
+++ b/src/tools/affordances.py
@@ -21,30 +21,30 @@ to query — it reads alongside the normal description.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class Cost(str, Enum):
-    FREE = "free"          # in-process, no I/O
-    LOW = "low"            # local filesystem / short local subprocess
-    MEDIUM = "medium"      # one network round-trip or one SSH call
-    HIGH = "high"          # many calls / large I/O / browser page
+class Cost(StrEnum):
+    FREE = "free"  # in-process, no I/O
+    LOW = "low"  # local filesystem / short local subprocess
+    MEDIUM = "medium"  # one network round-trip or one SSH call
+    HIGH = "high"  # many calls / large I/O / browser page
     VERY_HIGH = "very_high"  # LLM-in-tool, multi-file analysis
 
 
-class Risk(str, Enum):
-    NONE = "none"          # read-only, no state change
-    LOW = "low"             # mostly read-only / reversible state change
-    MEDIUM = "medium"       # state change, but scoped/reversible
-    HIGH = "high"           # potentially destructive / side-effecty
-    CRITICAL = "critical"   # destructive by design (delete, kill, purge)
+class Risk(StrEnum):
+    NONE = "none"  # read-only, no state change
+    LOW = "low"  # mostly read-only / reversible state change
+    MEDIUM = "medium"  # state change, but scoped/reversible
+    HIGH = "high"  # potentially destructive / side-effecty
+    CRITICAL = "critical"  # destructive by design (delete, kill, purge)
 
 
-class Latency(str, Enum):
-    INSTANT = "instant"    # in-process, <10ms
-    FAST = "fast"          # tens of ms to a few seconds
-    SECONDS = "seconds"    # typical one-off network/SSH call
-    MINUTES = "minutes"    # large analysis, orchestrated workflows
+class Latency(StrEnum):
+    INSTANT = "instant"  # in-process, <10ms
+    FAST = "fast"  # tens of ms to a few seconds
+    SECONDS = "seconds"  # typical one-off network/SSH call
+    MINUTES = "minutes"  # large analysis, orchestrated workflows
     UNBOUNDED = "unbounded"  # depends on target (loops, agents)
 
 
@@ -63,26 +63,43 @@ class Affordance:
 # ---------------------------------------------------------------------------
 _CATEGORY_DEFAULTS: list[tuple[str, Affordance]] = [
     # Shell execution on remote hosts
-    ("run_command", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS,
-        ("managed host alias configured", "SSH key available for non-local hosts"))),
-    ("run_script", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS,
-        ("managed host alias configured",))),
-    ("run_command_multi", Affordance(Cost.HIGH, Risk.HIGH, Latency.SECONDS,
-        ("managed host aliases configured",))),
+    (
+        "run_command",
+        Affordance(
+            Cost.MEDIUM,
+            Risk.HIGH,
+            Latency.SECONDS,
+            ("managed host alias configured", "SSH key available for non-local hosts"),
+        ),
+    ),
+    (
+        "run_script",
+        Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS, ("managed host alias configured",)),
+    ),
+    (
+        "run_command_multi",
+        Affordance(Cost.HIGH, Risk.HIGH, Latency.SECONDS, ("managed host aliases configured",)),
+    ),
     # File I/O
-    ("read_file", Affordance(Cost.LOW, Risk.NONE, Latency.FAST,
-        ("path accessible by ssh user",))),
-    ("write_file", Affordance(Cost.LOW, Risk.HIGH, Latency.FAST,
-        ("path writable by ssh user",))),
+    ("read_file", Affordance(Cost.LOW, Risk.NONE, Latency.FAST, ("path accessible by ssh user",))),
+    ("write_file", Affordance(Cost.LOW, Risk.HIGH, Latency.FAST, ("path writable by ssh user",))),
     # Browser
-    ("browser_read_", Affordance(Cost.MEDIUM, Risk.LOW, Latency.SECONDS,
-        ("browser session initialized",))),
-    ("browser_click", Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.SECONDS,
-        ("browser session initialized",))),
-    ("browser_fill", Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.SECONDS,
-        ("browser session initialized",))),
-    ("browser_evaluate", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS,
-        ("browser session initialized",))),
+    (
+        "browser_read_",
+        Affordance(Cost.MEDIUM, Risk.LOW, Latency.SECONDS, ("browser session initialized",)),
+    ),
+    (
+        "browser_click",
+        Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.SECONDS, ("browser session initialized",)),
+    ),
+    (
+        "browser_fill",
+        Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.SECONDS, ("browser session initialized",)),
+    ),
+    (
+        "browser_evaluate",
+        Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS, ("browser session initialized",)),
+    ),
     # Knowledge / search
     ("search_knowledge", Affordance(Cost.LOW, Risk.NONE, Latency.FAST, ())),
     ("search_history", Affordance(Cost.LOW, Risk.NONE, Latency.FAST, ())),
@@ -99,47 +116,113 @@ _CATEGORY_DEFAULTS: list[tuple[str, Affordance]] = [
     ("generate_file", Affordance(Cost.MEDIUM, Risk.LOW, Latency.SECONDS, ())),
     ("purge_messages", Affordance(Cost.LOW, Risk.CRITICAL, Latency.FAST, ())),
     # Agents / loops / scheduler
-    ("spawn_agent", Affordance(Cost.VERY_HIGH, Risk.HIGH, Latency.UNBOUNDED,
-        ("agent tool enabled",))),
+    (
+        "spawn_agent",
+        Affordance(Cost.VERY_HIGH, Risk.HIGH, Latency.UNBOUNDED, ("agent tool enabled",)),
+    ),
     ("kill_agent", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
     ("wait_for_agents", Affordance(Cost.LOW, Risk.NONE, Latency.UNBOUNDED, ())),
     ("get_agent_results", Affordance(Cost.LOW, Risk.NONE, Latency.FAST, ())),
     ("start_loop", Affordance(Cost.HIGH, Risk.HIGH, Latency.UNBOUNDED, ())),
     ("stop_loop", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
-    ("schedule_task", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, (),
-        ("workflow steps need populated tool_input with all required fields",
-         "run_at must be ISO format — use parse_time first for natural language"))),
+    (
+        "schedule_task",
+        Affordance(
+            Cost.LOW,
+            Risk.MEDIUM,
+            Latency.FAST,
+            (),
+            (
+                "workflow steps need populated tool_input with all required fields",
+                "run_at must be ISO format — use parse_time first for natural language",
+            ),
+        ),
+    ),
     ("delete_schedule", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
     ("update_schedule", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
-    ("delegate_task", Affordance(Cost.HIGH, Risk.HIGH, Latency.UNBOUNDED, (),
-        ("every run_command step needs tool_input.command",
-         "steps execute sequentially — use {prev_output} to chain results"))),
+    (
+        "delegate_task",
+        Affordance(
+            Cost.HIGH,
+            Risk.HIGH,
+            Latency.UNBOUNDED,
+            (),
+            (
+                "every run_command step needs tool_input.command",
+                "steps execute sequentially — use {prev_output} to chain results",
+            ),
+        ),
+    ),
     # Infra
-    ("git_ops", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS, (),
-        ("params go under params object, not top level",
-         "for complex git workflows, prefer run_command with raw git"))),
-    ("docker_ops", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS,
-        ("docker daemon reachable",),
-        ("action names are compose_up/compose_down, not up/down",
-         "for complex compose operations, prefer run_command with raw docker"))),
-    ("terraform_ops", Affordance(Cost.HIGH, Risk.CRITICAL, Latency.MINUTES,
-        ("terraform state accessible",))),
-    ("kubectl", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.SECONDS,
-        ("kubeconfig configured",),
-        ("for complex kubectl operations, prefer run_command with raw kubectl",))),
+    (
+        "git_ops",
+        Affordance(
+            Cost.MEDIUM,
+            Risk.HIGH,
+            Latency.SECONDS,
+            (),
+            (
+                "params go under params object, not top level",
+                "for complex git workflows, prefer run_command with raw git",
+            ),
+        ),
+    ),
+    (
+        "docker_ops",
+        Affordance(
+            Cost.MEDIUM,
+            Risk.HIGH,
+            Latency.SECONDS,
+            ("docker daemon reachable",),
+            (
+                "action names are compose_up/compose_down, not up/down",
+                "for complex compose operations, prefer run_command with raw docker",
+            ),
+        ),
+    ),
+    (
+        "terraform_ops",
+        Affordance(Cost.HIGH, Risk.CRITICAL, Latency.MINUTES, ("terraform state accessible",)),
+    ),
+    (
+        "kubectl",
+        Affordance(
+            Cost.MEDIUM,
+            Risk.HIGH,
+            Latency.SECONDS,
+            ("kubeconfig configured",),
+            ("for complex kubectl operations, prefer run_command with raw kubectl",),
+        ),
+    ),
     ("manage_process", Affordance(Cost.LOW, Risk.HIGH, Latency.FAST, ())),
     ("http_probe", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS, ())),
     # LLM-in-tool
-    ("claude_code", Affordance(Cost.VERY_HIGH, Risk.MEDIUM, Latency.MINUTES,
-        ("CLAUDE_CODE_OAUTH_TOKEN or network access to API",))),
+    (
+        "claude_code",
+        Affordance(
+            Cost.VERY_HIGH,
+            Risk.MEDIUM,
+            Latency.MINUTES,
+            ("CLAUDE_CODE_OAUTH_TOKEN or network access to API",),
+        ),
+    ),
     # Skills
     ("create_skill", Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.FAST, ())),
     ("edit_skill", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
     ("delete_skill", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
-    ("invoke_skill", Affordance(Cost.MEDIUM, Risk.HIGH, Latency.UNBOUNDED,
-        ("skill must exist",),
-        ("pass skill arguments under input, not at top level",
-         "use list_skills first if unsure about parameter names"))),
+    (
+        "invoke_skill",
+        Affordance(
+            Cost.MEDIUM,
+            Risk.HIGH,
+            Latency.UNBOUNDED,
+            ("skill must exist",),
+            (
+                "pass skill arguments under input, not at top level",
+                "use list_skills first if unsure about parameter names",
+            ),
+        ),
+    ),
     # Knowledge management
     ("ingest_document", Affordance(Cost.HIGH, Risk.LOW, Latency.SECONDS, ())),
     ("bulk_ingest_knowledge", Affordance(Cost.HIGH, Risk.LOW, Latency.MINUTES, ())),
@@ -150,14 +233,27 @@ _CATEGORY_DEFAULTS: list[tuple[str, Affordance]] = [
     ("set_permission", Affordance(Cost.LOW, Risk.HIGH, Latency.FAST, ())),
     ("parse_time", Affordance(Cost.FREE, Risk.NONE, Latency.INSTANT, ())),
     # Image / media gen
-    ("generate_image", Affordance(Cost.VERY_HIGH, Risk.LOW, Latency.MINUTES,
-        ("ComfyUI / image backend reachable",))),
+    (
+        "generate_image",
+        Affordance(
+            Cost.VERY_HIGH, Risk.LOW, Latency.MINUTES, ("ComfyUI / image backend reachable",)
+        ),
+    ),
     # Issues / tickets
-    ("issue_tracker", Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.SECONDS,
-        ("issue tracker configured",))),
+    (
+        "issue_tracker",
+        Affordance(Cost.MEDIUM, Risk.MEDIUM, Latency.SECONDS, ("issue tracker configured",)),
+    ),
     # Post-action validation + runbook detection (our new tools)
-    ("validate_action", Affordance(Cost.MEDIUM, Risk.NONE, Latency.SECONDS,
-        ("validation checks reference reachable hosts",))),
+    (
+        "validate_action",
+        Affordance(
+            Cost.MEDIUM,
+            Risk.NONE,
+            Latency.SECONDS,
+            ("validation checks reference reachable hosts",),
+        ),
+    ),
     # Audit / search
     ("search_audit", Affordance(Cost.LOW, Risk.NONE, Latency.FAST, ())),
     # Skill lifecycle (non-destructive toggles + packaging)
@@ -169,25 +265,47 @@ _CATEGORY_DEFAULTS: list[tuple[str, Affordance]] = [
     # Task lifecycle
     ("cancel_task", Affordance(Cost.LOW, Risk.MEDIUM, Latency.FAST, ())),
     # Browser (explicit leaf entries alongside the prefix)
-    ("browser_screenshot", Affordance(Cost.MEDIUM, Risk.LOW, Latency.SECONDS,
-        ("browser session initialized",))),
+    (
+        "browser_screenshot",
+        Affordance(Cost.MEDIUM, Risk.LOW, Latency.SECONDS, ("browser session initialized",)),
+    ),
     # Discord surfaces
     ("read_channel", Affordance(Cost.LOW, Risk.NONE, Latency.FAST, ())),
     # Agent messaging / orchestration
-    ("send_to_agent", Affordance(Cost.LOW, Risk.LOW, Latency.FAST,
-        ("target agent exists and is running",))),
-    ("spawn_loop_agents", Affordance(Cost.VERY_HIGH, Risk.HIGH, Latency.UNBOUNDED,
-        ("agent tool enabled",))),
+    (
+        "send_to_agent",
+        Affordance(Cost.LOW, Risk.LOW, Latency.FAST, ("target agent exists and is running",)),
+    ),
+    (
+        "spawn_loop_agents",
+        Affordance(Cost.VERY_HIGH, Risk.HIGH, Latency.UNBOUNDED, ("agent tool enabled",)),
+    ),
     ("collect_loop_agents", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS, ())),
     # Email tools (SMTP/IMAP)
-    ("email_send", Affordance(Cost.LOW, Risk.MEDIUM, Latency.SECONDS,
-        ("email.enabled", "SMTP credentials configured"))),
-    ("email_search", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS,
-        ("email.enabled", "IMAP credentials configured"))),
-    ("email_read", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS,
-        ("email.enabled", "IMAP credentials configured"))),
-    ("email_list_recent", Affordance(Cost.LOW, Risk.NONE, Latency.SECONDS,
-        ("email.enabled", "IMAP credentials configured"))),
+    (
+        "email_send",
+        Affordance(
+            Cost.LOW, Risk.MEDIUM, Latency.SECONDS, ("email.enabled", "SMTP credentials configured")
+        ),
+    ),
+    (
+        "email_search",
+        Affordance(
+            Cost.LOW, Risk.NONE, Latency.SECONDS, ("email.enabled", "IMAP credentials configured")
+        ),
+    ),
+    (
+        "email_read",
+        Affordance(
+            Cost.LOW, Risk.NONE, Latency.SECONDS, ("email.enabled", "IMAP credentials configured")
+        ),
+    ),
+    (
+        "email_list_recent",
+        Affordance(
+            Cost.LOW, Risk.NONE, Latency.SECONDS, ("email.enabled", "IMAP credentials configured")
+        ),
+    ),
 ]
 
 # Default when no prefix matches. Deliberately conservative: unknown

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -3,6 +3,7 @@
 Each loop iteration triggers a full LLM reasoning cycle with tool access.
 The LLM decides what to check, how to interpret results, and what to report.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -43,6 +44,7 @@ LOOP_STOP_SENTINEL = "LOOP_STOP"
 @dataclass
 class LoopInfo:
     """Metadata for an active autonomous loop."""
+
     id: str
     goal: str
     mode: str  # "notify", "act", "silent"
@@ -88,7 +90,10 @@ class LoopManager:
     ) -> str:
         """Start a new autonomous loop. Returns the loop ID or an error string."""
         if self.active_count >= MAX_CONCURRENT_LOOPS:
-            return f"Error: Maximum concurrent loops ({MAX_CONCURRENT_LOOPS}) reached. Stop a loop first."
+            return (
+                f"Error: Maximum concurrent loops ({MAX_CONCURRENT_LOOPS}) reached. "
+                "Stop a loop first."
+            )
 
         if mode not in ("notify", "act", "silent"):
             mode = "notify"
@@ -113,13 +118,15 @@ class LoopManager:
         )
         self._loops[loop_id] = info
 
-        info._task = asyncio.create_task(
-            self._run_loop(info, channel, iteration_callback)
-        )
+        info._task = asyncio.create_task(self._run_loop(info, channel, iteration_callback))
 
         log.info(
             "Loop %s started: goal=%r interval=%ds mode=%s max=%d",
-            loop_id, goal, interval_seconds, mode, max_iterations,
+            loop_id,
+            goal,
+            interval_seconds,
+            mode,
+            max_iterations,
         )
         return loop_id
 
@@ -197,12 +204,14 @@ class LoopManager:
         if tasks:
             try:
                 await asyncio.wait_for(
-                    asyncio.gather(*tasks, return_exceptions=True), timeout,
+                    asyncio.gather(*tasks, return_exceptions=True),
+                    timeout,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 log.warning(
                     "LoopManager shutdown: %d task(s) did not finish within %.0fs",
-                    len(tasks), timeout,
+                    len(tasks),
+                    timeout,
                 )
 
     async def _run_loop(
@@ -243,7 +252,9 @@ class LoopManager:
                 # Build previous context from iteration history
                 prev_context = None
                 if info._iteration_history:
-                    prev_context = "\n---\n".join(list(info._iteration_history)[-MAX_CONTEXT_HISTORY:])
+                    prev_context = "\n---\n".join(
+                        list(info._iteration_history)[-MAX_CONTEXT_HISTORY:]
+                    )
 
                 # Run the LLM iteration. The correlation context lets the
                 # iteration runner, audit logger, and trajectory saver stamp
@@ -253,6 +264,7 @@ class LoopManager:
                 # of the iteration about to run.
                 try:
                     from ..observability.correlation import reset_turn, set_turn
+
                     _turn_token = set_turn(
                         source="loop",
                         loop_id=info.id,
@@ -273,11 +285,15 @@ class LoopManager:
                         info.interval_seconds = max(info.interval_seconds, int(circuit_wait))
                         log.info(
                             "Loop %s: circuit breaker open, wait %.0fs",
-                            info.id, circuit_wait,
+                            info.id,
+                            circuit_wait,
                         )
                     log.warning(
                         "Loop %s iteration %d failed (%d consecutive): %s",
-                        info.id, info.iteration_count, consecutive_errors, e,
+                        info.id,
+                        info.iteration_count,
+                        consecutive_errors,
+                        e,
                     )
                     # Store error in history but don't crash the loop
                     info._iteration_history.append(
@@ -298,12 +314,14 @@ class LoopManager:
                     # skip the interval wait entirely, so a fast-failing
                     # callback hammered the failing endpoint at full speed.
                     backoff = min(
-                        info.interval_seconds * (2 ** consecutive_errors),
+                        info.interval_seconds * (2**consecutive_errors),
                         MAX_BACKOFF_SECONDS,
                     )
                     log.info(
                         "Loop %s: backing off %ds after %d consecutive error(s)",
-                        info.id, backoff, consecutive_errors,
+                        info.id,
+                        backoff,
+                        consecutive_errors,
                     )
                     if await self._interruptible_wait(info, backoff):
                         break
@@ -311,9 +329,7 @@ class LoopManager:
 
                 # Store iteration result (truncated) in history
                 summary = response[:500] if response else "(no output)"
-                info._iteration_history.append(
-                    f"Iteration {info.iteration_count}: {summary}"
-                )
+                info._iteration_history.append(f"Iteration {info.iteration_count}: {summary}")
 
                 # Check for LOOP_STOP sentinel
                 if LOOP_STOP_SENTINEL in response:
@@ -327,12 +343,15 @@ class LoopManager:
                     if consecutive_identical >= RUNAWAY_THRESHOLD:
                         old_interval = info.interval_seconds
                         info.interval_seconds = min(
-                            info.interval_seconds * 2, 3600,
+                            info.interval_seconds * 2,
+                            3600,
                         )
                         log.warning(
                             "Loop %s: %d identical outputs, interval %ds -> %ds",
-                            info.id, RUNAWAY_THRESHOLD,
-                            old_interval, info.interval_seconds,
+                            info.id,
+                            RUNAWAY_THRESHOLD,
+                            old_interval,
+                            info.interval_seconds,
                         )
                         try:
                             await channel.send(
@@ -427,11 +446,14 @@ class LoopManager:
         try:
             await asyncio.wait_for(info._cancel_event.wait(), timeout=seconds)
             return True
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return False
 
     async def _post_response(
-        self, info: LoopInfo, channel: Any, response: str,
+        self,
+        info: LoopInfo,
+        channel: Any,
+        response: str,
     ) -> None:
         """Post the loop iteration response to the channel, respecting mode.
 
@@ -442,7 +464,8 @@ class LoopManager:
             if "[NOTIFY]" not in response and "[ALERT]" not in response:
                 log.debug(
                     "Loop %s: silent mode suppressed output (%d chars)",
-                    info.id, len(response),
+                    info.id,
+                    len(response),
                 )
                 return
 

--- a/src/tools/branch_freshness.py
+++ b/src/tools/branch_freshness.py
@@ -4,6 +4,7 @@ When test commands fail, checks if the local branch is behind its remote
 tracking branch. Annotates the result so the LLM/loop knows the failure
 might be from outdated code rather than a real regression.
 """
+
 from __future__ import annotations
 
 import re
@@ -109,7 +110,7 @@ class FreshnessStats:
             self._stale_found += 1
         self._recent.append(event)
         if len(self._recent) > self._max_recent:
-            self._recent = self._recent[-self._max_recent:]
+            self._recent = self._recent[-self._max_recent :]
 
     def record_fetch_failure(self) -> None:
         self._fetch_failures += 1
@@ -155,34 +156,44 @@ async def check_branch_freshness(
     """
     try:
         code, branch_out = await exec_fn(
-            address, "git rev-parse --abbrev-ref HEAD 2>/dev/null", ssh_user,
+            address,
+            "git rev-parse --abbrev-ref HEAD 2>/dev/null",
+            ssh_user,
         )
     except Exception:
         return BranchStatus(
-            is_stale=False, commits_behind=0,
-            local_branch="unknown", remote_ref="unknown",
+            is_stale=False,
+            commits_behind=0,
+            local_branch="unknown",
+            remote_ref="unknown",
             error="exec_fn raised",
         )
 
     if code != 0:
         return BranchStatus(
-            is_stale=False, commits_behind=0,
-            local_branch="unknown", remote_ref="unknown",
+            is_stale=False,
+            commits_behind=0,
+            local_branch="unknown",
+            remote_ref="unknown",
             error="not a git repo",
         )
 
     branch = branch_out.strip()
     if not branch or branch == "HEAD":
         return BranchStatus(
-            is_stale=False, commits_behind=0,
-            local_branch=branch or "HEAD", remote_ref="unknown",
+            is_stale=False,
+            commits_behind=0,
+            local_branch=branch or "HEAD",
+            remote_ref="unknown",
             error="detached HEAD",
         )
 
     fetch_failed = False
     try:
         f_code, _ = await exec_fn(
-            address, "git fetch origin --quiet 2>&1", ssh_user,
+            address,
+            "git fetch origin --quiet 2>&1",
+            ssh_user,
         )
         if f_code != 0:
             fetch_failed = True
@@ -197,9 +208,12 @@ async def check_branch_freshness(
         )
     except Exception:
         return BranchStatus(
-            is_stale=False, commits_behind=0,
-            local_branch=branch, remote_ref=f"origin/{branch}",
-            fetch_failed=fetch_failed, error="rev-list failed",
+            is_stale=False,
+            commits_behind=0,
+            local_branch=branch,
+            remote_ref=f"origin/{branch}",
+            fetch_failed=fetch_failed,
+            error="rev-list failed",
         )
 
     try:

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -4,11 +4,12 @@ Launches a local headless Chromium on first use and reuses it across calls.
 All operations use isolated browser contexts (incognito) that are cleaned up
 after each call. Falls back to a remote CDP URL if configured.
 """
+
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
 
 from ..odin_log import get_logger
 
@@ -34,6 +35,7 @@ DEFAULT_USER_AGENT = (
 def _validate_url(url: str, allowed_urls: list[str] | None = None) -> None:
     """Reject dangerous URL schemes and SSRF targets."""
     from .url_safety import validate_url_safe
+
     validate_url_safe(url, allowed_urls=allowed_urls)
 
 
@@ -106,9 +108,7 @@ class BrowserManager:
                     )
                     log.info("Launched native headless Chromium")
                 else:
-                    self._browser = await self._playwright.chromium.connect_over_cdp(
-                        self._cdp_url
-                    )
+                    self._browser = await self._playwright.chromium.connect_over_cdp(self._cdp_url)
                     log.info("Connected to remote browser at %s", self._cdp_url.split("?")[0])
                 self._browser.on("disconnected", self._on_browser_disconnected)
             except Exception as e:
@@ -132,12 +132,15 @@ class BrowserManager:
         if not self._native:
             try:
                 cdp = await page.context.new_cdp_session(page)
-                await cdp.send("Emulation.setDeviceMetricsOverride", {
-                    "width": self._viewport["width"],
-                    "height": self._viewport["height"],
-                    "deviceScaleFactor": 1,
-                    "mobile": False,
-                })
+                await cdp.send(
+                    "Emulation.setDeviceMetricsOverride",
+                    {
+                        "width": self._viewport["width"],
+                        "height": self._viewport["height"],
+                        "deviceScaleFactor": 1,
+                        "mobile": False,
+                    },
+                )
             except Exception:
                 pass
         return context, page
@@ -190,7 +193,8 @@ class BrowserManager:
 
 
 async def handle_browser_screenshot(
-    manager: BrowserManager, inp: dict,
+    manager: BrowserManager,
+    inp: dict,
 ) -> tuple[str, bytes | None]:
     """Navigate to a URL, take a screenshot, return (description, png_bytes)."""
     url = inp["url"]
@@ -213,7 +217,8 @@ async def handle_browser_screenshot(
 
 
 async def handle_browser_read_page(
-    manager: BrowserManager, inp: dict,
+    manager: BrowserManager,
+    inp: dict,
 ) -> str:
     """Navigate to a URL, extract visible text content."""
     url = inp["url"]
@@ -245,7 +250,8 @@ async def handle_browser_read_page(
 
 
 async def handle_browser_read_table(
-    manager: BrowserManager, inp: dict,
+    manager: BrowserManager,
+    inp: dict,
 ) -> str:
     """Navigate to a URL, extract a table as markdown."""
     url = inp["url"]
@@ -259,7 +265,8 @@ async def handle_browser_read_table(
         if wait_seconds:
             await page.wait_for_timeout(wait_seconds * 1000)
 
-        table_data = await page.evaluate("""(index) => {
+        table_data = await page.evaluate(
+            """(index) => {
             const tables = document.querySelectorAll('table');
             if (index >= tables.length) return null;
             const table = tables[index];
@@ -272,7 +279,9 @@ async def handle_browser_read_table(
                 if (cells.length > 0) rows.push(cells);
             }
             return rows;
-        }""", table_index)
+        }""",
+            table_index,
+        )
 
         title = await page.title()
         table_count = await page.evaluate("document.querySelectorAll('table').length")
@@ -300,7 +309,8 @@ async def handle_browser_read_table(
 
 
 async def handle_browser_click(
-    manager: BrowserManager, inp: dict,
+    manager: BrowserManager,
+    inp: dict,
 ) -> str:
     """Click an element on a page by CSS selector."""
     url = inp["url"]
@@ -328,7 +338,8 @@ async def handle_browser_click(
 
 
 async def handle_browser_fill(
-    manager: BrowserManager, inp: dict,
+    manager: BrowserManager,
+    inp: dict,
 ) -> str:
     """Fill a form field on a page by CSS selector."""
     url = inp["url"]
@@ -363,7 +374,8 @@ async def handle_browser_fill(
 
 
 async def handle_browser_evaluate(
-    manager: BrowserManager, inp: dict,
+    manager: BrowserManager,
+    inp: dict,
 ) -> str:
     """Run JavaScript on a page and return the result."""
     url = inp["url"]
@@ -385,6 +397,7 @@ async def handle_browser_evaluate(
     # Convert result to string
     if isinstance(result, (dict, list)):
         import json
+
         text = json.dumps(result, indent=2, default=str)
     else:
         text = str(result)

--- a/src/tools/bulkhead.py
+++ b/src/tools/bulkhead.py
@@ -5,12 +5,13 @@ cascading into others by capping how many concurrent operations each category
 can have in flight. When a bulkhead is full, new requests either queue (up to
 a configurable depth) or are rejected immediately.
 """
+
 from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
 
 from ..odin_log import get_logger
 
@@ -89,7 +90,10 @@ class Bulkhead:
             self._last_rejection = time.monotonic()
             log.warning(
                 "Bulkhead '%s' rejecting request: %d active, %d queued (max %d)",
-                self.name, self._active, self._queued, self._max_queued,
+                self.name,
+                self._active,
+                self._queued,
+                self._max_queued,
             )
             raise BulkheadFullError(self.name, self._max_concurrent, self._max_queued)
 
@@ -146,8 +150,12 @@ class BulkheadRegistry:
         """Create and register a named bulkhead. Returns the bulkhead."""
         bh = Bulkhead(name, max_concurrent, max_queued)
         self._bulkheads[name] = bh
-        log.info("Registered bulkhead '%s': max_concurrent=%d, max_queued=%d",
-                 name, max_concurrent, max_queued)
+        log.info(
+            "Registered bulkhead '%s': max_concurrent=%d, max_queued=%d",
+            name,
+            max_concurrent,
+            max_queued,
+        )
         return bh
 
     def get(self, name: str) -> Bulkhead | None:
@@ -179,7 +187,6 @@ class BulkheadRegistry:
         result: dict = {"bulkhead_count": len(self._bulkheads)}
         for name, bh in self._bulkheads.items():
             m = bh.get_metrics()
-            for key in ("active", "queued", "total", "rejected", "errors",
-                        "max_concurrent"):
+            for key in ("active", "queued", "total", "rejected", "errors", "max_concurrent"):
                 result[f"bulkhead_{name}_{key}"] = m[key]
         return result

--- a/src/tools/comfyui.py
+++ b/src/tools/comfyui.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import uuid
 
 import aiohttp
@@ -102,9 +101,7 @@ class ComfyUIClient:
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 # Queue the prompt
-                async with session.post(
-                    f"{self.base_url}/prompt", json=payload
-                ) as resp:
+                async with session.post(f"{self.base_url}/prompt", json=payload) as resp:
                     if resp.status != 200:
                         body = await resp.text()
                         log.warning("ComfyUI /prompt failed (%s): %s", resp.status, body[:200])
@@ -115,10 +112,14 @@ class ComfyUIClient:
                         log.warning("ComfyUI returned no prompt_id")
                         return None
                     # Validate prompt_id to prevent path traversal in URL
-                    if not isinstance(prompt_id, str) or not all(
-                        c.isalnum() or c in "-_" for c in prompt_id
-                    ) or len(prompt_id) > 100:
-                        log.warning("ComfyUI returned suspicious prompt_id: %s", str(prompt_id)[:50])
+                    if (
+                        not isinstance(prompt_id, str)
+                        or not all(c.isalnum() or c in "-_" for c in prompt_id)
+                        or len(prompt_id) > 100
+                    ):
+                        log.warning(
+                            "ComfyUI returned suspicious prompt_id: %s", str(prompt_id)[:50]
+                        )
                         return None
 
                 # Poll /history until complete
@@ -136,7 +137,7 @@ class ComfyUIClient:
                         return None
                     return await resp.read()
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             log.warning("ComfyUI generation timed out (120s)")
             return None
         except aiohttp.ClientError as e:
@@ -167,16 +168,12 @@ class ComfyUIClient:
         except Exception:
             return preferred  # Can't check, try anyway
 
-    async def _poll_history(
-        self, session: aiohttp.ClientSession, prompt_id: str
-    ) -> str | None:
+    async def _poll_history(self, session: aiohttp.ClientSession, prompt_id: str) -> str | None:
         """Poll /history/{prompt_id} until the job completes. Returns filename."""
         for _ in range(120):  # 120 * 1s = 2 min max
             await asyncio.sleep(1)
             try:
-                async with session.get(
-                    f"{self.base_url}/history/{prompt_id}"
-                ) as resp:
+                async with session.get(f"{self.base_url}/history/{prompt_id}") as resp:
                     if resp.status != 200:
                         continue
                     data = await resp.json()

--- a/src/tools/docker_ops.py
+++ b/src/tools/docker_ops.py
@@ -9,11 +9,24 @@ from __future__ import annotations
 
 import shlex
 
-ALLOWED_ACTIONS = frozenset({
-    "ps", "run", "exec", "logs", "build", "pull", "stop", "rm",
-    "inspect", "stats", "compose_up", "compose_down", "compose_ps",
-    "compose_logs",
-})
+ALLOWED_ACTIONS = frozenset(
+    {
+        "ps",
+        "run",
+        "exec",
+        "logs",
+        "build",
+        "pull",
+        "stop",
+        "rm",
+        "inspect",
+        "stats",
+        "compose_up",
+        "compose_down",
+        "compose_ps",
+        "compose_logs",
+    }
+)
 
 _MAX_LOG_LINES = 500
 _DEFAULT_LOG_LINES = 100
@@ -30,8 +43,7 @@ def build_docker_command(action: str, params: dict) -> str:
     """
     if action not in ALLOWED_ACTIONS:
         raise ValueError(
-            f"Unknown docker action: {action}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
+            f"Unknown docker action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
         )
     builder = _BUILDERS.get(action)
     if builder is None:
@@ -77,11 +89,11 @@ def _build_run(params: dict) -> str:
         parts += ["--name", _sq(name)]
     if network:
         parts += ["--network", _sq(network)]
-    for k, v in (env.items() if isinstance(env, dict) else []):
+    for k, v in env.items() if isinstance(env, dict) else []:
         parts += ["-e", _sq(f"{k}={v}")]
-    for p in (ports if isinstance(ports, list) else []):
+    for p in ports if isinstance(ports, list) else []:
         parts += ["-p", _sq(str(p))]
-    for v in (volumes if isinstance(volumes, list) else []):
+    for v in volumes if isinstance(volumes, list) else []:
         parts += ["-v", _sq(str(v))]
     if extra_args:
         parts.append(_sq(str(extra_args)))
@@ -107,7 +119,7 @@ def _build_exec(params: dict) -> str:
         parts += ["-w", _sq(workdir)]
     if user:
         parts += ["-u", _sq(user)]
-    for k, v in (env.items() if isinstance(env, dict) else []):
+    for k, v in env.items() if isinstance(env, dict) else []:
         parts += ["-e", _sq(f"{k}={v}")]
     parts.append(_sq(container))
     parts += ["sh", "-c", _sq(command)]
@@ -165,7 +177,7 @@ def _build_build(params: dict) -> str:
         parts += ["--target", _sq(target)]
     if no_cache:
         parts.append("--no-cache")
-    for k, v in (build_args.items() if isinstance(build_args, dict) else []):
+    for k, v in build_args.items() if isinstance(build_args, dict) else []:
         parts += ["--build-arg", _sq(f"{k}={v}")]
     parts.append(_sq(path))
     return " ".join(parts)
@@ -268,7 +280,7 @@ def _build_compose_up(params: dict) -> str:
         parts.append("--build")
     if force_recreate:
         parts.append("--force-recreate")
-    for s in (services if isinstance(services, list) else []):
+    for s in services if isinstance(services, list) else []:
         parts.append(_sq(str(s)))
     return " ".join(parts)
 
@@ -304,7 +316,7 @@ def _build_compose_ps(params: dict) -> str:
     parts.append("ps")
     if format_str:
         parts += ["--format", _sq(format_str)]
-    for s in (services if isinstance(services, list) else []):
+    for s in services if isinstance(services, list) else []:
         parts.append(_sq(str(s)))
     return " ".join(parts)
 
@@ -339,7 +351,7 @@ def _build_compose_logs(params: dict) -> str:
     else:
         parts += ["--tail", str(_DEFAULT_LOG_LINES)]
 
-    for s in (services if isinstance(services, list) else []):
+    for s in services if isinstance(services, list) else []:
         parts.append(_sq(str(s)))
     return " ".join(parts)
 

--- a/src/tools/email_client.py
+++ b/src/tools/email_client.py
@@ -6,6 +6,7 @@ short-lived (created per call, closed after) — no pool, no persistent
 state.  Gmail's X-GM-RAW search extension is auto-detected from the IMAP
 host and used transparently when available.
 """
+
 from __future__ import annotations
 
 import email as email_lib
@@ -58,7 +59,10 @@ def _extract_body(msg: email_lib.message.Message, max_chars: int) -> str:
                     charset = part.get_content_charset() or "utf-8"
                     text = payload.decode(charset, errors="replace")
                     if len(text) > max_chars:
-                        return text[:max_chars] + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+                        return (
+                            text[:max_chars]
+                            + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+                        )
                     return text
         for part in msg.walk():
             ct = part.get_content_type()
@@ -68,7 +72,10 @@ def _extract_body(msg: email_lib.message.Message, max_chars: int) -> str:
                     charset = part.get_content_charset() or "utf-8"
                     text = payload.decode(charset, errors="replace")
                     if len(text) > max_chars:
-                        return text[:max_chars] + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+                        return (
+                            text[:max_chars]
+                            + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
+                        )
                     return f"[HTML content]\n{text}"
         return "[no text body found]"
     payload = msg.get_payload(decode=True)
@@ -89,11 +96,13 @@ def _attachment_metadata(msg: email_lib.message.Message) -> list[dict]:
             filename = part.get_filename() or "(unnamed)"
             filename = _decode_header_value(filename)
             size = len(part.get_payload(decode=True) or b"")
-            attachments.append({
-                "filename": filename,
-                "content_type": part.get_content_type(),
-                "size_bytes": size,
-            })
+            attachments.append(
+                {
+                    "filename": filename,
+                    "content_type": part.get_content_type(),
+                    "size_bytes": size,
+                }
+            )
     return attachments
 
 
@@ -158,16 +167,13 @@ def send_email(
         for filepath in attachments:
             real = os.path.realpath(filepath)
             if not any(real.startswith(d + os.sep) or real == d for d in resolved_allowed):
-                raise ValueError(
-                    f"Attachment path '{filepath}' is outside allowed directories"
-                )
+                raise ValueError(f"Attachment path '{filepath}' is outside allowed directories")
             if not os.path.isfile(real):
                 raise ValueError(f"Attachment '{filepath}' is not a file")
             size = os.path.getsize(real)
             if size > max_attachment_bytes:
                 raise ValueError(
-                    f"Attachment '{filepath}' is {size} bytes "
-                    f"(limit {max_attachment_bytes})"
+                    f"Attachment '{filepath}' is {size} bytes (limit {max_attachment_bytes})"
                 )
             ctype, _ = mimetypes.guess_type(real)
             if ctype is None:
@@ -178,7 +184,8 @@ def send_email(
                 att.set_payload(f.read())
             email_lib.encoders.encode_base64(att)
             att.add_header(
-                "Content-Disposition", "attachment",
+                "Content-Disposition",
+                "attachment",
                 filename=Path(real).name,
             )
             msg.attach(att)
@@ -191,8 +198,9 @@ def send_email(
     except Exception as e:
         raise RuntimeError(f"SMTP send failed: {_safe_error(e, password)}") from None
 
-    log.info("Email sent to %s, subject=%r, message_id=%s",
-             all_recipients, subject, msg["Message-ID"])
+    log.info(
+        "Email sent to %s, subject=%r, message_id=%s", all_recipients, subject, msg["Message-ID"]
+    )
 
     return {
         "status": "sent",
@@ -245,7 +253,9 @@ def search_email(
             raw = msg_data[0][1] if isinstance(msg_data[0], tuple) else msg_data[0]
             if isinstance(raw, bytes):
                 msg = email_lib.message_from_bytes(raw)
-                results.append(_message_summary(msg, uid.decode() if isinstance(uid, bytes) else str(uid)))
+                results.append(
+                    _message_summary(msg, uid.decode() if isinstance(uid, bytes) else str(uid))
+                )
 
         return results
     except RuntimeError:
@@ -336,18 +346,22 @@ def list_recent(
             raw_tuple = msg_data[0]
             if isinstance(raw_tuple, tuple):
                 raw = raw_tuple[1]
-                meta_line = raw_tuple[0].decode() if isinstance(raw_tuple[0], bytes) else str(raw_tuple[0])
+                meta_line = (
+                    raw_tuple[0].decode() if isinstance(raw_tuple[0], bytes) else str(raw_tuple[0])
+                )
             else:
                 continue
             msg = email_lib.message_from_bytes(raw)
             summary = _message_summary(msg, uid.decode() if isinstance(uid, bytes) else str(uid))
             if "RFC822.SIZE" in meta_line:
                 import re
+
                 m = re.search(r"RFC822\.SIZE\s+(\d+)", meta_line)
                 if m:
                     summary["size_bytes"] = int(m.group(1))
             if "FLAGS" in meta_line:
                 import re
+
                 m = re.search(r"FLAGS\s*\(([^)]*)\)", meta_line)
                 if m:
                     summary["flags"] = m.group(1).split()

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -10,28 +10,30 @@ from ..odin_log import get_logger
 from ..permissions.host_access import HostAccessManager
 from ..permissions.manager import PermissionManager
 from .branch_freshness import (
-    BranchStatus,
     FreshnessEvent,
     FreshnessStats,
     check_branch_freshness,
     format_staleness_warning,
 )
 from .bulkhead import BulkheadFullError, BulkheadRegistry
+from .output_streamer import ToolOutputStreamer
+from .post_validation import annotate_if_mutation
 from .recovery import (
+    UNSAFE_TO_RETRY,
     RecoveryCategory,
     RecoveryStats,
-    RecoveryStrategy,
-    UNSAFE_TO_RETRY,
-    classify_error as _classify_error,
-    classify_exception as _classify_exception,
-    decide_recovery_action as _decide_recovery_action,
-    get_policy as _get_recovery_policy,
-    get_retry_delay as _get_retry_delay,
 )
-from .post_validation import annotate_if_mutation
+from .recovery import (
+    classify_error as _classify_error,
+)
+from .recovery import (
+    classify_exception as _classify_exception,
+)
+from .recovery import (
+    decide_recovery_action as _decide_recovery_action,
+)
 from .result_validator import ResultValidationStats, ToolResult, validate_tool_result
-from .risk_classifier import RiskLevel, RiskStats, classify_tool
-from .output_streamer import ToolOutputStreamer
+from .risk_classifier import RiskStats, classify_tool
 from .ssh import is_local_address, run_local_command, run_ssh_command
 from .ssh_pool import SSHConnectionPool
 
@@ -70,12 +72,14 @@ def _build_bulkhead_registry(config: ToolsConfig) -> BulkheadRegistry:
     return registry
 
 
-# RFC-004 P2: explicit late-bound dispatch table — tool name -> (owner_key, attr).
+# RFC-004: THE explicit late-bound dispatch table — tool name -> (owner_key, attr).
 # Handlers are resolved via getattr(owner, attr) at CALL time, never pre-bound,
 # so instance-attribute patches (``executor._handle_x = fake``) keep governing
-# execution (the patch-seam contract in test_executor_dispatch_parity). All
-# entries point at the "core" owner until the P4–P6 waves rebind them to domain
-# owners. The characterization contract pins table keys == executor-routed set.
+# execution (the patch-seam contract in test_executor_dispatch_parity). Every
+# handler body lives on a domain owner in src/tools/handlers/; the "core" owner
+# key remains available for future middleware-adjacent handlers. The
+# characterization contract pins table keys == executor-routed set, and
+# __init__ asserts every entry resolves on its owner at construction.
 EXECUTOR_HANDLERS: dict[str, tuple[str, str]] = {
     "run_command": ("system", "_handle_run_command"),
     "run_script": ("system", "_handle_run_script"),
@@ -222,6 +226,16 @@ class ToolExecutor:
             "comms": self.comms_tools,
             "validation": self.validation_tools,
         }
+        # RFC-004 P7 startup assertion (plan advisory #5): every dispatch-table
+        # entry must resolve to a callable on its bound owner — a rebind typo
+        # or missing domain method fails HERE, at construction, not on the
+        # first live tool call.
+        for _name, (_owner_key, _attr) in EXECUTOR_HANDLERS.items():
+            _owner = self._handler_owners.get(_owner_key)
+            assert _owner is not None, f"EXECUTOR_HANDLERS[{_name!r}]: unbound owner {_owner_key!r}"
+            assert callable(getattr(_owner, _attr, None)), (
+                f"EXECUTOR_HANDLERS[{_name!r}]: {_owner_key}.{_attr} does not resolve"
+            )
 
     @property
     def _current_user_id(self) -> str | None:
@@ -284,39 +298,30 @@ class ToolExecutor:
         return None
 
     def _resolve_handler(self, tool_name: str):
-        """Resolve a tool handler at CALL time (RFC-004 P2).
+        """Resolve a tool handler at CALL time (RFC-004 P2, fallback retired P7).
 
-        Table-first: EXECUTOR_HANDLERS maps name -> (owner_key, attr) and the
-        handler is fetched with getattr(owner, attr) NOW — never pre-bound —
-        so instance-attribute patches keep governing execution. The legacy
-        f-string lookup remains as a logged fallback until P7 retires it.
+        Instance-attribute overrides win FIRST — the historical patch seam
+        (``executor._handle_x = fake``, 13+ test sites) keeps governing even
+        for handlers whose real bodies live on domain owners; checked via
+        ``__dict__`` so class-level methods can't short-circuit the table.
+        Otherwise EXECUTOR_HANDLERS maps name -> (owner_key, attr) and the
+        handler is fetched with getattr(owner, attr) NOW — never pre-bound.
+        This method is the ONLY sanctioned dynamic ``_handle_`` spelling in
+        src/ (the characterization contract's AST scan enforces that).
         """
-        # Instance-attribute overrides win FIRST — this is the historical
-        # patch seam (13+ test sites do ``executor._handle_x = fake``) and it
-        # must keep governing even for handlers whose real bodies now live on
-        # domain owners. Checked via __dict__ so class-level methods don't
-        # short-circuit table resolution.
         override = self.__dict__.get(f"_handle_{tool_name}")
         if override is not None:
             return override
         entry = EXECUTOR_HANDLERS.get(tool_name)
         # getattr: tolerate __init__-bypassing construction (ToolExecutor.__new__
-        # in older fixtures) — resolution then falls through to the legacy path.
+        # in older fixtures) — such instances resolve nothing table-side.
         owners = getattr(self, "_handler_owners", None)
-        if entry is not None and owners is not None:
-            owner_key, attr = entry
-            owner = owners.get(owner_key)
-            if owner is not None:
-                handler = getattr(owner, attr, None)
-                if handler is not None:
-                    return handler
-        legacy = getattr(self, f"_handle_{tool_name}", None)
-        if legacy is not None:
-            log.warning(
-                "Tool %s resolved via legacy getattr fallback — missing EXECUTOR_HANDLERS entry",
-                tool_name,
-            )
-        return legacy
+        if entry is None or owners is None:
+            return None
+        owner = owners.get(entry[0])
+        if owner is None:
+            return None
+        return getattr(owner, entry[1], None)
 
     async def execute(
         self, tool_name: str, tool_input: dict, *, user_id: str | None = None
@@ -394,7 +399,8 @@ class ToolExecutor:
                 elif decision.action == "skip":
                     if tool_name in UNSAFE_TO_RETRY:
                         log.warning(
-                            "Recovery skipped for %s (%s): tool is not safe to retry (may have already executed)",
+                            "Recovery skipped for %s (%s): tool is not safe to retry "
+                            "(may have already executed)",
                             tool_name,
                             category.value,
                         )
@@ -482,7 +488,7 @@ class ToolExecutor:
             self._metrics.setdefault(tool_name, {"calls": 0, "errors": 0, "timeouts": 0})
             self._metrics[tool_name]["calls"] += 1
             return result
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._metrics.setdefault(tool_name, {"calls": 0, "errors": 0, "timeouts": 0})
             self._metrics[tool_name]["errors"] += 1
             self._metrics[tool_name]["timeouts"] += 1

--- a/src/tools/git_ops.py
+++ b/src/tools/git_ops.py
@@ -8,10 +8,21 @@ from __future__ import annotations
 
 import shlex
 
-ALLOWED_ACTIONS = frozenset({
-    "clone", "status", "diff", "branch", "commit", "push", "log", "pull",
-    "checkout", "fetch", "stash",
-})
+ALLOWED_ACTIONS = frozenset(
+    {
+        "clone",
+        "status",
+        "diff",
+        "branch",
+        "commit",
+        "push",
+        "log",
+        "pull",
+        "checkout",
+        "fetch",
+        "stash",
+    }
+)
 
 _MAX_LOG_ENTRIES = 50
 _DEFAULT_LOG_ENTRIES = 20
@@ -30,8 +41,7 @@ def build_git_command(action: str, params: dict) -> str | list[str]:
     """
     if action not in ALLOWED_ACTIONS:
         raise ValueError(
-            f"Unknown git action: {action}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
+            f"Unknown git action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
         )
 
     builder = _BUILDERS.get(action)
@@ -149,8 +159,10 @@ def _build_push(params: dict) -> list[str]:
     freshness_script = (
         f"git -C {sq_repo} fetch {sq_remote} --quiet 2>&1 && "
         f"LOCAL=$(git -C {sq_repo} rev-parse HEAD) && "
-        f"MERGE_BASE=$(git -C {sq_repo} merge-base HEAD {sq_remote}/$(git -C {sq_repo} rev-parse --abbrev-ref HEAD) 2>/dev/null || echo NONE) && "
-        f"REMOTE=$(git -C {sq_repo} rev-parse {sq_remote}/$(git -C {sq_repo} rev-parse --abbrev-ref HEAD) 2>/dev/null || echo NONE) && "
+        f"MERGE_BASE=$(git -C {sq_repo} merge-base HEAD "
+        f"{sq_remote}/$(git -C {sq_repo} rev-parse --abbrev-ref HEAD) 2>/dev/null || echo NONE) && "
+        f"REMOTE=$(git -C {sq_repo} rev-parse "
+        f"{sq_remote}/$(git -C {sq_repo} rev-parse --abbrev-ref HEAD) 2>/dev/null || echo NONE) && "
         f'if [ "$REMOTE" = "NONE" ]; then echo "FRESH:no_remote_tracking"; '
         f'elif [ "$LOCAL" = "$REMOTE" ]; then echo "FRESH:up_to_date"; '
         f'elif [ "$MERGE_BASE" = "$REMOTE" ]; then echo "FRESH:ahead"; '

--- a/src/tools/http_probe_ops.py
+++ b/src/tools/http_probe_ops.py
@@ -12,9 +12,17 @@ from urllib.parse import urlparse
 
 from .url_safety import is_metadata_url
 
-ALLOWED_METHODS = frozenset({
-    "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
-})
+ALLOWED_METHODS = frozenset(
+    {
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS",
+    }
+)
 
 MAX_TIMEOUT = 120
 DEFAULT_TIMEOUT = 30
@@ -75,9 +83,7 @@ def validate_url(url: str) -> str:
     # we block only the metadata service (never a legitimate probe target and
     # the one that hands out instance credentials) rather than all private IPs.
     if is_metadata_url(url):
-        raise ValueError(
-            "URL blocked: targets a cloud-metadata endpoint (SSRF protection)."
-        )
+        raise ValueError("URL blocked: targets a cloud-metadata endpoint (SSRF protection).")
     return url
 
 
@@ -99,8 +105,7 @@ def build_http_probe_command(params: dict) -> str:
     method = params.get("method", "GET").upper()
     if method not in ALLOWED_METHODS:
         raise ValueError(
-            f"Invalid HTTP method: {method}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_METHODS))}"
+            f"Invalid HTTP method: {method}. Allowed: {', '.join(sorted(ALLOWED_METHODS))}"
         )
 
     parts = ["curl", "-sS"]
@@ -116,9 +121,7 @@ def build_http_probe_command(params: dict) -> str:
         parts.append(f"-X {method}")
 
     # Timeout
-    timeout = _clamp_int(
-        params.get("timeout"), DEFAULT_TIMEOUT, 1, MAX_TIMEOUT
-    )
+    timeout = _clamp_int(params.get("timeout"), DEFAULT_TIMEOUT, 1, MAX_TIMEOUT)
     parts.append(f"--max-time {timeout}")
     parts.append(f"--connect-timeout {min(timeout, 10)}")
 
@@ -139,14 +142,10 @@ def build_http_probe_command(params: dict) -> str:
         parts.append("-k")
 
     # Retries
-    retries = _clamp_int(
-        params.get("retries"), DEFAULT_RETRIES, 0, MAX_RETRIES
-    )
+    retries = _clamp_int(params.get("retries"), DEFAULT_RETRIES, 0, MAX_RETRIES)
     if retries > 0:
         parts.append(f"--retry {retries}")
-        retry_delay = _clamp_int(
-            params.get("retry_delay"), DEFAULT_RETRY_DELAY, 0, MAX_RETRY_DELAY
-        )
+        retry_delay = _clamp_int(params.get("retry_delay"), DEFAULT_RETRY_DELAY, 0, MAX_RETRY_DELAY)
         parts.append(f"--retry-delay {retry_delay}")
 
     # Custom headers

--- a/src/tools/kubectl_ops.py
+++ b/src/tools/kubectl_ops.py
@@ -8,10 +8,20 @@ from __future__ import annotations
 
 import shlex
 
-ALLOWED_ACTIONS = frozenset({
-    "get", "describe", "logs", "apply", "delete", "exec",
-    "rollout", "scale", "top", "config",
-})
+ALLOWED_ACTIONS = frozenset(
+    {
+        "get",
+        "describe",
+        "logs",
+        "apply",
+        "delete",
+        "exec",
+        "rollout",
+        "scale",
+        "top",
+        "config",
+    }
+)
 
 _MAX_LOG_LINES = 500
 _DEFAULT_LOG_LINES = 100
@@ -44,8 +54,7 @@ def build_kubectl_command(action: str, params: dict) -> str:
     """
     if action not in ALLOWED_ACTIONS:
         raise ValueError(
-            f"Unknown kubectl action: {action}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
+            f"Unknown kubectl action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
         )
     builder = _BUILDERS.get(action)
     if builder is None:
@@ -201,9 +210,7 @@ def _build_rollout(params: dict) -> str:
     subaction = params.get("subaction", "status")
     allowed_subs = {"status", "restart", "undo", "history", "pause", "resume"}
     if subaction not in allowed_subs:
-        raise ValueError(
-            f"rollout subaction must be one of: {', '.join(sorted(allowed_subs))}"
-        )
+        raise ValueError(f"rollout subaction must be one of: {', '.join(sorted(allowed_subs))}")
     resource = params.get("resource", "")
     if not resource:
         raise ValueError("rollout requires 'resource' (e.g. deployment/my-app)")
@@ -263,9 +270,7 @@ def _build_config(params: dict) -> str:
     subaction = params.get("subaction", "get-contexts")
     allowed_subs = {"get-contexts", "use-context", "current-context", "view"}
     if subaction not in allowed_subs:
-        raise ValueError(
-            f"config subaction must be one of: {', '.join(sorted(allowed_subs))}"
-        )
+        raise ValueError(f"config subaction must be one of: {', '.join(sorted(allowed_subs))}")
 
     parts = ["kubectl", "config", subaction]
     kubeconfig = params.get("kubeconfig", "")

--- a/src/tools/mcp_client.py
+++ b/src/tools/mcp_client.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from typing import Any
 
 from ..odin_log import get_logger
@@ -38,7 +37,7 @@ def parse_tool_name(namespaced: str) -> tuple[str, str] | None:
     idx = rest.find("_")
     if idx <= 0:
         return None
-    return rest[:idx], rest[idx + 1:]
+    return rest[:idx], rest[idx + 1 :]
 
 
 class MCPError(Exception):
@@ -127,6 +126,7 @@ class MCPServerConnection:
             raise MCPError(f"Server {self.name}: stdio transport requires 'command'")
 
         import os
+
         merged_env = {**os.environ, **self.env} if self.env else None
 
         try:
@@ -229,8 +229,10 @@ class MCPServerConnection:
 
             result = await asyncio.wait_for(future, timeout=self.timeout)
             return result
-        except asyncio.TimeoutError:
-            raise MCPError(f"Server {self.name}: request '{method}' timed out after {self.timeout}s")
+        except TimeoutError:
+            raise MCPError(
+                f"Server {self.name}: request '{method}' timed out after {self.timeout}s"
+            )
         finally:
             self._pending.pop(req_id, None)
 
@@ -255,13 +257,14 @@ class MCPServerConnection:
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
-                    self.url, json=request, headers=hdrs, timeout=aiohttp.ClientTimeout(total=self.timeout)
+                    self.url,
+                    json=request,
+                    headers=hdrs,
+                    timeout=aiohttp.ClientTimeout(total=self.timeout),
                 ) as resp:
                     if resp.status != 200:
                         body = await resp.text()
-                        raise MCPError(
-                            f"Server {self.name}: HTTP {resp.status}: {body[:500]}"
-                        )
+                        raise MCPError(f"Server {self.name}: HTTP {resp.status}: {body[:500]}")
                     return await resp.json()
         except aiohttp.ClientError as e:
             raise MCPError(f"Server {self.name}: HTTP error: {e}")
@@ -281,18 +284,19 @@ class MCPServerConnection:
     async def _initialize(self) -> None:
         """Perform the MCP initialize handshake."""
         resp = await asyncio.wait_for(
-            self._send_request("initialize", {
-                "protocolVersion": PROTOCOL_VERSION,
-                "capabilities": {},
-                "clientInfo": CLIENT_INFO,
-            }),
+            self._send_request(
+                "initialize",
+                {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": CLIENT_INFO,
+                },
+            ),
             timeout=_INIT_TIMEOUT,
         )
 
         if "error" in resp:
-            raise MCPError(
-                f"Server {self.name}: initialize failed: {resp['error']}"
-            )
+            raise MCPError(f"Server {self.name}: initialize failed: {resp['error']}")
 
         result = resp.get("result", {})
         self._server_info = result.get("serverInfo", {})
@@ -305,16 +309,17 @@ class MCPServerConnection:
 
     async def _initialize_http(self) -> None:
         """HTTP initialize handshake."""
-        resp = await self._send_http_request("initialize", {
-            "protocolVersion": PROTOCOL_VERSION,
-            "capabilities": {},
-            "clientInfo": CLIENT_INFO,
-        })
+        resp = await self._send_http_request(
+            "initialize",
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": CLIENT_INFO,
+            },
+        )
 
         if "error" in resp:
-            raise MCPError(
-                f"Server {self.name}: initialize failed: {resp['error']}"
-            )
+            raise MCPError(f"Server {self.name}: initialize failed: {resp['error']}")
 
         result = resp.get("result", {})
         self._server_info = result.get("serverInfo", {})
@@ -331,9 +336,7 @@ class MCPServerConnection:
         resp = await self._send_request("tools/list")
 
         if "error" in resp:
-            raise MCPError(
-                f"Server {self.name}: tools/list failed: {resp['error']}"
-            )
+            raise MCPError(f"Server {self.name}: tools/list failed: {resp['error']}")
 
         result = resp.get("result", {})
         raw_tools = result.get("tools", [])
@@ -342,11 +345,13 @@ class MCPServerConnection:
             name = t.get("name", "")
             if not name:
                 continue
-            self._tools.append({
-                "name": name,
-                "description": t.get("description", ""),
-                "inputSchema": t.get("inputSchema", {"type": "object", "properties": {}}),
-            })
+            self._tools.append(
+                {
+                    "name": name,
+                    "description": t.get("description", ""),
+                    "inputSchema": t.get("inputSchema", {"type": "object", "properties": {}}),
+                }
+            )
 
         log.info("MCP %s: discovered %d tools", self.name, len(self._tools))
         return self._tools
@@ -378,10 +383,13 @@ class MCPServerConnection:
         """Invoke a tool on the server and return the result as text."""
         await self._ensure_connected()
 
-        resp = await self._send_request("tools/call", {
-            "name": tool_name,
-            "arguments": arguments,
-        })
+        resp = await self._send_request(
+            "tools/call",
+            {
+                "name": tool_name,
+                "arguments": arguments,
+            },
+        )
 
         if "error" in resp:
             err = resp["error"]
@@ -431,7 +439,7 @@ class MCPServerConnection:
                 self._process.terminate()
                 try:
                     await asyncio.wait_for(self._process.wait(), timeout=5)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     self._process.kill()
             except ProcessLookupError:
                 pass
@@ -479,9 +487,13 @@ class MCPManager:
             )
 
         conn = MCPServerConnection(
-            name, transport,
-            command=command, args=args, url=url,
-            headers=headers, env=env,
+            name,
+            transport,
+            command=command,
+            args=args,
+            url=url,
+            headers=headers,
+            env=env,
             timeout=timeout or self._tool_timeout,
         )
 
@@ -529,11 +541,13 @@ class MCPManager:
                 continue
             for t in conn.tools:
                 namespaced = make_tool_name(server_name, t["name"])
-                defs.append({
-                    "name": namespaced,
-                    "description": f"[MCP:{server_name}] {t.get('description', '')}",
-                    "input_schema": t.get("inputSchema", {"type": "object", "properties": {}}),
-                })
+                defs.append(
+                    {
+                        "name": namespaced,
+                        "description": f"[MCP:{server_name}] {t.get('description', '')}",
+                        "input_schema": t.get("inputSchema", {"type": "object", "properties": {}}),
+                    }
+                )
 
         self._tool_cache = defs
         return defs
@@ -554,7 +568,7 @@ class MCPManager:
                 conn.call_tool(original_name, tool_input),
                 timeout=conn.timeout,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return f"MCP tool '{tool_name}' timed out after {conn.timeout}s"
         except MCPError as e:
             return f"MCP error: {e}"
@@ -566,14 +580,16 @@ class MCPManager:
         """Return status of all registered servers."""
         result = []
         for name, conn in self._servers.items():
-            result.append({
-                "name": name,
-                "transport": conn.transport,
-                "connected": conn.connected,
-                "server_info": conn.server_info,
-                "tool_count": len(conn.tools),
-                "tools": [make_tool_name(name, t["name"]) for t in conn.tools],
-            })
+            result.append(
+                {
+                    "name": name,
+                    "transport": conn.transport,
+                    "connected": conn.connected,
+                    "server_info": conn.server_info,
+                    "tool_count": len(conn.tools),
+                    "tools": [make_tool_name(name, t["name"]) for t in conn.tools],
+                }
+            )
         return result
 
     async def shutdown(self) -> None:

--- a/src/tools/output_streamer.py
+++ b/src/tools/output_streamer.py
@@ -5,13 +5,13 @@ Emits ``StreamChunk`` objects to registered async listeners (WebSocket, etc.).
 Rate-limited to avoid spamming: at most one chunk per ``chunk_interval``
 seconds per active stream.  A final chunk (``finished=True``) is always sent.
 """
+
 from __future__ import annotations
 
-import asyncio
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import UTC, datetime
 
 from ..odin_log import get_logger
 
@@ -119,7 +119,9 @@ class ToolOutputStreamer:
                 log.debug("Stream listener error", exc_info=True)
 
     def create_callback(
-        self, tool_name: str, channel_id: str = "",
+        self,
+        tool_name: str,
+        channel_id: str = "",
     ) -> tuple[str, Callable[[str], Awaitable[None]], Callable[[], Awaitable[None]]]:
         """Create a streaming callback for one tool invocation.
 
@@ -145,7 +147,7 @@ class ToolOutputStreamer:
             if now - stream.last_emit >= self._chunk_interval and stream.buffered:
                 chunk_text = stream.buffered[: self._max_chunk_chars]
                 stream.buffered = stream.buffered[self._max_chunk_chars :]
-                ts = datetime.now(timezone.utc).isoformat()
+                ts = datetime.now(UTC).isoformat()
                 chunk = StreamChunk(
                     tool_name=tool_name,
                     chunk=chunk_text,
@@ -158,7 +160,7 @@ class ToolOutputStreamer:
                 await self._emit(chunk)
 
         async def finish() -> None:
-            ts = datetime.now(timezone.utc).isoformat()
+            ts = datetime.now(UTC).isoformat()
             while stream.buffered:
                 chunk_text = stream.buffered[: self._max_chunk_chars]
                 stream.buffered = stream.buffered[self._max_chunk_chars :]

--- a/src/tools/post_validation.py
+++ b/src/tools/post_validation.py
@@ -24,8 +24,9 @@ import json
 import re
 import shlex
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from ..odin_log import get_logger
 
@@ -63,19 +64,40 @@ _REDOS_HEURISTIC = re.compile(
     re.VERBOSE,
 )
 
-VALID_TYPES = frozenset({
-    "http", "port", "service", "process", "log_absent", "log_present", "command",
-})
+VALID_TYPES = frozenset(
+    {
+        "http",
+        "port",
+        "service",
+        "process",
+        "log_absent",
+        "log_present",
+        "command",
+    }
+)
 VALID_SEVERITIES = frozenset({"critical", "warn", "info"})
-VALID_COMPARE_OPS = frozenset({
-    "equals", "status_in", "contains", "not_contains",
-    "exit_zero", "exit_nonzero", "regex_match",
-})
+VALID_COMPARE_OPS = frozenset(
+    {
+        "equals",
+        "status_in",
+        "contains",
+        "not_contains",
+        "exit_zero",
+        "exit_nonzero",
+        "regex_match",
+    }
+)
 
 # compare ops that require a non-empty 'expected' value
-_COMPARE_OPS_REQUIRING_EXPECTED = frozenset({
-    "equals", "contains", "not_contains", "regex_match", "status_in",
-})
+_COMPARE_OPS_REQUIRING_EXPECTED = frozenset(
+    {
+        "equals",
+        "contains",
+        "not_contains",
+        "regex_match",
+        "status_in",
+    }
+)
 
 # compare ops that are valid for each check type (others are rejected at parse
 # time so the API never silently promises flexibility it won't deliver).
@@ -86,10 +108,16 @@ _ALLOWED_COMPARE_FOR_TYPE: dict[str, frozenset[str]] = {
     "process": frozenset({"exit_zero"}),
     "log_absent": frozenset({"not_contains"}),
     "log_present": frozenset({"contains"}),
-    "command": frozenset({
-        "exit_zero", "exit_nonzero", "equals", "contains",
-        "not_contains", "regex_match",
-    }),
+    "command": frozenset(
+        {
+            "exit_zero",
+            "exit_nonzero",
+            "equals",
+            "contains",
+            "not_contains",
+            "regex_match",
+        }
+    ),
 }
 
 
@@ -171,7 +199,9 @@ def parse_checks(raw_checks: list[dict]) -> tuple[list[Check], list[str]]:
         if compare is not None:
             compare = str(compare).strip().lower()
             if compare not in VALID_COMPARE_OPS:
-                errors.append(f"check[{i}]: invalid compare '{compare}' (valid: {sorted(VALID_COMPARE_OPS)})")
+                errors.append(
+                    f"check[{i}]: invalid compare '{compare}' (valid: {sorted(VALID_COMPARE_OPS)})"
+                )
                 continue
             allowed_for_type = _ALLOWED_COMPARE_FOR_TYPE.get(c_type, frozenset())
             if compare not in allowed_for_type:
@@ -188,12 +218,13 @@ def parse_checks(raw_checks: list[dict]) -> tuple[list[Check], list[str]]:
         needs_expected = (
             compare is not None
             and compare in _COMPARE_OPS_REQUIRING_EXPECTED
-            and (expected is None or (isinstance(expected, (str, list, tuple)) and len(expected) == 0))
+            and (
+                expected is None
+                or (isinstance(expected, (str, list, tuple)) and len(expected) == 0)
+            )
         )
         if needs_expected:
-            errors.append(
-                f"check[{i}]: compare '{compare}' requires a non-empty 'expected' value"
-            )
+            errors.append(f"check[{i}]: compare '{compare}' requires a non-empty 'expected' value")
             continue
         timeout = int(raw.get("timeout_seconds", DEFAULT_CHECK_TIMEOUT))
         timeout = max(1, min(timeout, 120))
@@ -202,17 +233,19 @@ def parse_checks(raw_checks: list[dict]) -> tuple[list[Check], list[str]]:
         host = raw.get("host")
         host = str(host).strip() if host else None
 
-        checks.append(Check(
-            type=c_type,
-            target=target,
-            expected=raw.get("expected"),
-            severity=severity,
-            host=host,
-            compare=compare,
-            window_seconds=window,
-            timeout_seconds=timeout,
-            name=str(raw.get("name") or "").strip() or None,
-        ))
+        checks.append(
+            Check(
+                type=c_type,
+                target=target,
+                expected=raw.get("expected"),
+                severity=severity,
+                host=host,
+                compare=compare,
+                window_seconds=window,
+                timeout_seconds=timeout,
+                name=str(raw.get("name") or "").strip() or None,
+            )
+        )
     return checks, errors
 
 
@@ -252,7 +285,10 @@ def _build_command(check: Check) -> str | None:
             h, p = "127.0.0.1", tgt
         if not p.isdigit():
             return None
-        return f"timeout {timeout} bash -c 'cat < /dev/null > /dev/tcp/{shlex.quote(h)}/{p}' && echo OPEN || echo CLOSED"
+        return (
+            f"timeout {timeout} bash -c 'cat < /dev/null > /dev/tcp/{shlex.quote(h)}/{p}'"
+            " && echo OPEN || echo CLOSED"
+        )
     if t == "service":
         return f"systemctl is-active {shlex.quote(tgt)} 2>/dev/null || true"
     if t == "process":
@@ -301,8 +337,7 @@ def _evaluate(check: Check, exit_code: int, output: str) -> tuple[str, str]:
         else:
             return "error", f"invalid 'expected' for http check: {expected!r}"
         expected_codes = {
-            str(int(c)) for c in expected_list
-            if isinstance(c, (int, str)) and str(c).isdigit()
+            str(int(c)) for c in expected_list if isinstance(c, (int, str)) and str(c).isdigit()
         }
         if not expected_codes:
             return "error", f"'expected' for http check yielded no status codes: {expected!r}"
@@ -347,9 +382,17 @@ def _evaluate(check: Check, exit_code: int, output: str) -> tuple[str, str]:
 
     if check.type == "command":
         if compare == "exit_zero":
-            return ("pass", "") if exit_code == 0 else ("fail", f"exit {exit_code}: {out_stripped[:200]}")
+            return (
+                ("pass", "")
+                if exit_code == 0
+                else ("fail", f"exit {exit_code}: {out_stripped[:200]}")
+            )
         if compare == "exit_nonzero":
-            return ("pass", "") if exit_code != 0 else ("fail", "command succeeded but expected failure")
+            return (
+                ("pass", "")
+                if exit_code != 0
+                else ("fail", "command succeeded but expected failure")
+            )
         expected = check.expected
         if compare == "contains":
             if expected and str(expected) in output:
@@ -431,15 +474,24 @@ async def run_bundle(
     if parse_errors:
         dummies = [
             CheckResult(
-                name=f"parse_error[{i}]", type="parse", target="", severity="critical",
-                status="error", error=e,
+                name=f"parse_error[{i}]",
+                type="parse",
+                target="",
+                severity="critical",
+                status="error",
+                error=e,
             )
             for i, e in enumerate(parse_errors)
         ]
         return ValidationReport(
-            verdict="error", passed=0, failed=0, errored=len(dummies),
-            total=len(dummies), duration_ms=int((time.monotonic() - start) * 1000),
-            bundle=bundle_name, checks=dummies,
+            verdict="error",
+            passed=0,
+            failed=0,
+            errored=len(dummies),
+            total=len(dummies),
+            duration_ms=int((time.monotonic() - start) * 1000),
+            bundle=bundle_name,
+            checks=dummies,
         )
 
     # Bundle-level semaphore bounds fan-out so a 25-check bundle doesn't
@@ -451,8 +503,12 @@ async def run_bundle(
         resolved_host = check.host or default_host or "localhost"
         name = check.name or f"{check.type}[{idx}]"
         result = CheckResult(
-            name=name, type=check.type, target=check.target,
-            severity=check.severity, status="error", host=resolved_host,
+            name=name,
+            type=check.type,
+            target=check.target,
+            severity=check.severity,
+            status="error",
+            host=resolved_host,
         )
         t0 = time.monotonic()
         async with sem:
@@ -464,14 +520,16 @@ async def run_bundle(
                 address, ssh_user, _os = resolved
                 command = _build_command(check)
                 if command is None:
-                    result.error = f"could not build command for check type '{check.type}' (bad target?)"
+                    result.error = (
+                        f"could not build command for check type '{check.type}' (bad target?)"
+                    )
                     return result
                 try:
                     exit_code, output = await asyncio.wait_for(
                         exec_command(address, command, ssh_user, timeout=check.timeout_seconds),
                         timeout=check.timeout_seconds + 5,
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     result.status = "error"
                     result.error = f"timed out after {check.timeout_seconds}s"
                     return result
@@ -498,12 +556,23 @@ async def run_bundle(
     duration = int((time.monotonic() - start) * 1000)
 
     report = ValidationReport(
-        verdict=verdict, passed=passed, failed=failed, errored=errored,
-        total=len(results), duration_ms=duration, bundle=bundle_name, checks=results,
+        verdict=verdict,
+        passed=passed,
+        failed=failed,
+        errored=errored,
+        total=len(results),
+        duration_ms=duration,
+        bundle=bundle_name,
+        checks=results,
     )
     log.info(
         "validation bundle=%s verdict=%s passed=%d failed=%d errored=%d duration_ms=%d",
-        bundle_name, verdict, passed, failed, errored, duration,
+        bundle_name,
+        verdict,
+        passed,
+        failed,
+        errored,
+        duration,
     )
     return report
 
@@ -539,9 +608,15 @@ def report_as_json(report: ValidationReport) -> str:
 # into enforced code.
 
 _MUTATION_PATTERNS: list[tuple[re.Pattern, str]] = [
-    (re.compile(r"\bsystemctl\s+(restart|stop|start|reload|enable|disable)\b"), "service lifecycle change"),
+    (
+        re.compile(r"\bsystemctl\s+(restart|stop|start|reload|enable|disable)\b"),
+        "service lifecycle change",
+    ),
     (re.compile(r"\bservice\s+\S+\s+(restart|stop|start)\b"), "service lifecycle change"),
-    (re.compile(r"\bdocker\s+(compose\s+)?(up|down|restart|stop|start|rm)\b"), "container operation"),
+    (
+        re.compile(r"\bdocker\s+(compose\s+)?(up|down|restart|stop|start|rm)\b"),
+        "container operation",
+    ),
     (re.compile(r"\bdocker-compose\s+(up|down|restart|stop)\b"), "compose operation"),
     (re.compile(r"\bkubectl\s+(apply|delete|rollout|scale|patch)\b"), "kubernetes mutation"),
     (re.compile(r"\bterraform\s+(apply|destroy)\b"), "infrastructure mutation"),
@@ -608,7 +683,9 @@ def detect_mutation(tool_name: str, tool_input: dict) -> MutationDetection:
         command = tool_input.get("command", "")
     elif tool_name == "write_file":
         path = tool_input.get("path", "")
-        if any(p in path for p in ("/etc/", "/opt/", "nginx", "apache", "systemd", ".service", ".conf")):
+        if any(
+            p in path for p in ("/etc/", "/opt/", "nginx", "apache", "systemd", ".service", ".conf")
+        ):
             return MutationDetection(True, f"config write: {path}")
 
     if command:
@@ -620,7 +697,9 @@ def detect_mutation(tool_name: str, tool_input: dict) -> MutationDetection:
 
 
 def annotate_if_mutation(
-    tool_name: str, tool_input: dict, output: str,
+    tool_name: str,
+    tool_input: dict,
+    output: str,
 ) -> tuple[str, MutationDetection]:
     """Append a validation hint if a mutation was detected.
 

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -49,6 +49,7 @@ class ProcessRegistry:
     async def start(self, host: str, command: str, timeout: int = 300) -> str:
         """Start a background process locally. Returns confirmation with PID."""
         from ..tools.ssh import is_local_address
+
         if not is_local_address(host):
             return (
                 f"manage_process only supports local execution. "
@@ -85,7 +86,10 @@ class ProcessRegistry:
 
         # Auto-kill after max lifetime
         from ..async_utils import fire_and_forget
-        fire_and_forget(self._enforce_lifetime(pid, MAX_LIFETIME_SECONDS), name=f"process_lifetime:{pid}")
+
+        fire_and_forget(
+            self._enforce_lifetime(pid, MAX_LIFETIME_SECONDS), name=f"process_lifetime:{pid}"
+        )
 
         log.info("Started process PID %d: %s", pid, command[:80])
         return f"Process started (PID {pid}): {command[:120]}"
@@ -140,7 +144,7 @@ class ProcessRegistry:
                 # Give it a moment to exit gracefully
                 try:
                     await asyncio.wait_for(info.process.wait(), timeout=5)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     info.process.kill()
             info.status = "failed"
             info.exit_code = -9
@@ -193,9 +197,9 @@ class ProcessRegistry:
         """Remove dead processes older than 1 hour. Returns count removed."""
         now = time.time()
         to_remove = [
-            pid for pid, info in self._processes.items()
-            if info.status != "running"
-            and (now - info.start_time) > MAX_LIFETIME_SECONDS
+            pid
+            for pid, info in self._processes.items()
+            if info.status != "running" and (now - info.start_time) > MAX_LIFETIME_SECONDS
         ]
         for pid in to_remove:
             info = self._processes.pop(pid)

--- a/src/tools/recovery.py
+++ b/src/tools/recovery.py
@@ -4,15 +4,16 @@ Classifies error strings into recoverable categories and provides
 single-retry recovery with appropriate delays. Known transient failure
 patterns are retried once automatically before surfacing to the user.
 """
+
 from __future__ import annotations
 
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field
-from enum import Enum
+from dataclasses import dataclass
+from enum import StrEnum
 
 
-class RecoveryCategory(str, Enum):
+class RecoveryCategory(StrEnum):
     SSH_TRANSIENT = "ssh_transient"
     CONNECTION_ERROR = "connection_error"
     RESOURCE_BUSY = "resource_busy"
@@ -29,7 +30,7 @@ class RecoveryCategory(str, Enum):
     PERMISSION_DENIED = "permission_denied"
 
 
-class RecoveryStrategy(str, Enum):
+class RecoveryStrategy(StrEnum):
     """What to do when a category fires.
 
     RETRY_WITH_DELAY — sleep and try the same call once more (legacy behavior).
@@ -39,58 +40,61 @@ class RecoveryStrategy(str, Enum):
     NO_ACTION — don't retry, don't annotate (e.g. the error is already
         self-explanatory or the tool declines recovery).
     """
+
     RETRY_WITH_DELAY = "retry"
     HINT_AND_ESCALATE = "hint"
     NO_ACTION = "none"
 
 
-UNSAFE_TO_RETRY: frozenset[str] = frozenset({
-    "run_command",
-    "run_script",
-    "run_command_multi",
-    "write_file",
-    "git_ops",
-    "manage_process",
-    "claude_code",
-    "delete_knowledge",
-    "delete_schedule",
-    "update_schedule",
-    "purge_messages",
-    "create_skill",
-    "edit_skill",
-    "delete_skill",
-    "invoke_skill",
-    "spawn_agent",
-    "kill_agent",
-    "start_loop",
-    "stop_loop",
-    "schedule_task",
-    "delegate_task",
-    "generate_image",
-    "browser_click",
-    "browser_fill",
-    "browser_evaluate",
-    "post_file",
-    "generate_file",
-    "add_reaction",
-    "create_poll",
-    "set_permission",
-    "memory_manage",
-    "manage_list",
-    "ingest_document",
-    "bulk_ingest_knowledge",
-    "docker_ops",
-    "terraform_ops",
-    "kubectl",
-    "issue_tracker",
-    # Side-effecting tools missing from the original set. email_send is the
-    # dangerous one: SMTP can fail after DATA is accepted, so an auto-retry
-    # duplicates the mail.
-    "email_send",
-    "install_skill",
-    "send_to_agent",
-    "cancel_task",
-})
+UNSAFE_TO_RETRY: frozenset[str] = frozenset(
+    {
+        "run_command",
+        "run_script",
+        "run_command_multi",
+        "write_file",
+        "git_ops",
+        "manage_process",
+        "claude_code",
+        "delete_knowledge",
+        "delete_schedule",
+        "update_schedule",
+        "purge_messages",
+        "create_skill",
+        "edit_skill",
+        "delete_skill",
+        "invoke_skill",
+        "spawn_agent",
+        "kill_agent",
+        "start_loop",
+        "stop_loop",
+        "schedule_task",
+        "delegate_task",
+        "generate_image",
+        "browser_click",
+        "browser_fill",
+        "browser_evaluate",
+        "post_file",
+        "generate_file",
+        "add_reaction",
+        "create_poll",
+        "set_permission",
+        "memory_manage",
+        "manage_list",
+        "ingest_document",
+        "bulk_ingest_knowledge",
+        "docker_ops",
+        "terraform_ops",
+        "kubectl",
+        "issue_tracker",
+        # Side-effecting tools missing from the original set. email_send is the
+        # dangerous one: SMTP can fail after DATA is accepted, so an auto-retry
+        # duplicates the mail.
+        "email_send",
+        "install_skill",
+        "send_to_agent",
+        "cancel_task",
+    }
+)
 
 
 # Substrings that indicate a transient, recoverable failure.
@@ -118,18 +122,14 @@ _RECOVERABLE_PATTERNS: dict[RecoveryCategory, tuple[str, ...]] = {
         "resource temporarily unavailable",
         "Resource temporarily unavailable",
     ),
-    RecoveryCategory.TIMEOUT: (
-        "timed out",
-    ),
+    RecoveryCategory.TIMEOUT: ("timed out",),
     RecoveryCategory.RATE_LIMITED: (
         "rate limit exceeded",
         "Rate limit exceeded",
         "RateLimitError",
         "Too Many Requests",
     ),
-    RecoveryCategory.BULKHEAD_FULL: (
-        "bulkhead full",
-    ),
+    RecoveryCategory.BULKHEAD_FULL: ("bulkhead full",),
     RecoveryCategory.AUTH_FAILURE: (
         "authentication failed",
         "Authentication failed",
@@ -206,9 +206,11 @@ _CATEGORY_DELAYS: dict[RecoveryCategory, float] = {
 
 # Categories that should NOT be retried at the tool-result level
 # (they already have their own internal retry logic).
-_SKIP_RESULT_CATEGORIES = frozenset({
-    RecoveryCategory.TIMEOUT,
-})
+_SKIP_RESULT_CATEGORIES = frozenset(
+    {
+        RecoveryCategory.TIMEOUT,
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -221,6 +223,7 @@ class RecoveryPolicy:
     identical-retry is often wasted effort; a different next step is
     frequently the actual recovery.
     """
+
     strategy: RecoveryStrategy
     delay_seconds: float = 1.0
     hint: str = ""
@@ -231,25 +234,32 @@ class RecoveryPolicy:
 # (retrying a 401 produces a second 401 — escalate to the LLM instead).
 _DEFAULT_POLICIES: dict[RecoveryCategory, RecoveryPolicy] = {
     RecoveryCategory.SSH_TRANSIENT: RecoveryPolicy(
-        RecoveryStrategy.RETRY_WITH_DELAY, 2.0,
+        RecoveryStrategy.RETRY_WITH_DELAY,
+        2.0,
     ),
     RecoveryCategory.CONNECTION_ERROR: RecoveryPolicy(
-        RecoveryStrategy.RETRY_WITH_DELAY, 1.0,
+        RecoveryStrategy.RETRY_WITH_DELAY,
+        1.0,
     ),
     RecoveryCategory.RESOURCE_BUSY: RecoveryPolicy(
-        RecoveryStrategy.RETRY_WITH_DELAY, 1.0,
+        RecoveryStrategy.RETRY_WITH_DELAY,
+        1.0,
     ),
     RecoveryCategory.TIMEOUT: RecoveryPolicy(
-        RecoveryStrategy.NO_ACTION, 0.0,
+        RecoveryStrategy.NO_ACTION,
+        0.0,
     ),
     RecoveryCategory.RATE_LIMITED: RecoveryPolicy(
-        RecoveryStrategy.RETRY_WITH_DELAY, 2.0,
+        RecoveryStrategy.RETRY_WITH_DELAY,
+        2.0,
     ),
     RecoveryCategory.BULKHEAD_FULL: RecoveryPolicy(
-        RecoveryStrategy.RETRY_WITH_DELAY, 1.0,
+        RecoveryStrategy.RETRY_WITH_DELAY,
+        1.0,
     ),
     RecoveryCategory.AUTH_FAILURE: RecoveryPolicy(
-        RecoveryStrategy.HINT_AND_ESCALATE, 0.0,
+        RecoveryStrategy.HINT_AND_ESCALATE,
+        0.0,
         hint=(
             "[recovery hint: authentication failure — do not retry the same "
             "call. Verify credentials, refresh the token/key, or escalate to "
@@ -258,7 +268,8 @@ _DEFAULT_POLICIES: dict[RecoveryCategory, RecoveryPolicy] = {
         ),
     ),
     RecoveryCategory.NOT_FOUND: RecoveryPolicy(
-        RecoveryStrategy.HINT_AND_ESCALATE, 0.0,
+        RecoveryStrategy.HINT_AND_ESCALATE,
+        0.0,
         hint=(
             "[recovery hint: target not found — do not retry with the same "
             "path/URL. Use read_file or http_probe on a parent path to locate "
@@ -266,7 +277,8 @@ _DEFAULT_POLICIES: dict[RecoveryCategory, RecoveryPolicy] = {
         ),
     ),
     RecoveryCategory.DISK_FULL: RecoveryPolicy(
-        RecoveryStrategy.HINT_AND_ESCALATE, 0.0,
+        RecoveryStrategy.HINT_AND_ESCALATE,
+        0.0,
         hint=(
             "[recovery hint: disk full on target host — do not retry. Run "
             "'df -h' to confirm, then identify a cleanup candidate (logs, "
@@ -274,7 +286,8 @@ _DEFAULT_POLICIES: dict[RecoveryCategory, RecoveryPolicy] = {
         ),
     ),
     RecoveryCategory.DEPENDENCY_MISSING: RecoveryPolicy(
-        RecoveryStrategy.HINT_AND_ESCALATE, 0.0,
+        RecoveryStrategy.HINT_AND_ESCALATE,
+        0.0,
         hint=(
             "[recovery hint: missing dependency — do not retry. The command "
             "or module is not installed on the target. Propose an install "
@@ -283,7 +296,8 @@ _DEFAULT_POLICIES: dict[RecoveryCategory, RecoveryPolicy] = {
         ),
     ),
     RecoveryCategory.PERMISSION_DENIED: RecoveryPolicy(
-        RecoveryStrategy.HINT_AND_ESCALATE, 0.0,
+        RecoveryStrategy.HINT_AND_ESCALATE,
+        0.0,
         hint=(
             "[recovery hint: permission denied — do not retry with the same "
             "user. Verify file mode/owner (ls -l), consider sudo if the "
@@ -341,6 +355,7 @@ class RecoveryAction:
     accidentally bypass the UNSAFE_TO_RETRY guard, because this function
     is the sole place the guard is consulted.
     """
+
     action: str  # "retry" | "hint" | "skip"
     category: RecoveryCategory | None
     delay_seconds: float = 0.0
@@ -348,7 +363,9 @@ class RecoveryAction:
 
 
 def decide_recovery_action(
-    *, tool_name: str, category: RecoveryCategory | None,
+    *,
+    tool_name: str,
+    category: RecoveryCategory | None,
 ) -> RecoveryAction:
     """Single source of truth for 'what do we do about this failure'.
 
@@ -364,7 +381,9 @@ def decide_recovery_action(
     policy = get_policy(category)
     if policy.strategy == RecoveryStrategy.HINT_AND_ESCALATE:
         return RecoveryAction(
-            action="hint", category=category, hint_text=policy.hint,
+            action="hint",
+            category=category,
+            hint_text=policy.hint,
         )
     if policy.strategy == RecoveryStrategy.NO_ACTION:
         return RecoveryAction(action="skip", category=category)
@@ -373,7 +392,9 @@ def decide_recovery_action(
         return RecoveryAction(action="skip", category=category)
     delay = policy.delay_seconds if policy.delay_seconds else get_retry_delay(category)
     return RecoveryAction(
-        action="retry", category=category, delay_seconds=delay,
+        action="retry",
+        category=category,
+        delay_seconds=delay,
     )
 
 
@@ -423,6 +444,7 @@ def get_retry_delay(category: RecoveryCategory) -> float:
 @dataclass
 class RecoveryEvent:
     """Record of a single recovery attempt."""
+
     tool_name: str
     category: str
     succeeded: bool
@@ -442,22 +464,32 @@ class RecoveryStats:
         self._recent: list[RecoveryEvent] = []
         self._max_recent = max_recent
 
-    def record_attempt(self, tool_name: str, category: RecoveryCategory, error_snippet: str = "") -> None:
+    def record_attempt(
+        self, tool_name: str, category: RecoveryCategory, error_snippet: str = ""
+    ) -> None:
         self._attempts[category.value] += 1
         self._tool_attempts[tool_name] += 1
 
-    def record_success(self, tool_name: str, category: RecoveryCategory, error_snippet: str = "") -> None:
+    def record_success(
+        self, tool_name: str, category: RecoveryCategory, error_snippet: str = ""
+    ) -> None:
         self._successes[category.value] += 1
         self._tool_successes[tool_name] += 1
-        self._recent.append(RecoveryEvent(tool_name, category.value, True, time.time(), error_snippet))
+        self._recent.append(
+            RecoveryEvent(tool_name, category.value, True, time.time(), error_snippet)
+        )
         if len(self._recent) > self._max_recent:
-            self._recent = self._recent[-self._max_recent:]
+            self._recent = self._recent[-self._max_recent :]
 
-    def record_failure(self, tool_name: str, category: RecoveryCategory, error_snippet: str = "") -> None:
+    def record_failure(
+        self, tool_name: str, category: RecoveryCategory, error_snippet: str = ""
+    ) -> None:
         self._failures[category.value] += 1
-        self._recent.append(RecoveryEvent(tool_name, category.value, False, time.time(), error_snippet))
+        self._recent.append(
+            RecoveryEvent(tool_name, category.value, False, time.time(), error_snippet)
+        )
         if len(self._recent) > self._max_recent:
-            self._recent = self._recent[-self._max_recent:]
+            self._recent = self._recent[-self._max_recent :]
 
     def get_summary(self) -> dict:
         all_cats = set(list(self._attempts) + list(self._successes) + list(self._failures))

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -28,6 +28,12 @@ TOOLS: list[dict] = [
 
 TOOL_MAP: dict[str, dict] = {t["name"]: t for t in TOOLS}
 
+# RFC-004 P7 startup assertion (plan advisory #5): duplicate names in the
+# section slices would collapse silently in TOOL_MAP — fail at import
+# instead. (The exact count/order is pinned by the characterization
+# contract, where changing it is a reviewed edit rather than a prod crash.)
+assert len(TOOL_MAP) == len(TOOLS), "duplicate tool name across defs/ sections"
+
 # NOTE: the old MUTATING_TOOLS / READ_ONLY_TOOLS frozensets were removed — they
 # were imported only by a schema test and NOT consulted by any runtime
 # authorization path (the governor uses risk_classifier; mutation detection uses

--- a/src/tools/result_validator.py
+++ b/src/tools/result_validator.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from dataclasses import dataclass, field
 
 log = logging.getLogger("odin.tools.result_validator")
@@ -45,23 +44,27 @@ class ToolResultSchema:
 
 
 # Tools whose handlers may legitimately return an empty/blank string
-_EMPTY_OK_TOOLS = frozenset({
-    "write_file",
-    "browser_click",
-    "browser_fill",
-    "add_reaction",
-    "memory_manage",
-    "manage_list",
-    "delete_schedule",
-    "update_schedule",
-    "stop_loop",
-    "kill_agent",
-})
+_EMPTY_OK_TOOLS = frozenset(
+    {
+        "write_file",
+        "browser_click",
+        "browser_fill",
+        "add_reaction",
+        "memory_manage",
+        "manage_list",
+        "delete_schedule",
+        "update_schedule",
+        "stop_loop",
+        "kill_agent",
+    }
+)
 
 # Tools whose results should be valid JSON
-_JSON_TOOLS = frozenset({
-    "manage_process",
-})
+_JSON_TOOLS = frozenset(
+    {
+        "manage_process",
+    }
+)
 
 TOOL_SCHEMAS: dict[str, ToolResultSchema] = {}
 
@@ -157,11 +160,7 @@ def _truncate_smart(text: str, max_chars: int) -> str:
         return text
     half = max_chars // 2
     omitted = len(text) - max_chars
-    return (
-        text[:half]
-        + f"\n\n[... {omitted} characters omitted ...]\n\n"
-        + text[-half:]
-    )
+    return text[:half] + f"\n\n[... {omitted} characters omitted ...]\n\n" + text[-half:]
 
 
 def validate_tool_result(

--- a/src/tools/risk_classifier.py
+++ b/src/tools/risk_classifier.py
@@ -5,12 +5,13 @@ high, critical) so operators can monitor dangerous operations.  Never blocks
 execution — the classification is logged in audit entries and exposed via
 metrics.
 """
+
 from __future__ import annotations
 
 import re
 import threading
 from collections import defaultdict
-from enum import Enum
+from enum import StrEnum
 from typing import NamedTuple
 
 from ..odin_log import get_logger
@@ -18,7 +19,7 @@ from ..odin_log import get_logger
 log = get_logger("risk_classifier")
 
 
-class RiskLevel(str, Enum):
+class RiskLevel(StrEnum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
@@ -40,13 +41,19 @@ _CRITICAL_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bmkfs\b"), "filesystem format"),
     (re.compile(r"\bdd\s+.*\bif="), "raw disk write"),
     (re.compile(r":\(\)\s*\{\s*:\|:&\s*\}\s*;"), "fork bomb"),
-    (re.compile(r"(?:^|[;&|]\s*|sudo\s+)(?:/sbin/)?(shutdown|poweroff|halt)\b", re.MULTILINE), "system shutdown"),
+    (
+        re.compile(r"(?:^|[;&|]\s*|sudo\s+)(?:/sbin/)?(shutdown|poweroff|halt)\b", re.MULTILINE),
+        "system shutdown",
+    ),
     (re.compile(r"\binit\s+0\b"), "system shutdown"),
     (re.compile(r"(?:^|[;&|]\s*|sudo\s+)(?:/sbin/)?reboot\b", re.MULTILINE), "system reboot"),
     (re.compile(r"\bchmod\s+.*-[a-zA-Z]*R.*\s+777\s+/"), "recursive world-writable root"),
     (re.compile(r"\biptables\s+.*-F\b"), "firewall flush"),
     (re.compile(r"\bufw\s+disable\b"), "firewall disable"),
-    (re.compile(r"\b(DROP|TRUNCATE)\s+(DATABASE|TABLE)\b", re.IGNORECASE), "database drop/truncate"),
+    (
+        re.compile(r"\b(DROP|TRUNCATE)\s+(DATABASE|TABLE)\b", re.IGNORECASE),
+        "database drop/truncate",
+    ),
     (re.compile(r"\bcrontab\s+.*-r\b"), "crontab remove all"),
     (re.compile(r">\s*/dev/sd[a-z]"), "write to block device"),
     # Bypass closures — the root-delete rules above anchor on a trailing "/",
@@ -55,15 +62,20 @@ _CRITICAL_PATTERNS: list[tuple[re.Pattern, str]] = [
     # catastrophic forms the original set missed.
     (re.compile(r"\brm\s+.*-[a-zA-Z]*[rf][a-zA-Z]*\s+/\*"), "recursive delete on root glob"),
     (re.compile(r"\brm\s+.*--no-preserve-root"), "delete overriding root guard"),
-    (re.compile(r"\brm\s+.*-[a-zA-Z]*[rf][a-zA-Z]*\s+/\s*[;&|]"), "recursive delete on root (chained)"),
+    (
+        re.compile(r"\brm\s+.*-[a-zA-Z]*[rf][a-zA-Z]*\s+/\s*[;&|]"),
+        "recursive delete on root (chained)",
+    ),
     (re.compile(r"\bfind\s+/\s+.*-delete\b"), "recursive delete from root via find"),
     (re.compile(r"\bfind\s+/\s+.*-exec\s+rm\b"), "recursive delete from root via find -exec"),
     (re.compile(r"\bdd\s+.*\bof=/dev/(sd|nvme|vd|xvd|mmcblk)"), "raw write to block device"),
     # chmod 777 on root, either flag order (chmod -R 777 / or chmod 777 -R /).
     (re.compile(r"\bchmod\s+.*\b777\b.*\s+/\s*($|[;&|])"), "world-writable on root"),
     # Decode/download piped into a shell — arbitrary remote code execution.
-    (re.compile(r"\bbase64\s+.*(--decode|-d)\b.*\|\s*(sudo\s+)?(sh|bash|zsh)\b"),
-     "base64 decode piped to shell"),
+    (
+        re.compile(r"\bbase64\s+.*(--decode|-d)\b.*\|\s*(sudo\s+)?(sh|bash|zsh)\b"),
+        "base64 decode piped to shell",
+    ),
     (re.compile(r"\|\s*sudo\s+(sh|bash|zsh)\b"), "piped into privileged shell"),
 ]
 
@@ -89,7 +101,10 @@ _HIGH_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bchown\s+.*-[a-zA-Z]*R"), "recursive ownership change"),
     (re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE), "database delete"),
     (re.compile(r"\bALTER\s+TABLE\b", re.IGNORECASE), "database schema change"),
-    (re.compile(r"\bDROP\s+(INDEX|VIEW|FUNCTION|TRIGGER)\b", re.IGNORECASE), "database object drop"),
+    (
+        re.compile(r"\bDROP\s+(INDEX|VIEW|FUNCTION|TRIGGER)\b", re.IGNORECASE),
+        "database object drop",
+    ),
 ]
 
 _MEDIUM_PATTERNS: list[tuple[re.Pattern, str]] = [
@@ -239,6 +254,7 @@ _EXFIL_PATTERNS: list[tuple[re.Pattern, str]] = [
 
 class CommandGovernorResult:
     """Result of a command governor check."""
+
     __slots__ = ("allowed", "risk", "reason", "suggestion")
 
     def __init__(self, allowed: bool, risk: RiskLevel, reason: str, suggestion: str = ""):
@@ -298,7 +314,7 @@ class CommandGovernor:
         self._stats = GovernorStats()
 
     @property
-    def stats(self) -> "GovernorStats":
+    def stats(self) -> GovernorStats:
         return self._stats
 
     def check(
@@ -326,12 +342,19 @@ class CommandGovernor:
                     if is_admin and self._admin_can_override:
                         log.warning(
                             "Governor ALLOWED (admin override, exfil): %s — %s",
-                            reason, command[:200],
+                            reason,
+                            command[:200],
                         )
-                        self._stats.record_allow(command, RiskAssessment(RiskLevel.CRITICAL, reason))
-                        return CommandGovernorResult(True, RiskLevel.CRITICAL, f"{reason} (admin override)")
+                        self._stats.record_allow(
+                            command, RiskAssessment(RiskLevel.CRITICAL, reason)
+                        )
+                        return CommandGovernorResult(
+                            True, RiskLevel.CRITICAL, f"{reason} (admin override)"
+                        )
                     result = CommandGovernorResult(
-                        False, RiskLevel.CRITICAL, reason,
+                        False,
+                        RiskLevel.CRITICAL,
+                        reason,
                         _SUGGESTION_MAP.get(reason, ""),
                     )
                     self._stats.record_block(command, result)
@@ -345,12 +368,17 @@ class CommandGovernor:
             if is_admin and self._admin_can_override:
                 log.warning(
                     "Governor ALLOWED (admin override, critical): %s — %s",
-                    assessment.reason, command[:200],
+                    assessment.reason,
+                    command[:200],
                 )
                 self._stats.record_allow(command, assessment)
-                return CommandGovernorResult(True, RiskLevel.CRITICAL, f"{assessment.reason} (admin override)")
+                return CommandGovernorResult(
+                    True, RiskLevel.CRITICAL, f"{assessment.reason} (admin override)"
+                )
             result = CommandGovernorResult(
-                False, RiskLevel.CRITICAL, assessment.reason,
+                False,
+                RiskLevel.CRITICAL,
+                assessment.reason,
                 _SUGGESTION_MAP.get(assessment.reason, ""),
             )
             self._stats.record_block(command, result)
@@ -360,11 +388,15 @@ class CommandGovernor:
         host_policy = self._host_overrides.get(host, "") if host else ""
         if host_policy == "strict" and assessment.level == RiskLevel.HIGH:
             result = CommandGovernorResult(
-                False, assessment.level, f"{assessment.reason} (host '{host}' is strict-mode)",
+                False,
+                assessment.level,
+                f"{assessment.reason} (host '{host}' is strict-mode)",
                 _SUGGESTION_MAP.get(assessment.reason, ""),
             )
             self._stats.record_block(command, result)
-            log.warning("Governor BLOCKED (strict host %s): %s — %s", host, assessment.reason, command[:200])
+            log.warning(
+                "Governor BLOCKED (strict host %s): %s — %s", host, assessment.reason, command[:200]
+            )
             return result
 
         if assessment.level == RiskLevel.HIGH:
@@ -387,22 +419,26 @@ class GovernorStats:
     def record_block(self, command: str, result: CommandGovernorResult) -> None:
         with self._lock:
             self._block_count += 1
-            self._blocked.append({
-                "command": command[:200],
-                "risk": result.risk.value,
-                "reason": result.reason,
-            })
+            self._blocked.append(
+                {
+                    "command": command[:200],
+                    "risk": result.risk.value,
+                    "reason": result.reason,
+                }
+            )
             if len(self._blocked) > 50:
                 self._blocked = self._blocked[-50:]
 
     def record_allow(self, command: str, assessment: RiskAssessment) -> None:
         with self._lock:
             self._allow_count += 1
-            self._allowed_high.append({
-                "command": command[:200],
-                "risk": assessment.level.value,
-                "reason": assessment.reason,
-            })
+            self._allowed_high.append(
+                {
+                    "command": command[:200],
+                    "risk": assessment.level.value,
+                    "reason": assessment.reason,
+                }
+            )
             if len(self._allowed_high) > 50:
                 self._allowed_high = self._allowed_high[-50:]
 
@@ -438,7 +474,7 @@ class RiskStats:
             }
             self._recent.append(entry)
             if len(self._recent) > self._max_recent:
-                self._recent = self._recent[-self._max_recent:]
+                self._recent = self._recent[-self._max_recent :]
 
     def get_summary(self) -> dict:
         """Return aggregated risk statistics."""

--- a/src/tools/skill_context.py
+++ b/src/tools/skill_context.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import ipaddress
 import json
 import re
 import threading
-from dataclasses import dataclass, field
-from pathlib import Path
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
 
 import aiohttp
 
@@ -26,9 +24,11 @@ if TYPE_CHECKING:
 # Resource tracking
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ResourceTracker:
     """Tracks resource usage during a single skill execution."""
+
     tool_calls: int = 0
     http_requests: int = 0
     messages_sent: int = 0
@@ -59,13 +59,13 @@ MAX_SKILL_FILES = 10
 
 # File path patterns that skills are NOT allowed to read.
 _DENIED_PATH_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"(^|/)\.env($|\.)"),       # .env, .env.local, etc.
-    re.compile(r"(^|/)config\.ya?ml$"),     # config.yml / config.yaml
-    re.compile(r"/etc/shadow$"),            # system shadow passwords
+    re.compile(r"(^|/)\.env($|\.)"),  # .env, .env.local, etc.
+    re.compile(r"(^|/)config\.ya?ml$"),  # config.yml / config.yaml
+    re.compile(r"/etc/shadow$"),  # system shadow passwords
     re.compile(r"(^|/)id_(rsa|ed25519|ecdsa|dsa)$"),  # SSH private keys
-    re.compile(r"(^|/)\.ssh/"),             # entire .ssh directory
-    re.compile(r"(^|/)credentials\.json$"), # service credentials
-    re.compile(r"(^|/)\.kube/config$"),     # kubernetes config
+    re.compile(r"(^|/)\.ssh/"),  # entire .ssh directory
+    re.compile(r"(^|/)credentials\.json$"),  # service credentials
+    re.compile(r"(^|/)\.kube/config$"),  # kubernetes config
 ]
 
 
@@ -92,29 +92,34 @@ def set_skill_allowed_urls(urls: list[str]) -> None:
 def is_url_blocked(url: str) -> bool:
     """Return True if a URL targets localhost, private IPs, or metadata endpoints."""
     from .url_safety import is_url_blocked as _shared_check
-    return _shared_check(url, allowed_urls=list(_SKILL_ALLOWED_URLS) if _SKILL_ALLOWED_URLS else None)
+
+    return _shared_check(
+        url, allowed_urls=list(_SKILL_ALLOWED_URLS) if _SKILL_ALLOWED_URLS else None
+    )
 
 
 # Tools that skills are allowed to call via execute_tool().
 # Only read-only / non-destructive tools are included.
-SKILL_SAFE_TOOLS: frozenset[str] = frozenset({
-    "read_file",
-    "search_history",
-    "search_audit",
-    "search_knowledge",
-    "list_knowledge",
-    "list_schedules",
-    "list_skills",
-    "list_tasks",
-    "memory_manage",
-    "parse_time",
-    "web_search",
-    "fetch_url",
-    "http_probe",
-    "browser_screenshot",
-    "browser_read_page",
-    "browser_read_table",
-})
+SKILL_SAFE_TOOLS: frozenset[str] = frozenset(
+    {
+        "read_file",
+        "search_history",
+        "search_audit",
+        "search_knowledge",
+        "list_knowledge",
+        "list_schedules",
+        "list_skills",
+        "list_tasks",
+        "memory_manage",
+        "parse_time",
+        "web_search",
+        "fetch_url",
+        "http_probe",
+        "browser_screenshot",
+        "browser_read_page",
+        "browser_read_table",
+    }
+)
 
 
 class SkillContext:
@@ -167,20 +172,33 @@ class SkillContext:
             return "No hosts configured to reach Prometheus."
         host = hosts[0]
         from urllib.parse import quote as url_quote
+
         encoded_query = url_quote(query)
-        return str(await self._executor.execute("run_command", {
-            "host": host,
-            "command": f"curl -sf 'http://localhost:9090/api/v1/query?query={encoded_query}'",
-        }))
+        return str(
+            await self._executor.execute(
+                "run_command",
+                {
+                    "host": host,
+                    "command": f"curl -sf 'http://localhost:9090/api/v1/query?query={encoded_query}'",
+                },
+            )
+        )
 
     async def read_file(self, host: str, path: str, lines: int = 200) -> str:
         """Read a file from a managed host. Returns file content."""
         if is_path_denied(path):
             self._log.warning("Skill attempted to read denied path: %s", path)
             return f"Access denied: '{path}' is a restricted path."
-        return str(await self._executor.execute("read_file", {
-            "host": host, "path": path, "lines": lines,
-        }))
+        return str(
+            await self._executor.execute(
+                "read_file",
+                {
+                    "host": host,
+                    "path": path,
+                    "lines": lines,
+                },
+            )
+        )
 
     async def post_message(self, text: str) -> None:
         """Send a message to the channel that invoked this skill."""
@@ -260,7 +278,9 @@ class SkillContext:
             merged.update(headers)
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                url, params=params, headers=merged,
+                url,
+                params=params,
+                headers=merged,
                 timeout=aiohttp.ClientTimeout(total=timeout),
             ) as resp:
                 ct = resp.content_type or ""
@@ -301,7 +321,10 @@ class SkillContext:
             merged.update(headers)
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                url, json=json, data=data, headers=merged or None,
+                url,
+                json=json,
+                data=data,
+                headers=merged or None,
                 timeout=aiohttp.ClientTimeout(total=timeout),
             ) as resp:
                 ct = resp.content_type or ""
@@ -381,7 +404,10 @@ class SkillContext:
         """
         if tool_name not in SKILL_SAFE_TOOLS:
             self._log.warning("Skill attempted blocked tool: %s", tool_name)
-            return f"Tool '{tool_name}' is not allowed from skills. Only read-only tools are permitted."
+            return (
+                f"Tool '{tool_name}' is not allowed from skills. "
+                "Only read-only tools are permitted."
+            )
         if self._tracker.tool_calls >= MAX_SKILL_TOOL_CALLS:
             return f"Tool call limit ({MAX_SKILL_TOOL_CALLS}) exceeded."
         self._tracker.tool_calls += 1

--- a/src/tools/skill_manager.py
+++ b/src/tools/skill_manager.py
@@ -9,12 +9,12 @@ import subprocess
 import sys
 import time
 import urllib.parse
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
-from collections.abc import Callable
 from typing import Any
 
 from ..odin_log import get_logger
@@ -54,28 +54,74 @@ _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 # trusted (admin-authored) and stays unrestricted; install_skill fetches code
 # from a prompt-influenceable URL, so URL installs get this AST denylist as
 # defense-in-depth against injected-instruction RCE.
-_URL_SKILL_DENIED_IMPORTS = frozenset({
-    "os", "subprocess", "socket", "sys", "ctypes", "shutil",
-    "multiprocessing", "importlib", "pty", "fcntl", "resource", "signal",
-    # Added: low-level / interpreter-escape modules the original list missed
-    # (e.g. `import posix; posix.system(...)`, `runpy.run_path`, pickle/marshal
-    # code execution, pdb shell-out).
-    "posix", "nt", "builtins", "runpy", "pdb", "pickle", "marshal",
-    "code", "codeop", "gc", "cProfile", "commands", "popen2",
-})
+_URL_SKILL_DENIED_IMPORTS = frozenset(
+    {
+        "os",
+        "subprocess",
+        "socket",
+        "sys",
+        "ctypes",
+        "shutil",
+        "multiprocessing",
+        "importlib",
+        "pty",
+        "fcntl",
+        "resource",
+        "signal",
+        # Added: low-level / interpreter-escape modules the original list missed
+        # (e.g. `import posix; posix.system(...)`, `runpy.run_path`, pickle/marshal
+        # code execution, pdb shell-out).
+        "posix",
+        "nt",
+        "builtins",
+        "runpy",
+        "pdb",
+        "pickle",
+        "marshal",
+        "code",
+        "codeop",
+        "gc",
+        "cProfile",
+        "commands",
+        "popen2",
+    }
+)
 _URL_SKILL_DENIED_CALLS = frozenset({"eval", "exec", "compile", "__import__", "open"})
 # Attribute-form calls a URL skill must not make — catches things the bare-Name
 # check missed, e.g. `builtins.__import__("os")`, `x.system(...)`, `y.popen(...)`.
-_URL_SKILL_DENIED_ATTR_CALLS = frozenset({
-    "system", "popen", "popen2", "popen3", "spawn", "spawnl", "spawnv",
-    "execv", "execve", "execl", "fork", "__import__", "run_path", "run_module",
-    "loads", "load",  # pickle/marshal deserialization
-})
+_URL_SKILL_DENIED_ATTR_CALLS = frozenset(
+    {
+        "system",
+        "popen",
+        "popen2",
+        "popen3",
+        "spawn",
+        "spawnl",
+        "spawnv",
+        "execv",
+        "execve",
+        "execl",
+        "fork",
+        "__import__",
+        "run_path",
+        "run_module",
+        "loads",
+        "load",  # pickle/marshal deserialization
+    }
+)
 # Dunder escape hatches (sandbox breakouts) denied anywhere in URL skills.
-_URL_SKILL_DENIED_DUNDERS = frozenset({
-    "__import__", "__builtins__", "__globals__", "__subclasses__",
-    "__bases__", "__mro__", "__code__", "__loader__",
-})
+_URL_SKILL_DENIED_DUNDERS = frozenset(
+    {
+        "__import__",
+        "__builtins__",
+        "__globals__",
+        "__subclasses__",
+        "__bases__",
+        "__mro__",
+        "__code__",
+        "__loader__",
+    }
+)
 
 
 def _scan_url_skill_ast(code: str) -> list[str]:
@@ -137,9 +183,10 @@ def is_safe_dependency_spec(spec: str) -> bool:
     if (
         "@" in s
         or "://" in s
-        or ";" in s          # environment markers / command chaining
+        or ";" in s  # environment markers / command chaining
         or s.startswith("-")  # pip options (-e, --index-url, etc.)
-        or "/" in s or "\\" in s
+        or "/" in s
+        or "\\" in s
         or any(lowered.startswith(v + "+") for v in ("git", "hg", "svn", "bzr"))
         or any(c.isspace() for c in s)
     ):
@@ -148,7 +195,7 @@ def is_safe_dependency_spec(spec: str) -> bool:
     if not name:
         return False
     # Whatever follows the name[extras] must be a plain version specifier.
-    remainder = s.split("]", 1)[1] if "[" in s and "]" in s else s[len(name):]
+    remainder = s.split("]", 1)[1] if "[" in s and "]" in s else s[len(name) :]
     return bool(_DEP_VERSION_RE.match(remainder.strip()))
 
 
@@ -167,7 +214,9 @@ def _install_packages(specs: list[str], timeout: int = _PIP_INSTALL_TIMEOUT) -> 
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install", "--quiet", "--disable-pip-version-check"]
             + specs,
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
         output = (result.stdout + result.stderr).strip()
         return result.returncode == 0, output
@@ -226,7 +275,7 @@ def _extract_skill_name_from_source(source: str) -> str:
     return ""
 
 
-def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list["SkillDiagnostic"]]:
+def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list[SkillDiagnostic]]:
     """Resolve skill pip dependencies.
 
     Returns ``(already_installed, newly_installed, diagnostics)``.
@@ -237,10 +286,12 @@ def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list["S
         return [], [], diagnostics
 
     if len(deps) > MAX_SKILL_DEPENDENCIES:
-        diagnostics.append(SkillDiagnostic(
-            "error",
-            f"Too many dependencies ({len(deps)}). Maximum is {MAX_SKILL_DEPENDENCIES}.",
-        ))
+        diagnostics.append(
+            SkillDiagnostic(
+                "error",
+                f"Too many dependencies ({len(deps)}). Maximum is {MAX_SKILL_DEPENDENCIES}.",
+            )
+        )
         return [], [], diagnostics
 
     already_installed: list[str] = []
@@ -250,12 +301,14 @@ def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list["S
         # Block install-time RCE via direct-reference / URL / VCS / path specs
         # BEFORE anything reaches pip.
         if not is_safe_dependency_spec(spec):
-            diagnostics.append(SkillDiagnostic(
-                "error",
-                f"Refused unsafe dependency spec {spec!r}: only plain "
-                "'name[extras]<version>' from a package index is allowed "
-                "(no URLs, @ direct references, VCS, or local paths).",
-            ))
+            diagnostics.append(
+                SkillDiagnostic(
+                    "error",
+                    f"Refused unsafe dependency spec {spec!r}: only plain "
+                    "'name[extras]<version>' from a package index is allowed "
+                    "(no URLs, @ direct references, VCS, or local paths).",
+                )
+            )
             return [], [], diagnostics
         name = _parse_package_name(spec)
         if not name:
@@ -271,13 +324,19 @@ def resolve_dependencies(deps: list[str]) -> tuple[list[str], list[str], list["S
         success, output = _install_packages(to_install)
         if success:
             newly_installed = to_install
-            diagnostics.append(SkillDiagnostic(
-                "warn", f"Auto-installed dependencies: {', '.join(to_install)}",
-            ))
+            diagnostics.append(
+                SkillDiagnostic(
+                    "warn",
+                    f"Auto-installed dependencies: {', '.join(to_install)}",
+                )
+            )
         else:
-            diagnostics.append(SkillDiagnostic(
-                "error", f"Failed to install dependencies [{', '.join(to_install)}]: {output}",
-            ))
+            diagnostics.append(
+                SkillDiagnostic(
+                    "error",
+                    f"Failed to install dependencies [{', '.join(to_install)}]: {output}",
+                )
+            )
 
     return already_installed, newly_installed, diagnostics
 
@@ -309,7 +368,11 @@ def validate_config_value(field_name: str, field_schema: dict, value: Any) -> st
         return f"'{field_name}': value {value!r} not in allowed values {enum}"
 
     # Numeric constraints
-    if ftype in ("integer", "number") and isinstance(value, (int, float)) and not isinstance(value, bool):
+    if (
+        ftype in ("integer", "number")
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+    ):
         minimum = field_schema.get("minimum")
         if minimum is not None and value < minimum:
             return f"'{field_name}': value {value} is below minimum {minimum}"
@@ -378,8 +441,9 @@ def apply_defaults(schema: dict, values: dict) -> dict:
     return result
 
 
-class SkillStatus(str, Enum):
+class SkillStatus(StrEnum):
     """Lifecycle state of a skill."""
+
     LOADED = "loaded"
     DISABLED = "disabled"
     ERROR = "error"
@@ -388,6 +452,7 @@ class SkillStatus(str, Enum):
 @dataclass
 class SkillDiagnostic:
     """A warning or error collected during skill load/validation."""
+
     level: str  # "warn" or "error"
     message: str
 
@@ -395,6 +460,7 @@ class SkillDiagnostic:
 @dataclass
 class SkillMetadata:
     """Rich metadata parsed from SKILL_DEFINITION."""
+
     version: str = "0.0.0"
     author: str = ""
     homepage: str = ""
@@ -412,9 +478,13 @@ class SkillMetadata:
         raw_version = definition.get("version", "0.0.0")
         if isinstance(raw_version, str):
             if raw_version and not _SEMVER_PATTERN.match(raw_version):
-                diagnostics.append(SkillDiagnostic(
-                    "warn", f"Invalid version '{raw_version}', expected semver (e.g. 1.0.0). Using 0.0.0.",
-                ))
+                diagnostics.append(
+                    SkillDiagnostic(
+                        "warn",
+                        f"Invalid version '{raw_version}', expected semver (e.g. 1.0.0). "
+                        "Using 0.0.0.",
+                    )
+                )
                 kwargs["version"] = "0.0.0"
             else:
                 kwargs["version"] = raw_version or "0.0.0"
@@ -448,7 +518,9 @@ class SkillMetadata:
         if isinstance(raw_deps, list) and all(isinstance(d, str) for d in raw_deps):
             kwargs["dependencies"] = raw_deps
         elif raw_deps:
-            diagnostics.append(SkillDiagnostic("warn", "dependencies must be a list of strings. Ignored."))
+            diagnostics.append(
+                SkillDiagnostic("warn", "dependencies must be a list of strings. Ignored.")
+            )
 
         # config_schema (JSON Schema dict)
         raw_cs = definition.get("config_schema", {})
@@ -463,6 +535,7 @@ class SkillMetadata:
 @dataclass
 class SkillExecutionStats:
     """Resource usage from a single skill execution."""
+
     wall_time_ms: float = 0.0
     output_chars: int = 0
     truncated: bool = False
@@ -504,7 +577,9 @@ class SkillManager:
     """Manages user-created Python skill files in data/skills/."""
 
     def __init__(
-        self, skills_dir: str, tool_executor: ToolExecutor,
+        self,
+        skills_dir: str,
+        tool_executor: ToolExecutor,
         memory_path: str | None = None,
         tool_timeouts: dict[str, int] | None = None,
     ) -> None:
@@ -688,12 +763,18 @@ class SkillManager:
         skill = self._load_skill(path)
         if not skill:
             path.unlink(missing_ok=True)
-            return f"Skill file written but failed to load. Check syntax and required exports (SKILL_DEFINITION dict + async execute function)."
+            return (
+                "Skill file written but failed to load. Check syntax and required "
+                "exports (SKILL_DEFINITION dict + async execute function)."
+            )
 
         if skill.name != name:
             self._unload_skill(skill.name)
             path.unlink(missing_ok=True)
-            return f"SKILL_DEFINITION.name ('{skill.name}') doesn't match filename ('{name}'). They must be identical."
+            return (
+                f"SKILL_DEFINITION.name ('{skill.name}') doesn't match filename "
+                f"('{name}'). They must be identical."
+            )
 
         self._skills[name] = skill
         return f"Skill '{name}' created and loaded successfully. It's now available as a tool."
@@ -719,7 +800,7 @@ class SkillManager:
             old_skill = self._load_skill(path)
             if old_skill:
                 self._skills[name] = old_skill
-            return f"New code failed to load. Reverted to previous version."
+            return "New code failed to load. Reverted to previous version."
 
         if skill.name != name:
             # Name mismatch — revert to old code
@@ -836,10 +917,7 @@ class SkillManager:
                 "tags": s.metadata.tags,
                 "dependencies": s.metadata.dependencies,
                 "has_config": bool(s.metadata.config_schema),
-                "diagnostics": [
-                    {"level": d.level, "message": d.message}
-                    for d in s.diagnostics
-                ],
+                "diagnostics": [{"level": d.level, "message": d.message} for d in s.diagnostics],
                 "total_executions": s.total_executions,
                 "last_execution": s.last_execution.to_dict() if s.last_execution else None,
             }
@@ -864,11 +942,13 @@ class SkillManager:
         results = []
         for spec in deps:
             pkg_name = _parse_package_name(spec)
-            results.append({
-                "spec": spec,
-                "package": pkg_name,
-                "installed": _is_package_installed(pkg_name) if pkg_name else False,
-            })
+            results.append(
+                {
+                    "spec": spec,
+                    "package": pkg_name,
+                    "installed": _is_package_installed(pkg_name) if pkg_name else False,
+                }
+            )
         return {
             "dependencies": results,
             "all_satisfied": all(r["installed"] for r in results),
@@ -911,17 +991,20 @@ class SkillManager:
         except SyntaxError as e:
             errors.append(f"Syntax error at line {e.lineno}: {e.msg}")
             return {
-                "valid": False, "errors": errors, "warnings": warnings,
-                "metadata": None, "definition_keys": [],
+                "valid": False,
+                "errors": errors,
+                "warnings": warnings,
+                "metadata": None,
+                "definition_keys": [],
             }
 
         # 2. Static analysis — extract SKILL_DEFINITION from AST without exec
         import ast as _ast
+
         tree = _ast.parse(code, filename)
 
         has_execute = any(
-            isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef))
-            and node.name == "execute"
+            isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef)) and node.name == "execute"
             for node in _ast.walk(tree)
         )
         if not has_execute:
@@ -936,7 +1019,10 @@ class SkillManager:
                         try:
                             definition = _ast.literal_eval(node.value)
                         except Exception:
-                            warnings.append("SKILL_DEFINITION is not a static literal — will be validated at load time.")
+                            warnings.append(
+                                "SKILL_DEFINITION is not a static literal — "
+                                "will be validated at load time."
+                            )
 
         if definition is None and not any("SKILL_DEFINITION" in e for e in errors):
             errors.append("Missing or invalid SKILL_DEFINITION dict.")
@@ -958,8 +1044,10 @@ class SkillManager:
             # Parse metadata
             meta, diags = SkillMetadata.from_definition(definition)
             metadata_out = {
-                "version": meta.version, "author": meta.author,
-                "homepage": meta.homepage, "tags": meta.tags,
+                "version": meta.version,
+                "author": meta.author,
+                "homepage": meta.homepage,
+                "tags": meta.tags,
                 "dependencies": meta.dependencies,
                 "has_config": bool(meta.config_schema),
             }
@@ -972,7 +1060,9 @@ class SkillManager:
             for node in _ast.walk(tree)
         )
         if has_execute and not execute_is_async:
-            warnings.append("execute() is not async. It should be 'async def execute(inp, context)'.")
+            warnings.append(
+                "execute() is not async. It should be 'async def execute(inp, context)'."
+            )
 
         return {
             "valid": len(errors) == 0,
@@ -1009,10 +1099,7 @@ class SkillManager:
                 "config_schema": skill.metadata.config_schema,
             },
             "config": self.get_skill_config(name),
-            "diagnostics": [
-                {"level": d.level, "message": d.message}
-                for d in skill.diagnostics
-            ],
+            "diagnostics": [{"level": d.level, "message": d.message} for d in skill.diagnostics],
             "handoff_to_codex": skill.definition.get("handoff_to_codex", False),
             "code": code,
             "total_executions": skill.total_executions,
@@ -1020,7 +1107,9 @@ class SkillManager:
         }
 
     async def execute(
-        self, tool_name: str, tool_input: dict,
+        self,
+        tool_name: str,
+        tool_input: dict,
         message_callback: Callable | None = None,
         file_callback: Callable | None = None,
     ) -> str:
@@ -1036,7 +1125,8 @@ class SkillManager:
 
         tracker = ResourceTracker()
         context = SkillContext(
-            self._executor, tool_name,
+            self._executor,
+            tool_name,
             memory_path=self._memory_path,
             message_callback=message_callback,
             file_callback=file_callback,
@@ -1061,11 +1151,14 @@ class SkillManager:
                 result = str(result)
             # Enforce output limit
             if len(result) > MAX_SKILL_OUTPUT_CHARS:
-                result = result[:MAX_SKILL_OUTPUT_CHARS] + f"\n... [truncated at {MAX_SKILL_OUTPUT_CHARS} chars]"
+                result = (
+                    result[:MAX_SKILL_OUTPUT_CHARS]
+                    + f"\n... [truncated at {MAX_SKILL_OUTPUT_CHARS} chars]"
+                )
                 truncated = True
             output_chars = len(result)
             return result
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return f"Skill '{tool_name}' timed out after {skill_timeout}s."
         except Exception as e:
             log.error("Skill %s execution error: %s", tool_name, e, exc_info=True)
@@ -1100,12 +1193,14 @@ class SkillManager:
         if not parsed.netloc:
             return "Invalid URL: no host specified."
         from .url_safety import is_url_blocked
+
         if is_url_blocked(url):
             return "Error: blocked URL (localhost / private IP / cloud-metadata address)."
 
         # Download
         try:
             import aiohttp
+
             timeout = aiohttp.ClientTimeout(total=_URL_DOWNLOAD_TIMEOUT)
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url) as resp:
@@ -1114,14 +1209,19 @@ class SkillManager:
                     # Check content length header if available
                     cl = resp.content_length
                     if cl and cl > MAX_SKILL_DOWNLOAD_BYTES:
-                        return f"File too large ({cl} bytes). Maximum is {MAX_SKILL_DOWNLOAD_BYTES}."
+                        return (
+                            f"File too large ({cl} bytes). Maximum is {MAX_SKILL_DOWNLOAD_BYTES}."
+                        )
                     data = await resp.content.read(MAX_SKILL_DOWNLOAD_BYTES + 1)
                     if len(data) > MAX_SKILL_DOWNLOAD_BYTES:
-                        return f"File too large (>{MAX_SKILL_DOWNLOAD_BYTES} bytes). Maximum is {MAX_SKILL_DOWNLOAD_BYTES}."
+                        return (
+                            f"File too large (>{MAX_SKILL_DOWNLOAD_BYTES} bytes). "
+                            f"Maximum is {MAX_SKILL_DOWNLOAD_BYTES}."
+                        )
                     code = data.decode("utf-8")
         except UnicodeDecodeError:
             return "Downloaded file is not valid UTF-8 text."
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return f"Download timed out after {_URL_DOWNLOAD_TIMEOUT}s."
         except Exception as e:
             return f"Download error: {e}"
@@ -1147,9 +1247,11 @@ class SkillManager:
                 "create_skill instead."
             )
         import hashlib
+
         log.warning(
             "Installing skill from URL %s (sha256=%s)",
-            url, hashlib.sha256(code.encode()).hexdigest()[:16],
+            url,
+            hashlib.sha256(code.encode()).hexdigest()[:16],
         )
 
         # Extract skill name STATICALLY — never exec URL code just to read a
@@ -1200,7 +1302,9 @@ class SkillManager:
 
         if skill.last_execution:
             ex = skill.last_execution
-            lines.append(f"Last execution: {ex.timestamp} ({ex.wall_time_ms:.0f}ms, {ex.output_chars} chars)")
+            lines.append(
+                f"Last execution: {ex.timestamp} ({ex.wall_time_ms:.0f}ms, {ex.output_chars} chars)"
+            )
 
         if skill.metadata.dependencies:
             dep_status = self.check_dependencies(name)
@@ -1208,7 +1312,7 @@ class SkillManager:
             for d in dep_status.get("dependencies", []):
                 status = "installed" if d["installed"] else "MISSING"
                 dep_lines.append(f"  {d['spec']} [{status}]")
-            lines.append(f"Dependencies:\n" + "\n".join(dep_lines))
+            lines.append("Dependencies:\n" + "\n".join(dep_lines))
 
         if skill.metadata.config_schema:
             config = self.get_skill_config(name)
@@ -1216,6 +1320,6 @@ class SkillManager:
 
         if skill.diagnostics:
             diag_lines = [f"  [{d.level}] {d.message}" for d in skill.diagnostics]
-            lines.append(f"Diagnostics:\n" + "\n".join(diag_lines))
+            lines.append("Diagnostics:\n" + "\n".join(diag_lines))
 
         return "\n".join(lines)

--- a/src/tools/ssh.py
+++ b/src/tools/ssh.py
@@ -79,9 +79,9 @@ async def _read_lines_with_callback(
         # Wait for process exit with a bounded timeout to avoid indefinite hang
         try:
             await asyncio.wait_for(proc.wait(), timeout=min(timeout, 10))
-        except asyncio.TimeoutError:
+        except TimeoutError:
             proc.kill()
-    except (asyncio.TimeoutError, TimeoutError):
+    except TimeoutError:
         proc.kill()
         return 1, f"Command timed out after {timeout} seconds"
     output = "".join(lines)
@@ -113,7 +113,7 @@ async def run_local_command(
         output = stdout.decode("utf-8", errors="replace")
         return proc.returncode or 0, _truncate_output(output)
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         proc.kill()
         return 1, f"Command timed out after {timeout} seconds"
     except Exception as e:
@@ -145,16 +145,25 @@ async def run_ssh_command(
     """
     if pool is not None:
         ssh_args = pool.get_ssh_args(
-            host, command, ssh_key_path, known_hosts_path, ssh_user,
+            host,
+            command,
+            ssh_key_path,
+            known_hosts_path,
+            ssh_user,
         )
     else:
         ssh_args = [
             "ssh",
-            "-i", ssh_key_path,
-            "-o", f"UserKnownHostsFile={known_hosts_path}",
-            "-o", "StrictHostKeyChecking=yes",
-            "-o", "ConnectTimeout=10",
-            "-o", "BatchMode=yes",
+            "-i",
+            ssh_key_path,
+            "-o",
+            f"UserKnownHostsFile={known_hosts_path}",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "BatchMode=yes",
             f"{ssh_user}@{host}",
             command,
         ]
@@ -172,7 +181,9 @@ async def run_ssh_command(
             )
             if on_output is not None:
                 exit_code, output = await _read_lines_with_callback(
-                    proc, timeout, on_output,
+                    proc,
+                    timeout,
+                    on_output,
                 )
             else:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
@@ -189,23 +200,33 @@ async def run_ssh_command(
                 wait = compute_backoff(attempt, retry_base_delay, retry_max_delay)
                 log.warning(
                     "SSH transient failure to %s (attempt %d/%d): %s. Retrying in %.1fs...",
-                    host, attempt + 1, max_retries, output.strip()[:200], wait,
+                    host,
+                    attempt + 1,
+                    max_retries,
+                    output.strip()[:200],
+                    wait,
                 )
                 await asyncio.sleep(wait)
             else:
                 log.warning(
                     "SSH transient failure to %s (attempt %d/%d, exhausted): %s",
-                    host, attempt + 1, max_retries, output.strip()[:200],
+                    host,
+                    attempt + 1,
+                    max_retries,
+                    output.strip()[:200],
                 )
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             last_exit_code = 1
             last_output = f"Command timed out after {timeout} seconds"
             if attempt < max_retries - 1:
                 wait = compute_backoff(attempt, retry_base_delay, retry_max_delay)
                 log.warning(
                     "SSH timeout to %s (attempt %d/%d). Retrying in %.1fs...",
-                    host, attempt + 1, max_retries, wait,
+                    host,
+                    attempt + 1,
+                    max_retries,
+                    wait,
                 )
                 await asyncio.sleep(wait)
             else:

--- a/src/tools/ssh_pool.py
+++ b/src/tools/ssh_pool.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from pathlib import Path
 
 from ..odin_log import get_logger
 
@@ -63,14 +62,22 @@ class SSHConnectionPool:
 
         return [
             "ssh",
-            "-i", ssh_key_path,
-            "-o", f"UserKnownHostsFile={known_hosts_path}",
-            "-o", "StrictHostKeyChecking=yes",
-            "-o", "ConnectTimeout=10",
-            "-o", "BatchMode=yes",
-            "-o", "ControlMaster=auto",
-            "-o", f"ControlPath={socket}",
-            "-o", f"ControlPersist={self.control_persist}",
+            "-i",
+            ssh_key_path,
+            "-o",
+            f"UserKnownHostsFile={known_hosts_path}",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            f"ControlPath={socket}",
+            "-o",
+            f"ControlPersist={self.control_persist}",
             f"{ssh_user}@{host}",
             command,
         ]
@@ -83,8 +90,7 @@ class SSHConnectionPool:
     def get_active_hosts(self) -> list[str]:
         """Return list of host keys with active sockets."""
         return [
-            key for key in self._connections
-            if os.path.exists(os.path.join(self.socket_dir, key))
+            key for key in self._connections if os.path.exists(os.path.join(self.socket_dir, key))
         ]
 
     async def close_host(self, host: str, ssh_user: str = "root") -> bool:
@@ -98,7 +104,11 @@ class SSHConnectionPool:
 
         try:
             proc = await asyncio.create_subprocess_exec(
-                "ssh", "-o", f"ControlPath={socket}", "-O", "exit",
+                "ssh",
+                "-o",
+                f"ControlPath={socket}",
+                "-O",
+                "exit",
                 f"{ssh_user}@{host}",
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
@@ -107,7 +117,7 @@ class SSHConnectionPool:
             self._connections.pop(key, None)
             log.info("Closed SSH connection to %s@%s", ssh_user, host)
             return True
-        except asyncio.TimeoutError:
+        except TimeoutError:
             log.warning("Timeout closing SSH connection to %s@%s, killing process", ssh_user, host)
             try:
                 proc.kill()

--- a/src/tools/terraform_ops.py
+++ b/src/tools/terraform_ops.py
@@ -9,10 +9,20 @@ from __future__ import annotations
 
 import shlex
 
-ALLOWED_ACTIONS = frozenset({
-    "init", "plan", "apply", "output", "show", "validate",
-    "fmt", "state", "workspace", "import",
-})
+ALLOWED_ACTIONS = frozenset(
+    {
+        "init",
+        "plan",
+        "apply",
+        "output",
+        "show",
+        "validate",
+        "fmt",
+        "state",
+        "workspace",
+        "import",
+    }
+)
 
 
 def _sq(value: str) -> str:
@@ -34,8 +44,7 @@ def build_terraform_command(action: str, params: dict) -> str:
     """
     if action not in ALLOWED_ACTIONS:
         raise ValueError(
-            f"Unknown terraform action: {action}. "
-            f"Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
+            f"Unknown terraform action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
         )
     builder = _BUILDERS.get(action)
     if builder is None:
@@ -56,7 +65,7 @@ def _build_init(params: dict) -> str:
         parts.append("-reconfigure")
     if migrate_state:
         parts.append("-migrate-state")
-    for k, v in (backend_config.items() if isinstance(backend_config, dict) else []):
+    for k, v in backend_config.items() if isinstance(backend_config, dict) else []:
         parts.append(f"-backend-config={_sq(f'{k}={v}')}")
     parts.append("-input=false")
     return " ".join(parts)
@@ -73,11 +82,11 @@ def _build_plan(params: dict) -> str:
     parts = ["terraform"] + _chdir_flag(params) + ["plan"]
     if destroy:
         parts.append("-destroy")
-    for k, v in (var.items() if isinstance(var, dict) else []):
+    for k, v in var.items() if isinstance(var, dict) else []:
         parts.append(f"-var={_sq(f'{k}={v}')}")
     if var_file:
         parts.append(f"-var-file={_sq(var_file)}")
-    for t in (target if isinstance(target, list) else []):
+    for t in target if isinstance(target, list) else []:
         parts.append(f"-target={_sq(str(t))}")
     if out:
         parts.append(f"-out={_sq(out)}")
@@ -154,8 +163,7 @@ def _build_state(params: dict) -> str:
     allowed = {"list", "show", "mv", "rm", "pull"}
     if subaction not in allowed:
         raise ValueError(
-            f"Unknown state subaction: {subaction}. "
-            f"Allowed: {', '.join(sorted(allowed))}"
+            f"Unknown state subaction: {subaction}. Allowed: {', '.join(sorted(allowed))}"
         )
 
     parts = ["terraform"] + _chdir_flag(params) + ["state", subaction]
@@ -189,8 +197,7 @@ def _build_workspace(params: dict) -> str:
     allowed = {"list", "select", "new", "delete", "show"}
     if subaction not in allowed:
         raise ValueError(
-            f"Unknown workspace subaction: {subaction}. "
-            f"Allowed: {', '.join(sorted(allowed))}"
+            f"Unknown workspace subaction: {subaction}. Allowed: {', '.join(sorted(allowed))}"
         )
 
     parts = ["terraform"] + _chdir_flag(params) + ["workspace", subaction]
@@ -215,7 +222,7 @@ def _build_import(params: dict) -> str:
     var_file = params.get("var_file", "")
 
     parts = ["terraform"] + _chdir_flag(params) + ["import"]
-    for k, v in (var.items() if isinstance(var, dict) else []):
+    for k, v in var.items() if isinstance(var, dict) else []:
         parts.append(f"-var={_sq(f'{k}={v}')}")
     if var_file:
         parts.append(f"-var-file={_sq(var_file)}")

--- a/src/tools/time_parser.py
+++ b/src/tools/time_parser.py
@@ -18,20 +18,50 @@ def set_default_timezone(tz_name: str) -> None:
     global _default_tz
     _default_tz = ZoneInfo(tz_name)
 
+
 # Day name → weekday number (Monday=0)
 DAY_NAMES = {
-    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
-    "friday": 4, "saturday": 5, "sunday": 6,
-    "mon": 0, "tue": 1, "tues": 1, "wed": 2, "thu": 3, "thur": 3,
-    "thurs": 3, "fri": 4, "sat": 5, "sun": 6,
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+    "mon": 0,
+    "tue": 1,
+    "tues": 1,
+    "wed": 2,
+    "thu": 3,
+    "thur": 3,
+    "thurs": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
 }
 
 UNIT_SECONDS = {
-    "second": 1, "seconds": 1, "sec": 1, "secs": 1, "s": 1,
-    "minute": 60, "minutes": 60, "min": 60, "mins": 60, "m": 60,
-    "hour": 3600, "hours": 3600, "hr": 3600, "hrs": 3600, "h": 3600,
-    "day": 86400, "days": 86400, "d": 86400,
-    "week": 604800, "weeks": 604800, "w": 604800,
+    "second": 1,
+    "seconds": 1,
+    "sec": 1,
+    "secs": 1,
+    "s": 1,
+    "minute": 60,
+    "minutes": 60,
+    "min": 60,
+    "mins": 60,
+    "m": 60,
+    "hour": 3600,
+    "hours": 3600,
+    "hr": 3600,
+    "hrs": 3600,
+    "h": 3600,
+    "day": 86400,
+    "days": 86400,
+    "d": 86400,
+    "week": 604800,
+    "weeks": 604800,
+    "w": 604800,
 }
 
 

--- a/src/tools/url_safety.py
+++ b/src/tools/url_safety.py
@@ -4,6 +4,7 @@ Rejects URLs targeting localhost, private IP ranges, cloud metadata
 endpoints, and link-local addresses. Validates both literal hostnames
 and DNS-resolved IPs to prevent rebinding attacks.
 """
+
 from __future__ import annotations
 
 import ipaddress
@@ -88,7 +89,9 @@ def _matches_allowlist(parsed, allowed_urls: list[str]) -> bool:
     return False
 
 
-def is_url_blocked(url: str, allowed_urls: list[str] | None = None, resolve_dns: bool = True) -> bool:
+def is_url_blocked(
+    url: str, allowed_urls: list[str] | None = None, resolve_dns: bool = True
+) -> bool:
     """Return True if a URL targets localhost, private IPs, or metadata endpoints.
 
     When resolve_dns is True (default), also resolves the hostname and
@@ -139,6 +142,8 @@ def validate_url_safe(url: str, allowed_urls: list[str] | None = None) -> None:
         raise ValueError("URL is required")
     url = url.strip()
     if not any(url.lower().startswith(s) for s in ALLOWED_SCHEMES):
-        raise ValueError(f"URL must start with http:// or https://")
+        raise ValueError("URL must start with http:// or https://")
     if is_url_blocked(url, allowed_urls=allowed_urls):
-        raise ValueError("URL targets a blocked address (localhost, private IP, or metadata endpoint)")
+        raise ValueError(
+            "URL targets a blocked address (localhost, private IP, or metadata endpoint)"
+        )

--- a/src/tools/web.py
+++ b/src/tools/web.py
@@ -2,6 +2,7 @@
 
 Replaces the fragile fetch_url and search_news skills with proper built-in tools.
 """
+
 from __future__ import annotations
 
 import re
@@ -19,7 +20,10 @@ FETCH_TIMEOUT = aiohttp.ClientTimeout(total=15)
 SEARCH_TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 # User-Agent to avoid bot blocking
-USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
 
 
 class _HTMLToText(HTMLParser):
@@ -66,6 +70,7 @@ async def fetch_url(url: str, max_chars: int = MAX_CONTENT_CHARS) -> str:
     and plain text. Truncates to max_chars.
     """
     from .url_safety import is_url_blocked
+
     if is_url_blocked(url):
         return "Error: URL targets a blocked address (localhost, private IP, or metadata endpoint)"
     try:
@@ -166,9 +171,10 @@ def _parse_ddg_results(html: str, max_results: int) -> str:
             actual = re.search(r"uddg=([^&]+)", url)
             if actual:
                 from urllib.parse import unquote
+
                 url = unquote(actual.group(1))
 
-        result = f"**{i+1}. {clean_title}**\n{url}"
+        result = f"**{i + 1}. {clean_title}**\n{url}"
         if clean_snippet:
             result += f"\n{clean_snippet}"
         results.append(result)

--- a/tests/characterization/test_executor_dispatch_parity.py
+++ b/tests/characterization/test_executor_dispatch_parity.py
@@ -154,6 +154,46 @@ class TestDispatchTable:
                     f"{name} is domain-owned but ToolExecutor still defines it"
                 )
 
+    def test_dynamic_handle_spelling_banned_outside_resolver(self):
+        """P7 (AST/token-aware, per the plan-review advisory): the f-string
+        ``_handle_`` spelling — dynamic handler-name construction — is
+        allowed in exactly ONE place in src/: ToolExecutor._resolve_handler
+        (the patch-seam __dict__ probe). Raw grep would flag comments,
+        fixture names, and literal attr strings; this scan walks the AST
+        and only flags JoinedStr (f-string) nodes that build a
+        ``_handle_...`` name."""
+        import ast as _ast
+        from pathlib import Path as _Path
+
+        src_root = _Path(__file__).resolve().parents[2] / "src"
+        offenders: list[str] = []
+        for py in sorted(src_root.rglob("*.py")):
+            tree = _ast.parse(py.read_text(), filename=str(py))
+            for node in _ast.walk(tree):
+                if isinstance(node, _ast.JoinedStr):
+                    for part in node.values:
+                        if (
+                            isinstance(part, _ast.Constant)
+                            and isinstance(part.value, str)
+                            and "_handle_" in part.value
+                        ):
+                            offenders.append(f"{py.relative_to(src_root)}:{node.lineno}")
+        allowed = {"tools/executor.py"}
+        bad = [o for o in offenders if o.split(":")[0] not in allowed]
+        assert not bad, f"dynamic _handle_ f-string spelling outside the resolver: {bad}"
+        # exactly one sanctioned site remains (the __dict__ patch-seam probe)
+        sanctioned = [o for o in offenders if o.split(":")[0] in allowed]
+        assert len(sanctioned) == 1, (
+            f"expected exactly 1 sanctioned dynamic spelling in executor.py, found: {sanctioned}"
+        )
+
+    async def test_retired_fallback_unknown_entry_returns_none(self):
+        """P7: with the legacy fallback retired, a name absent from the
+        table resolves to None (→ unknown_tool) even if a same-named
+        class-level method existed — the table is the only class path."""
+        ex = _executor()
+        assert ex._resolve_handler("definitely_not_a_tool") is None
+
     async def test_instance_override_beats_domain_owner(self):
         """The historical executor-instance patch seam keeps governing even
         for handlers whose real bodies moved to domain owners (13+ existing


### PR DESCRIPTION
## RFC-004 P7 — retirement + zero-lint + R2 (campaign code-complete)

- **Legacy fallback retired**: `_resolve_handler` is now instance-`__dict__` override (the sanctioned patch seam) → table → None. The f-string lookup is gone.
- **AST-aware spelling ban** (your re-review advisory): a JoinedStr scan of `src/` permits exactly ONE dynamic `_handle_` construction — the resolver probe. Comments, fixture names, and literal attr strings cannot false-positive.
- **Production startup assertions** (advisory #5): registry import asserts no duplicate names across sections; executor `__init__` asserts every table entry resolves callable on its owner. **Declared deviation**: invariants instead of the literal `len(TOOLS)==74` — a hardcoded count in prod fails the next legitimate tool addition in the wrong place; the count/order pin lives in the characterization contract where changing it is a reviewed edit. Push back if you want the literal count too.
- **`src/tools/` at ZERO ruff findings**: 105 resolved this phase — autofix, format, 12 value-preserving string wraps, and 7 `StrEnum` conversions (verified no bare-interpolation call site depends on the old `str()` form; full suite green).
- Plan **R2 results** section committed.

**Campaign totals**: registry 1,978 → **82** · executor 1,893 → **723** (middleware core) · 9 defs sections + 8 handler domains + `skills_tools` · both patch seams live · ~230 pre-existing lint findings resolved · suite 6,079 → **6,127**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3
