### PR TITLE
Hardening: nonzero exit on fatal startup + audit HMAC unsigned-prefix tolerance

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -144,6 +144,10 @@ attachments:
   retention_hours: 24
 
 # Audit log integrity — HMAC signing for audit.jsonl entries
+# Generate a key with: openssl rand -hex 32
+# Enabling on an existing install is safe: history written before enablement
+# is not retroactively signed — /api/audit/verify reports it as
+# unsigned_prefix and verifies the chain from the first signed entry on.
 audit:
   hmac_key: ''  # Set a secret to enable HMAC-SHA256 signing; empty = disabled
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -130,7 +130,14 @@ def main() -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
+    # Fatal paths set this nonzero so supervisors (systemd Restart=on-failure,
+    # monitoring) can distinguish a crash from a clean stop. Historically every
+    # fatal startup error (bad token, boot-time DNS failure) exited 0 and only
+    # Restart=always kept the service recovering.
+    exit_code = 0
+
     async def run() -> None:
+        nonlocal exit_code
         await health.start()
 
         async def _webhook_send(channel_id: str, text: str) -> None:
@@ -158,6 +165,7 @@ def main() -> None:
             log.info("Connecting to Discord…")
             await bot.start(config.discord.token)
         except Exception as exc:
+            exit_code = 1
             log.error("Fatal error: %s", exc, exc_info=True)
             await shutdown()
 
@@ -191,11 +199,31 @@ def main() -> None:
 
     try:
         loop.run_until_complete(run())
-    except (KeyboardInterrupt, SystemExit):
+    except (KeyboardInterrupt, SystemExit) as exc:
+        # Ctrl-C stays a clean stop; an intentional SystemExit keeps its
+        # original code rather than being normalized.
+        if isinstance(exc, SystemExit) and exc.code:
+            exit_code = exc.code if isinstance(exc.code, int) else 1
         loop.run_until_complete(shutdown())
+    except asyncio.CancelledError:
+        # Cancellation reaching the top level is a shutdown path, not a
+        # fatal error — exit clean unless a fatal path already set a code.
+        loop.run_until_complete(shutdown())
+    except Exception:
+        # Failures outside run()'s own guard (e.g. the health server's port
+        # bind) previously tracebacked out with no clean shutdown. Cleanup
+        # failures are logged separately and never mask the fatal code.
+        exit_code = 1
+        log.exception("Fatal error during startup")
+        try:
+            loop.run_until_complete(shutdown())
+        except Exception:
+            log.exception("Cleanup after fatal startup error failed")
     finally:
         loop.close()
         log.info("Odin stopped")
+    if exit_code:
+        sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -519,6 +519,7 @@ class AuditLogger:
                 "valid": False,
                 "total": 0,
                 "verified": 0,
+                "unsigned_prefix": 0,
                 "first_bad": None,
                 "error": "Signing not enabled (no hmac_key configured)",
             }

--- a/src/audit/signer.py
+++ b/src/audit/signer.py
@@ -64,26 +64,51 @@ def _canonical(entry: dict) -> str:
 async def verify_log(path, key: str) -> dict:
     """Verify the full HMAC chain of an audit log file.
 
-    Returns a dict with ``valid`` (bool), ``total`` (int), ``verified`` (int),
-    ``first_bad`` (int or None — 1-indexed line number), and ``error`` (str or None).
+    Entries written before signing was enabled (no ``_hmac`` field) are
+    tolerated as an *unsigned prefix*: counted in ``unsigned_prefix`` and
+    skipped, with the chain verified strictly from the first signed entry.
+    Enabling a key does not retroactively sign history — the chain simply
+    begins at GENESIS_HASH at the first entry written after enablement, so
+    tamper evidence covers the signed suffix only. An unsigned entry
+    appearing AFTER the first signed one still fails verification: once a
+    chain exists, gaps in it are tamper evidence.
+
+    Returns a dict with ``valid`` (bool), ``total`` (int), ``verified``
+    (signed entries verified, int), ``unsigned_prefix`` (int), ``first_bad``
+    (int or None — 1-indexed line number), and ``error`` (str or None).
     """
     import aiofiles
     from pathlib import Path
 
     p = Path(path)
     if not p.exists():
-        return {"valid": True, "total": 0, "verified": 0, "first_bad": None, "error": None}
+        return {
+            "valid": True,
+            "total": 0,
+            "verified": 0,
+            "unsigned_prefix": 0,
+            "first_bad": None,
+            "error": None,
+        }
 
     signer = AuditSigner(key)
     prev = GENESIS_HASH
     total = 0
     verified = 0
+    unsigned_prefix = 0
 
     try:
         async with aiofiles.open(p, "r") as f:
             lines = await f.readlines()
     except Exception as exc:
-        return {"valid": False, "total": 0, "verified": 0, "first_bad": None, "error": str(exc)}
+        return {
+            "valid": False,
+            "total": 0,
+            "verified": 0,
+            "unsigned_prefix": 0,
+            "first_bad": None,
+            "error": str(exc),
+        }
 
     for i, line in enumerate(lines, 1):
         line = line.strip()
@@ -98,17 +123,25 @@ async def verify_log(path, key: str) -> dict:
                 "valid": False,
                 "total": total,
                 "verified": verified,
+                "unsigned_prefix": unsigned_prefix,
                 "first_bad": i,
                 "error": f"Line {i}: invalid JSON",
             }
 
         if "_hmac" not in entry:
+            # verified == 0 ⟺ no signed entry seen yet (a signed entry that
+            # fails returns immediately), i.e. still in the pre-enablement
+            # prefix.
+            if verified == 0:
+                unsigned_prefix += 1
+                continue
             return {
                 "valid": False,
                 "total": total,
                 "verified": verified,
+                "unsigned_prefix": unsigned_prefix,
                 "first_bad": i,
-                "error": f"Line {i}: missing _hmac field (unsigned entry)",
+                "error": f"Line {i}: missing _hmac field (unsigned entry after chain began)",
             }
 
         if not signer.verify_entry(entry, prev):
@@ -116,6 +149,7 @@ async def verify_log(path, key: str) -> dict:
                 "valid": False,
                 "total": total,
                 "verified": verified,
+                "unsigned_prefix": unsigned_prefix,
                 "first_bad": i,
                 "error": f"Line {i}: HMAC verification failed (tampered or reordered)",
             }
@@ -123,4 +157,11 @@ async def verify_log(path, key: str) -> dict:
         prev = entry["_hmac"]
         verified += 1
 
-    return {"valid": True, "total": total, "verified": verified, "first_bad": None, "error": None}
+    return {
+        "valid": True,
+        "total": total,
+        "verified": verified,
+        "unsigned_prefix": unsigned_prefix,
+        "first_bad": None,
+        "error": None,
+    }

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -338,7 +338,9 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
         log.warning(
             "Audit HMAC signing is DISABLED (config.audit.hmac_key is empty): "
             "audit.jsonl is NOT tamper-evident and verify_integrity() will fail. "
-            "Set audit.hmac_key to enable the integrity chain."
+            "Set audit.hmac_key to enable the integrity chain — enabling later is "
+            "safe: pre-enablement history is reported as unsigned_prefix and the "
+            "chain is verified from the first signed entry."
         )
     api_token_manager = ApiTokenManager("./data/api_tokens.json")
 

--- a/tests/test_audit_signing.py
+++ b/tests/test_audit_signing.py
@@ -319,13 +319,21 @@ class TestVerifyLog:
         assert result["valid"] is False
         assert "invalid JSON" in result["error"]
 
-    async def test_missing_hmac_field(self, tmp_path):
+    async def test_missing_hmac_field_is_tolerated_as_prefix(self, tmp_path):
+        # Migration semantics (deliberate change from the original strict
+        # pin): entries written BEFORE hmac_key was enabled are not
+        # retroactively signed, so an unsigned prefix is tolerated and
+        # reported instead of failing the whole file — otherwise enabling
+        # signing on an existing install permanently breaks verification.
+        # Unsigned entries AFTER the chain begins still fail (see
+        # TestUnsignedPrefix).
         p = tmp_path / "audit.jsonl"
         entry = {"data": "unsigned"}
         p.write_text(json.dumps(entry) + "\n")
         result = await verify_log(p, "key")
-        assert result["valid"] is False
-        assert "missing _hmac" in result["error"]
+        assert result["valid"] is True
+        assert result["verified"] == 0
+        assert result["unsigned_prefix"] == 1
 
     async def test_wrong_key(self, tmp_path):
         p = tmp_path / "audit.jsonl"
@@ -356,6 +364,92 @@ class TestVerifyLog:
         assert result["valid"] is True
         assert result["total"] == 1
         assert result["verified"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Unsigned prefix: enabling hmac_key over pre-existing unsigned history
+# ---------------------------------------------------------------------------
+
+class TestUnsignedPrefix:
+    """Verification of files whose history predates signing enablement.
+
+    ``unsigned* signed+`` is valid (the prefix is reported, the chain is
+    verified from the first signed entry); ``signed+ unsigned`` is tamper
+    evidence and stays invalid.
+    """
+
+    def _write_mixed(self, path, unsigned: int, signed: int, key: str = "key"):
+        """Unsigned prefix + signed suffix, as produced by enabling a key on
+        an existing file: initialize_chain finds no signed entry, so the
+        first signed entry chains from GENESIS."""
+        lines = [json.dumps({"seq": i, "legacy": True}) for i in range(unsigned)]
+        signer = AuditSigner(key)
+        for i in range(signed):
+            entry = {"seq": unsigned + i, "data": f"signed-{i}"}
+            signer.sign(entry)
+            lines.append(json.dumps(entry, default=str))
+        path.write_text("\n".join(lines) + "\n")
+
+    async def test_all_unsigned_with_key_enabled(self, tmp_path):
+        p = tmp_path / "audit.jsonl"
+        self._write_mixed(p, unsigned=4, signed=0)
+        result = await verify_log(p, "key")
+        assert result["valid"] is True
+        assert result["verified"] == 0
+        assert result["unsigned_prefix"] == 4
+        assert result["total"] == 4
+
+    async def test_unsigned_prefix_then_valid_chain(self, tmp_path):
+        p = tmp_path / "audit.jsonl"
+        self._write_mixed(p, unsigned=3, signed=5)
+        result = await verify_log(p, "key")
+        assert result["valid"] is True
+        assert result["unsigned_prefix"] == 3
+        assert result["verified"] == 5
+        assert result["total"] == 8
+        assert result["first_bad"] is None
+
+    async def test_unsigned_entry_after_signed_is_invalid(self, tmp_path):
+        p = tmp_path / "audit.jsonl"
+        self._write_mixed(p, unsigned=2, signed=2)
+        with p.open("a") as f:
+            f.write(json.dumps({"sneaky": "append"}) + "\n")
+        result = await verify_log(p, "key")
+        assert result["valid"] is False
+        assert result["first_bad"] == 5
+        assert "after chain began" in result["error"]
+        assert result["unsigned_prefix"] == 2
+        assert result["verified"] == 2
+
+    async def test_bad_hmac_after_unsigned_prefix_is_invalid(self, tmp_path):
+        p = tmp_path / "audit.jsonl"
+        self._write_mixed(p, unsigned=2, signed=3)
+        lines = p.read_text().splitlines()
+        tampered = json.loads(lines[3])
+        tampered["data"] = "edited"
+        lines[3] = json.dumps(tampered, default=str)
+        p.write_text("\n".join(lines) + "\n")
+        result = await verify_log(p, "key")
+        assert result["valid"] is False
+        assert result["first_bad"] == 4
+        assert result["unsigned_prefix"] == 2
+
+    async def test_fully_signed_reports_zero_prefix(self, tmp_path):
+        # Stable response shape: unsigned_prefix present even when zero.
+        p = tmp_path / "audit.jsonl"
+        self._write_mixed(p, unsigned=0, signed=3)
+        result = await verify_log(p, "key")
+        assert result["valid"] is True
+        assert result["unsigned_prefix"] == 0
+        assert result["verified"] == 3
+
+    async def test_empty_and_missing_files_report_zero_prefix(self, tmp_path):
+        empty = tmp_path / "audit.jsonl"
+        empty.write_text("")
+        result = await verify_log(empty, "key")
+        assert result["unsigned_prefix"] == 0
+        result = await verify_log(tmp_path / "missing.jsonl", "key")
+        assert result["unsigned_prefix"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -574,6 +668,8 @@ class TestVerifyIntegrity:
         result = await logger.verify_integrity()
         assert result["valid"] is False
         assert "not enabled" in result["error"]
+        # Stable response shape across all verify outcomes
+        assert result["unsigned_prefix"] == 0
 
     async def test_empty_log(self, tmp_path):
         p = tmp_path / "audit.jsonl"
@@ -693,6 +789,39 @@ class TestAuditVerifyAPI:
             data = await resp.json()
             assert data["valid"] is False
             assert "not enabled" in data["error"]
+            assert data["unsigned_prefix"] == 0
+
+    async def test_unsigned_prefix_returns_200_with_count(self, tmp_path):
+        # Signing enabled over an existing unsigned history: verification
+        # succeeds and reports how many legacy entries predate the chain.
+        from aiohttp import web as aio_web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from src.web.api import create_api_routes
+
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            "\n".join(json.dumps({"seq": i, "legacy": True}) for i in range(3)) + "\n"
+        )
+        logger = AuditLogger(path=str(p), hmac_key="key")
+        await logger.initialize_chain()
+        await logger.log_execution(
+            user_id="u1", user_name="test", channel_id="c1",
+            tool_name="t1", tool_input={},
+            approved=True, result_summary="ok", execution_time_ms=1,
+        )
+        bot = self._make_bot(logger)
+        routes = create_api_routes(bot)
+        app = aio_web.Application()
+        app.router.add_routes(routes)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/audit/verify")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["valid"] is True
+            assert data["unsigned_prefix"] == 3
+            assert data["verified"] == 1
 
     async def test_empty_signed_log_returns_200(self, tmp_path):
         from aiohttp.test_utils import TestClient, TestServer

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -1,0 +1,185 @@
+"""Exit-code behavior of the ``python -m src`` entry point.
+
+Fatal startup errors must exit nonzero so process supervisors (systemd
+``Restart=on-failure``, monitoring) can distinguish a crash from a clean
+stop. Historically every fatal path exited 0 — the live service only
+recovered because the unit uses ``Restart=always``.
+
+These tests drive the real ``main()`` control flow with the heavy
+collaborators (OdinBot, HealthServer, load_config) replaced by fakes:
+``main()`` imports them inside the function body, so monkeypatching the
+source module attributes is enough.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+
+class _FakeMetrics:
+    def register_source(self, name, fn):
+        pass
+
+
+class _FakeHealthServer:
+    """Stands in for src.health.HealthServer; records lifecycle calls."""
+
+    instances: list[_FakeHealthServer] = []
+
+    def __init__(self, *args, **kwargs):
+        self.metrics = _FakeMetrics()
+        self.started = False
+        self.stopped = False
+        self.fail_start: Exception | None = None
+        _FakeHealthServer.instances.append(self)
+
+    async def start(self):
+        if self.fail_start is not None:
+            raise self.fail_start
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+    def set_bot(self, bot):
+        pass
+
+    def set_send_message(self, cb):
+        pass
+
+    def set_trigger_callback(self, cb):
+        pass
+
+    def set_ready(self, value):
+        pass
+
+    def register_component(self, name, fn):
+        pass
+
+
+class _FakeBot:
+    """Stands in for OdinBot; ``start_error`` drives the scenario."""
+
+    instances: list[_FakeBot] = []
+    start_error: BaseException | None = None
+
+    def __init__(self, config):
+        self.config = config
+        self.closed = False
+        self.sessions = None
+        _FakeBot.instances.append(self)
+
+    @property
+    def latency(self):
+        return 0.0
+
+    def is_ready(self):
+        return False
+
+    def get_channel(self, channel_id):
+        return None
+
+    async def start(self, token):
+        if type(self).start_error is not None:
+            raise type(self).start_error
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def entry_point(monkeypatch, tmp_path):
+    """Wire main() to the fakes and return a callable that runs it."""
+    import src.config
+    import src.discord.client
+    import src.health
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("# contents irrelevant; load_config is faked\n")
+
+    from src.config.schema import Config
+
+    _FakeBot.instances = []
+    _FakeBot.start_error = None
+    _FakeHealthServer.instances = []
+
+    monkeypatch.setattr(
+        src.config, "load_config", lambda path: Config(discord={"token": "fake-token"})
+    )
+    monkeypatch.setattr(src.discord.client, "OdinBot", _FakeBot)
+    monkeypatch.setattr(src.health, "HealthServer", _FakeHealthServer)
+    monkeypatch.setattr(sys, "argv", ["odin", str(cfg_path)])
+
+    from src.__main__ import main
+
+    return main
+
+
+class TestFatalStartupExitsNonzero:
+    def test_bot_start_failure_exits_1(self, entry_point):
+        # The historical bug: bad token / boot-time DNS failure exited 0.
+        _FakeBot.start_error = RuntimeError("Temporary failure in name resolution")
+        with pytest.raises(SystemExit) as excinfo:
+            entry_point()
+        assert excinfo.value.code == 1
+
+    def test_bot_start_failure_still_cleans_up(self, entry_point):
+        _FakeBot.start_error = RuntimeError("boom")
+        with pytest.raises(SystemExit):
+            entry_point()
+        assert _FakeBot.instances[0].closed is True
+        assert _FakeHealthServer.instances[0].stopped is True
+
+    def test_health_start_failure_exits_1_with_cleanup(self, entry_point, monkeypatch):
+        # Failures BEFORE run()'s own try block (e.g. port bind) previously
+        # tracebacked out of main() with no clean shutdown at all.
+        def _fail_health_init(*args, **kwargs):
+            server = _FakeHealthServer()
+            server.fail_start = OSError(98, "address already in use")
+            return server
+
+        import src.health
+
+        monkeypatch.setattr(src.health, "HealthServer", _fail_health_init)
+        with pytest.raises(SystemExit) as excinfo:
+            entry_point()
+        assert excinfo.value.code == 1
+        assert _FakeBot.instances[0].closed is True
+
+    def test_intentional_systemexit_code_preserved(self, entry_point):
+        # An explicit SystemExit(3) must not be normalized to 1.
+        _FakeBot.start_error = SystemExit(3)
+        with pytest.raises(SystemExit) as excinfo:
+            entry_point()
+        assert excinfo.value.code == 3
+
+
+class TestCleanStopsExitZero:
+    def test_clean_return_does_not_exit(self, entry_point):
+        # bot.start() returning (close-triggered) is a clean stop: main()
+        # returns normally instead of raising SystemExit.
+        assert entry_point() is None
+
+    def test_keyboard_interrupt_is_clean(self, entry_point):
+        _FakeBot.start_error = KeyboardInterrupt()
+        assert entry_point() is None
+        assert _FakeBot.instances[0].closed is True
+
+    def test_cancelled_error_is_clean(self, entry_point):
+        # CancelledError is BaseException, so run()'s `except Exception`
+        # doesn't turn it fatal — top-level cancellation is a shutdown path.
+        _FakeBot.start_error = asyncio.CancelledError()
+        assert entry_point() is None
+        assert _FakeBot.instances[0].closed is True
+
+
+class TestMissingConfig:
+    def test_missing_config_exits_1(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "argv", ["odin", str(tmp_path / "nope.yml")])
+        from src.__main__ import main
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+        assert excinfo.value.code == 1


### PR DESCRIPTION
Two small operational-hardening changes, one commit each. Both designs were discussed with Odin over the bridge before implementation; all his advisories are incorporated.

## 1. `main: exit nonzero on fatal startup`

Fatal startup errors (bad token, boot-time DNS failure) were logged and swallowed — `main()` returned normally, exiting **0**. Failures outside `run()`'s guard (e.g. health-server port bind) tracebacked out with no clean shutdown. Supervisors could never distinguish a crash from a clean stop; the packaged unit only recovers because it uses `Restart=always`.

- `run()`'s fatal path now sets exit code 1; `main()` ends with `sys.exit(code)` only when nonzero (no unconditional `sys.exit(0)` churn).
- Failures escaping `run()` get logged, a guarded cleanup (cleanup failures are logged separately and never mask the fatal code), and exit 1.
- Intentional `SystemExit(N)` keeps its original code — never normalized to 1.
- Clean stops stay exit 0: SIGTERM, Ctrl-C, top-level `CancelledError` (BaseException, so it can't be caught by the fatal `except Exception` — pinned by test), close-triggered return.
- New `tests/test_main_exit_codes.py` (8 tests) drives the real `main()` control flow with faked `OdinBot`/`HealthServer`/`load_config`, asserting both exit codes and that cleanup ran.

## 2. `audit: tolerate unsigned prefix when HMAC is enabled`

`verify_log()` failed the **entire file** at the first entry missing `_hmac`, so enabling `audit.hmac_key` on an install with existing unsigned history left `GET /api/audit/verify` permanently 409. Enabling tamper-evidence should not require discarding forensic history.

Invariant: `unsigned* signed+` is valid; `signed+ unsigned` is not.

- Entries predating enablement are tolerated as an *unsigned prefix*, counted in a new `unsigned_prefix` response field (present in every verify response, including errors and not-enabled, for a stable shape).
- The chain is verified strictly from the first signed entry, which chains from `GENESIS` — exactly what `initialize_chain()` produces over an all-unsigned file. Strict tamper semantics after that point are unchanged (missing/bad `_hmac`, bad prev, reorder all still fail).
- `verified` now unambiguously counts signed entries only. Verification stays per-file; rotated files keep their own self-consistent chains.
- Rejected alternative: auto-rotate-on-enable (pushes pre-HMAC history into the `.1`–`.5` rotation cycle where it eventually gets deleted, and hides the provenance boundary instead of representing it).
- Docs: config template explains key generation and the transition semantics; the startup warning mentions enabling-later is safe.
- Tests: the strict pin is deliberately updated with a migration-semantics comment; new `TestUnsignedPrefix` covers all-unsigned, prefix+valid-chain, unsigned-after-signed (tamper), bad-HMAC-after-prefix, zero-prefix shape; a new endpoint test exercises the full enablement flow (existing unsigned file → key on → `initialize_chain()` → new signed entry → 200 with counts).

## Verification

- Full suite: **6,144 passed, 4 skipped** (baseline 6,133 + 15 new)
- Lint gate vs merge-base: **new=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3