### PR TITLE
learning: repair damaged entries during consolidation

### DIFF
--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -872,11 +872,15 @@ class ConversationReflector:
     def _repair_output_ok(result: str) -> bool:
         """Validation gauntlet for repair output — reject anything suspect.
 
-        JSON-shaped output is rejected explicitly: ``]`` and ``}`` would
-        otherwise sail past the sentence-boundary heuristic (both are in
-        _SENTENCE_TERMINATORS) and replace a lesson with serialized noise.
+        Wrapper-shaped output is rejected by its leading character: JSON
+        (``[``/``{``), quoted strings (``"``/``'``), and code fences
+        (backtick) would all sail past the sentence-boundary heuristic —
+        ``]``, ``}``, ``"``, ``'``, and the backtick are every one of them
+        in _SENTENCE_TERMINATORS — and replace a lesson with wrapped noise.
+        Reject, don't sanitize: a rejected entry stays damaged and gets
+        another attempt next cycle.
         """
-        if not result or result[0] in "[{":
+        if not result or result[0] in "[{\"'`":
             return False
         if _TRUNCATION_MARKER.strip() in result:
             return False

--- a/src/learning/reflector.py
+++ b/src/learning/reflector.py
@@ -38,6 +38,15 @@ _HARD_CONTENT_CHARS = 1000
 _TRUNCATION_MARKER = " [truncated: needs resummary]"
 _SENTENCE_TERMINATORS = (".", "!", "?", "…", '"', "'", ")", "]", "`")
 
+# Damaged-entry repair (runs inside _consolidate): at most this many LLM
+# resummarization attempts per consolidation cycle, so a large damaged
+# backlog can never turn consolidation into a rewrite engine.
+_REPAIR_BUDGET = 5
+_REPAIR_SYSTEM = (
+    "You repair truncated learned-memory entries. "
+    "Return only the rewritten lesson text."
+)
+
 _LEARNED_SCHEMA_VERSION = 2
 
 # Category-aware expiry: corrections and preferences never auto-expire
@@ -794,13 +803,98 @@ class ConversationReflector:
             compact.append(item)
         return json.dumps(compact, indent=2)
 
+    async def _repair_damaged(
+        self, damaged: list[dict]
+    ) -> tuple[list[dict], list[dict]]:
+        """Resummarize clipped entries so the damage quarantine isn't permanent.
+
+        Attempts up to ``_REPAIR_BUDGET`` entries per cycle. A successful
+        repair replaces the content (truncation marker gone, ``damaged`` flag
+        cleared) so the entry rejoins the consolidation candidate pool. On
+        ANY failure — no backend, LLM error, rejected output, budget spent —
+        the original entry object passes through untouched, in order:
+        byte-for-byte the pre-repair passthrough behavior. Only ``content``
+        and the ``damaged`` flag are ever modified; repair is maintenance,
+        not evidence of reuse, so timestamps and expiry semantics stay as-is.
+        """
+        if not damaged or not self._text_fn:
+            return [], damaged
+        repaired: list[dict] = []
+        still_damaged: list[dict] = []
+        attempted = 0
+        for entry in damaged:
+            if attempted >= _REPAIR_BUDGET:
+                still_damaged.append(entry)
+                continue
+            attempted += 1
+            lesson = entry.get("content", "").replace(_TRUNCATION_MARKER, "").strip()
+            prompt = (
+                "This learned-memory lesson was truncated mid-thought. "
+                "Rewrite it as a complete, self-contained version.\n"
+                "STRICT RULES:\n"
+                "- Rewrite only the given lesson; do not infer missing details.\n"
+                "- Do not add examples, causes, or context that are not present.\n"
+                f"- Keep it under {_SOFT_CONTENT_CHARS} characters.\n"
+                "- End with a complete sentence.\n"
+                "- Return only the rewritten lesson text — no JSON, no quotes, "
+                "no commentary.\n\n"
+                "Lesson:\n" + lesson
+            )
+            try:
+                raw = await self._text_fn(
+                    [{"role": "user", "content": prompt}], _REPAIR_SYSTEM
+                )
+            except Exception as exc:
+                log.warning(
+                    "Damaged-entry repair errored for %r: %s", entry.get("key"), exc
+                )
+                still_damaged.append(entry)
+                continue
+            result = (raw or "").strip()
+            if not self._repair_output_ok(result):
+                log.warning(
+                    "Damaged-entry repair rejected for %r (%d chars)",
+                    entry.get("key"), len(result),
+                )
+                still_damaged.append(entry)
+                continue
+            entry["content"] = result
+            entry.pop("damaged", None)
+            repaired.append(entry)
+        if repaired or still_damaged:
+            log.info(
+                "Damaged-entry repair: %d repaired, %d still damaged (%d attempted)",
+                len(repaired), len(still_damaged), attempted,
+            )
+        return repaired, still_damaged
+
+    @staticmethod
+    def _repair_output_ok(result: str) -> bool:
+        """Validation gauntlet for repair output — reject anything suspect.
+
+        JSON-shaped output is rejected explicitly: ``]`` and ``}`` would
+        otherwise sail past the sentence-boundary heuristic (both are in
+        _SENTENCE_TERMINATORS) and replace a lesson with serialized noise.
+        """
+        if not result or result[0] in "[{":
+            return False
+        if _TRUNCATION_MARKER.strip() in result:
+            return False
+        if len(result) > _HARD_CONTENT_CHARS or _looks_chopped(result):
+            return False
+        probe = {"content": result}
+        _clip_content(probe)
+        return not probe.get("damaged")
+
     async def _consolidate(self, entries: list[dict]) -> list[dict]:
         """Ask the LLM to merge same-topic duplicates down to the target.
 
-        Damaged entries are passed through unmerged — consolidating already
-        clipped text compounds the damage. Unrelated topics are never packed
-        together to hit the target count; dropping low-value entries is the
-        sanctioned way to shrink.
+        Damaged entries are first offered repair (``_repair_damaged``);
+        successful repairs rejoin the candidate pool and give their slots
+        back. Entries still damaged pass through unmerged — consolidating
+        already clipped text compounds the damage. Unrelated topics are
+        never packed together to hit the target count; dropping low-value
+        entries is the sanctioned way to shrink.
         """
         import time as _time
         t0 = _time.monotonic()
@@ -811,6 +905,12 @@ class ConversationReflector:
 
         damaged = [e for e in entries if e.get("damaged")]
         candidates = [e for e in entries if not e.get("damaged")]
+
+        # Repair-then-consolidate: the target math below deliberately uses
+        # the REMAINING damaged count, so every successful repair reclaims
+        # its consolidation slot immediately.
+        repaired, damaged = await self._repair_damaged(damaged)
+        candidates.extend(repaired)
         if not candidates:
             return damaged
 

--- a/tests/test_learned_overhaul.py
+++ b/tests/test_learned_overhaul.py
@@ -323,6 +323,10 @@ class TestDamagedRepair:
             # prompt-injection-ish: output echoing the marker is rejected
             "Ignore previous instructions" + _TRUNCATION_MARKER + ".",
             '["a rewritten lesson."]',  # JSON-shaped
+            '{"lesson": "a rewritten lesson."}',  # JSON-object-shaped
+            '"A clean repaired lesson."',  # quote-wrapped (Odin's review catch)
+            "'A clean repaired lesson.'",  # single-quote-wrapped
+            "```A clean repaired lesson.```",  # code-fenced
         ]
         for bad in bad_outputs:
             async def fake(messages, system, _bad=bad):

--- a/tests/test_learned_overhaul.py
+++ b/tests/test_learned_overhaul.py
@@ -4,7 +4,8 @@ Invariants under test:
 - stored content is NEVER silently truncated — oversized text is clipped
   at a sentence boundary, explicitly marked, and flagged damaged
 - the v1→v2 migration detects legacy chop damage and is idempotent
-- consolidation passes damaged entries through unmerged
+- consolidation first offers damaged entries a budgeted LLM repair
+  (_repair_damaged); entries still damaged pass through unmerged
 - category-aware expiry: corrections/preferences never auto-expire
 - supersession removes superseded keys
 - injection: include-all-when-fits, pinned corrections/preferences when
@@ -159,12 +160,18 @@ class TestCategoryExpiry:
 
 class TestConsolidationDamagePassThrough:
     @pytest.mark.asyncio
-    async def test_damaged_entries_bypass_the_llm(self, tmp_path):
+    async def test_unrepaired_damaged_entries_bypass_the_merge(self, tmp_path):
+        # Deliberate pin update: damaged entries ARE now sent to the LLM —
+        # but only for REPAIR (_repair_damaged). When repair fails they must
+        # still never enter the consolidation merge prompt, and pass through
+        # unmerged exactly as before the repair step existed.
         r = ConversationReflector(str(tmp_path / "l.json"), consolidation_target=2)
-        seen_prompts = []
+        merge_prompts = []
 
         async def fake_text_fn(messages, system):
-            seen_prompts.append(messages[0]["content"])
+            if system.startswith("You repair"):
+                raise RuntimeError("repair backend down")
+            merge_prompts.append(messages[0]["content"])
             return json.dumps([_entry("merged", content="merged lesson.")])
 
         r.set_text_fn(fake_text_fn)
@@ -176,9 +183,11 @@ class TestConsolidationDamagePassThrough:
                    damaged=True, created_at=now, updated_at=now),
         ]
         result = await r._consolidate(entries)
-        keys = {e["key"] for e in result}
-        assert "hurt" in keys  # passed through unmerged
-        assert "hurt" not in seen_prompts[0]  # never sent to the LLM
+        by_key = {e["key"]: e for e in result}
+        assert "hurt" in by_key  # passed through unmerged
+        assert by_key["hurt"]["damaged"] is True  # untouched by failed repair
+        assert len(merge_prompts) == 1
+        assert "chopped tex" not in merge_prompts[0]  # never in the merge prompt
 
     @pytest.mark.asyncio
     async def test_llm_failure_falls_back_without_data_loss(self, tmp_path):
@@ -195,6 +204,184 @@ class TestConsolidationDamagePassThrough:
         ]
         result = await r._consolidate(entries)
         assert len(result) == 3
+
+
+def _damaged_entry(key, lesson="a chopped lesso", **kw):
+    return _entry(key, content=lesson + _TRUNCATION_MARKER, damaged=True, **kw)
+
+
+class TestDamagedRepair:
+    """_repair_damaged: the quarantine is no longer permanent.
+
+    Every failure path (no backend, LLM error, rejected output, budget
+    exhausted) must pass the ORIGINAL entry object through untouched and in
+    order — byte-for-byte the pre-repair passthrough behavior.
+    """
+
+    def _reflector(self, tmp_path, **kw):
+        return ConversationReflector(str(tmp_path / "l.json"), **kw)
+
+    @pytest.mark.asyncio
+    async def test_repair_success_clears_flag_and_marker(self, tmp_path):
+        r = self._reflector(tmp_path)
+
+        async def fake(messages, system):
+            return "A clean repaired lesson."
+
+        r.set_text_fn(fake)
+        entry = _damaged_entry("d1")
+        repaired, still = await r._repair_damaged([entry])
+        assert still == []
+        assert repaired == [entry]  # same object, mutated in place
+        assert repaired[0]["content"] == "A clean repaired lesson."
+        assert _TRUNCATION_MARKER not in repaired[0]["content"]
+        assert "damaged" not in repaired[0]
+
+    @pytest.mark.asyncio
+    async def test_repair_does_not_mutate_unrelated_fields(self, tmp_path):
+        r = self._reflector(tmp_path)
+
+        async def fake(messages, system):
+            return "A clean repaired lesson."
+
+        r.set_text_fn(fake)
+        entry = _damaged_entry(
+            "d1", category="correction", user_id="u9", topic="deploys",
+            tags=["git"], confidence="high",
+            created_at="2026-01-01T00:00:00", updated_at="2026-02-02T00:00:00",
+            last_used_at="2026-03-03T00:00:00",
+        )
+        repaired, _ = await r._repair_damaged([entry])
+        e = repaired[0]
+        assert (e["key"], e["category"], e["user_id"], e["topic"]) == (
+            "d1", "correction", "u9", "deploys")
+        assert e["tags"] == ["git"] and e["confidence"] == "high"
+        # Repair is maintenance, not reuse: timestamps must be untouched.
+        assert e["created_at"] == "2026-01-01T00:00:00"
+        assert e["updated_at"] == "2026-02-02T00:00:00"
+        assert e["last_used_at"] == "2026-03-03T00:00:00"
+
+    @pytest.mark.asyncio
+    async def test_marker_is_stripped_from_repair_input(self, tmp_path):
+        r = self._reflector(tmp_path)
+        repair_prompts = []
+
+        async def fake(messages, system):
+            repair_prompts.append(messages[0]["content"])
+            return "A clean repaired lesson."
+
+        r.set_text_fn(fake)
+        await r._repair_damaged([_damaged_entry("d1", lesson="the real text")])
+        assert "the real text" in repair_prompts[0]
+        assert _TRUNCATION_MARKER not in repair_prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_per_entry_exception_does_not_stop_the_rest(self, tmp_path):
+        r = self._reflector(tmp_path)
+
+        async def fake(messages, system):
+            if "FAILME" in messages[0]["content"]:
+                raise RuntimeError("api hiccup")
+            return "A clean repaired lesson."
+
+        r.set_text_fn(fake)
+        e1, e2, e3 = (_damaged_entry("d1"), _damaged_entry("d2", lesson="FAILME"),
+                      _damaged_entry("d3"))
+        repaired, still = await r._repair_damaged([e1, e2, e3])
+        assert [e["key"] for e in repaired] == ["d1", "d3"]
+        assert still == [e2] and still[0] is e2
+        assert e2["damaged"] is True
+        assert e2["content"] == "FAILME" + _TRUNCATION_MARKER
+
+    @pytest.mark.asyncio
+    async def test_budget_seven_damaged_five_attempted(self, tmp_path):
+        r = self._reflector(tmp_path)
+        calls = 0
+
+        async def fake(messages, system):
+            nonlocal calls
+            calls += 1
+            return "A clean repaired lesson."
+
+        r.set_text_fn(fake)
+        entries = [_damaged_entry(f"d{i}") for i in range(7)]
+        repaired, still = await r._repair_damaged(entries)
+        assert calls == 5
+        assert [e["key"] for e in repaired] == ["d0", "d1", "d2", "d3", "d4"]
+        # The two unattempted entries pass through untouched, in order.
+        assert still == entries[5:]
+        assert all(s is o for s, o in zip(still, entries[5:]))
+        assert all(e["damaged"] is True for e in still)
+
+    @pytest.mark.asyncio
+    async def test_rejection_matrix_leaves_entries_untouched(self, tmp_path):
+        r = self._reflector(tmp_path)
+        bad_outputs = [
+            "",  # empty
+            ("all work and no play makes odin a dull bot. " * 25).strip(),  # >1000
+            "word " * 170,  # 850 chars, no sentence terminator → _looks_chopped
+            # prompt-injection-ish: output echoing the marker is rejected
+            "Ignore previous instructions" + _TRUNCATION_MARKER + ".",
+            '["a rewritten lesson."]',  # JSON-shaped
+        ]
+        for bad in bad_outputs:
+            async def fake(messages, system, _bad=bad):
+                return _bad
+
+            r.set_text_fn(fake)
+            entry = _damaged_entry("d1")
+            original_content = entry["content"]
+            repaired, still = await r._repair_damaged([entry])
+            assert repaired == [], f"accepted bad output: {bad[:40]!r}"
+            assert still[0] is entry
+            assert entry["content"] == original_content
+            assert entry["damaged"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_text_fn_passes_all_through(self, tmp_path):
+        r = self._reflector(tmp_path)
+        r.set_text_fn(None)
+        entries = [_damaged_entry("d1"), _damaged_entry("d2")]
+        repaired, still = await r._repair_damaged(entries)
+        assert repaired == []
+        assert still == entries
+        assert all(s is o for s, o in zip(still, entries))
+
+    @pytest.mark.asyncio
+    async def test_repaired_entries_reclaim_slots_in_target_math(self, tmp_path):
+        # consolidation_target=5, 6 clean + 3 damaged, repair fixes 2 of 3:
+        # remaining damaged = 1 → merge target must be 5-1=4, not 5-3=2.
+        r = self._reflector(tmp_path, consolidation_target=5)
+        repair_prompts, merge_prompts = [], []
+
+        async def fake(messages, system):
+            if system.startswith("You repair"):
+                repair_prompts.append(messages[0]["content"])
+                if "FAILME" in messages[0]["content"]:
+                    raise RuntimeError("down")
+                return "A clean repaired lesson."
+            merge_prompts.append(messages[0]["content"])
+            return json.dumps([_entry("merged", content="merged lesson.")])
+
+        r.set_text_fn(fake)
+        now = datetime.now(UTC).isoformat(timespec="seconds")
+        entries = [
+            _entry(f"c{i}", content=f"clean lesson {i}.", created_at=now,
+                   updated_at=now)
+            for i in range(6)
+        ] + [
+            _damaged_entry("d1", created_at=now, updated_at=now),
+            _damaged_entry("d2", lesson="FAILME", created_at=now, updated_at=now),
+            _damaged_entry("d3", created_at=now, updated_at=now),
+        ]
+        result = await r._consolidate(entries)
+        assert len(merge_prompts) == 1
+        assert "entries to 4 or fewer" in merge_prompts[0]
+        # Only damaged content reaches repair; clean lessons never do.
+        assert all("clean lesson" not in p for p in repair_prompts)
+        # The unrepaired entry passes through the merge untouched.
+        by_key = {e["key"]: e for e in result}
+        assert by_key["d2"]["damaged"] is True
 
 
 class TestConsolidationSkipAndCompact:


### PR DESCRIPTION
Closes the learned-memory dead end: entries clipped over the 1,000-char cap were flagged `damaged: true` "until resummarized," but no resummarization existed — they stayed quarantined forever, injecting truncation-marker noise and permanently shrinking the consolidation target (`target = consolidation_target − len(damaged)`).

Design was discussed with Odin over the bridge before implementation; all advisories incorporated.

## What changes

`_consolidate` now runs a **repair pass** on damaged entries after the damaged/candidates partition and before the merge:

- Per-entry `_text_fn` resummarize, budget **5 per cycle** (historical damaged counts: 0–4), with a strict preserve-meaning prompt ("rewrite only the given lesson; do not infer missing details; no examples/causes/context not present").
- The truncation marker is stripped from the LLM input; output must survive a **validation gauntlet**: non-empty · not JSON-shaped (`]`/`}` count as sentence terminators, so serialized output would otherwise pass the chopped heuristic) · no truncation marker (rejects marker echoes) · ≤ hard cap · not `_looks_chopped` · clean through `_clip_content`.
- **Success**: content replaced, flag cleared, entry rejoins the candidate pool — target math uses the *remaining* damaged count, so each repair reclaims its consolidation slot immediately.
- **Any failure** (no backend, LLM error, rejected output, budget spent): the original entry object passes through untouched, in order — byte-for-byte the previous passthrough behavior.
- Only `content` and `damaged` are ever modified. Repair is maintenance, not reuse: timestamps and expiry semantics unchanged. No schema/config/API changes.

## Tests (+8, one deliberate pin update)

New `TestDamagedRepair`: success clears flag+marker · unrelated fields (incl. all timestamps) unmutated · marker stripped from repair input · per-entry exception isolation (entry 2 failing doesn't stop 3–5) · budget 7→5 attempted, 2 untouched in order · rejection matrix (empty / >1000 / chopped / marker-echo prompt-injection / JSON-shaped) leaves same objects untouched · no-text_fn passthrough · target-math regression (3 damaged, 2 repaired → merge target `T−1`, not `T−3`, asserted from the captured merge prompt, which also proves clean lessons never reach repair and unrepaired entries never reach the merge).

The pin `test_damaged_entries_bypass_the_llm` is deliberately updated (with comment): damaged entries now reach the LLM **for repair only**, and still never enter the consolidation merge prompt unrepaired.

## Verification

- Full suite: **6,152 passed / 4 skipped** (baseline 6,148 + 8)
- Lint gate vs merge-base: **new=0**
- Integration on a **copy** of the live 150-entry corpus (live file untouched), damage seeded through the real clip path:

```
seeded damaged: 2 | attempted: 2 | repaired: 2 | remaining damaged: 0
markers gone, sentence-terminated, timestamps untouched
all 150 live entries byte-identical through the pass
```

A second run forcing the consolidation-fallback path showed repaired entries then competing in the shrink like any clean entry (150+2 → 120, fallback pins corrections/prefs) — repair and shrink compose without special cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3