### PR TITLE
RFC-005 P1: small-package annotation wave (388 → 338)

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -143,7 +143,9 @@ def main() -> None:
         async def _webhook_send(channel_id: str, text: str) -> None:
             channel = bot.get_channel(int(channel_id))
             if channel:
-                await channel.send(scrub_response_secrets(text))
+                # Admin-configured webhook target; kind not enforced, so the
+                # union includes send-less channel types (Category/Forum).
+                await channel.send(scrub_response_secrets(text))  # type: ignore[union-attr]
             else:
                 log.warning("Webhook: channel %s not found", channel_id)
 
@@ -172,8 +174,19 @@ def main() -> None:
     async def shutdown() -> None:
         log.info("Shutting down…")
         for label, action in (
-            ("voice", lambda: getattr(bot, "voice_manager", None) and bot.voice_manager.shutdown()),
-            ("browser", lambda: getattr(bot, "browser_manager", None) and bot.browser_manager.shutdown()),
+            # The getattr-and-call lambdas short-circuit on absent/None
+            # managers; mypy can't relate the getattr probe to the direct
+            # attribute access that follows it.
+            (
+                "voice",
+                lambda: getattr(bot, "voice_manager", None)
+                and bot.voice_manager.shutdown(),  # type: ignore[union-attr]
+            ),
+            (
+                "browser",
+                lambda: getattr(bot, "browser_manager", None)
+                and bot.browser_manager.shutdown(),  # type: ignore[attr-defined]
+            ),
             ("scheduler", lambda: getattr(bot, "scheduler", None) and bot.scheduler.stop()),
         ):
             try:

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -215,7 +215,7 @@ class AuditLogger:
     ) -> None:
         """Log a generic state-changing event (agents, schedules, permissions, etc.)."""
         elapsed = (metadata or {}).get("elapsed_ms")
-        entry = {
+        entry: dict = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "type": event_type,
             "action": action,

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -786,7 +786,9 @@ def _warn_unknown_config_keys(data: dict) -> None:
     # Also accept field aliases if any are defined.
     for f in Config.model_fields.values():
         if getattr(f, "alias", None):
-            known.add(f.alias)
+            # The getattr probe above guarantees a truthy (str) alias, but
+            # mypy can't connect it to the direct attribute read.
+            known.add(f.alias)  # type: ignore[arg-type]
     unknown = [k for k in data if k not in known]
     if unknown:
         get_logger("config").warning(

--- a/src/health/checker.py
+++ b/src/health/checker.py
@@ -15,6 +15,7 @@ from ..odin_log import get_logger
 
 if TYPE_CHECKING:
     from ..discord.client import OdinBot
+    from .subsystem_guard import SubsystemGuard
 
 log = get_logger("health.checker")
 
@@ -543,7 +544,7 @@ def check_all(bot: OdinBot) -> dict[str, Any]:
 
 def sync_guard_from_health(
     health_results: dict[str, Any],
-    guard: object,
+    guard: SubsystemGuard,
 ) -> None:
     """Bridge health check results into a SubsystemGuard.
 
@@ -552,8 +553,8 @@ def sync_guard_from_health(
     component that is registered with it.  Components in "unconfigured"
     status are ignored (they were never meant to run).
 
-    *guard* is typed as ``object`` to avoid circular imports — at
-    runtime it must be a ``SubsystemGuard`` instance.
+    The ``SubsystemGuard`` annotation is TYPE_CHECKING-only to avoid a
+    circular import at runtime.
     """
     components = health_results.get("components", [])
     for comp in components:

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -27,7 +27,10 @@ from .grafana_alerts import (
 from .metrics import MetricsCollector
 
 if TYPE_CHECKING:
+    from aiohttp.typedefs import Middleware
+
     from ..discord.client import OdinBot
+    from ..tools.output_streamer import StreamChunk
 
 log = get_logger("health")
 
@@ -190,7 +193,7 @@ class SessionManager:
 def _make_auth_middleware(
     web_config: WebConfig,
     session_manager: SessionManager,
-) -> web.middleware:
+) -> Middleware:
     """Create middleware that enforces Bearer token auth on /api/ routes.
 
     Accepts either the raw api_token or a valid session token.
@@ -277,7 +280,7 @@ def _make_auth_middleware(
     return auth_middleware
 
 
-def _make_admin_middleware(web_config) -> web.middleware:
+def _make_admin_middleware(web_config) -> Middleware:
     """Enforce the admin tier on control-plane prefixes (ADMIN_ONLY_PREFIXES).
 
     Runs after auth_middleware, so request._api_identity is already resolved.
@@ -306,7 +309,7 @@ def _make_admin_middleware(web_config) -> web.middleware:
     return admin_middleware
 
 
-def _make_rate_limit_middleware(trusted_proxies: tuple[str, ...] = ()) -> web.middleware:
+def _make_rate_limit_middleware(trusted_proxies: tuple[str, ...] = ()) -> Middleware:
     """Simple in-memory rate limiter for /api/ routes (per client IP)."""
     # {ip: [timestamp, ...]}
     _buckets: dict[str, list[float]] = defaultdict(list)
@@ -341,7 +344,7 @@ def _make_rate_limit_middleware(trusted_proxies: tuple[str, ...] = ()) -> web.mi
     return rate_limit_middleware
 
 
-def _make_security_headers_middleware() -> web.middleware:
+def _make_security_headers_middleware() -> Middleware:
     """Add security headers (CSP, X-Frame-Options, etc.) to all responses."""
 
     @web.middleware
@@ -363,7 +366,7 @@ def _make_security_headers_middleware() -> web.middleware:
     return security_headers_middleware
 
 
-def _make_csrf_middleware() -> web.middleware:
+def _make_csrf_middleware() -> Middleware:
     """Validate Origin/Referer on state-changing requests (defense-in-depth).
 
     Bearer tokens already prevent CSRF (not auto-sent by browsers), but this
@@ -412,7 +415,7 @@ def _make_csrf_middleware() -> web.middleware:
     return csrf_middleware
 
 
-def _make_web_audit_middleware(trusted_proxies: tuple[str, ...] = ()) -> web.middleware:
+def _make_web_audit_middleware(trusted_proxies: tuple[str, ...] = ()) -> Middleware:
     """Log state-changing API requests to the audit log."""
 
     @web.middleware
@@ -480,7 +483,7 @@ class HealthServer:
         self._components: dict[str, ComponentCheck] = {}
 
         # Grafana alert handler
-        rules = []
+        rules: list[RemediationRule] = []
         for rc in self._grafana_alert_config.rules:
             rules.append(RemediationRule(
                 id=rc.id or f"rule_{len(rules)}",
@@ -623,7 +626,7 @@ class HealthServer:
         executor = getattr(bot, "tool_executor", None)
         streamer = getattr(executor, "output_streamer", None) if executor else None
         if streamer is not None:
-            async def _stream_to_ws(chunk: object) -> None:
+            async def _stream_to_ws(chunk: StreamChunk) -> None:
                 await ws_mgr.broadcast_event({
                     "type": "tool_stream",
                     **chunk.to_dict(),
@@ -637,7 +640,7 @@ class HealthServer:
         """Redirect / to /ui/."""
         raise web.HTTPFound("/ui/")
 
-    async def _serve_ui_file(self, request: web.Request) -> web.Response:
+    async def _serve_ui_file(self, request: web.Request) -> web.StreamResponse:
         """Serve static UI files, defaulting to index.html for SPA routing."""
         path = request.match_info.get("path", "")
         if not path or path == "/":

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -144,7 +144,9 @@ class CodexAuth:
                 if time.time() >= creds.get("expires_at", 0) - REFRESH_MARGIN:
                     log.info("Access token expired or expiring soon, refreshing...")
                     await self._refresh(creds)
-                creds = self._credentials
+                # _load()/_refresh() above always leave _credentials set;
+                # mypy only sees the Optional attribute declaration.
+                creds = self._credentials  # type: ignore[assignment]
 
         return creds["access_token"]
 
@@ -422,9 +424,11 @@ class CodexAuthPool:
                     and shadow.get("account_id") == creds.get("account_id")
                 )
                 if (
+                    # same_account (above) already requires shadow is not
+                    # None; mypy doesn't carry that through the variable.
                     same_account
-                    and shadow.get("access_token")
-                    and shadow.get("expires_at", 0) >= creds.get("expires_at", 0)
+                    and shadow.get("access_token")  # type: ignore[union-attr]
+                    and shadow.get("expires_at", 0) >= creds.get("expires_at", 0)  # type: ignore[union-attr]
                 ):
                     # Shadow holds newer (rotated) tokens — keep it and pull
                     # the canonical entry up to date instead of the reverse.

--- a/src/llm/kimi.py
+++ b/src/llm/kimi.py
@@ -213,7 +213,7 @@ class KimiClient(LLMProvider):
         session = await self._get_session()
         self._total_requests += 1
         url = f"{self.base_url}/chat/completions"
-        last_error = None
+        last_error: Exception | None = None
 
         for attempt in range(self.max_retries + 1):
             try:

--- a/src/llm/ollama.py
+++ b/src/llm/ollama.py
@@ -184,7 +184,7 @@ class OllamaClient(LLMProvider):
         session = await self._get_session()
         self._total_requests += 1
         url = f"{self.base_url}/api/chat"
-        last_error = None
+        last_error: Exception | None = None
 
         for attempt in range(self.max_retries + 1):
             try:

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -679,7 +679,9 @@ class CodexChatClient:
                 idx = event.get("output_index", 0)
                 if item.get("type") == "function_call" and idx in pending_calls:
                     # If arguments.done wasn't received, try to parse from the done item
-                    call_info = pending_calls.pop(idx, None)
+                    # Standard pop-with-None-sentinel idiom; guarded by
+                    # the truthiness check on the next line.
+                    call_info = pending_calls.pop(idx, None)  # type: ignore[arg-type]
                     if call_info and not any(tc.id == call_info["call_id"] for tc in tool_calls):
                         args_str = item.get("arguments", call_info.get("args", ""))
                         parse_error = None

--- a/src/notifications/issue_tracker.py
+++ b/src/notifications/issue_tracker.py
@@ -489,7 +489,9 @@ class IssueTrackerClient:
     # Unified dispatch
     # ------------------------------------------------------------------
 
-    async def execute(self, action: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def execute(
+        self, action: str, params: dict[str, Any]
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         action = validate_action(action)
         if self._scrub:
             for key in ("title", "description", "body", "comment"):
@@ -510,7 +512,9 @@ class IssueTrackerClient:
             self._error_count += 1
             raise IssueTrackerError(f"{self._provider} error: {exc}") from exc
 
-    async def _dispatch_linear(self, action: str, params: dict) -> dict[str, Any]:
+    async def _dispatch_linear(
+        self, action: str, params: dict
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         if action == "create_issue":
             return await self._linear_create_issue(
                 title=params.get("title", ""),
@@ -541,7 +545,9 @@ class IssueTrackerClient:
             )
         return {}
 
-    async def _dispatch_jira(self, action: str, params: dict) -> dict[str, Any]:
+    async def _dispatch_jira(
+        self, action: str, params: dict
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         if action == "create_issue":
             return await self._jira_create_issue(
                 title=params.get("title", ""),

--- a/src/notifications/outbound_webhooks.py
+++ b/src/notifications/outbound_webhooks.py
@@ -372,7 +372,9 @@ class OutboundWebhookDispatcher:
                     target.url,
                     data=payload_body,
                     headers=headers,
-                    ssl=ssl_ctx,
+                    # aiohttp accepts ssl=None ("use default") at
+                    # runtime; the public stub omits None.
+                    ssl=ssl_ctx,  # type: ignore[arg-type]
                 ) as resp:
                     latency = (time.monotonic() - t0) * 1000
                     success = 200 <= resp.status < 300

--- a/src/observability/aggregates.py
+++ b/src/observability/aggregates.py
@@ -108,7 +108,9 @@ def context_aggregates(trajectory_dir: str, window_hours: int = 24) -> dict:
         if (
             delta is not None
             and abs(delta) >= DRIFT_ABS_TOKENS
-            and prev_avg > 0
+            # delta is not None (above) implies prev_avg is not None
+            # by the ternary that produced delta.
+            and prev_avg > 0  # type: ignore[operator]
             and abs(delta) / prev_avg >= DRIFT_REL_FRACTION
         ):
             drift_candidates.append({

--- a/src/observability/context_trace.py
+++ b/src/observability/context_trace.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import re
 import time
+from typing import Any
 
 from ..odin_log import get_logger
 
@@ -241,7 +242,7 @@ class ContextTraceCollector:
         try:
             duration_ms = round((time.monotonic() - self._started) * 1000, 2)
             total_tokens = sum(s.get("tokens", 0) for s in self._sections)
-            trace = {
+            trace: dict[str, Any] = {
                 "schema_version": TRACE_SCHEMA_VERSION,
                 "assembly": {
                     "version": ASSEMBLY_VERSION,

--- a/src/odin/planner.py
+++ b/src/odin/planner.py
@@ -9,7 +9,7 @@ from typing import Any
 from src.odin.context import ExecutionContext
 from src.odin.executor import StepExecutor
 from src.odin.registry import ToolRegistry
-from src.odin.types import PlanResult, PlanSpec, StepResult, StepStatus
+from src.odin.types import PlanResult, PlanSpec, StepResult, StepSpec, StepStatus
 
 
 class PlanValidationError(Exception):

--- a/src/packaging/validate.py
+++ b/src/packaging/validate.py
@@ -502,7 +502,9 @@ def validate_release_workflow(config: dict[str, Any]) -> list[str]:
 
     # Trigger: must be push with v* tag
     # PyYAML converts the bare key 'on' to boolean True
-    on_config = config.get("on") or config.get(True, {})
+    # PyYAML parses a bare "on:" key as boolean True (see comment above);
+    # the True-key lookup is deliberate and outside the declared key type.
+    on_config = config.get("on") or config.get(True, {})  # type: ignore[call-overload]
     if isinstance(on_config, dict):
         push = on_config.get("push", {})
         if isinstance(push, dict):

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import aiohttp
@@ -222,7 +222,9 @@ class Scheduler:
                     datetime.fromisoformat(run_at)
                 except (ValueError, TypeError):
                     raise ValueError(f"Invalid ISO datetime for run_at: {run_at!r}")
-            normalized = _utc_iso(datetime.fromisoformat(run_at))
+            # Validated above: a one-time schedule without run_at already
+            # raised; cast records the guarantee for the checker.
+            normalized = _utc_iso(datetime.fromisoformat(cast(str, run_at)))
             schedule["run_at"] = normalized
             schedule["next_run"] = normalized
             schedule["one_time"] = True
@@ -233,7 +235,10 @@ class Scheduler:
             schedule["tool_name"] = tool_name
             schedule["tool_input"] = tool_input or {}
         elif action == "webhook":
-            schedule["webhook_config"] = self._normalize_webhook_config(webhook_config)
+            # action == "webhook" already raised unless webhook_config is a dict.
+            schedule["webhook_config"] = self._normalize_webhook_config(
+                cast(dict, webhook_config)
+            )
         elif action == "workflow":
             schedule["steps"] = steps
 

--- a/src/search/embedder.py
+++ b/src/search/embedder.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
+from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+
+if TYPE_CHECKING:
+    from fastembed import TextEmbedding
 
 log = get_logger("search.embedder")
 
@@ -18,7 +22,7 @@ class LocalEmbedder:
     DIMENSIONS = 384
 
     def __init__(self) -> None:
-        self._model = None
+        self._model: TextEmbedding | None = None
 
     def _ensure_model(self):
         if self._model is None:
@@ -40,5 +44,6 @@ class LocalEmbedder:
             return None
 
     def _embed_sync(self, text: str) -> list[float]:
-        vectors = list(self._model.embed([text]))
+        # _ensure_model() has run in every caller before dispatch here.
+        vectors = list(self._model.embed([text]))  # type: ignore[union-attr]
         return vectors[0].tolist()

--- a/src/search/vectorstore.py
+++ b/src/search/vectorstore.py
@@ -123,14 +123,16 @@ class SessionVectorStore:
         vector: list[float] | None,
     ) -> None:
         """Write session metadata, FTS, and vector to database (sync)."""
-        self._conn.execute(
+        # Only dispatched by callers that checked self.available first,
+        # which requires _conn (and _fts where used) to be set.
+        self._conn.execute(  # type: ignore[union-attr]
             "INSERT OR REPLACE INTO session_archives "
             "(doc_id, content, channel_id, last_active, message_count) "
             "VALUES (?, ?, ?, ?, ?)",
             (doc_id, doc_text, channel_id, last_active, message_count),
         )
         if self._fts:
-            self._fts.index_session(doc_id, doc_text, channel_id, last_active)
+            self._fts.index_session(doc_id, doc_text, channel_id, last_active)  # type: ignore[union-attr]
         if vector is not None:
             vec_bytes = serialize_vector(vector)
             # vec0 virtual tables do NOT honor INSERT OR REPLACE conflict
@@ -139,12 +141,14 @@ class SessionVectorStore:
             # Delete-then-insert makes re-indexing idempotent. (The backfill
             # existence check is keyed on session_archives, so a doc_id present
             # only in session_vec would otherwise error on every startup.)
-            self._conn.execute("DELETE FROM session_vec WHERE doc_id = ?", (doc_id,))
-            self._conn.execute(
+            self._conn.execute(  # type: ignore[union-attr]
+                "DELETE FROM session_vec WHERE doc_id = ?", (doc_id,)
+            )
+            self._conn.execute(  # type: ignore[union-attr]
                 "INSERT INTO session_vec (doc_id, embedding) VALUES (?, ?)",
                 (doc_id, vec_bytes),
             )
-        self._conn.commit()
+        self._conn.commit()  # type: ignore[union-attr]
 
     async def search(self, query: str, embedder: LocalEmbedder, limit: int = 10) -> list[dict]:
         """Semantic search across archived sessions."""
@@ -179,7 +183,8 @@ class SessionVectorStore:
 
     def _search_vec_sync(self, vec_bytes: bytes, limit: int) -> list:
         """Execute vector similarity search (sync, for use with asyncio.to_thread)."""
-        return self._conn.execute(
+        # Caller (search) checks self.available first.
+        return self._conn.execute(  # type: ignore[union-attr]
             """
             SELECT v.doc_id, v.distance, a.content, a.channel_id, a.last_active
             FROM session_vec v
@@ -220,22 +225,26 @@ class SessionVectorStore:
 
     def _get_indexed_ids_sync(self) -> set[str]:
         """Get set of already-indexed doc IDs (sync)."""
+        # Caller (backfill) checks self.available first.
         return {
             r[0] for r in
-            self._conn.execute("SELECT doc_id FROM session_archives").fetchall()
+            self._conn.execute(  # type: ignore[union-attr]
+                "SELECT doc_id FROM session_archives"
+            ).fetchall()
         }
 
     def _backfill_fts_sync(self, archive_dir: Path) -> None:
         """Backfill FTS5 index from archive JSON files (sync)."""
         for path in sorted(archive_dir.glob("*.json")):
             doc_id = path.stem
-            if self._fts.has_session(doc_id):
+            # Caller (backfill) only dispatches this inside "if self._fts:".
+            if self._fts.has_session(doc_id):  # type: ignore[union-attr]
                 continue
             try:
                 data = json.loads(path.read_text())
                 doc_text = self._build_document_text(data)
                 if doc_text:
-                    self._fts.index_session(
+                    self._fts.index_session(  # type: ignore[union-attr]
                         doc_id, doc_text,
                         str(data.get("channel_id", "")),
                         float(data.get("last_active", 0)),

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -6,7 +6,7 @@ import json
 import re
 import time
 from datetime import datetime
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1240,8 +1240,12 @@ class SessionManager:
 
     async def _safe_index(self, archive_path: Path) -> None:
         """Index an archived session for semantic search, catching all errors."""
+        # Only scheduled by _archive_session inside
+        # "if self._vector_store and self._vector_store.available:".
         try:
-            await self._vector_store.index_session(archive_path, self._embedder)
+            await self._vector_store.index_session(  # type: ignore[union-attr]
+                archive_path, self._embedder,  # type: ignore[arg-type]
+            )
         except Exception as e:
             log.error("Session indexing failed for %s: %s", archive_path, e)
 
@@ -1333,7 +1337,7 @@ class SessionManager:
             return True
 
         # Step 1: keyword search on current sessions
-        sessions_iter = self._sessions.values()
+        sessions_iter: Iterable[Session] = self._sessions.values()
         if channel_id:
             s = self._sessions.get(channel_id)
             sessions_iter = [s] if s else []
@@ -1471,8 +1475,9 @@ class SessionManager:
         user_ids: list[str] | None = None,
     ) -> None:
         """Reflect on a completed session, catching all errors."""
+        # Only scheduled by _archive_session inside "if self._reflector and ...".
         try:
-            await self._reflector.reflect_on_session(
+            await self._reflector.reflect_on_session(  # type: ignore[union-attr]
                 session, user_ids=user_ids or ([session.last_user_id] if session.last_user_id else []),
             )
         except Exception as e:
@@ -1483,8 +1488,9 @@ class SessionManager:
         user_ids: list[str] | None = None,
     ) -> None:
         """Reflect on compacted messages, catching all errors."""
+        # Only scheduled by the compaction path inside "if self._reflector and ...".
         try:
-            await self._reflector.reflect_on_compacted(
+            await self._reflector.reflect_on_compacted(  # type: ignore[union-attr]
                 messages, summary, user_ids=user_ids or [],
             )
         except Exception as e:


### PR DESCRIPTION
First annotation wave per `docs/plans/type-safety-plan.md` §6. **Annotation-only** — §4 rules and the mechanical checklist apply to every hunk.

## Movement

`type_gate --base-ref origin/types/rfc005`: **resolved=50, new=0.** Total 388 → 338. The only in-scope survivors are the ledgered lines, untouched by design: TS-0002 (`diff_tracker.py:91,97`), TS-0003 (`odin/cli.py:76`), and the dead `src.setup` import (wave-guidance observation).

Packages cleared: `__main__`, audit (minus TS-0002), config, health (14), llm (6), notifications, observability, odin (minus TS-0003), packaging, scheduler, search (9), sessions (5), setup_wizard (minus the dead import).

## Edit inventory (checklist self-assessment)

- **Annotations:** attributes (`embedder._model`), locals (`last_error: Exception | None`, `rules: list[RemediationRule]`, `trace: dict[str, Any]`, `sessions_iter: Iterable[Session]`), params (`guard: SubsystemGuard`, `chunk: StreamChunk`), returns (six `-> web.middleware` → `-> Middleware` — those annotations were *wrong today*, aiohttp's decorator used as a type; `FileResponse` handler → `StreamResponse`; issue-tracker dispatchers → the union they actually return, with the ripple widening `execute()` whose single consumer `json.dumps`es the result).
- **TYPE_CHECKING imports:** `SubsystemGuard`, `StreamChunk`, `Middleware`, `TextEmbedding` — no runtime import graph changes.
- **`cast()` ×2** (scheduler): both record guarantees already enforced by earlier `raise` statements.
- **Reasoned ignores** on runtime-guarded sites mypy can't narrow: getattr-probe lambdas in `__main__` shutdown, `same_account`-guarded shadow reads, caller-side `self.available` checks in vectorstore/sessions, aiohttp `ssl=None` stub gap, the deliberate PyYAML bare-`on` workaround. Every ignore carries its reason.
- **One real import change:** `StepSpec` added to planner's existing `types` import — the annotation only ever resolved because future-annotations deferred evaluation (`name-defined` baseline error). Runtime-inert: module already imported.
- **AST-identical reflows** where an ignore comment would exceed the line limit (`__main__` shutdown tuple, vectorstore execute calls, dispatch signatures).

## Reviewer attention requested

One scripted edit mis-fired during the wave: a 12-space-indent search string substring-matched inside a deeper-indented *second* occurrence in `scheduler.update_schedule`, breaking indentation. Caught by mypy (`syntax`) and repaired by restoring that site verbatim — the update path needs no cast (`elif run_at is not None` narrows natively). Please eyeball `scheduler.py` around both `fromisoformat` sites.

## Verification

- Suite: **6,164 passed / 4 skipped** — identical to post-P0
- Lint gate: new=0 · Type gate: **new=0, resolved=50**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3