### PR TITLE
RFC-005 P2: web + agents annotation wave (338 → 301)

### DIFF
--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -14,8 +14,18 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+
+if TYPE_CHECKING:
+    from .manager import (
+        AgentManager,
+        AnnounceCallback,
+        IterationCallback,
+        ToolExecutorCallback,
+    )
+    from .trajectory import AgentTrajectorySaver
 
 log = get_logger("loop_bridge")
 
@@ -41,7 +51,11 @@ class LoopAgentRecord:
 class LoopAgentBridge:
     """Bridges LoopManager and AgentManager for agent-aware loops."""
 
-    def __init__(self, agent_manager: object, trajectory_saver: object | None = None) -> None:
+    def __init__(
+        self,
+        agent_manager: AgentManager,
+        trajectory_saver: AgentTrajectorySaver | None = None,
+    ) -> None:
         self._agent_manager = agent_manager
         self._trajectory_saver = trajectory_saver
         # loop_id → list of LoopAgentRecords
@@ -65,9 +79,9 @@ class LoopAgentBridge:
         channel_id: str,
         requester_id: str,
         requester_name: str,
-        iteration_callback: object,
-        tool_executor_callback: object,
-        announce_callback: object = None,
+        iteration_callback: IterationCallback,
+        tool_executor_callback: ToolExecutorCallback,
+        announce_callback: AnnounceCallback | None = None,
         tools: list[dict] | None = None,
         system_prompt: str = "",
         tool_timeouts: dict[str, int] | None = None,

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -7,6 +7,7 @@ up to a configurable nesting depth (default 2).
 from __future__ import annotations
 
 import asyncio
+import builtins
 import time
 import uuid
 from collections import deque
@@ -315,14 +316,14 @@ class AgentManager:
         iteration_callback: IterationCallback,
         tool_executor_callback: ToolExecutorCallback,
         announce_callback: AnnounceCallback | None = None,
-        tools: list[dict] | None = None,
+        tools: builtins.list[dict] | None = None,
         system_prompt: str = "",
         tool_timeouts: dict[str, int] | None = None,
         trajectory_saver: AgentTrajectorySaver | None = None,
         parent_id: str | None = None,
         max_depth: int = MAX_NESTING_DEPTH,
         max_iterations: int | None = None,
-        budget_warnings: list[int] | None = None,
+        budget_warnings: builtins.list[int] | None = None,
         context_compression_enabled: bool = False,
         max_context_chars: int = 750000,
         keep_recent_iterations: int = 30,
@@ -442,7 +443,7 @@ class AgentManager:
         if not message:
             return "Error: Message cannot be empty."
 
-        agent._inbox.put_nowait(message)
+        agent._inbox.put_nowait(message)  # type: ignore[union-attr]  # __post_init__ always sets it
         log.info("Sent message to agent %s (%s): %s", agent_id, agent.label, message[:80])
         return f"Message delivered to agent '{agent.label}'."
 
@@ -479,7 +480,7 @@ class AgentManager:
         run's `except CancelledError` + `finally` still finalize the
         trajectory cleanly.
         """
-        agent._cancel_event.set()
+        agent._cancel_event.set()  # type: ignore[union-attr]  # __post_init__ always sets it
         task = getattr(agent, "_task", None)
         if task is not None and not task.done():
             task.cancel()
@@ -538,7 +539,7 @@ class AgentManager:
             "children_ids": list(agent.children_ids),
         }
 
-    def get_children(self, agent_id: str) -> list[dict]:
+    def get_children(self, agent_id: str) -> builtins.list[dict]:
         """Get results of all direct children of an agent."""
         agent = self._agents.get(agent_id)
         if not agent:
@@ -550,7 +551,7 @@ class AgentManager:
                 results.append(r)
         return results
 
-    def get_lineage(self, agent_id: str) -> list[str]:
+    def get_lineage(self, agent_id: str) -> builtins.list[str]:
         """Get the chain of parent IDs from root to this agent (inclusive)."""
         lineage: list[str] = []
         current = agent_id
@@ -565,7 +566,7 @@ class AgentManager:
         lineage.reverse()
         return lineage
 
-    def get_descendants(self, agent_id: str) -> list[str]:
+    def get_descendants(self, agent_id: str) -> builtins.list[str]:
         """Get all descendant agent IDs (children, grandchildren, etc.)."""
         agent = self._agents.get(agent_id)
         if not agent:
@@ -586,7 +587,7 @@ class AgentManager:
 
     async def wait_for_agents(
         self,
-        agent_ids: list[str],
+        agent_ids: builtins.list[str],
         timeout: float = WAIT_DEFAULT_TIMEOUT,
         poll_interval: float = WAIT_POLL_INTERVAL,
     ) -> dict[str, dict]:
@@ -641,24 +642,24 @@ class AgentManager:
 
     def spawn_group(
         self,
-        tasks: list[dict],
+        tasks: builtins.list[dict],
         channel_id: str,
         requester_id: str,
         requester_name: str,
         iteration_callback: IterationCallback,
         tool_executor_callback: ToolExecutorCallback,
         announce_callback: AnnounceCallback | None = None,
-        tools: list[dict] | None = None,
+        tools: builtins.list[dict] | None = None,
         system_prompt: str = "",
         tool_timeouts: dict[str, int] | None = None,
         trajectory_saver: AgentTrajectorySaver | None = None,
         max_depth: int = MAX_NESTING_DEPTH,
         max_iterations: int | None = None,
-        budget_warnings: list[int] | None = None,
+        budget_warnings: builtins.list[int] | None = None,
         context_compression_enabled: bool = False,
         max_context_chars: int = 750000,
         keep_recent_iterations: int = 30,
-    ) -> list[str]:
+    ) -> builtins.list[str]:
         """Spawn multiple agents at once. Returns list of agent_ids (or error strings).
 
         Each task dict must have 'label' and 'goal' keys.
@@ -800,7 +801,7 @@ async def _run_agent(
     agent_start = time.time()
 
     def _check_kill() -> bool:
-        if agent._cancel_event.is_set():
+        if agent._cancel_event.is_set():  # type: ignore[union-attr]  # __post_init__ always sets it
             if agent._sm.is_terminal:
                 return True
             try:
@@ -835,9 +836,9 @@ async def _run_agent(
                 return
 
             # Check inbox for injected messages
-            while not agent._inbox.empty():
+            while not agent._inbox.empty():  # type: ignore[union-attr]  # __post_init__ always sets it
                 try:
-                    msg = agent._inbox.get_nowait()
+                    msg = agent._inbox.get_nowait()  # type: ignore[union-attr]  # __post_init__ always sets it
                     agent.messages.append({
                         "role": "user",
                         "content": f"[Message from parent] {msg}",

--- a/src/web/api/sessions_chat.py
+++ b/src/web/api/sessions_chat.py
@@ -245,7 +245,8 @@ def register_sessions(routes: web.RouteTableDef, bot) -> None:
         limit = _safe_int_param(request, "limit", 20, hi=50)
         channel_id = request.query.get("channel_id") or None
         if not is_admin:
-            channel_id = identity.user_id
+            # is_admin is only False when identity was truthy (see above).
+            channel_id = identity.user_id  # type: ignore[union-attr]
         user_id = request.query.get("user_id") or None
         after: float | None = None
         before: float | None = None

--- a/src/web/api_common.py
+++ b/src/web/api_common.py
@@ -82,7 +82,7 @@ def _scoped_chat_channel(user_id: str, session_id: str) -> str:
     return f"web:{user_id}:session:{session_id}"
 
 
-def _sanitize_error(msg: str) -> str:
+def _sanitize_error(msg: str | BaseException) -> str:
     """Scrub secrets from error messages before returning to clients."""
     return scrub_output_secrets(str(msg))
 
@@ -138,7 +138,7 @@ def _redact_config(obj: Any, *, _depth: int = 0) -> Any:
     return obj
 
 
-def _write_config(path: Path, data: dict) -> None:
+def _write_config(path: Path | str, data: dict) -> None:
     """Write config dict to YAML file."""
     with open(path, "w") as f:
         yaml.dump(data, f, default_flow_style=False)

--- a/src/web/chat.py
+++ b/src/web/chat.py
@@ -145,7 +145,7 @@ class WebMessage:
         self.channel = _WebChannel(channel_id)
         self.author = _WebAuthor(user_id, username)
         self.webhook_id = None
-        self.attachments = []
+        self.attachments: list = []
         self.guild = None
         self.allowed_tools = allowed_tools
 
@@ -246,7 +246,10 @@ async def _do_process_web_chat(
         try:
             response, _already_sent, is_error, tools_used, handoff = (
                 await bot.tool_loop.run(
-                    msg, history, system_prompt_override=sp, trace=trace,
+                    # WebMessage is the documented duck-typed stand-in
+                    # for discord.Message (see class docstring).
+                    msg,  # type: ignore[arg-type]
+                    history, system_prompt_override=sp, trace=trace,
                 )
             )
         finally:

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -97,8 +97,8 @@ class WebSocketManager:
         ws = web.WebSocketResponse(heartbeat=30.0)
         await ws.prepare(request)
         self._clients.add(ws)
-        ws._odin_session_id = getattr(request, "_session_id", None) or "ws-anon"
-        ws._odin_identity = identity
+        ws._odin_session_id = getattr(request, "_session_id", None) or "ws-anon"  # type: ignore[attr-defined]  # sanctioned dynamic attr
+        ws._odin_identity = identity  # type: ignore[attr-defined]  # sanctioned dynamic attr
         log.info("WebSocket client connected (%d total)", len(self._clients))
 
         log_task: asyncio.Task | None = None
@@ -175,11 +175,11 @@ class WebSocketManager:
         now = _time.monotonic()
         window_start = getattr(ws, "_chat_window_start", None)
         if window_start is None or not isinstance(window_start, (int, float)) or now - window_start > _WS_CHAT_RATE_WINDOW:
-            ws._chat_window_start = now
-            ws._chat_count = 0
+            ws._chat_window_start = now  # type: ignore[attr-defined]  # sanctioned dynamic attr
+            ws._chat_count = 0  # type: ignore[attr-defined]  # sanctioned dynamic attr
         chat_count = getattr(ws, "_chat_count", None)
-        ws._chat_count = (chat_count + 1) if isinstance(chat_count, int) else 1
-        if ws._chat_count > _WS_CHAT_RATE_LIMIT:
+        ws._chat_count = (chat_count + 1) if isinstance(chat_count, int) else 1  # type: ignore[attr-defined]  # sanctioned dynamic attr
+        if ws._chat_count > _WS_CHAT_RATE_LIMIT:  # type: ignore[attr-defined]  # sanctioned dynamic attr
             await ws.send_json({"type": "chat_error", "error": "rate limit exceeded (10/min)"})
             return
 


### PR DESCRIPTION
Second annotation wave per plan §6. **Annotation-only**, §4 checklist applies to every hunk.

## Movement

`type_gate --base-ref origin/types/rfc005`: **resolved=37, new=0.** Total 338 → 301. P2 scope (web + agents) is at **zero** remaining findings.

Notable: typing `loop_bridge`'s `AgentManager` param immediately surfaced 4 previously-invisible findings at the `spawn()` call (its callback args were `object`-typed) — the annotate-to-extend-reach effect the plan §1 describes, resolved in the same wave by giving the bridge's params their real callback types via TYPE_CHECKING imports.

## Edit inventory

- **`agents/manager.py`** — the method literally named `list` shadows `builtins.list` inside the class body, corrupting ten signature annotations under future-annotations (`"list?[str]" not iterable`, `Function ... not valid as a type`). Fixed type-only: those signatures now spell `builtins.list[...]` (+ `import builtins`). Renaming the public method would be an API change — out of wave scope, per the ledger's wave guidance.
- **`__post_init__`-guaranteed fields** (`_inbox`, `_cancel_event`): Optional in the dataclass declaration, unconditionally set in `__post_init__` — reasoned ignores at the five use sites.
- **`loop_bridge`**: `AgentManager`, callback aliases, and `AgentTrajectorySaver` annotations via TYPE_CHECKING (no runtime import changes).
- **`api_common`**: `_sanitize_error` widened to `str | BaseException` (first statement is `str(msg)`; six callers pass exceptions — fixes all six findings at the source instead of six ignores); `_write_config` widened to `Path | str` (callers pass the `"config.yml"` str default).
- **`web/chat.py`**: `attachments: list` annotation; the documented WebMessage duck-type into `tool_loop.run` gets a reasoned ignore.
- **`web/websocket.py`**: the six sanctioned dynamic attrs (`_odin_session_id`, `_chat_count`, …) get reasoned ignores — runtime `__dict__` behavior verified in triage.
- **`sessions_chat`**: `is_admin`-implies-identity guard, reasoned ignore.

## Verification

- Suite: **6,164 passed / 4 skipped** — identical
- Lint gate: new=0 · Type gate: **new=0, resolved=37**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3