### PR TITLE
RFC-005 P3: knowledge + tools annotation wave (301 → 226)

### DIFF
--- a/src/knowledge/store.py
+++ b/src/knowledge/store.py
@@ -30,7 +30,13 @@ NEAR_DUPE_THRESHOLD = 0.8  # chunk overlap ratio to consider near-duplicate
 
 
 class KnowledgeStore:
-    """Semantic search over ingested documents (runbooks, configs, READMEs, etc.)."""
+    """Semantic search over ingested documents (runbooks, configs, READMEs, etc.).
+
+    Every public entry point checks ``self.available`` before touching
+    ``_conn``/``_fts``; the per-line union-attr ignores record that
+    invariant where mypy cannot see across the caller boundary.
+    """
+
 
     def __init__(self, db_path: str, fts_index: FullTextIndex | None = None) -> None:
         self._conn: sqlite3.Connection | None = None
@@ -269,7 +275,7 @@ class KnowledgeStore:
             chunk_id = f"{doc_hash}_{i}"
             chunk_hash = self._content_hash(chunk)
             try:
-                self._conn.execute(
+                self._conn.execute(  # type: ignore[union-attr]
                     "INSERT OR REPLACE INTO knowledge_chunks "
                     "(chunk_id, content, source, chunk_index, total_chunks, "
                     "uploader, ingested_at, content_hash, doc_content_hash) "
@@ -280,20 +286,20 @@ class KnowledgeStore:
                 if self._fts:
                     self._fts.index_knowledge_chunk(chunk_id, chunk, source, i)
                 if vectors[i] is not None:
-                    vec_bytes = serialize_vector(vectors[i])
+                    vec_bytes = serialize_vector(vectors[i])  # type: ignore[arg-type]  # guarded by is-not-None above
                     # vec0 tables don't honor INSERT OR REPLACE (same issue as
                     # session_vec) — delete-then-insert keeps re-ingest idempotent.
-                    self._conn.execute(
+                    self._conn.execute(  # type: ignore[union-attr]
                         "DELETE FROM knowledge_vec WHERE chunk_id = ?", (chunk_id,)
                     )
-                    self._conn.execute(
+                    self._conn.execute(  # type: ignore[union-attr]
                         "INSERT INTO knowledge_vec (chunk_id, embedding) VALUES (?, ?)",
                         (chunk_id, vec_bytes),
                     )
                 indexed += 1
             except Exception as e:
                 log.error("Failed to index chunk %d of '%s': %s", i, source, e)
-        self._conn.commit()
+        self._conn.commit()  # type: ignore[union-attr]
         return indexed
 
     async def search(
@@ -341,7 +347,7 @@ class KnowledgeStore:
 
     def _search_vec_sync(self, vec_bytes: bytes, limit: int) -> list:
         """Execute vector similarity search (sync, for use with asyncio.to_thread)."""
-        return self._conn.execute(
+        return self._conn.execute(  # type: ignore[union-attr]
             """
             SELECT v.chunk_id, v.distance, c.content, c.source, c.chunk_index
             FROM knowledge_vec v
@@ -359,7 +365,7 @@ class KnowledgeStore:
             return []
 
         try:
-            rows = self._conn.execute(
+            rows = self._conn.execute(  # type: ignore[union-attr]
                 """
                 SELECT source, COUNT(*) as chunks, uploader,
                        MAX(ingested_at) as ingested_at,
@@ -383,7 +389,7 @@ class KnowledgeStore:
             }
             # Add preview from first chunk
             try:
-                first = self._conn.execute(
+                first = self._conn.execute(  # type: ignore[union-attr]
                     "SELECT content FROM knowledge_chunks WHERE source = ? ORDER BY chunk_index LIMIT 1",
                     (r[0],),
                 ).fetchone()
@@ -402,7 +408,7 @@ class KnowledgeStore:
         if not self.available:
             return []
         try:
-            rows = self._conn.execute(
+            rows = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT chunk_id, content, chunk_index, total_chunks, ingested_at "
                 "FROM knowledge_chunks WHERE source = ? ORDER BY chunk_index",
                 (source,),
@@ -426,7 +432,7 @@ class KnowledgeStore:
         if not self.available:
             return None
         try:
-            rows = self._conn.execute(
+            rows = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT content FROM knowledge_chunks WHERE source = ? ORDER BY chunk_index",
                 (source,),
             ).fetchall()
@@ -445,7 +451,7 @@ class KnowledgeStore:
             # Get chunk IDs for this source
             ids = [
                 r[0] for r in
-                self._conn.execute(
+                self._conn.execute(  # type: ignore[union-attr]
                     "SELECT chunk_id FROM knowledge_chunks WHERE source = ?", (source,)
                 ).fetchall()
             ]
@@ -463,14 +469,14 @@ class KnowledgeStore:
             # Delete from vector table
             if self._has_vec:
                 for chunk_id in ids:
-                    self._conn.execute(
+                    self._conn.execute(  # type: ignore[union-attr]
                         "DELETE FROM knowledge_vec WHERE chunk_id = ?", (chunk_id,)
                     )
             # Delete from chunks table
-            self._conn.execute(
+            self._conn.execute(  # type: ignore[union-attr]
                 "DELETE FROM knowledge_chunks WHERE source = ?", (source,)
             )
-            self._conn.commit()
+            self._conn.commit()  # type: ignore[union-attr]
             # Delete from FTS
             if self._fts:
                 self._fts.delete_knowledge_source(source)
@@ -528,7 +534,7 @@ class KnowledgeStore:
         if not self._fts or not self.available:
             return 0
         try:
-            rows = self._conn.execute(
+            rows = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT chunk_id, content, source, chunk_index FROM knowledge_chunks"
             ).fetchall()
         except Exception:
@@ -593,7 +599,7 @@ class KnowledgeStore:
         if not self.available:
             return []
         try:
-            rows = self._conn.execute(
+            rows = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT doc_content_hash, GROUP_CONCAT(DISTINCT source) as sources, "
                 "COUNT(DISTINCT source) as src_count "
                 "FROM knowledge_chunks "
@@ -622,7 +628,7 @@ class KnowledgeStore:
         if not self.available:
             return []
         try:
-            sources = self._conn.execute(
+            sources = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT DISTINCT source FROM knowledge_chunks "
                 "WHERE content_hash IS NOT NULL AND content_hash != ''"
             ).fetchall()
@@ -634,7 +640,7 @@ class KnowledgeStore:
         hash_sets: dict[str, set[str]] = {}
         for src in source_list:
             try:
-                rows = self._conn.execute(
+                rows = self._conn.execute(  # type: ignore[union-attr]
                     "SELECT content_hash FROM knowledge_chunks "
                     "WHERE source = ? AND content_hash IS NOT NULL",
                     (src,),
@@ -679,7 +685,7 @@ class KnowledgeStore:
         """
         if not self.available or keep_source == remove_source:
             return 0
-        keep_exists = self._conn.execute(
+        keep_exists = self._conn.execute(  # type: ignore[union-attr]
             "SELECT 1 FROM knowledge_chunks WHERE source = ? LIMIT 1",
             (keep_source,),
         ).fetchone()
@@ -693,7 +699,7 @@ class KnowledgeStore:
 
     def _next_version(self, source: str) -> int:
         """Return the next version number for *source*."""
-        row = self._conn.execute(
+        row = self._conn.execute(  # type: ignore[union-attr]
             "SELECT MAX(version) FROM knowledge_versions WHERE source = ?",
             (source,),
         ).fetchone()
@@ -754,7 +760,7 @@ class KnowledgeStore:
         if not self.available:
             return []
         try:
-            rows = self._conn.execute(
+            rows = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT id, version, content_hash, chunk_count, uploader, "
                 "action, created_at, diff_summary "
                 "FROM knowledge_versions WHERE source = ? ORDER BY version DESC",
@@ -781,7 +787,7 @@ class KnowledgeStore:
         if not self.available:
             return None
         try:
-            row = self._conn.execute(
+            row = self._conn.execute(  # type: ignore[union-attr]
                 "SELECT id, version, content_hash, content, chunk_count, "
                 "uploader, action, created_at, diff_summary "
                 "FROM knowledge_versions WHERE source = ? AND version = ?",

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -143,7 +143,9 @@ class LoopManager:
                 return "No active loops to stop."
             return f"Stopped {len(stopped)} loop(s): {', '.join(stopped)}"
 
-        info = self._loops.get(loop_id)
+        # mypy binds `info` to the non-Optional loop var of the 'all'
+        # branch above (which always returns) — false conflict.
+        info = self._loops.get(loop_id)  # type: ignore[assignment]
         if not info:
             return f"No loop found with ID `{loop_id}`."
         if info.status != "running":

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+
+if TYPE_CHECKING:
+    from playwright.async_api import Browser, Playwright
 
 log = get_logger("browser")
 
@@ -53,8 +57,8 @@ class BrowserManager:
         self._cdp_url = cdp_url
         self._default_timeout_ms = default_timeout_ms
         self._viewport = {"width": viewport_width, "height": viewport_height}
-        self._playwright = None
-        self._browser = None
+        self._playwright: Playwright | None = None
+        self._browser: Browser | None = None
         self._lock = asyncio.Lock()
         self._native = not bool(cdp_url)
         self.allowed_urls = allow_private_targets or []
@@ -123,7 +127,8 @@ class BrowserManager:
 
     async def _create_page(self, timeout_ms: int | None = None):
         """Create a new browser context and page. Returns (context, page)."""
-        context = await self._browser.new_context(
+        # _ensure_connected() (every caller) sets _browser before this.
+        context = await self._browser.new_context(  # type: ignore[union-attr]
             viewport=self._viewport,
             user_agent=DEFAULT_USER_AGENT,
         )

--- a/src/tools/comfyui.py
+++ b/src/tools/comfyui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from typing import Any
 
 import aiohttp
 
@@ -13,7 +14,7 @@ log = get_logger("comfyui")
 
 # Default txt2img workflow template.
 # The {prompt}, {negative}, {width}, {height} placeholders are filled at runtime.
-_DEFAULT_WORKFLOW = {
+_DEFAULT_WORKFLOW: dict[str, Any] = {
     "3": {
         "class_type": "KSampler",
         "inputs": {

--- a/src/tools/email_client.py
+++ b/src/tools/email_client.py
@@ -57,7 +57,7 @@ def _extract_body(msg: email_lib.message.Message, max_chars: int) -> str:
                 payload = part.get_payload(decode=True)
                 if payload:
                     charset = part.get_content_charset() or "utf-8"
-                    text = payload.decode(charset, errors="replace")
+                    text = payload.decode(charset, errors="replace")  # type: ignore[union-attr]  # get_payload(decode=True) never returns Message
                     if len(text) > max_chars:
                         return (
                             text[:max_chars]
@@ -70,7 +70,7 @@ def _extract_body(msg: email_lib.message.Message, max_chars: int) -> str:
                 payload = part.get_payload(decode=True)
                 if payload:
                     charset = part.get_content_charset() or "utf-8"
-                    text = payload.decode(charset, errors="replace")
+                    text = payload.decode(charset, errors="replace")  # type: ignore[union-attr]  # get_payload(decode=True) never returns Message
                     if len(text) > max_chars:
                         return (
                             text[:max_chars]
@@ -81,7 +81,7 @@ def _extract_body(msg: email_lib.message.Message, max_chars: int) -> str:
     payload = msg.get_payload(decode=True)
     if payload:
         charset = msg.get_content_charset() or "utf-8"
-        text = payload.decode(charset, errors="replace")
+        text = payload.decode(charset, errors="replace")  # type: ignore[union-attr]  # get_payload(decode=True) never returns Message
         if len(text) > max_chars:
             return text[:max_chars] + f"\n\n[truncated at {max_chars} chars, original {len(text)}]"
         return text
@@ -234,9 +234,9 @@ def search_email(
 
         if _GMAIL_HOST_MARKER in imap_host.lower():
             escaped = query.replace("\\", "\\\\").replace('"', '\\"')
-            status, data = conn.uid("SEARCH", None, "X-GM-RAW", f'"{escaped}"')
+            status, data = conn.uid("SEARCH", None, "X-GM-RAW", f'"{escaped}"')  # type: ignore[arg-type]  # stdlib None-charset idiom; IMAP4._command skips None
         else:
-            status, data = conn.uid("SEARCH", None, query)
+            status, data = conn.uid("SEARCH", None, query)  # type: ignore[arg-type]  # stdlib None-charset idiom; IMAP4._command skips None
 
         if status != "OK":
             return []
@@ -330,7 +330,7 @@ def list_recent(
         conn.login(username, password)
         conn.select(f'"{folder}"', readonly=True)
 
-        status, data = conn.uid("SEARCH", None, "ALL")
+        status, data = conn.uid("SEARCH", None, "ALL")  # type: ignore[arg-type]  # stdlib None-charset idiom; IMAP4._command skips None
         if status != "OK" or not data[0]:
             return []
 

--- a/src/tools/executor.py
+++ b/src/tools/executor.py
@@ -4,6 +4,7 @@ import asyncio
 import contextvars
 import json
 from pathlib import Path
+from typing import Any
 
 from ..config.schema import ToolsConfig
 from ..odin_log import get_logger
@@ -34,7 +35,12 @@ from .recovery import (
 )
 from .result_validator import ResultValidationStats, ToolResult, validate_tool_result
 from .risk_classifier import RiskStats, classify_tool
-from .ssh import is_local_address, run_local_command, run_ssh_command
+from .ssh import (
+    OutputCallback,
+    is_local_address,
+    run_local_command,
+    run_ssh_command,
+)
 from .ssh_pool import SSHConnectionPool
 
 log = get_logger("tools")
@@ -344,9 +350,11 @@ class ToolExecutor:
 
         denial = self.check_permission(tool_name, user_id)
         if denial:
+            # A truthy denial implies _permission_manager and user_id were
+            # both set (check_permission returns None otherwise).
             log.warning(
                 "RBAC denied %s for user %s on tool %s",
-                self._permission_manager.get_tier(user_id),
+                self._permission_manager.get_tier(user_id),  # type: ignore[union-attr, arg-type]
                 user_id,
                 tool_name,
             )
@@ -578,7 +586,7 @@ class ToolExecutor:
         command: str,
         ssh_user: str = "root",
         timeout: int | None = None,
-        on_output: object | None = None,
+        on_output: OutputCallback | None = None,
     ) -> tuple[int, str]:
         """Execute a command locally or via SSH depending on host address.
 
@@ -606,7 +614,7 @@ class ToolExecutor:
                     return 1, "Error: subprocess bulkhead full — too many concurrent local commands"
             return await run_local_command(command, timeout=timeout, on_output=on_output)
         ssh_retry = self.config.ssh_retry
-        ssh_kwargs = dict(
+        ssh_kwargs: dict[str, Any] = dict(
             host=address,
             command=command,
             ssh_key_path=self.config.ssh_key_path,

--- a/src/tools/git_ops.py
+++ b/src/tools/git_ops.py
@@ -7,6 +7,7 @@ log, and pull — with branch freshness checks before push.
 from __future__ import annotations
 
 import shlex
+from collections.abc import Callable
 
 ALLOWED_ACTIONS = frozenset(
     {
@@ -261,7 +262,7 @@ def _build_stash(params: dict) -> str:
     return " ".join(parts)
 
 
-_BUILDERS = {
+_BUILDERS: dict[str, Callable[[dict], str | list[str]]] = {
     "clone": _build_clone,
     "status": _build_status,
     "diff": _build_diff,

--- a/src/tools/handlers/devops.py
+++ b/src/tools/handlers/devops.py
@@ -13,7 +13,7 @@ from .deps import HandlerBase
 
 
 class DevOpsTools(HandlerBase):
-    async def _handle_git_ops(self, inp: dict) -> str:
+    async def _handle_git_ops(self, inp: dict) -> str | tuple[str, int]:
         from ..git_ops import ALLOWED_ACTIONS, build_git_command
 
         action = inp.get("action", "")
@@ -34,7 +34,8 @@ class DevOpsTools(HandlerBase):
             return f"git_ops error: {e}"
 
         if action == "push":
-            freshness_cmd, push_cmd = cmds
+            # action == 'push' always builds the 2-element list form.
+            freshness_cmd, push_cmd = cmds  # type: ignore[str-unpack]
             allowed, denial, _ = self._govern_command(push_cmd, host)
             if not allowed:
                 return denial
@@ -71,7 +72,7 @@ class DevOpsTools(HandlerBase):
                 else f"git {action} completed successfully."
             ), 0
 
-    async def _handle_kubectl(self, inp: dict) -> str:
+    async def _handle_kubectl(self, inp: dict) -> str | tuple[str, int]:
         from ..kubectl_ops import ALLOWED_ACTIONS as KUBECTL_ACTIONS
         from ..kubectl_ops import build_kubectl_command
 
@@ -107,7 +108,7 @@ class DevOpsTools(HandlerBase):
             else f"kubectl {action} completed successfully."
         ), 0
 
-    async def _handle_docker_ops(self, inp: dict) -> str:
+    async def _handle_docker_ops(self, inp: dict) -> str | tuple[str, int]:
         from ..docker_ops import ALLOWED_ACTIONS as DOCKER_ACTIONS
         from ..docker_ops import build_docker_command
 
@@ -141,7 +142,7 @@ class DevOpsTools(HandlerBase):
             else f"docker {action} completed successfully."
         ), 0
 
-    async def _handle_terraform_ops(self, inp: dict) -> str:
+    async def _handle_terraform_ops(self, inp: dict) -> str | tuple[str, int]:
         from ..terraform_ops import ALLOWED_ACTIONS as TF_ACTIONS
         from ..terraform_ops import build_terraform_command
 

--- a/src/tools/handlers/system.py
+++ b/src/tools/handlers/system.py
@@ -24,7 +24,7 @@ from .deps import HandlerBase
 
 
 class SystemTools(HandlerBase):
-    async def _handle_run_command(self, inp: dict) -> str:
+    async def _handle_run_command(self, inp: dict) -> str | tuple[str, int]:
         command = inp.get("command")
         host = inp.get("host")
         if not command:
@@ -75,7 +75,7 @@ class SystemTools(HandlerBase):
         text = f"{governor_note}{output}" if governor_note else output
         return text, code
 
-    async def _handle_run_script(self, inp: dict) -> str:
+    async def _handle_run_script(self, inp: dict) -> str | tuple[str, int]:
         """Write a script to a temp file, execute it, and clean up."""
         host = inp.get("host")
         script = inp.get("script")
@@ -213,7 +213,7 @@ class SystemTools(HandlerBase):
                 parts.append(f"### {h}\n```\nError: {r}\n```")
                 any_run_error = True
             else:
-                markdown, host_err = r
+                markdown, host_err = r  # type: ignore[misc]  # gather() excs are filtered above; cancellation propagates before this
                 parts.append(markdown)
                 any_run_error = any_run_error or host_err
         for h, denial in blocked_hosts:

--- a/src/tools/skill_manager.py
+++ b/src/tools/skill_manager.py
@@ -594,7 +594,7 @@ class SkillManager:
         # executor's scoped memory structure (global/user_* namespaces).
         if memory_path:
             p = Path(memory_path)
-            self._memory_path = str(p.parent / f"{p.stem}_skills{p.suffix}")
+            self._memory_path: str | None = str(p.parent / f"{p.stem}_skills{p.suffix}")
         else:
             self._memory_path = None
         self._skills: dict[str, LoadedSkill] = {}
@@ -1011,7 +1011,9 @@ class SkillManager:
             errors.append("Missing 'execute' function (async def execute(inp, context)).")
 
         definition = None
-        definition_keys: list[str] = []
+        # Dead duplicate of the declaration 28 lines up (harmless; slated
+        # for a deliberate cleanup PR — removal is out of wave scope).
+        definition_keys: list[str] = []  # type: ignore[no-redef]
         for node in _ast.iter_child_nodes(tree):
             if isinstance(node, _ast.Assign):
                 for target in node.targets:

--- a/src/tools/url_safety.py
+++ b/src/tools/url_safety.py
@@ -127,7 +127,9 @@ def is_url_blocked(
             resolved = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
             for _family, _type, _proto, _canonname, sockaddr in resolved:
                 ip = sockaddr[0]
-                if _is_ip_blocked(ip):
+                # AF_UNSPEC+SOCK_STREAM resolution yields only AF_INET/6
+                # sockaddrs, whose first element is always str.
+                if _is_ip_blocked(ip):  # type: ignore[arg-type]
                     log.warning("DNS rebinding blocked: %s resolves to private IP %s", host, ip)
                     return True
         except socket.gaierror:


### PR DESCRIPTION
Third annotation wave per plan §6. **Annotation-only**, §4 checklist applies.

## Movement

`type_gate --base-ref origin/types/rfc005`: **resolved=75, new=0.** Total 301 → 226. P3 scope is at zero remaining except the **three ledgered lines** (TS-0004 `skill_context.py:162`, TS-0005 `:336` ×2) awaiting Aaron's verdicts — untouched by design.

## Edit inventory

- **Handler truth-telling**: the six devops/system handlers that return `(output, exit_code)` tuples (executor unpacks `isinstance(raw, tuple)` — that was always the contract) now declare `-> str | tuple[str, int]` instead of the `-> str` lie.
- **`executor.py`**: `on_output` gets its real `OutputCallback` type (from `.ssh`); `ssh_kwargs: dict[str, Any]` so the `**` unpack type-checks against `run_ssh_command` (clears 10); RBAC denial-log invariant ignore (truthy denial ⟹ manager+user set).
- **`git_ops._BUILDERS`** annotated `dict[str, Callable[[dict], str | list[str]]]`.
- **`browser.py`**: `_playwright`/`_browser` attrs annotated via TYPE_CHECKING playwright imports (resolve through the optional-extra override); guarded `new_context` ignore.
- **`comfyui._DEFAULT_WORKFLOW: dict[str, Any]`** (clears 7).
- **`knowledge/store.py`**: 22 targeted `union-attr`/`arg-type` ignores for the `self.available`-guarded connection family, with the invariant documented once in the class docstring.
- **Reasoned ignores**: imaplib None-charset idiom ×3, `get_payload(decode=True)` stub gap ×3, gather-exception narrowing, autonomous_loop one-type-per-name false conflict, url_safety AF_INET sockaddr, skill_manager dead duplicate declaration (removal deferred to a deliberate cleanup PR — out of wave scope), devops push-list unpack.

## Process notes for review

Two self-caught slips during the wave, both worth reviewer eyes: my knowledge-store docstring insertion initially landed *outside* a one-line docstring (mypy caught the syntax error immediately; repaired into a proper multi-line docstring), and one ignore initially used the wrong error code (`misc` vs `str-unpack` on `devops.py:38`).

## Verification

- Suite: **6,164 passed / 4 skipped** — identical (re-run after the final import relocation)
- Lint gate: new=0 · Type gate: **new=0, resolved=75**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3