### PR TITLE
RFC-005 P4: discord annotation wave (226 → 9 — the ledger is all that remains)

### DIFF
--- a/src/discord/attachments.py
+++ b/src/discord/attachments.py
@@ -15,9 +15,9 @@ import hashlib
 import os
 import re
 import shutil
+import tarfile
 import time
 import zipfile
-import tarfile
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -128,7 +128,9 @@ def _preview_text(text: str, ext: str, max_chars: int = 12000) -> str:
     return text[:max_chars] + f"\n\n[... truncated at {max_chars:,} chars ...]"
 
 
-def _is_text_file(filename: str, content_type: str | None) -> bool:
+def _is_text_file(filename: str, content_type: str | None) -> bool | str | None:
+    # Truthiness contract: both call sites only test the result; the
+    # and/or chain legitimately yields "" / None for falsy inputs.
     ext = _get_ext(filename)
     return ext in _TEXT_EXTENSIONS or (content_type and "text" in content_type)
 
@@ -336,7 +338,7 @@ class AttachmentProcessor:
             archive_path.write_bytes(data)
 
             ext = _get_ext(att.filename)
-            manifest_lines = []
+            manifest_lines: list[str] = []
             extract_dir = ws / safe.rsplit(".", 1)[0]
 
             if ext == ".zip":
@@ -415,7 +417,9 @@ class AttachmentProcessor:
     def _extract_tar(self, archive_path: Path, extract_dir: Path) -> tuple[list[str], bool]:
         manifest = []
         mode = "r:gz" if str(archive_path).endswith((".tar.gz", ".tgz")) else "r"
-        with tarfile.open(archive_path, mode) as tf:
+        # mode is always one of the literal read modes; the ternary widens
+        # it to plain str, which the Literal-only stub overloads reject.
+        with tarfile.open(archive_path, mode) as tf:  # type: ignore[call-overload]
             members = tf.getmembers()
             manifest.append(f"Entries: {len(members)}")
             total_size = sum(m.size for m in members if m.isfile())

--- a/src/discord/channel_state.py
+++ b/src/discord/channel_state.py
@@ -18,8 +18,12 @@ from __future__ import annotations
 import asyncio
 import collections
 import time
+from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+
+if TYPE_CHECKING:
+    from .background_task import BackgroundTask
 
 log = get_logger("discord")
 
@@ -63,7 +67,7 @@ class ChannelStateRegistry:
         self.recent_actions_max = recent_actions_max
         self.recent_actions_expiry = recent_actions_expiry  # seconds
         # Background task tracking
-        self.background_tasks: dict[str, object] = {}
+        self.background_tasks: dict[str, BackgroundTask] = {}
         self.background_tasks_max = background_tasks_max
         # Throttled housekeeping
         self.last_cleanup: float = 0.0

--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -15,14 +15,15 @@ from __future__ import annotations
 import os
 import time
 
-import discord
 from discord.ext import commands
 
+import discord
+
+from ..async_utils import fire_and_forget
 from ..config.schema import Config
 from ..monitoring import InfraWatcher
 from ..odin_log import get_logger
 from ..tools import get_tool_definitions
-from ..async_utils import fire_and_forget
 from .slash_commands import register_commands
 from .tool_loop_helpers import init_allowed_webhook_ids as _init_allowed_webhook_ids_impl
 from .voice import VoiceManager, VoiceMessageProxy
@@ -260,7 +261,7 @@ class OdinBot(commands.Bot):
         log.info("OdinBot shutdown complete")
 
     async def on_ready(self) -> None:
-        log.info("Logged in as %s (ID: %s)", self.user, self.user.id)
+        log.info("Logged in as %s (ID: %s)", self.user, self.user.id)  # type: ignore[union-attr]  # on_ready fires post-login
         log.info("Tools loaded: %d definitions", len(get_tool_definitions()))
         # Prune stale sessions loaded from disk.  load() reads ALL persisted
         # session files regardless of age; pruning here removes expired ones
@@ -288,7 +289,7 @@ class OdinBot(commands.Bot):
         """Backfill semantic search index and FTS5 with existing archive files."""
         try:
             archive_dir = self.sessions.persist_dir / "archive"
-            count = await self._vector_store.backfill(archive_dir, self._embedder)
+            count = await self._vector_store.backfill(archive_dir, self._embedder)  # type: ignore[union-attr, arg-type]  # built together under search.enabled
             if count:
                 log.info("Backfilled %d archive sessions into vector store", count)
             else:
@@ -356,6 +357,6 @@ class OdinBot(commands.Bot):
                 await self.voice_manager.speak(response)
 
         await self.pipeline.run(
-            proxy, text,
+            proxy, text,  # type: ignore[arg-type]  # documented duck-typed voice proxy
             voice_callback=voice_callback,
         )

--- a/src/discord/cogs/logging_cog.py
+++ b/src/discord/cogs/logging_cog.py
@@ -43,7 +43,7 @@ class Logging(commands.Cog):
         embed = log_embed(
             "Message Deleted",
             f"**Author:** {message.author.mention}\n"
-            f"**Channel:** {message.channel.mention}\n"
+            f"**Channel:** {message.channel.mention}\n"  # type: ignore[union-attr]  # guild-None early return above
             f"**Content:** {content}",
         )
         await self._send_log(message.guild, embed)
@@ -59,7 +59,7 @@ class Logging(commands.Cog):
         embed = log_embed(
             "Message Edited",
             f"**Author:** {before.author.mention}\n"
-            f"**Channel:** {before.channel.mention}\n"
+            f"**Channel:** {before.channel.mention}\n"  # type: ignore[union-attr]  # guild-None early return above
             f"**Before:** {before.content[:512]}\n"
             f"**After:** {after.content[:512]}",
         )

--- a/src/discord/cogs/message_triggers.py
+++ b/src/discord/cogs/message_triggers.py
@@ -102,7 +102,7 @@ class MessageTriggers(commands.Cog):
         )
 
         try:
-            fired = await self._scheduler.fire_triggers("discord_message", event_data)
+            fired = await self._scheduler.fire_triggers("discord_message", event_data)  # type: ignore[union-attr]  # self.enabled requires _scheduler
             if fired:
                 logger.info(
                     "Message from %s fired %d trigger(s) in channel %s",

--- a/src/discord/cogs/moderation.py
+++ b/src/discord/cogs/moderation.py
@@ -161,7 +161,8 @@ class Moderation(commands.Cog):
     ) -> None:
         """Delete messages from the current channel (default 10, max 100)."""
         count = min(max(count, 1), 100)
-        deleted = await ctx.channel.purge(limit=count + 1)  # +1 for command msg
+        # +1 for the command message itself.
+        deleted = await ctx.channel.purge(limit=count + 1)  # type: ignore[union-attr]  # bot_has_guild_permissions precludes DMs
         await ctx.send(
             embed=success_embed(f"Deleted {len(deleted) - 1} messages."),
             delete_after=5,

--- a/src/discord/cogs/reaction_triggers.py
+++ b/src/discord/cogs/reaction_triggers.py
@@ -85,7 +85,7 @@ class ReactionTriggers(commands.Cog):
             return
 
         # Ignore bot's own reactions
-        if payload.user_id == self.bot.user.id:
+        if payload.user_id == self.bot.user.id:  # type: ignore[union-attr]  # raw events fire post-READY
             return
 
         # Check channel allowlist
@@ -119,7 +119,7 @@ class ReactionTriggers(commands.Cog):
         )
 
         try:
-            fired = await self._scheduler.fire_triggers("discord_reaction", event_data)
+            fired = await self._scheduler.fire_triggers("discord_reaction", event_data)  # type: ignore[union-attr]  # self.enabled requires _scheduler
             if fired:
                 logger.info(
                     "Reaction %s fired %d trigger(s)",

--- a/src/discord/cogs/reminders.py
+++ b/src/discord/cogs/reminders.py
@@ -34,7 +34,7 @@ class Reminders(commands.Cog):
         self._next_id = 1
         self._check_reminders.start()
 
-    def cog_unload(self) -> None:
+    def cog_unload(self) -> None:  # type: ignore[override]  # Cog.cog_unload is documented maybecoro
         self._check_reminders.cancel()
 
     @tasks.loop(seconds=15)

--- a/src/discord/cogs/utility.py
+++ b/src/discord/cogs/utility.py
@@ -62,13 +62,13 @@ class Utility(commands.Cog):
         """Show information about a user."""
         member = member or ctx.author  # type: ignore[assignment]
         fields = {
-            "ID": str(member.id),
+            "ID": str(member.id),  # type: ignore[union-attr]  # member or ctx.author is never None
             "Joined": discord.utils.format_dt(member.joined_at, "R") if member.joined_at else "Unknown",
-            "Created": discord.utils.format_dt(member.created_at, "R"),
+            "Created": discord.utils.format_dt(member.created_at, "R"),  # type: ignore[union-attr]  # member or ctx.author is never None
             "Roles": ", ".join(r.mention for r in member.roles[1:]) or "None",
         }
         embed = info_embed(str(member), fields)
-        embed.set_thumbnail(url=member.display_avatar.url)
+        embed.set_thumbnail(url=member.display_avatar.url)  # type: ignore[union-attr]  # member or ctx.author is never None
         await ctx.send(embed=embed)
 
     @commands.command()
@@ -78,7 +78,7 @@ class Utility(commands.Cog):
         """Show a user's avatar."""
         member = member or ctx.author  # type: ignore[assignment]
         embed = odin_embed(title=f"{member}'s Avatar")
-        embed.set_image(url=member.display_avatar.url)
+        embed.set_image(url=member.display_avatar.url)  # type: ignore[union-attr]  # member or ctx.author is never None
         await ctx.send(embed=embed)
 
 

--- a/src/discord/intake_pipeline.py
+++ b/src/discord/intake_pipeline.py
@@ -24,6 +24,7 @@ import io
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import discord
 
@@ -32,6 +33,19 @@ from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
 from ..sessions.manager import CHAT_RESPONSE_MAX_CHARS, summarize_tool_response
 from .response_guards import combine_bot_messages, scrub_response_secrets
+
+if TYPE_CHECKING:
+    from ..permissions.manager import PermissionManager
+    from ..sessions.manager import SessionManager
+    from .channel_config import ChannelConfigManager
+    from .channel_logger import ChannelLogger
+    from .channel_state import ChannelStateRegistry
+    from .delivery import ResponseDelivery
+    from .housekeeping import Housekeeping
+    from .llm_gateway import LLMGateway
+    from .prompts import PromptBuilder
+    from .tool_loop import ToolLoopRunner
+    from .turn_recorder import TurnRecorder
 
 log = get_logger("discord")
 
@@ -58,11 +72,11 @@ class MessageIntakeDeps:
     get_user: Callable  # live — None until the gateway login completes
     get_voice_manager: Callable  # live — constructed on the bot, may be None
     process_commands: Callable  # cog prefix-command dispatch (bot-bound)
-    channel_logger: object
-    channel_config: object
-    channel_state: object
-    sessions: object
-    pipeline: object  # MessagePipeline — the post-gate hand-off
+    channel_logger: ChannelLogger
+    channel_config: ChannelConfigManager
+    channel_state: ChannelStateRegistry
+    sessions: SessionManager
+    pipeline: MessagePipeline  # the post-gate hand-off
 
 
 class MessageIntake:
@@ -428,15 +442,15 @@ class MessageIntake:
 class MessagePipelineDeps:
     """The true dependency surface of the message pipeline."""
 
-    channel_state: object  # per-channel locks, pending files, op details
-    sessions: object
-    permissions: object  # guest-tier routing
-    llm_gateway: object  # owns the swappable provider clients
-    prompt_builder: object
-    turn_recorder: object  # context traces + operational reflection
-    tool_loop: object  # ToolLoopRunner — the tools route
-    delivery: object  # status, retries, chunked sends
-    housekeeping: object  # post-turn cache maintenance
+    channel_state: ChannelStateRegistry  # per-channel locks, pending files, ops
+    sessions: SessionManager
+    permissions: PermissionManager  # guest-tier routing
+    llm_gateway: LLMGateway  # owns the swappable provider clients
+    prompt_builder: PromptBuilder
+    turn_recorder: TurnRecorder  # context traces + operational reflection
+    tool_loop: ToolLoopRunner  # the tools route
+    delivery: ResponseDelivery  # status, retries, chunked sends
+    housekeeping: Housekeeping  # post-turn cache maintenance
 
 
 class MessagePipeline:
@@ -550,9 +564,11 @@ class MessagePipeline:
                             if isinstance(last_msg["content"], str)
                             else str(last_msg["content"])
                         )
+                        # Vision turns legitimately swap str content for
+                        # a block list; the LLM layer handles both shapes.
                         history[-1] = {
                             "role": "user",
-                            "content": image_blocks + [{"type": "text", "text": text_content}],
+                            "content": image_blocks + [{"type": "text", "text": text_content}],  # type: ignore[dict-item]
                         }
                     log.info("Attached %d image(s) to message for Claude vision", len(image_blocks))
                 if self._llm_gateway.active_client:
@@ -627,9 +643,11 @@ class MessagePipeline:
                         if isinstance(last["content"], str)
                         else str(last["content"])
                     )
+                    # Vision turns legitimately swap str content for
+                    # a block list; the LLM layer handles both shapes.
                     task_history[-1] = {
                         "role": "user",
-                        "content": image_blocks + [{"type": "text", "text": text}],
+                        "content": image_blocks + [{"type": "text", "text": text}],  # type: ignore[dict-item]
                     }
                     log.info("Attached %d image(s) to message for Claude vision", len(image_blocks))
                 try:

--- a/src/discord/llm_gateway.py
+++ b/src/discord/llm_gateway.py
@@ -138,7 +138,7 @@ class LLMGateway:
             self.ollama_client = None
             if old:
                 asyncio.get_event_loop().call_later(
-                    5, lambda: asyncio.ensure_future(old.close())
+                    5, lambda: asyncio.ensure_future(old.close())  # type: ignore[union-attr]  # deferred close inside if old:
                 )
             return {"configured": False, "reason": "ollama disabled in config"}
 
@@ -174,7 +174,7 @@ class LLMGateway:
             self.kimi_client = None
             if old:
                 asyncio.get_event_loop().call_later(
-                    5, lambda: asyncio.ensure_future(old.close())
+                    5, lambda: asyncio.ensure_future(old.close())  # type: ignore[union-attr]  # deferred close inside if old:
                 )
             return {"configured": False, "reason": "kimi disabled in config"}
         if not kimi_cfg.api_key:

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import discord
 
@@ -25,6 +26,22 @@ from ...odin_log import get_logger
 from ..background_task import MAX_STEPS, BackgroundTask, create_task_id, run_background_task
 from ..tool_loop import _LoopMessageProxy
 
+if TYPE_CHECKING:
+    from ...agents.loop_bridge import LoopAgentBridge
+    from ...agents.manager import AgentManager
+    from ...agents.trajectory import AgentTrajectorySaver
+    from ...audit.logger import AuditLogger
+    from ...search.embedder import LocalEmbedder
+    from ...tools.autonomous_loop import LoopManager
+    from ...tools.executor import ToolExecutor
+    from ...tools.skill_manager import SkillManager
+    from ..channel_state import ChannelStateRegistry
+    from ..llm_gateway import LLMGateway
+    from ..prompts import PromptBuilder
+    from ..tool_catalog import ToolCatalog
+    from ..tool_loop import ToolLoopRunner
+    from ..turn_recorder import TurnRecorder
+
 log = get_logger("discord")
 
 
@@ -33,22 +50,22 @@ class AgentTaskDeps:
     """The true dependency surface of the agents/tasks/loops handlers."""
 
     get_config: Callable  # live root — replaced by config hot-reload
-    llm_gateway: object  # owns the swappable provider clients
-    channel_state: object  # background-task registry + caps
-    tool_executor: object
-    skill_manager: object
+    llm_gateway: LLMGateway  # owns the swappable provider clients
+    channel_state: ChannelStateRegistry  # background-task registry + caps
+    tool_executor: ToolExecutor
+    skill_manager: SkillManager
     get_knowledge_store: Callable  # swappable via bot.knowledge reloads
-    embedder: object
-    audit: object
-    agent_manager: object
-    loop_manager: object
-    loop_agent_bridge: object
-    agent_trajectory_saver: object
+    embedder: LocalEmbedder | None
+    audit: AuditLogger
+    agent_manager: AgentManager
+    loop_manager: LoopManager
+    loop_agent_bridge: LoopAgentBridge
+    agent_trajectory_saver: AgentTrajectorySaver | None
     get_context_compressor: Callable  # live read — tests swap it on the bot
-    tool_loop: object  # ToolLoopRunner — loop iterations + tool dispatch
-    turn_recorder: object  # lifecycle webhook emission
-    prompt_builder: object
-    tool_catalog: object
+    tool_loop: ToolLoopRunner  # loop iterations + tool dispatch
+    turn_recorder: TurnRecorder  # lifecycle webhook emission
+    prompt_builder: PromptBuilder
+    tool_catalog: ToolCatalog
 
 
 class AgentTaskTools:

--- a/src/discord/native_tools/skills_tools.py
+++ b/src/discord/native_tools/skills_tools.py
@@ -19,12 +19,15 @@ from __future__ import annotations
 
 import asyncio
 import io
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import discord
 
 from ...odin_log import get_logger
 from ..response_guards import scrub_response_secrets
+
+if TYPE_CHECKING:
+    from .registry import NativeToolEffects
 
 log = get_logger("discord")
 
@@ -79,7 +82,7 @@ class SkillTools:
         user_id: str,
         skill_file_delivery: Literal["send", "stage"],
         effects,
-    ) -> tuple[Any, object]:
+    ) -> tuple[Any, NativeToolEffects]:
         """Dispatch a skill-flavored tool. ``effects`` is the caller-owned
         NativeToolEffects instance (constructed in registry.dispatch) —
         passed in rather than imported to keep the module dependency

--- a/src/discord/scheduled_events.py
+++ b/src/discord/scheduled_events.py
@@ -17,6 +17,7 @@ import asyncio
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import discord
 
@@ -24,6 +25,13 @@ from ..odin_log import get_logger
 from ..tools import ToolResult
 from .response_guards import scrub_response_secrets
 from .tool_loop import _LoopMessageProxy
+
+if TYPE_CHECKING:
+    from ..audit.logger import AuditLogger
+    from ..tools.executor import ToolExecutor
+    from .llm_gateway import LLMGateway
+    from .native_tools.agents_tasks import AgentTaskTools
+    from .tool_loop import ToolLoopRunner
 
 log = get_logger("discord")
 
@@ -35,11 +43,11 @@ class ScheduledEventsDeps:
     get_config: Callable  # live root — replaced by config hot-reload
     get_channel: Callable  # discord.Client.get_channel (bound method)
     get_guilds: Callable  # live — the guild list changes at runtime
-    tool_executor: object
-    audit: object
-    llm_gateway: object  # owns the swappable provider clients
-    tool_loop: object  # ToolLoopRunner — shared dispatch path
-    agent_task_tools: object  # agent result collection in workflows
+    tool_executor: ToolExecutor
+    audit: AuditLogger
+    llm_gateway: LLMGateway  # owns the swappable provider clients
+    tool_loop: ToolLoopRunner  # shared dispatch path
+    agent_task_tools: AgentTaskTools  # agent result collection in workflows
 
 
 class ScheduledEventHandlers:
@@ -409,7 +417,7 @@ class ScheduledEventHandlers:
             req_name = schedule.get("requester") or schedule.get("created_by") or "scheduler"
             try:
                 result = await self._execute_scheduled_tool(
-                    tool_name,
+                    tool_name,  # type: ignore[arg-type]  # creation-time validation guarantees tool_name
                     tool_input,
                     channel,
                     req_id,

--- a/src/discord/slash_commands.py
+++ b/src/discord/slash_commands.py
@@ -76,7 +76,7 @@ def register_commands(bot) -> None:
             return
         count = min(count, 500)
         await interaction.response.defer(ephemeral=True)
-        deleted = await interaction.channel.purge(limit=count)
+        deleted = await interaction.channel.purge(limit=count)  # type: ignore[union-attr]  # guild-only command sync; these kinds unreachable
         bot.sessions.reset(str(interaction.channel_id))
         await interaction.followup.send(
             f"Deleted {len(deleted)} messages and reset conversation history.",

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -30,6 +30,7 @@ import asyncio
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
 
 import discord
 
@@ -38,6 +39,24 @@ from ..llm.secret_scrubber import scrub_output_secrets
 from ..observability.correlation import get_turn, set_turn
 from ..odin_log import get_logger
 from ..tools import ToolResult
+
+if TYPE_CHECKING:
+    from ..audit.logger import AuditLogger
+    from ..observability.context_trace import ContextTraceCollector
+    from ..permissions.manager import PermissionManager
+    from ..tools.autonomous_loop import LoopManager
+    from ..tools.executor import ToolExecutor
+    from ..tools.skill_manager import SkillManager
+    from ..trajectories.saver import TrajectoryTurn
+    from .channel_state import ChannelStateRegistry
+    from .completion import CompletionClassifier
+    from .delivery import ResponseDelivery
+    from .llm_gateway import LLMGateway
+    from .native_tools.registry import NativeToolDispatcher
+    from .prompts import PromptBuilder
+    from .response_guards import StuckLoopTracker
+    from .tool_catalog import ToolCatalog
+    from .turn_recorder import TurnRecorder
 from .delivery import DISCORD_MAX_LEN, TOOL_STATUS_LABELS
 from .response_guards import (
     _CODE_HEDGING_RETRY_MSG,
@@ -106,7 +125,7 @@ class LoopPolicy:
     characterization pin saying so.
     """
 
-    skill_file_delivery: str  # "send" (chat) | "stage" (autonomous)
+    skill_file_delivery: Literal["send", "stage"]  # chat sends, autonomous stages
     trajectory_source: str  # "discord" | "loop"
     audit_event_style: str  # "chat" (tool_start/tool_end) | "loop" (loop_tool)
     iteration_cap_key: str  # config.tools.max_tool_iterations_{chat,loop}
@@ -165,14 +184,14 @@ class _ChatTurn:
 
     message: discord.Message
     policy: LoopPolicy
-    trace: object | None
+    trace: ContextTraceCollector | None
     system_prompt: str  # rebound on skill-CRUD prompt rebuilds (was `nonlocal`)
     tools: list | None
     messages: list
     user_id: str
     chat_cap: int
-    stuck_tracker: object
-    _trajectory: object
+    stuck_tracker: StuckLoopTracker
+    _trajectory: TrajectoryTurn
     _result_store_cap: int
     _cancel: asyncio.Event
     _ch_id: str
@@ -206,8 +225,8 @@ class _LoopTurn:
     msg_proxy: _LoopMessageProxy
     requester_name: str
     _loop_id: str
-    _trace: object | None
-    _trajectory: object | None
+    _trace: ContextTraceCollector | None
+    _trajectory: TrajectoryTurn | None
     _result_store_cap: int
     messages: list
     system_prompt: str  # rebound on skill-CRUD rebuilds (was `nonlocal`)
@@ -228,20 +247,20 @@ class ToolLoopDeps:
     get_config: Callable  # live root — replaced by config hot-reload
     get_default_system_prompt: Callable  # live — rebuilt on config/context reload
     get_context_compressor: Callable  # live read — tests swap it on the bot
-    llm_gateway: object  # owns the swappable provider clients + guarded calls
-    prompt_builder: object
-    tool_catalog: object
-    channel_state: object  # cancel events, active requests, op details, actions
-    delivery: object  # presence updates
-    turn_recorder: object  # trajectories, traces, lifecycle events, reflection
-    completion_classifier: object
-    native_tools: object  # the shared dispatch table
-    tool_executor: object
-    permissions: object
-    skill_manager: object
-    audit: object
-    loop_manager: object
-    stuck_loop_tracker_cls: type
+    llm_gateway: LLMGateway  # owns the swappable provider clients + guarded calls
+    prompt_builder: PromptBuilder
+    tool_catalog: ToolCatalog
+    channel_state: ChannelStateRegistry  # cancel events, active requests, op details
+    delivery: ResponseDelivery  # presence updates
+    turn_recorder: TurnRecorder  # trajectories, traces, lifecycle events, reflection
+    completion_classifier: CompletionClassifier
+    native_tools: NativeToolDispatcher  # the shared dispatch table
+    tool_executor: ToolExecutor
+    permissions: PermissionManager
+    skill_manager: SkillManager
+    audit: AuditLogger
+    loop_manager: LoopManager
+    stuck_loop_tracker_cls: type[StuckLoopTracker]
 
 
 class ToolLoopRunner:
@@ -383,7 +402,9 @@ class ToolLoopRunner:
         _ch_name = getattr(_ch, "name", None) or str(_ch.id)
         _is_thread = isinstance(_ch, discord.Thread)
         if _is_thread and getattr(_ch, "parent", None):
-            channel_ctx = f"Channel: #{_ch.parent.name} → thread: {_ch_name}"
+            # Guarded: _is_thread + the getattr probe exclude every
+            # parent-less/None case; mypy cannot narrow via the bool var.
+            channel_ctx = f"Channel: #{_ch.parent.name} → thread: {_ch_name}"  # type: ignore[union-attr]
         else:
             channel_ctx = f"Channel: #{_ch_name}"
         preamble = build_request_preamble(
@@ -1588,7 +1609,7 @@ class ToolLoopRunner:
         tool_input: dict,
         msg_proxy: _LoopMessageProxy,
         user_id: str,
-    ) -> str | dict:
+    ) -> str | dict | ToolResult:
         """Dispatch a tool call to the correct handler within a loop iteration.
 
         Mirrors the Discord-native tool dispatch in the chat pipeline, using
@@ -1619,7 +1640,7 @@ class ToolLoopRunner:
         tool_input: dict,
         msg_proxy: _LoopMessageProxy,
         user_id: str,
-    ) -> str | dict:
+    ) -> str | dict | ToolResult:
         # Central RBAC gate: same enforcement as the message tool loop — these
         # handlers bypass ToolExecutor.execute(), so check permission for EVERY tool.
         _rbac_denial = self._tool_executor.check_permission(tool_name, user_id)

--- a/src/discord/views/role_select.py
+++ b/src/discord/views/role_select.py
@@ -25,11 +25,13 @@ class RoleSelectView(discord.ui.View):
             discord.SelectOption(label=role.name, value=str(role.id))
             for role in roles[:25]
         ]
-        self.select = discord.ui.Select(
+        self.select: discord.ui.Select = discord.ui.Select(
             placeholder="Select a role…",
             options=options,
         )
-        self.select.callback = self._on_select
+        # Standard discord.py idiom for dynamically-built views: bind a
+        # per-instance callback over the base Item.callback method.
+        self.select.callback = self._on_select  # type: ignore[method-assign]
         self.add_item(self.select)
         self._role_map = {str(r.id): r for r in roles}
 

--- a/src/discord/voice.py
+++ b/src/discord/voice.py
@@ -9,14 +9,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum, auto
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import discord
+
 try:
-    from discord.ext import voice_recv
+    from discord.ext import voice_recv  # type: ignore[attr-defined]  # optional [voice] extra
 except ImportError:
     voice_recv = None
 
@@ -146,12 +147,12 @@ class VoiceManager:
 
     def __init__(
         self,
-        config: "VoiceConfig",
+        config: VoiceConfig,
         bot: discord.Client,
     ) -> None:
         self._config = config
         self._bot = bot
-        self._voice_client = None
+        self._voice_client: discord.VoiceClient | None = None
         self._ws = None
         self._ws_task: asyncio.Task | None = None
         self._tts_buffer: bytearray = bytearray()
@@ -170,7 +171,7 @@ class VoiceManager:
         return self._voice_client is not None and self._voice_client.is_connected()
 
     @property
-    def current_channel(self) -> discord.VoiceChannel | None:
+    def current_channel(self) -> discord.VoiceChannel | discord.StageChannel | None:
         if self._voice_client and self._voice_client.is_connected():
             return self._voice_client.channel
         return None
@@ -181,11 +182,13 @@ class VoiceManager:
         if self._config.transcript_channel_id:
             ch = self._bot.get_channel(int(self._config.transcript_channel_id))
             if ch:
-                self._transcript_channel = ch
-                return ch
+                # transcript_channel_id is trusted config: assumed to
+                # reference a text channel (no runtime kind check).
+                self._transcript_channel = cast("discord.TextChannel", ch)
+                return self._transcript_channel
         return None
 
-    async def join_channel(self, channel: discord.VoiceChannel) -> str:
+    async def join_channel(self, channel: discord.VoiceChannel | discord.StageChannel) -> str:
         """Join a voice channel and start the full audio pipeline."""
         if not self._config.enabled:
             return "Voice support is disabled in config."
@@ -231,12 +234,12 @@ class VoiceManager:
         if not self.is_connected:
             return "Not in a voice channel."
 
-        channel_name = self._voice_client.channel.name
+        channel_name = self._voice_client.channel.name  # type: ignore[union-attr]  # is_connected property guards
         self._stop_listening()
         await self._ws_disconnect()
 
         try:
-            await self._voice_client.disconnect()
+            await self._voice_client.disconnect()  # type: ignore[union-attr]  # is_connected property guards
         except Exception as e:
             log.warning("Error disconnecting voice: %s", e)
 
@@ -282,7 +285,7 @@ class VoiceManager:
                     )
 
             sink = voice_recv.BasicSink(on_audio)
-            self._voice_client.listen(sink)
+            self._voice_client.listen(sink)  # type: ignore[attr-defined]  # VoiceRecvClient ([voice] extra) provides it
             log.info("Audio listening started via voice_recv")
         except Exception as e:
             log.error("Failed to start listening: %s", e, exc_info=True)
@@ -290,7 +293,7 @@ class VoiceManager:
     def _stop_listening(self) -> None:
         if self._voice_client:
             try:
-                self._voice_client.stop_listening()
+                self._voice_client.stop_listening()  # type: ignore[attr-defined]  # VoiceRecvClient ([voice] extra) provides it
             except Exception:
                 pass
 
@@ -475,8 +478,10 @@ class VoiceManager:
         if self._config.transcript_channel_id:
             ch = self._bot.get_channel(int(self._config.transcript_channel_id))
             if ch:
-                self._transcript_channel = ch
-                return ch
+                # transcript_channel_id is trusted config: assumed to
+                # reference a text channel (no runtime kind check).
+                self._transcript_channel = cast("discord.TextChannel", ch)
+                return self._transcript_channel
         if self._voice_client and self._voice_client.channel:
             for ch in self._voice_client.channel.guild.text_channels:
                 return ch


### PR DESCRIPTION
Final annotation wave per plan §6. **Annotation-only**, §4 checklist applies.

## Movement

`type_gate --base-ref origin/types/rfc005`: **resolved=217, new=0.** Total 226 → **9**, and the nine survivors across all of `src/` are exactly the ledgered lines awaiting Aaron's triage: TS-0001 (`utility.py:66,68`), TS-0002 (`diff_tracker.py:91,97`), TS-0003 (`odin/cli.py:76`), TS-0004 (`skill_context.py:162`), TS-0005 (`:336` ×2), plus the dead `src.setup` import. **The campaign's remaining type debt IS the bug list.**

## How the bulk fell

Typing the RFC-002 narrow-deps dataclasses via `TYPE_CHECKING` imports — runtime import graph unchanged, frozen semantics unchanged, test fakes unaffected (dataclasses don't enforce types at runtime): `ToolLoopDeps` (14 fields), `MessageIntakeDeps`/`MessagePipelineDeps`, `AgentTaskDeps`, `ScheduledEventsDeps`, `channel_state.background_tasks` values, and the `_ChatTurn`/`_LoopTurn` trace/trajectory/stuck fields. One dataclass often collapsed 30–60 findings at a stroke.

Each collapse **lit up** a handful of previously-invisible findings inside the newly-typed seams (§1's reach effect), all resolved in-wave — the interesting ones being genuine truth-fixes:
- `LoopPolicy.skill_file_delivery` is now the `Literal["send", "stage"]` the dispatcher demands
- `dispatch_loop_tool`/`_inner` declare the `ToolResult` they actually return
- `VoiceManager.join_channel` accepts the `StageChannel` it already handles
- `skills_tools.dispatch` declares its true `NativeToolEffects` (the object-typing was an import-cycle workaround; TYPE_CHECKING dissolves the cycle)
- `_is_text_file`'s declared `-> bool` was a lie (truthiness contract now documented in the signature)

## Ignores

Reasoned trailing comments on the triage-verified guarded-noise family: cog guild/READY/enabled guards, gateway deferred-close closures, `is_connected` property guards, creation-time schedule validation, tarfile Literal-only stub overloads, the discord.py view callback-override idiom. TS-0001's two lines carry **no ignore** — they stay visible until Aaron's verdict.

## Process notes

- One env-only test failure appeared mid-wave: the stale odin-owned `/tmp/odin-attachments` (the same one Odin hit and diagnosed in his P3 review) — cleared, not a code issue; suite green before and after.
- `ruff --fix --select I001,UP037` was run on the wave's own files to normalize my scripted import-block insertions (blank-line counts, alphabetization) — reflows of new imports only.
- mypy taught me its comment grammar the hard way: a `type: ignore` after an existing trailing comment is not honored (moderation.py) — reordered.

## Verification

- Suite: **6,164 passed / 4 skipped** — identical
- Lint gate: new=0 · Type gate: **new=0, resolved=217**
- Full-src mypy total: **9** (= the ledger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3