### PR TITLE
RFC-005 P5: full-body checking + R2 results (strictness flip deferred by measurement)

### DIFF
--- a/docs/plans/type-safety-findings.md
+++ b/docs/plans/type-safety-findings.md
@@ -62,6 +62,13 @@ mypy through `tool_loop`, `intake_pipeline`, `agents_tasks`, and
 - Proposed fix: import alias (`import json as _json`) or rename the parameter (`json_body=` keeping `json=` at the aiohttp call); regression test with a text/plain response.
 - Aaron verdict: PENDING · Status: OPEN
 
+## Campaign close-out (P5, 2026-07-06)
+
+All four annotation waves are merged; **the live mypy output equals the TS
+ledger + the dead import, exactly** (9 lines). Every non-ledgered finding in
+this file's appendix has been resolved; the appendix stays as the historical
+baseline record. Verdict fields below remain PENDING until Aaron rules.
+
 ## Wave guidance (observations, not runtime bugs)
 
 - `src/agents/manager.py` — a method literally named `list` shadows `builtins.list` in 14 findings' annotations under future-annotations. Wave fix is type-only: spell `builtins.list[...]` in that module (renaming the public method would be an API change — out of wave scope).

--- a/docs/plans/type-safety-plan.md
+++ b/docs/plans/type-safety-plan.md
@@ -71,6 +71,15 @@ Blocker, fixed: **B1** — the type gate compares **Counter multisets** of norma
 
 No wall-clock pressure between phases; the gate protects from P0 onward regardless of wave pace.
 
+## 6b. R2 — results (code-complete, 2026-07-06)
+
+**Baseline 388 → 9, and the nine survivors are exactly the findings ledger**: TS-0001 (`utility.py:66,68`), TS-0002 (`diff_tracker.py:91,97`), TS-0003 (`odin/cli.py:76`), TS-0004 (`skill_context.py:162`), TS-0005 (`:336` ×2), and the dead `src.setup` import. The checker's remaining output and the suspected-real-bug ledger are the same list — the campaign's intended end state.
+
+- Waves: P1 small packages −50 (PR #180) · P2 web+agents −37 (#181) · P3 knowledge+tools −75 (#182) · P4 discord −217 (#183). Every wave Odin-reviewed; suite pinned at 6,164 passed / 4 skipped throughout; both gates `new=0` on every PR. Odin's wave verification evolved into an AST-equivalence check (strip annotations/TYPE_CHECKING → compare) — stronger than the plan's checklist and recommended for any future annotation work.
+- The single highest-leverage mechanic: typing the RFC-002 narrow-deps dataclass fields via `TYPE_CHECKING` imports (~180 findings). Each collapse lit up a handful of previously-invisible findings (§1's reach effect), several of which were annotation *lies* worth fixing (`-> str` handlers returning tuples, a Literal-valued policy field, decorator-as-type middleware annotations).
+- **P5 executed as amended (measured deviation):** `check_untyped_defs = True` adopted globally — measured cost was exactly ONE finding (a monkey-patch marker attr, reasoned ignore), so every function body is now checked. The planned per-package `disallow_untyped_defs` flips were **measured at 228 findings and deferred** to a possible future campaign: flipping mid-P5 would either violate the campaign's own `new=0` discipline or smuggle a fifth annotation wave into a config phase. The operative regression lock is the Counter-multiset gate + full-body checking: new errors of any kind, in any file, block the PR.
+- Bugs found by the campaign before any fix shipped: 5 confirmed (TS-0001…0005), two sharing the `_run_on_host` tuple-return root cause, one hiding behind a pre-existing `type: ignore`.
+
 ## 7. Risks
 
 - **pydantic + `from __future__ import annotations` interplay** (`config/schema.py` wave): pydantic v2 resolves stringified annotations routinely; the extensive config test coverage plus full suite gates the wave. If a specific model misbehaves, that module skips the future-import (annotations stay evaluated — also inert).

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,12 @@ python_version = 3.12
 plugins = pydantic.mypy
 show_error_codes = True
 pretty = False
+# P5: bodies of unannotated functions are checked too (measured cost at
+# adoption: exactly one finding). disallow_untyped_defs was measured at 228
+# findings and deliberately deferred to a future campaign — the Counter
+# ratchet in type_gate.py plus full-body checking is the operative
+# regression lock (see docs/plans/type-safety-plan.md R2).
+check_untyped_defs = True
 
 # --- Optional-extra and unstubbed third-party imports -----------------------
 # Policy: per-module overrides only — never a global ignore_missing_imports.

--- a/src/discord/voice.py
+++ b/src/discord/voice.py
@@ -80,7 +80,7 @@ def _patch_voice_recv_dave():
 
             return _original_decode(self, packet)
 
-        _patched_decode._odin_dave_patched = True
+        _patched_decode._odin_dave_patched = True  # type: ignore[attr-defined]  # patch-once marker on the function object
         PacketDecoder._decode_packet = _patched_decode
         log.info("Patched voice_recv with DAVE decryption support")
     except ImportError:


### PR DESCRIPTION
Campaign-closing phase. Config + docs + one reasoned ignore — and one **measured deviation** from the plan, submitted for your R2 sign-off.

## The deviation (§6 P5 as planned vs. as executed)

The plan called for per-package `disallow_untyped_defs` override flips. Measured against the post-P4 tree: **228 new findings** — flipping would either violate the campaign's own `new=0` discipline or turn a config phase into a fifth annotation wave. Meanwhile `check_untyped_defs = True` measured at a cost of exactly **one** finding.

Executed accordingly:
- **`check_untyped_defs = True` globally** — every function body is now checked, annotated or not. The one surfaced finding (voice.py's DAVE monkey-patch marker attribute on a function object) carries a reasoned ignore.
- **`disallow_untyped_defs` deferred** to a possible future campaign, documented in R2. The operative regression lock is the Counter-multiset gate + full-body checking: any new error, any file, blocks the PR.

## R2 results (now in the plan doc)

**388 → 9**, and the nine survivors are exactly the findings ledger: TS-0001…TS-0005 + the dead `src.setup` import. Waves: −50 (#180), −37 (#181), −75 (#182), −217 (#183); suite pinned at 6,164/4 throughout; both gates `new=0` on every PR; 5 confirmed real bugs found before a single fix shipped.

## Also noted

The recurring `/tmp/odin-attachments` failure (you've cleared it twice, I've cleared it twice) is a genuine test-hygiene bug — `test_attachments` uses a fixed shared `/tmp` path that ping-pongs ownership between our review environments. Flagged for a tiny follow-up PR (test change, out of this campaign's scope).

## Verification

- Suite: **6,164 passed / 4 skipped** · Lint gate: new=0 · Type gate: new=0, resolved=1 · Full-src mypy: **9 = the ledger**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3