### PR TITLE
fix: TS-0001…TS-0005 — the five findings-ledger bugs

### DIFF
--- a/docs/plans/type-safety-findings.md
+++ b/docs/plans/type-safety-findings.md
@@ -32,42 +32,42 @@ mypy through `tool_loop`, `intake_pipeline`, `agents_tasks`, and
 - `member = member or ctx.author` falls back to a plain `discord.User` in DMs; `User` has no `.joined_at` (line 66 raises before its own truthiness check) and no `.roles` (68). `!userinfo` in a DM dies with AttributeError; the pre-existing `# type: ignore[assignment]` on line 63 silenced the warning pointing at exactly this.
 - Impact: LOW — cosmetic command, guild usage unaffected.
 - Proposed fix: branch on `isinstance(member, discord.Member)` for the guild-only fields.
-- Aaron verdict: PENDING · Status: OPEN
+- Aaron verdict: FIX (2026-07-06) · Status: FIXED (PR #186)
 
 ### TS-0002 — audit diff-tracker records fiction on every overwrite
 - `src/audit/diff_tracker.py:91,97` · union-attr / assignment
 - `capture_before` calls `.startswith()` on `_run_on_host`'s return, which is a `(output, exit_code)` **tuple** for every resolvable host → AttributeError on every snapshot, swallowed by the bare `except Exception` → the "before" content is always `""`. Every audit diff for a file overwrite shows the file as previously empty; real prior content has never been captured. Silent — no log line.
 - Impact: MEDIUM — the audit `diff` field (and `search_diffs`) is actively misleading for overwrites; forensics-relevant.
 - Proposed fix: unpack the tuple (`output, _code = …`) and keep the unknown-host str branch; add a regression test with a fake executor.
-- Aaron verdict: PENDING · Status: OPEN
+- Aaron verdict: FIX (2026-07-06) · Status: FIXED (PR #186)
 
 ### TS-0003 — plan-CLI error reporter crashes instead of reporting
 - `src/odin/cli.py:76` · attr-defined
 - `except PlanValidationError as exc: for e in exc.errors:` — but `PlanValidationError` is a bare `Exception` subclass raised as `PlanValidationError("; ".join(errors))`; `.errors` has never existed. `odin run <plan>` with any invalid plan (duplicate step id, unknown tool, dangling dep, cycle) tracebacks in the error handler instead of printing errors and exiting 2.
 - Impact: LOW-MEDIUM — plan-runner CLI surface; the failure path has never worked.
 - Proposed fix: either give `PlanValidationError` an `errors: list[str]` field or print `str(exc)`; pin with a CLI test.
-- Aaron verdict: PENDING · Status: OPEN
+- Aaron verdict: FIX (2026-07-06) · Status: FIXED (PR #186)
 
 ### TS-0004 — `SkillContext.run_on_host` violates its documented contract
 - `src/tools/skill_context.py:162` · return-value
 - Declared `-> str`, docstring "Returns output string", skills.md documents the same — but it forwards `_run_on_host`'s raw `(output, exit_code)` tuple for every resolved host (only unknown-host returns str). Any skill treating the result as a string per the docs breaks. Same root cause as TS-0002: two independent victims of the `_run_on_host` tuple-return change.
 - Impact: MEDIUM — public skill API contract is false.
 - Proposed fix: unpack and return output (preserving the unknown-host message), or return a typed result; audit installed skills for accidental tuple-dependence before choosing.
-- Aaron verdict: PENDING · Status: OPEN
+- Aaron verdict: FIX (2026-07-06) · Status: FIXED (PR #186)
 
 ### TS-0005 — `SkillContext.http_post` shadows the `json` module
 - `src/tools/skill_context.py:336` (×2 union members) · union-attr
 - The parameter `json: dict | None` shadows the stdlib import, so `json.loads(text)` calls `.loads` on the parameter — AttributeError whether it's None or a dict, and the surrounding `except (ValueError, TypeError)` doesn't catch it. Works only when the response advertises a JSON content-type (the `resp.json()` path), which is why it half-works in the wild.
 - Impact: MEDIUM — any skill POSTing to an endpoint that returns non-JSON content-type crashes.
 - Proposed fix: import alias (`import json as _json`) or rename the parameter (`json_body=` keeping `json=` at the aiohttp call); regression test with a text/plain response.
-- Aaron verdict: PENDING · Status: OPEN
+- Aaron verdict: FIX (2026-07-06) · Status: FIXED (PR #186)
 
 ## Campaign close-out (P5, 2026-07-06)
 
 All four annotation waves are merged; **the live mypy output equals the TS
 ledger + the dead import, exactly** (9 lines). Every non-ledgered finding in
 this file's appendix has been resolved; the appendix stays as the historical
-baseline record. Verdict fields below remain PENDING until Aaron rules.
+baseline record. Aaron ruled FIX on all five (2026-07-06); the fixes + regression tests ship as PR #186. Post-fix full-src mypy = 1 (the dead src.setup import, unruled).
 
 ## Wave guidance (observations, not runtime bugs)
 

--- a/src/audit/diff_tracker.py
+++ b/src/audit/diff_tracker.py
@@ -87,9 +87,16 @@ class DiffTracker:
         host, path = target
         safe_path = shlex.quote(path)
         try:
-            content = await executor._run_on_host(host, f"cat {safe_path} 2>/dev/null || true")
-            if content.startswith("Unknown or disallowed host:"):
-                content = ""
+            # _run_on_host returns (output, exit_code) for resolved hosts and a
+            # bare denial string for unknown ones (TS-0002 — treating the tuple
+            # as str raised AttributeError on every snapshot, silently recording
+            # "" as the before-content of every overwrite).
+            raw = await executor._run_on_host(host, f"cat {safe_path} 2>/dev/null || true")
+            if isinstance(raw, tuple):
+                output, code = raw
+                content = output if code == 0 else ""
+            else:
+                content = ""  # host-denial message; nothing readable
         except Exception:
             content = ""
 

--- a/src/discord/cogs/utility.py
+++ b/src/discord/cogs/utility.py
@@ -61,11 +61,23 @@ class Utility(commands.Cog):
     ) -> None:
         """Show information about a user."""
         member = member or ctx.author  # type: ignore[assignment]
+        # In DMs ctx.author is a plain discord.User: no joined_at, no roles
+        # (TS-0001 — this command used to raise AttributeError there). Inline
+        # isinstance checks so the narrowing is visible to the checker too.
         fields = {
             "ID": str(member.id),  # type: ignore[union-attr]  # member or ctx.author is never None
-            "Joined": discord.utils.format_dt(member.joined_at, "R") if member.joined_at else "Unknown",
+            "Joined": (
+                discord.utils.format_dt(member.joined_at, "R")
+                if isinstance(member, discord.Member) and member.joined_at
+                else "Unknown"
+            ),
             "Created": discord.utils.format_dt(member.created_at, "R"),  # type: ignore[union-attr]  # member or ctx.author is never None
-            "Roles": ", ".join(r.mention for r in member.roles[1:]) or "None",
+            "Roles": (
+                ", ".join(r.mention for r in member.roles[1:])
+                if isinstance(member, discord.Member)
+                else ""
+            )
+            or "None",
         }
         embed = info_embed(str(member), fields)
         embed.set_thumbnail(url=member.display_avatar.url)  # type: ignore[union-attr]  # member or ctx.author is never None

--- a/src/odin/planner.py
+++ b/src/odin/planner.py
@@ -13,7 +13,12 @@ from src.odin.types import PlanResult, PlanSpec, StepResult, StepSpec, StepStatu
 
 
 class PlanValidationError(Exception):
-    pass
+    """Raised when a plan fails validation; carries the individual errors
+    (TS-0003 — the CLI error reporter iterates ``.errors``)."""
+
+    def __init__(self, errors: list[str]) -> None:
+        super().__init__("; ".join(errors))
+        self.errors = errors
 
 
 class Planner:
@@ -58,7 +63,7 @@ class Planner:
     ) -> PlanResult:
         errors = self.validate(plan)
         if errors:
-            raise PlanValidationError("; ".join(errors))
+            raise PlanValidationError(errors)
 
         # Merge runtime inputs over spec-level defaults
         merged_inputs = dict(plan.inputs)

--- a/src/tools/skill_context.py
+++ b/src/tools/skill_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import json as _json  # http_post's `json=` parameter shadows the module (TS-0005)
 import re
 import threading
 from collections.abc import Awaitable, Callable
@@ -159,7 +160,13 @@ class SkillContext:
 
     async def run_on_host(self, alias: str, command: str) -> str:
         """Run a shell command on a managed host via SSH. Returns output string."""
-        return await self._executor._run_on_host(alias, command)
+        # _run_on_host returns (output, exit_code) for resolved hosts and a bare
+        # denial string for unknown ones (TS-0004 — forwarding the raw tuple
+        # violated this method's documented str contract for every real host).
+        raw = await self._executor._run_on_host(alias, command)
+        if isinstance(raw, tuple):
+            return raw[0]
+        return raw
 
     async def query_prometheus(self, query: str) -> str:
         """Run a PromQL instant query against Prometheus via curl.
@@ -294,7 +301,7 @@ class SkillContext:
                 text = await resp.text()
                 self._tracker.bytes_downloaded += len(text.encode())
                 try:
-                    return json.loads(text)
+                    return _json.loads(text)
                 except (ValueError, TypeError):
                     return text
 
@@ -333,7 +340,7 @@ class SkillContext:
                 text = await resp.text()
                 self._tracker.bytes_downloaded += len(text.encode())
                 try:
-                    return json.loads(text)
+                    return _json.loads(text)
                 except (ValueError, TypeError):
                     return text
 

--- a/tests/test_action_diffs.py
+++ b/tests/test_action_diffs.py
@@ -189,7 +189,7 @@ class TestMaxDiffChars:
 class TestDiffTracker:
     async def test_capture_before_write_file(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="old content\n")
+        executor._run_on_host = AsyncMock(return_value=("old content\n", 0))
         tracker = DiffTracker()
         key = await tracker.capture_before(
             "write_file", {"host": "server1", "path": "/tmp/f.txt"}, executor,
@@ -228,7 +228,7 @@ class TestDiffTracker:
 
     async def test_compute_diff_write_file(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="old line\n")
+        executor._run_on_host = AsyncMock(return_value=("old line\n", 0))
         tracker = DiffTracker()
         key = await tracker.capture_before(
             "write_file", {"host": "h", "path": "/tmp/test.txt", "content": "new line\n"}, executor,
@@ -242,7 +242,7 @@ class TestDiffTracker:
 
     async def test_compute_diff_no_change(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="same\n")
+        executor._run_on_host = AsyncMock(return_value=("same\n", 0))
         tracker = DiffTracker()
         key = await tracker.capture_before(
             "write_file", {"host": "h", "path": "/tmp/f.txt", "content": "same\n"}, executor,
@@ -254,7 +254,7 @@ class TestDiffTracker:
 
     async def test_compute_diff_new_file(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="")
+        executor._run_on_host = AsyncMock(return_value=("", 0))
         tracker = DiffTracker()
         key = await tracker.capture_before(
             "write_file", {"host": "h", "path": "/tmp/new.txt", "content": "hello\n"}, executor,
@@ -277,7 +277,7 @@ class TestDiffTracker:
 
     async def test_snapshot_cleanup_after_compute(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="old\n")
+        executor._run_on_host = AsyncMock(return_value=("old\n", 0))
         tracker = DiffTracker()
         key = await tracker.capture_before(
             "write_file", {"host": "h", "path": "/tmp/f.txt", "content": "new\n"}, executor,
@@ -301,7 +301,7 @@ class TestDiffTracker:
 
     async def test_path_used_as_diff_label(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="old\n")
+        executor._run_on_host = AsyncMock(return_value=("old\n", 0))
         tracker = DiffTracker()
         key = await tracker.capture_before(
             "write_file", {"host": "h", "path": "/etc/nginx.conf", "content": "new\n"}, executor,
@@ -547,7 +547,7 @@ class TestBackgroundTaskDiffIntegration:
         executor = MagicMock()
         executor.config = MagicMock()
         executor.config.hosts = {"localhost": MagicMock()}
-        executor._run_on_host = AsyncMock(return_value="old content\n")
+        executor._run_on_host = AsyncMock(return_value=("old content\n", 0))
         executor.execute = AsyncMock(return_value="File written successfully")
 
         skill_manager = MagicMock()
@@ -811,7 +811,7 @@ class TestEdgeCases:
 
     async def test_multiple_writes_tracked_independently(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(side_effect=["old1\n", "old2\n"])
+        executor._run_on_host = AsyncMock(side_effect=[("old1\n", 0), ("old2\n", 0)])
         tracker = DiffTracker()
         key1 = await tracker.capture_before(
             "write_file", {"host": "h", "path": "/tmp/a.txt"}, executor,
@@ -860,7 +860,7 @@ class TestEdgeCases:
 
     async def test_capture_before_quotes_path(self):
         executor = MagicMock()
-        executor._run_on_host = AsyncMock(return_value="content")
+        executor._run_on_host = AsyncMock(return_value=("content", 0))
         tracker = DiffTracker()
         await tracker.capture_before(
             "write_file", {"host": "h", "path": "/tmp/file with spaces.txt"}, executor,

--- a/tests/test_ts_ledger_fixes.py
+++ b/tests/test_ts_ledger_fixes.py
@@ -1,0 +1,221 @@
+"""Regression tests for the RFC-005 findings-ledger fixes (TS-0001…TS-0005).
+
+Each test pins the exact failure mode the type checker surfaced and Aaron
+ruled FIX — see docs/plans/type-safety-findings.md for the ledger entries.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import discord
+from src.audit.diff_tracker import DiffTracker
+from src.odin.planner import PlanValidationError
+from src.tools.skill_context import SkillContext
+
+
+class _FakeExecutor:
+    """Just enough executor for the two tuple-contract fixes."""
+
+    def __init__(self, raw):
+        self._raw = raw
+        self.config = MagicMock()
+
+    async def _run_on_host(self, alias, command):
+        if isinstance(self._raw, Exception):
+            raise self._raw
+        return self._raw
+
+
+class TestTS0002DiffTrackerBeforeSnapshot:
+    """TS-0002: every overwrite used to snapshot '' because the executor's
+    (output, exit_code) tuple hit .startswith() and the AttributeError was
+    silently swallowed."""
+
+    async def _capture(self, raw):
+        tracker = DiffTracker()
+        key = await tracker.capture_before(
+            "write_file", {"host": "server", "path": "/tmp/f.txt", "content": "new"},
+            _FakeExecutor(raw),
+        )
+        assert key is not None
+        return tracker._snapshots[key]
+
+    @pytest.mark.asyncio
+    async def test_success_tuple_records_real_content(self):
+        assert await self._capture(("the old file body\n", 0)) == "the old file body\n"
+
+    @pytest.mark.asyncio
+    async def test_host_denial_string_records_empty(self):
+        assert await self._capture("Unknown or disallowed host: nope") == ""
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_tuple_records_empty(self):
+        assert await self._capture(("Command failed (exit 255):\nssh: boom", 255)) == ""
+
+    @pytest.mark.asyncio
+    async def test_executor_exception_records_empty(self):
+        assert await self._capture(RuntimeError("ssh pool down")) == ""
+
+
+class TestTS0004SkillRunOnHostContract:
+    """TS-0004: the documented `run_on_host -> str` contract was violated by
+    forwarding the raw executor tuple for every resolved host."""
+
+    def _ctx(self, raw):
+        ctx = SkillContext.__new__(SkillContext)
+        ctx._executor = _FakeExecutor(raw)
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_resolved_host_returns_output_string(self):
+        result = await self._ctx(("uptime output", 0)).run_on_host("server", "uptime")
+        assert result == "uptime output"
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_failure_tuple_returns_its_output_string(self):
+        result = await self._ctx(("Command failed (exit 7):\nboom", 7)).run_on_host(
+            "server", "false")
+        assert result == "Command failed (exit 7):\nboom"
+
+    @pytest.mark.asyncio
+    async def test_unknown_host_returns_denial_string(self):
+        result = await self._ctx("Unknown or disallowed host: nope").run_on_host(
+            "nope", "uptime")
+        assert result == "Unknown or disallowed host: nope"
+
+
+class TestTS0003PlanValidationError:
+    """TS-0003: `odin run` crashed inside its own error reporter — the
+    exception never had the .errors the CLI iterates."""
+
+    def test_carries_error_list(self):
+        exc = PlanValidationError(["duplicate step id: a", "unknown tool: x"])
+        assert exc.errors == ["duplicate step id: a", "unknown tool: x"]
+        assert "duplicate step id: a; unknown tool: x" == str(exc)
+
+    @pytest.mark.asyncio
+    async def test_planner_execute_raises_with_errors(self):
+        # validate() returns the error list; execute() is the raise site the
+        # CLI catches — drive the real path with an invalid plan.
+        from src.odin.planner import Planner
+        from src.odin.registry import ToolRegistry
+        from src.odin.types import PlanSpec, StepSpec
+
+        plan = PlanSpec(
+            name="bad", steps=[
+                StepSpec(id="a", tool="run_command", params={}),
+                StepSpec(id="a", tool="run_command", params={}),
+            ],
+        )
+        planner = Planner(ToolRegistry.with_defaults())
+        with pytest.raises(PlanValidationError) as excinfo:
+            await planner.execute(plan)
+        assert any("duplicate" in e.lower() for e in excinfo.value.errors)
+
+
+class TestTS0001UserinfoInDMs:
+    """TS-0001: `!userinfo` in a DM raised AttributeError — ctx.author is a
+    plain discord.User there, with no joined_at and no roles."""
+
+    def _cog_and_ctx(self, author):
+        from src.discord.cogs.utility import Utility
+
+        cog = Utility.__new__(Utility)
+        ctx = MagicMock()
+        ctx.author = author
+        ctx.send = AsyncMock()
+        return cog, ctx
+
+    @pytest.mark.asyncio
+    async def test_dm_user_without_member_arg_does_not_raise(self):
+        from src.discord.cogs.utility import Utility
+
+        user = MagicMock(spec=discord.User)  # spec: no .roles / .joined_at
+        user.id = 1234
+        user.created_at = discord.utils.utcnow()
+        user.display_avatar.url = "https://cdn.example/avatar.png"
+        user.__str__ = lambda self: "someone"
+        cog, ctx = self._cog_and_ctx(user)
+        await Utility.userinfo.callback(cog, ctx, member=None)
+        ctx.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_guild_member_still_gets_roles_and_joined(self):
+        from src.discord.cogs.utility import Utility
+
+        member = MagicMock(spec=discord.Member)
+        member.id = 42
+        member.joined_at = discord.utils.utcnow()
+        member.created_at = discord.utils.utcnow()
+        role = MagicMock()
+        role.mention = "@role"
+        member.roles = [MagicMock(), role]
+        member.display_avatar.url = "https://cdn.example/avatar.png"
+        member.__str__ = lambda self: "member"
+        cog, ctx = self._cog_and_ctx(member)
+        await Utility.userinfo.callback(cog, ctx, member=None)
+        ctx.send.assert_awaited()
+
+
+class TestTS0005HttpPostJsonShadowing:
+    """TS-0005: http_post's `json=` parameter shadowed the stdlib module, so
+    any non-JSON-content-type response crashed on `json.loads`.
+
+    aioresponses 0.7.x is incompatible with this aiohttp (see the skip in
+    tests/test_tools/test_http.py), so the client session is faked directly.
+    """
+
+    class _FakeResp:
+        def __init__(self, content_type: str, body: str) -> None:
+            self.content_type = content_type
+            self._body = body
+
+        async def text(self):
+            return self._body
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    def _patch_session(self, monkeypatch, resp):
+        import aiohttp
+
+        class _FakeSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def post(self, url, **kwargs):
+                return resp
+
+        monkeypatch.setattr(aiohttp, "ClientSession", _FakeSession)
+
+    def _ctx(self):
+        ctx = SkillContext.__new__(SkillContext)
+        from src.tools.skill_context import ResourceTracker
+
+        ctx._tracker = ResourceTracker()
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_text_plain_response_returns_text(self, monkeypatch):
+        self._patch_session(monkeypatch, self._FakeResp("text/plain", "plain ok"))
+        result = await self._ctx().http_post("https://api.example/hook", json={"a": 1})
+        assert result == "plain ok"
+
+    @pytest.mark.asyncio
+    async def test_json_body_in_text_content_type_is_parsed(self, monkeypatch):
+        self._patch_session(
+            monkeypatch, self._FakeResp("text/plain", '{"parsed": true}'))
+        result = await self._ctx().http_post("https://api.example/hook")
+        assert result == {"parsed": True}


### PR DESCRIPTION
Aaron ruled **fix all five**. Each fix pins its exact failure mode with regression tests; the `test_action_diffs.py` fakes are updated to the real executor tuple contract they never matched.

| ID | Fix | Test coverage |
|---|---|---|
| TS-0001 | `userinfo` guild-only fields behind inline `isinstance(member, discord.Member)` — DM `User` no longer crashes | DM-User + guild-Member paths |
| TS-0002 | `capture_before` unpacks `(output, exit_code)`; transport failures/denials still snapshot `""` — **audit diffs record real before-content for the first time** | success tuple / denial str / failure tuple / exception |
| TS-0003 | `PlanValidationError` carries `.errors`; the CLI reporter that had never worked now prints and exits 2 | exception shape + real `execute()` raise path |
| TS-0004 | `run_on_host` honors its documented `-> str` (skills.md contract) | tuple, failure-tuple, denial paths |
| TS-0005 | `import json as _json`; `http_post` keeps its documented `json=` param, non-JSON responses no longer crash | text/plain passthrough + JSON-in-text parse (session faked — aioresponses incompatible with this aiohttp, same skip as test_tools/test_http.py) |

**Type-gate effect:** resolved=8, new=0 — full-src mypy is now **1** (the unruled dead `src.setup` import). Ledger verdicts recorded FIX → FIXED (PR #186).

## Verification
- Suite: **6,177 passed / 4 skipped** · Lint gate: new=0 · Type gate: new=0, resolved=8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3