### PR TITLE
RFC-006 P1: security wave — permissions 100%, web/api/security 17→95%

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -696,21 +696,21 @@
   "statements": 3
  },
  "src/permissions/host_access.py": {
-  "covered": 60,
-  "missing": 94,
-  "percent": 38.96,
+  "covered": 154,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 154
  },
  "src/permissions/manager.py": {
-  "covered": 63,
-  "missing": 15,
-  "percent": 80.77,
+  "covered": 78,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 78
  },
  "src/permissions/token_manager.py": {
-  "covered": 31,
-  "missing": 101,
-  "percent": 23.48,
+  "covered": 132,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 132
  },
  "src/planning/__init__.py": {
@@ -1170,9 +1170,9 @@
   "statements": 110
  },
  "src/web/api/security.py": {
-  "covered": 58,
-  "missing": 291,
-  "percent": 16.62,
+  "covered": 332,
+  "missing": 17,
+  "percent": 95.13,
   "statements": 349
  },
  "src/web/api/self_update.py": {
@@ -1194,9 +1194,9 @@
   "statements": 135
  },
  "src/web/api_common.py": {
-  "covered": 53,
-  "missing": 34,
-  "percent": 60.92,
+  "covered": 62,
+  "missing": 25,
+  "percent": 71.26,
   "statements": 87
  },
  "src/web/chat.py": {

--- a/tests/test_host_access.py
+++ b/tests/test_host_access.py
@@ -1,0 +1,251 @@
+"""Coverage for HostAccessManager (RFC-006 P1 — security bucket, target ≥90%).
+
+This is the live host-authorization boundary (verified live 2026-07-06:
+unlisted identities are playground-jailed, not inherit-all). The tests drive
+the real enforcement matrix — None=inherit-all vs []=deny-all vs whitelist,
+crossed with request-scoped contextvar narrowing — plus persistence and the
+default-host resolution rules.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.permissions.host_access import HostAccessEntry, HostAccessManager
+
+HOSTS = ["alpha", "beta", "gamma"]
+
+
+def _mgr(tmp_path, available=HOSTS):
+    return HostAccessManager(path=str(tmp_path / "host_access.json"),
+                             available_hosts=available)
+
+
+class TestEntrySemantics:
+    def test_from_dict_null_hosts_is_inherit_all(self):
+        e = HostAccessEntry.from_dict({"allowed_hosts": None, "default_host": "x"})
+        assert e.allowed_hosts is None and e.default_host == "x"
+
+    def test_from_dict_empty_list_is_deny_all(self):
+        assert HostAccessEntry.from_dict({"allowed_hosts": []}).allowed_hosts == []
+
+    def test_from_dict_missing_key_is_inherit_all(self):
+        assert HostAccessEntry.from_dict({}).allowed_hosts is None
+
+    def test_to_dict_roundtrip(self):
+        e = HostAccessEntry(["alpha"], "alpha")
+        assert e.to_dict() == {"allowed_hosts": ["alpha"], "default_host": "alpha"}
+
+
+class TestIsHostAllowed:
+    def test_no_entry_inherits_all_available(self, tmp_path):
+        # Default policy is inherit-all (None) out of the box.
+        mgr = _mgr(tmp_path)
+        assert mgr.is_host_allowed("stranger", "alpha") is True
+        assert mgr.is_host_allowed("stranger", "not-a-host") is False
+
+    @pytest.mark.asyncio
+    async def test_whitelist_entry_allows_only_listed(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["alpha"], "alpha")
+        assert mgr.is_host_allowed("u1", "alpha") is True
+        assert mgr.is_host_allowed("u1", "beta") is False
+
+    @pytest.mark.asyncio
+    async def test_empty_list_entry_denies_all(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("locked", [], "")
+        assert mgr.is_host_allowed("locked", "alpha") is False
+
+    def test_request_scope_narrows_scopeless_user(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        tok = mgr.set_request_host_scope(["alpha"])
+        try:
+            assert mgr.is_host_allowed("stranger", "alpha") is True
+            assert mgr.is_host_allowed("stranger", "beta") is False
+        finally:
+            mgr.reset_request_host_scope(tok)
+
+    @pytest.mark.asyncio
+    async def test_request_scope_further_narrows_entried_user(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["alpha", "beta"], "alpha")
+        tok = mgr.set_request_host_scope(["alpha"])
+        try:
+            assert mgr.is_host_allowed("u1", "alpha") is True
+            assert mgr.is_host_allowed("u1", "beta") is False  # scope removes it
+        finally:
+            mgr.reset_request_host_scope(tok)
+
+
+class TestGetAllowedHosts:
+    def test_no_entry_returns_all_available(self, tmp_path):
+        assert _mgr(tmp_path).get_allowed_hosts("stranger") == HOSTS
+
+    @pytest.mark.asyncio
+    async def test_whitelist_intersected_with_available(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        # "ghost" isn't an available host; set_user filters it at write time,
+        # so read-back is only the valid subset.
+        await mgr.set_user("u1", ["alpha", "ghost"], "alpha")
+        assert mgr.get_allowed_hosts("u1") == ["alpha"]
+
+    def test_scope_only_for_scopeless_user(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        tok = mgr.set_request_host_scope(["beta", "ghost"])
+        try:
+            assert mgr.get_allowed_hosts("stranger") == ["beta"]
+        finally:
+            mgr.reset_request_host_scope(tok)
+
+    @pytest.mark.asyncio
+    async def test_scope_narrows_entried_user_allowed_list(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["alpha", "beta"], "alpha")
+        tok = mgr.set_request_host_scope(["beta"])
+        try:
+            assert mgr.get_allowed_hosts("u1") == ["beta"]  # scope trims alpha
+        finally:
+            mgr.reset_request_host_scope(tok)
+
+
+class TestGetDefaultHost:
+    @pytest.mark.asyncio
+    async def test_entry_default_host_used_when_valid(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["alpha", "beta"], "beta")
+        assert mgr.get_default_host("u1") == "beta"
+
+    def test_request_default_wins_when_in_effective(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        tok = mgr.set_request_default_host("gamma")
+        try:
+            assert mgr.get_default_host("stranger") == "gamma"
+        finally:
+            mgr.reset_request_default_host(tok)
+
+    def test_request_default_ignored_when_not_available(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        tok = mgr.set_request_default_host("nonexistent")
+        try:
+            # falls through to first allowed
+            assert mgr.get_default_host("stranger") == "alpha"
+        finally:
+            mgr.reset_request_default_host(tok)
+
+    def test_scopeless_user_falls_back_to_first_allowed(self, tmp_path):
+        assert _mgr(tmp_path).get_default_host("stranger") == "alpha"
+
+    def test_scope_no_entry_returns_first_of_scope(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        tok = mgr.set_request_host_scope(["beta", "gamma"])
+        try:
+            assert mgr.get_default_host("stranger") == "beta"
+        finally:
+            mgr.reset_request_host_scope(tok)
+
+    @pytest.mark.asyncio
+    async def test_deny_all_user_has_empty_default(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("locked", [], "")
+        assert mgr.get_default_host("locked") == ""
+
+
+class TestSetUserNormalization:
+    @pytest.mark.asyncio
+    async def test_default_host_snapped_to_first_valid(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        # default 'beta' not in the whitelist -> snapped to first valid (alpha)
+        await mgr.set_user("u1", ["alpha"], "beta")
+        assert mgr.get_entry("u1").default_host == "alpha"
+
+    @pytest.mark.asyncio
+    async def test_default_host_cleared_when_no_valid_hosts(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["ghost"], "ghost")  # all invalid
+        entry = mgr.get_entry("u1")
+        assert entry.allowed_hosts == [] and entry.default_host == ""
+
+    @pytest.mark.asyncio
+    async def test_inherit_all_allows_any_real_default(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", None, "gamma")
+        assert mgr.get_entry("u1").allowed_hosts is None
+        assert mgr.get_entry("u1").default_host == "gamma"
+
+    @pytest.mark.asyncio
+    async def test_bogus_default_cleared_under_inherit_all(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", None, "ghost")
+        assert mgr.get_entry("u1").default_host == ""
+
+
+class TestDefaultPolicyAndCrud:
+    @pytest.mark.asyncio
+    async def test_set_default_policy_applies_to_strangers(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_default_policy(["alpha"], "alpha")
+        assert mgr.is_host_allowed("stranger", "beta") is False
+        assert mgr.is_host_allowed("stranger", "alpha") is True
+
+    @pytest.mark.asyncio
+    async def test_set_default_policy_snaps_default(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_default_policy(["alpha"], "beta")
+        assert mgr.default_policy.default_host == "alpha"
+
+    @pytest.mark.asyncio
+    async def test_set_default_policy_filters_invalid_hosts(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_default_policy(["alpha", "ghost"], "alpha")
+        assert mgr.default_policy.allowed_hosts == ["alpha"]
+
+    @pytest.mark.asyncio
+    async def test_set_default_policy_clears_unavailable_default(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_default_policy(None, "ghost")
+        assert mgr.default_policy.default_host == ""
+
+    @pytest.mark.asyncio
+    async def test_delete_user_present_and_absent(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["alpha"], "alpha")
+        assert await mgr.delete_user("u1") is True
+        assert await mgr.delete_user("u1") is False
+
+    @pytest.mark.asyncio
+    async def test_has_user_entry_and_list(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.set_user("u1", ["alpha"], "alpha")
+        assert mgr.has_user_entry("u1") and not mgr.has_user_entry("nobody")
+        assert "u1" in mgr.list_users()
+
+    def test_available_hosts_property_and_setter(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        assert mgr.available_hosts == HOSTS
+        mgr.set_available_hosts(["only"])
+        assert mgr.available_hosts == ["only"]
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_entries_and_policy_survive_reload(self, tmp_path):
+        path = str(tmp_path / "host_access.json")
+        mgr = HostAccessManager(path=path, available_hosts=HOSTS)
+        await mgr.set_user("u1", ["alpha"], "alpha")
+        await mgr.set_default_policy(["beta"], "beta")
+        reloaded = HostAccessManager(path=path, available_hosts=HOSTS)
+        assert reloaded.get_entry("u1").allowed_hosts == ["alpha"]
+        assert reloaded.default_policy.allowed_hosts == ["beta"]
+
+    def test_non_dict_root_ignored(self, tmp_path):
+        p = tmp_path / "host_access.json"
+        p.write_text(json.dumps(["not", "a", "dict"]))
+        mgr = HostAccessManager(path=str(p), available_hosts=HOSTS)
+        assert mgr.list_users() == {}
+
+    def test_invalid_json_ignored(self, tmp_path):
+        p = tmp_path / "host_access.json"
+        p.write_text("{ broken")
+        assert HostAccessManager(path=str(p), available_hosts=HOSTS).list_users() == {}

--- a/tests/test_permission_manager_coverage.py
+++ b/tests/test_permission_manager_coverage.py
@@ -1,0 +1,95 @@
+"""Extra coverage for PermissionManager (RFC-006 P1 — manager.py 81→95).
+
+Complements test_permissions.py: the request-scoped tier contextvar, the
+async CRUD lock paths, invalid-tier rejection, overrides persistence, and the
+guest/user tool-filtering branches.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.permissions.manager import USER_TIER_TOOLS, PermissionManager
+
+
+def _mgr(tmp_path, config_tiers=None, default="user"):
+    return PermissionManager(
+        config_tiers=config_tiers or {},
+        default_tier=default,
+        overrides_path=str(tmp_path / "permissions.json"),
+    )
+
+
+class TestGetTierPrecedence:
+    def test_request_scope_beats_override_and_config(self, tmp_path):
+        mgr = _mgr(tmp_path, {"u1": "admin"})
+        mgr.set_tier("u1", "guest")
+        tok = mgr.set_request_tier("user")
+        try:
+            assert mgr.get_tier("u1") == "user"
+        finally:
+            mgr.reset_request_tier(tok)
+        # after reset, override wins over config
+        assert mgr.get_tier("u1") == "guest"
+
+    def test_invalid_request_tier_is_ignored(self, tmp_path):
+        mgr = _mgr(tmp_path, default="user")
+        tok = mgr.set_request_tier("wizard")  # not a valid tier -> None
+        try:
+            assert mgr.get_tier("anyone") == "user"
+        finally:
+            mgr.reset_request_tier(tok)
+
+    def test_config_then_default(self, tmp_path):
+        mgr = _mgr(tmp_path, {"u1": "admin"}, default="guest")
+        assert mgr.get_tier("u1") == "admin"
+        assert mgr.get_tier("stranger") == "guest"
+
+
+class TestSetTier:
+    def test_invalid_tier_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid tier"):
+            _mgr(tmp_path).set_tier("u1", "wizard")
+
+    @pytest.mark.asyncio
+    async def test_async_set_and_delete(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.async_set_tier("u1", "admin")
+        assert mgr.get_tier("u1") == "admin"
+        assert await mgr.async_delete_tier("u1") is True
+        assert await mgr.async_delete_tier("u1") is False
+
+    def test_overrides_persist_across_reload(self, tmp_path):
+        path = str(tmp_path / "permissions.json")
+        PermissionManager({}, "user", path).set_tier("u1", "admin")
+        assert PermissionManager({}, "user", path).get_tier("u1") == "admin"
+
+    def test_corrupt_overrides_file_ignored(self, tmp_path):
+        path = tmp_path / "permissions.json"
+        path.write_text("{ not valid json")
+        mgr = PermissionManager({}, "user", str(path))
+        assert mgr.get_tier("anyone") == "user"  # falls back cleanly
+
+
+class TestToolFiltering:
+    _TOOLS = [{"name": n} for n in ("web_search", "run_command", "write_file")]
+
+    def test_admin_gets_everything(self, tmp_path):
+        mgr = _mgr(tmp_path, {"a": "admin"})
+        assert mgr.filter_tools("a", self._TOOLS) == self._TOOLS
+        assert mgr.allowed_tool_names("a") is None
+
+    def test_guest_gets_nothing(self, tmp_path):
+        mgr = _mgr(tmp_path, {"g": "guest"})
+        assert mgr.filter_tools("g", self._TOOLS) is None
+        assert mgr.allowed_tool_names("g") == set()
+
+    def test_user_gets_readonly_allowlist(self, tmp_path):
+        mgr = _mgr(tmp_path, {"u": "user"})
+        names = {t["name"] for t in mgr.filter_tools("u", self._TOOLS)}
+        assert names == {"web_search"}  # only the allowlisted read-only tool
+        assert mgr.allowed_tool_names("u") == set(USER_TIER_TOOLS)
+
+    def test_is_admin_and_is_guest(self, tmp_path):
+        mgr = _mgr(tmp_path, {"a": "admin", "g": "guest"})
+        assert mgr.is_admin("a") and not mgr.is_admin("g")
+        assert mgr.is_guest("g") and not mgr.is_guest("a")

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,182 @@
+"""Coverage for ApiTokenManager (RFC-006 P1 — security bucket, target ≥90%).
+
+Drives the real manager against tmp_path JSON files: load-validation branches,
+HMAC-safe resolve, the async CRUD lifecycle, and the security invariant that
+raw token values are never persisted or listed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.permissions.token_manager import ApiTokenManager, _hash_token
+
+
+def _mgr(tmp_path):
+    return ApiTokenManager(path=str(tmp_path / "api_tokens.json"))
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_valid_token_resolves_to_identity(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        ident = await mgr.create_token("u1", username="Alice", tier="admin")
+        resolved = mgr.resolve(ident.token)
+        assert resolved is not None and resolved.user_id == "u1"
+
+    def test_empty_token_returns_none(self, tmp_path):
+        assert _mgr(tmp_path).resolve("") is None
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_returns_none(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.create_token("u1")
+        assert mgr.resolve("not-the-token") is None
+
+
+class TestCreateAndSecurity:
+    @pytest.mark.asyncio
+    async def test_create_returns_raw_token_once(self, tmp_path):
+        ident = await _mgr(tmp_path).create_token("u1")
+        assert ident.token and len(ident.token) > 20
+
+    @pytest.mark.asyncio
+    async def test_duplicate_user_id_rejected(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.create_token("u1")
+        with pytest.raises(ValueError, match="already exists"):
+            await mgr.create_token("u1")
+
+    @pytest.mark.asyncio
+    async def test_raw_token_never_persisted(self, tmp_path):
+        # The crown-jewel invariant: only the hash + 8-char prefix hit disk.
+        path = tmp_path / "api_tokens.json"
+        ident = await ApiTokenManager(path=str(path)).create_token("u1")
+        on_disk = json.loads(path.read_text())
+        assert on_disk[0]["token_hash"] == _hash_token(ident.token)
+        assert ident.token not in path.read_text()
+        assert "token" not in on_disk[0] or on_disk[0].get("token") == ""
+
+    @pytest.mark.asyncio
+    async def test_list_tokens_masks_to_prefix(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        ident = await mgr.create_token("u1")
+        listed = mgr.list_tokens()
+        assert listed[0]["token"].endswith("...")
+        assert ident.token not in listed[0]["token"]
+        assert listed[0]["source"] == "dynamic"
+
+
+class TestGetUpdateRegenerateDelete:
+    @pytest.mark.asyncio
+    async def test_get_present_and_absent(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.create_token("u1", tier="user")
+        assert mgr.get("u1").tier == "user"
+        assert mgr.get("nobody") is None
+
+    @pytest.mark.asyncio
+    async def test_update_changes_fields(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.create_token("u1", tier="admin")
+        updated = await mgr.update_token("u1", tier="guest", label="lowered")
+        assert updated.tier == "guest" and updated.label == "lowered"
+
+    @pytest.mark.asyncio
+    async def test_update_absent_user_returns_none(self, tmp_path):
+        assert await _mgr(tmp_path).update_token("nobody", tier="guest") is None
+
+    @pytest.mark.asyncio
+    async def test_regenerate_changes_token_and_invalidates_old(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        old = (await mgr.create_token("u1")).token
+        new = await mgr.regenerate_token("u1")
+        assert new and new != old
+        assert mgr.resolve(old) is None
+        assert mgr.resolve(new).user_id == "u1"
+
+    @pytest.mark.asyncio
+    async def test_regenerate_absent_user_returns_none(self, tmp_path):
+        assert await _mgr(tmp_path).regenerate_token("nobody") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_present_and_absent(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        await mgr.create_token("u1")
+        assert await mgr.delete_token("u1") is True
+        assert await mgr.delete_token("u1") is False
+
+
+class TestPersistenceAndReload:
+    @pytest.mark.asyncio
+    async def test_tokens_survive_reload(self, tmp_path):
+        path = str(tmp_path / "api_tokens.json")
+        ident = await ApiTokenManager(path=path).create_token(
+            "u1", tier="user", allowed_tools=["web_search"], allowed_hosts=["h1"])
+        reloaded = ApiTokenManager(path=path)
+        assert reloaded.resolve(ident.token).user_id == "u1"
+        got = reloaded.get("u1")
+        assert got.tier == "user" and got.allowed_tools == ["web_search"]
+        assert got.allowed_hosts == ["h1"]
+
+
+class TestLoadValidation:
+    def _write(self, tmp_path, data):
+        p = tmp_path / "api_tokens.json"
+        p.write_text(json.dumps(data) if not isinstance(data, str) else data)
+        return ApiTokenManager(path=str(p))
+
+    def test_missing_file_is_empty(self, tmp_path):
+        assert _mgr(tmp_path).list_tokens() == []
+
+    def test_non_list_root_ignored(self, tmp_path):
+        assert self._write(tmp_path, {"not": "a list"}).list_tokens() == []
+
+    def test_invalid_json_ignored(self, tmp_path):
+        assert self._write(tmp_path, "{ broken json").list_tokens() == []
+
+    def test_entry_missing_user_id_skipped(self, tmp_path):
+        mgr = self._write(tmp_path, [{"token_hash": "abc"}])
+        assert mgr.list_tokens() == []
+
+    def test_entry_missing_hash_skipped(self, tmp_path):
+        mgr = self._write(tmp_path, [{"user_id": "u1"}])
+        assert mgr.list_tokens() == []
+
+    def test_invalid_tier_skipped(self, tmp_path):
+        mgr = self._write(tmp_path, [{"user_id": "u1", "token_hash": "h", "tier": "wizard"}])
+        assert mgr.list_tokens() == []
+
+    def test_bad_allowed_tools_skipped(self, tmp_path):
+        mgr = self._write(tmp_path, [
+            {"user_id": "u1", "token_hash": "h", "allowed_tools": [1, 2]}])
+        assert mgr.list_tokens() == []
+
+    def test_bad_allowed_hosts_skipped(self, tmp_path):
+        mgr = self._write(tmp_path, [
+            {"user_id": "u1", "token_hash": "h", "allowed_hosts": "not-a-list"}])
+        assert mgr.list_tokens() == []
+
+    def test_null_allowed_hosts_becomes_none(self, tmp_path):
+        mgr = self._write(tmp_path, [
+            {"user_id": "u1", "token_hash": "h", "allowed_hosts": None}])
+        assert mgr.get("u1").allowed_hosts is None
+
+    def test_non_dict_entry_caught_per_entry(self, tmp_path):
+        # A non-dict list item makes entry.get() raise — the per-entry
+        # except swallows it and keeps loading the rest.
+        mgr = self._write(tmp_path, [
+            "i am not a dict",
+            {"user_id": "u2", "token_hash": "h2"},
+        ])
+        assert [t["user_id"] for t in mgr.list_tokens()] == ["u2"]
+
+    def test_valid_entry_loads(self, tmp_path):
+        mgr = self._write(tmp_path, [{
+            "user_id": "u1", "token_hash": "h", "token_prefix": "pre",
+            "tier": "user", "allowed_tools": ["web_search"], "allowed_hosts": ["h1"],
+            "default_host": "h1", "username": "Bob", "label": "svc",
+        }])
+        got = mgr.get("u1")
+        assert got.tier == "user" and got.username == "Bob" and got.default_host == "h1"

--- a/tests/test_web_api_security_routes.py
+++ b/tests/test_web_api_security_routes.py
@@ -1,0 +1,468 @@
+"""Route-level coverage for src/web/api/security.py (RFC-006 P1, ≥90%).
+
+Drives the RBAC, host-access, API-token, and auth registrars through the real
+aiohttp route layer (Odin's advisory: real routes, faked boundaries). The bot
+is faked but the managers are REAL (PermissionManager / HostAccessManager /
+ApiTokenManager on tmp files), so the handlers exercise genuine behavior.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.permissions.host_access import HostAccessManager
+from src.permissions.manager import PermissionManager
+from src.permissions.token_manager import ApiTokenManager
+from src.web.api.security import (
+    register_api_tokens,
+    register_auth,
+    register_host_access,
+    register_permissions_rbac,
+)
+
+HOSTS = ["alpha", "beta"]
+
+
+def _make_bot(tmp_path, *, auth_configured=True, with_managers=True):
+    bot = MagicMock()
+    bot.config.web.api_token = "cfg-token" if auth_configured else ""
+    bot.config.web.api_tokens = []
+    bot.audit = MagicMock()
+    bot.audit.log_event = AsyncMock()
+    if with_managers:
+        bot.permissions = PermissionManager(
+            {"admin-user": "admin"}, "user", str(tmp_path / "perms.json"))
+        bot.host_access_manager = HostAccessManager(
+            path=str(tmp_path / "hosts.json"), available_hosts=HOSTS)
+        bot.api_token_manager = ApiTokenManager(path=str(tmp_path / "tokens.json"))
+    else:
+        bot.permissions = None
+        bot.host_access_manager = None
+        bot.api_token_manager = None
+    return bot
+
+
+def _app(bot, *, identity="__admin__"):
+    """Build an app with all security registrars; inject an api-identity so the
+    admin gate can be exercised. identity=None → no identity (unauthenticated);
+    "__admin__" → an admin-tier identity; otherwise a namespace with .tier."""
+    routes = web.RouteTableDef()
+    register_permissions_rbac(routes, bot)
+    register_host_access(routes, bot)
+    register_api_tokens(routes, bot)
+    register_auth(routes, bot)
+
+    if identity == "__admin__":
+        ident = SimpleNamespace(tier="admin", user_id="admin-user")
+    else:
+        ident = identity
+
+    @web.middleware
+    async def _inject(request, handler):
+        if ident is not None:
+            request["_api_identity_holder"] = ident
+            request.__dict__["_api_identity"] = ident
+        return await handler(request)
+
+    app = web.Application(middlewares=[_inject])
+    app.router.add_routes(routes)
+    return app
+
+
+# ── RBAC ─────────────────────────────────────────────────────────────
+
+class TestRbacRoutes:
+    @pytest.mark.asyncio
+    async def test_list_tiers(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.get("/api/permissions/tiers")
+            assert r.status == 200
+            body = await r.json()
+            assert "admin" in body["valid_tiers"] and body["default_tier"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_list_tiers_503_without_manager(self, tmp_path):
+        bot = _make_bot(tmp_path, with_managers=False)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.get("/api/permissions/tiers")).status == 503
+
+    @pytest.mark.asyncio
+    async def test_get_user_tier(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            body = await (await c.get("/api/permissions/user/admin-user")).json()
+            assert body["tier"] == "admin" and body["allowed_tools"] is None
+
+    @pytest.mark.asyncio
+    async def test_set_user_tier_and_audits(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.put("/api/permissions/user/u2", json={"tier": "guest"})
+            assert r.status == 200
+            assert bot.permissions.get_tier("u2") == "guest"
+            bot.audit.log_event.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_user_tier_rejects_bad_tier(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.put("/api/permissions/user/u2", json={"tier": "wizard"})
+            assert r.status == 400
+
+    @pytest.mark.asyncio
+    async def test_set_user_tier_missing_tier_and_bad_json(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/permissions/user/u2", json={})).status == 400
+            r = await c.put("/api/permissions/user/u2", data="not json")
+            assert r.status == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_user_tier_present_and_absent(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        await bot.permissions.async_set_tier("u2", "guest")
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.delete("/api/permissions/user/u2")).status == 200
+            assert (await c.delete("/api/permissions/user/u2")).status == 404
+
+
+# ── Host access ──────────────────────────────────────────────────────
+
+class TestHostAccessRoutes:
+    @pytest.mark.asyncio
+    async def test_get_host_access(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            body = await (await c.get("/api/host-access")).json()
+            assert body["available_hosts"] == HOSTS
+
+    @pytest.mark.asyncio
+    async def test_set_user_and_audit(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.put("/api/host-access/user/u1",
+                            json={"allowed_hosts": ["alpha"], "default_host": "alpha"})
+            assert r.status == 200
+            assert bot.host_access_manager.is_host_allowed("u1", "alpha")
+            bot.audit.log_event.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_user_validation_errors(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/host-access/user/u1",
+                                json={"allowed_hosts": "x"})).status == 400
+            assert (await c.put("/api/host-access/user/u1",
+                                json={"allowed_hosts": [1]})).status == 400
+            assert (await c.put("/api/host-access/user/u1",
+                                json={"default_host": 5})).status == 400
+            assert (await c.put("/api/host-access/user/u1", data="bad")).status == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_user_present_and_absent(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        await bot.host_access_manager.set_user("u1", ["alpha"], "alpha")
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.delete("/api/host-access/user/u1")).status == 200
+            assert (await c.delete("/api/host-access/user/u1")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_set_default_policy(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.put("/api/host-access/default-policy",
+                            json={"allowed_hosts": ["alpha"], "default_host": "alpha"})
+            assert r.status == 200
+            assert not bot.host_access_manager.is_host_allowed("stranger", "beta")
+
+    @pytest.mark.asyncio
+    async def test_default_policy_validation_and_503(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/host-access/default-policy",
+                                json={"allowed_hosts": "x"})).status == 400
+        bot2 = _make_bot(tmp_path, with_managers=False)
+        async with TestClient(TestServer(_app(bot2))) as c:
+            assert (await c.get("/api/host-access")).status == 503
+
+
+# ── API tokens (admin-gated) ─────────────────────────────────────────
+
+class TestApiTokenRoutes:
+    @pytest.mark.asyncio
+    async def test_create_list_update_regen_delete_lifecycle(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.post("/api/tokens", json={"user_id": "svc1", "tier": "user"})
+            assert r.status == 201
+            created = await r.json()
+            assert created["token"] and created["tier"] == "user"
+
+            listed = await (await c.get("/api/tokens")).json()
+            assert any(t["user_id"] == "svc1" for t in listed["tokens"])
+
+            assert (await c.put("/api/tokens/svc1",
+                                json={"label": "renamed"})).status == 200
+            regen = await (await c.post("/api/tokens/svc1/regenerate")).json()
+            assert regen["token"] != created["token"]
+            assert (await c.delete("/api/tokens/svc1")).status == 200
+            assert (await c.delete("/api/tokens/svc1")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_create_validation_matrix(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.post("/api/tokens", json={})).status == 400          # no user_id
+            assert (await c.post("/api/tokens",
+                                 json={"user_id": "bad id!"})).status == 400     # bad chars
+            assert (await c.post("/api/tokens",
+                                 json={"user_id": "u", "tier": "x"})).status == 400
+            assert (await c.post("/api/tokens",
+                                 json={"user_id": "u", "allowed_hosts": "x"})).status == 400
+            assert (await c.post("/api/tokens",
+                                 json={"user_id": "u", "allowed_tools": [1]})).status == 400
+            assert (await c.post("/api/tokens",
+                                 json={"user_id": "u", "allowed_hosts": ["ghost"]})).status == 400
+            assert (await c.post("/api/tokens", data="bad")).status == 400
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_conflicts(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            await c.post("/api/tokens", json={"user_id": "dup"})
+            assert (await c.post("/api/tokens", json={"user_id": "dup"})).status == 409
+
+    @pytest.mark.asyncio
+    async def test_default_host_must_be_in_allowed(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.post("/api/tokens", json={
+                "user_id": "u", "allowed_hosts": ["alpha"], "default_host": "beta"})
+            assert r.status == 400
+
+    @pytest.mark.asyncio
+    async def test_update_not_found_and_no_fields(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/tokens/ghost", json={})).status == 400  # no fields
+            assert (await c.put("/api/tokens/ghost",
+                                json={"label": "x"})).status == 404
+            assert (await c.post("/api/tokens/ghost/regenerate")).status == 404
+            assert (await c.delete("/api/tokens/ghost")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_admin_gate_denies_non_admin(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        non_admin = SimpleNamespace(tier="user", user_id="u")
+        async with TestClient(TestServer(_app(bot, identity=non_admin))) as c:
+            assert (await c.get("/api/tokens")).status == 403
+            assert (await c.post("/api/tokens", json={"user_id": "x"})).status == 403
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_allows_without_identity(self, tmp_path):
+        # No auth configured anywhere → admin gate is open.
+        bot = _make_bot(tmp_path, auth_configured=False)
+        async with TestClient(TestServer(_app(bot, identity=None))) as c:
+            assert (await c.get("/api/tokens")).status == 200
+
+
+# ── Auth ─────────────────────────────────────────────────────────────
+
+class TestAuthRoutes:
+    def _bot_with_sessions(self, tmp_path, **kw):
+        bot = _make_bot(tmp_path, **kw)
+        sm = MagicMock()
+        sm.create.return_value = ("sess-123", 3600)
+        sm.validate.return_value = True
+        sm.timeout_seconds = 3600
+        sm.active_count = 1
+        return bot, sm
+
+    def _app_with_sm(self, bot, sm, identity="__admin__"):
+        app = _app(bot, identity=identity)
+        app["session_manager"] = sm
+        return app
+
+    @pytest.mark.asyncio
+    async def test_login_with_config_token(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        bot.config.web.resolve_api_identity = MagicMock(return_value=None)
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            r = await c.post("/api/auth/login", json={"token": "cfg-token"})
+            assert r.status == 200 and (await r.json())["session_id"] == "sess-123"
+
+    @pytest.mark.asyncio
+    async def test_login_invalid_token_401(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        bot.config.web.resolve_api_identity = MagicMock(return_value=None)
+        bot.api_token_manager = None  # force fall-through to legacy compare
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            r = await c.post("/api/auth/login", json={"token": "wrong"})
+            assert r.status == 401
+
+    @pytest.mark.asyncio
+    async def test_login_missing_token_and_bad_json(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            assert (await c.post("/api/auth/login", json={})).status == 400
+            assert (await c.post("/api/auth/login", data="x")).status == 400
+
+    @pytest.mark.asyncio
+    async def test_login_dev_mode_issues_session(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path, auth_configured=False)
+        bot.api_token_manager = None
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            r = await c.post("/api/auth/login", json={"token": "anything"})
+            assert r.status == 200
+
+    @pytest.mark.asyncio
+    async def test_login_dynamic_token_identity(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        ident = await bot.api_token_manager.create_token("svc", tier="user")
+        bot.config.web.resolve_api_identity = MagicMock(return_value=None)
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            r = await c.post("/api/auth/login", json={"token": ident.token})
+            assert r.status == 200
+
+    @pytest.mark.asyncio
+    async def test_logout(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            r = await c.post("/api/auth/logout",
+                             headers={"Authorization": "Bearer sess-123"})
+            assert (await r.json())["status"] == "logged_out"
+            sm.destroy.assert_called_once_with("sess-123")
+
+    @pytest.mark.asyncio
+    async def test_session_check(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        app = self._app_with_sm(bot, sm)
+        app["api_token"] = "cfg-token"
+        async with TestClient(TestServer(app)) as c:
+            body = await (await c.get(
+                "/api/auth/session",
+                headers={"Authorization": "Bearer cfg-token"})).json()
+            assert body["authenticated"] is True
+
+    @pytest.mark.asyncio
+    async def test_session_check_unauthenticated_and_via_session(self, tmp_path):
+        bot, sm = self._bot_with_sessions(tmp_path)
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            # No app-level api_token → falls to sm.validate (mocked True)
+            body = await (await c.get(
+                "/api/auth/session",
+                headers={"Authorization": "Bearer some-session"})).json()
+            assert body["authenticated"] is True
+            # No auth header at all → unauthenticated
+            body2 = await (await c.get("/api/auth/session")).json()
+            assert body2["authenticated"] is False
+
+    @pytest.mark.asyncio
+    async def test_login_resolves_dynamic_identity_path(self, tmp_path):
+        # api_token_manager.resolve returns None, config.resolve_api_identity
+        # returns an identity → the identity branch issues a session.
+        bot, sm = self._bot_with_sessions(tmp_path)
+        bot.api_token_manager = MagicMock()
+        bot.api_token_manager.resolve.return_value = None
+        bot.api_token_manager.list_tokens.return_value = [{"x": 1}]  # auth configured
+        ident = SimpleNamespace(user_id="cfgid", tier="user")
+        bot.config.web.resolve_api_identity = MagicMock(return_value=ident)
+        async with TestClient(TestServer(self._app_with_sm(bot, sm))) as c:
+            r = await c.post("/api/auth/login", json={"token": "matches-config"})
+            assert r.status == 200
+
+    @pytest.mark.asyncio
+    async def test_logout_without_session_manager(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        # no session_manager on the app
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.post("/api/auth/logout")
+            assert (await r.json())["status"] == "ok"
+
+
+class TestTokenRoute503AndTeardown:
+    @pytest.mark.asyncio
+    async def test_token_routes_503_when_manager_missing(self, tmp_path):
+        # auth still configured (api_token set) so the admin gate passes, but
+        # the token manager is absent → each mutating route 503s.
+        bot = _make_bot(tmp_path, with_managers=False)
+        bot.config.web.api_token = "cfg-token"
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.post("/api/tokens", json={"user_id": "x"})).status == 503
+            assert (await c.put("/api/tokens/x", json={"label": "y"})).status == 503
+            assert (await c.post("/api/tokens/x/regenerate")).status == 503
+            assert (await c.delete("/api/tokens/x")).status == 503
+
+    @pytest.mark.asyncio
+    async def test_rbac_and_host_routes_503(self, tmp_path):
+        bot = _make_bot(tmp_path, with_managers=False)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.get("/api/permissions/user/x")).status == 503
+            assert (await c.put("/api/permissions/user/x", json={"tier": "user"})).status == 503
+            assert (await c.delete("/api/permissions/user/x")).status == 503
+            assert (await c.put("/api/host-access/user/x", json={})).status == 503
+            assert (await c.delete("/api/host-access/user/x")).status == 503
+            assert (await c.put("/api/host-access/default-policy", json={})).status == 503
+
+    @pytest.mark.asyncio
+    async def test_update_token_host_validation(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        await bot.api_token_manager.create_token("svc", allowed_hosts=["alpha"],
+                                                 default_host="alpha")
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/tokens/svc",
+                                json={"tier": "wizard"})).status == 400
+            assert (await c.put("/api/tokens/svc",
+                                json={"allowed_tools": [1]})).status == 400
+            assert (await c.put("/api/tokens/svc",
+                                json={"allowed_hosts": [1]})).status == 400
+            assert (await c.put("/api/tokens/svc",
+                                json={"allowed_hosts": ["ghost"]})).status == 400
+            assert (await c.put("/api/tokens/svc",
+                                json={"default_host": "ghost"})).status == 400
+            assert (await c.put("/api/tokens/svc",
+                                json={"default_host": "beta"})).status == 400  # not in allowed
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_never_breaks_the_operation(self, tmp_path):
+        # A raising audit sink must not fail the permission/host change — the
+        # except-pass around every audit call is a resilience property.
+        bot = _make_bot(tmp_path)
+        bot.audit.log_event = AsyncMock(side_effect=RuntimeError("audit down"))
+        await bot.permissions.async_set_tier("u9", "guest")
+        await bot.host_access_manager.set_user("u9", ["alpha"], "alpha")
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/permissions/user/u9",
+                                json={"tier": "user"})).status == 200
+            assert (await c.delete("/api/permissions/user/u9")).status == 200
+            assert (await c.put("/api/host-access/user/u9",
+                                json={"allowed_hosts": ["alpha"]})).status == 200
+
+    @pytest.mark.asyncio
+    async def test_login_dev_mode_no_session_manager_500(self, tmp_path):
+        bot = _make_bot(tmp_path, auth_configured=False)
+        bot.api_token_manager = None
+        # no session_manager on the app → dev-mode login can't issue a session
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.post("/api/auth/login", json={"token": "x"})).status == 500
+
+    @pytest.mark.asyncio
+    async def test_regenerate_and_delete_trigger_session_teardown(self, tmp_path):
+        bot = _make_bot(tmp_path)
+        await bot.api_token_manager.create_token("svc")
+        sm = MagicMock()
+        ws = MagicMock()
+        ws.close_by_user_id = AsyncMock()
+        app = _app(bot)
+        app["session_manager"] = sm
+        app["ws_manager"] = ws
+        async with TestClient(TestServer(app)) as c:
+            assert (await c.post("/api/tokens/svc/regenerate")).status == 200
+            assert (await c.delete("/api/tokens/svc")).status == 200
+        sm.destroy_by_user_id.assert_called_with("svc")
+        ws.close_by_user_id.assert_awaited_with("svc")


### PR DESCRIPTION
The crown-jewel wave. The authorization boundary was running effectively untested; this closes that.

## Coverage movement (baseline ratcheted via ceremony — improved 5, decreased 0)

| File | Before | After |
|---|---|---|
| `permissions/token_manager.py` | 23% | **100%** |
| `permissions/host_access.py` | 39% | **100%** |
| `permissions/manager.py` | 81% | **100%** |
| `web/api/security.py` | 17% | **95%** |

Total repo coverage (reported): **66.8% → 68.6%**.

## What's driven

- **token_manager**: HMAC-safe `resolve`, full async CRUD, every `_load` validation branch, and the invariant that **raw tokens never hit disk or `list_tokens`** (only hash + 8-char prefix).
- **host_access**: the real enforcement matrix — `None`=inherit-all / `[]`=deny-all / whitelist, crossed with request-scoped contextvar narrowing — plus default-host resolution and persistence. This is the gate that live-proved playground-jailing on 2026-07-06.
- **manager**: request-tier precedence, async-lock CRUD, tier tool-filtering, corrupt-overrides fallback.
- **security.py routes**: RBAC / host-access / API-token / auth registrars through the **real aiohttp route layer** (per your advisory — faked boundaries, real managers), covering validation matrices, the admin gate (allow / deny non-admin / dev-mode), per-route 503 fallbacks, session+ws teardown on token revoke, and the resilience property that **a failing audit sink never breaks a permission change**.

## Ledger

**Empty.** No bugs surfaced — the authorization logic behaved exactly as the tests pinned correct behavior. For a security boundary, that silence is the good outcome.

## Verification

Suite **6,317 passed / 4 skipped** (+115) · ruff clean · mypy 0 · coverage gate green on the ratcheted baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3