### PR TITLE
RFC-006 P2: LLM credential paths — codex_auth 54→93, openai_codex 61→85

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -414,9 +414,9 @@
   "statements": 42
  },
  "src/llm/codex_auth.py": {
-  "covered": 217,
-  "missing": 185,
-  "percent": 53.98,
+  "covered": 375,
+  "missing": 27,
+  "percent": 93.28,
   "statements": 402
  },
  "src/llm/context_compressor.py": {
@@ -450,9 +450,9 @@
   "statements": 177
  },
  "src/llm/openai_codex.py": {
-  "covered": 272,
-  "missing": 172,
-  "percent": 61.26,
+  "covered": 379,
+  "missing": 65,
+  "percent": 85.36,
   "statements": 444
  },
  "src/llm/provider.py": {

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -1,0 +1,475 @@
+"""Coverage for CodexAuth / CodexAuthPool (RFC-006 P2 — credential paths ≥85%).
+
+This is the multi-account token-rotation subsystem whose single-use-refresh-
+token mishandling once killed all accounts on every restart. The tests drive
+the real token lifecycle and pool rotation against tmp files, faking only the
+aiohttp transport (aioresponses is incompatible with this aiohttp version).
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from src.llm import codex_auth as ca
+from src.llm.codex_auth import CodexAuth, CodexAuthPool
+
+
+def _jwt(payload: dict) -> str:
+    def _b64(d: bytes) -> str:
+        return base64.urlsafe_b64encode(d).rstrip(b"=").decode()
+    body = _b64(json.dumps(payload).encode())
+    return f"{_b64(b'{}')}.{body}.{_b64(b'sig')}"
+
+
+def _creds(access="tok", refresh="ref", expires_at=9_999_999_999, **extra):
+    return {"access_token": access, "refresh_token": refresh,
+            "expires_at": expires_at, **extra}
+
+
+class _FakeResp:
+    def __init__(self, status=200, body=b""):
+        self.status = status
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    """Records posts and returns a scripted response; fakes aiohttp.ClientSession."""
+
+    last = None
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def post(self, url, **kwargs):
+        _FakeSession.last = (url, kwargs)
+        return _FakeSession.response
+
+
+# ── module-level helpers ─────────────────────────────────────────────
+
+class TestModuleHelpers:
+    def test_atomic_write_is_0600(self, tmp_path):
+        p = tmp_path / "secret.json"
+        ca._atomic_write_secure(p, "data")
+        assert p.read_text() == "data"
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+    def test_generate_pkce_shapes(self):
+        verifier, challenge = ca._generate_pkce()
+        assert verifier and challenge and "=" not in verifier and "=" not in challenge
+
+    def test_decode_jwt_flattens_nested_claims(self):
+        token = _jwt({
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acct-1"},
+            "https://api.openai.com/profile": {"email": "a@b.co"},
+        })
+        payload = ca._decode_jwt_payload(token)
+        assert payload["chatgpt_account_id"] == "acct-1" and payload["email"] == "a@b.co"
+
+    def test_decode_jwt_malformed_returns_empty(self):
+        assert ca._decode_jwt_payload("not-a-jwt") == {}
+        assert ca._decode_jwt_payload(_jwt({}) .split(".")[0]) == {}  # single part
+
+
+# ── CodexAuth ────────────────────────────────────────────────────────
+
+class TestCodexAuthBasics:
+    def _auth(self, tmp_path, creds=None):
+        p = tmp_path / "creds.json"
+        if creds is not None:
+            p.write_text(json.dumps(creds))
+        return CodexAuth(str(p))
+
+    def test_is_configured_variants(self, tmp_path):
+        assert not self._auth(tmp_path).is_configured()
+        assert self._auth(tmp_path, _creds()).is_configured()
+        bad = tmp_path / "creds.json"
+        bad.write_text("{ broken")
+        assert not CodexAuth(str(bad)).is_configured()
+
+    def test_load_missing_raises(self, tmp_path):
+        with pytest.raises(RuntimeError, match="not found"):
+            self._auth(tmp_path)._load()
+
+    def test_save_invokes_on_save_and_swallows_errors(self, tmp_path):
+        seen = []
+        a = CodexAuth(str(tmp_path / "c.json"), on_save=lambda c: seen.append(c))
+        a._save(_creds(access="new"))
+        assert seen and seen[0]["access_token"] == "new"
+        # on_save that raises must not break _save
+        a2 = CodexAuth(str(tmp_path / "c2.json"),
+                       on_save=lambda c: (_ for _ in ()).throw(RuntimeError("boom")))
+        a2._save(_creds())  # no exception
+
+    def test_get_account_id(self, tmp_path):
+        assert self._auth(tmp_path, _creds(account_id="acct")).get_account_id() == "acct"
+
+    @pytest.mark.asyncio
+    async def test_get_access_token_fresh_no_refresh(self, tmp_path):
+        a = self._auth(tmp_path, _creds(access="fresh"))
+        assert await a.get_access_token() == "fresh"
+
+    @pytest.mark.asyncio
+    async def test_get_access_token_refreshes_when_expiring(self, tmp_path, monkeypatch):
+        a = self._auth(tmp_path, _creds(access="old", expires_at=0))
+        called = []
+
+        async def fake_refresh(creds):
+            a._credentials = _creds(access="refreshed")
+            called.append(True)
+        monkeypatch.setattr(a, "_refresh", fake_refresh)
+        assert await a.get_access_token() == "refreshed" and called
+
+    @pytest.mark.asyncio
+    async def test_invalidate_current_clears_cache(self, tmp_path):
+        a = self._auth(tmp_path, _creds())
+        a._load()
+        await a.invalidate_current()
+        assert a._credentials is None
+
+    @pytest.mark.asyncio
+    async def test_mark_current_auth_failed_single_is_false(self, tmp_path):
+        assert await self._auth(tmp_path, _creds()).mark_current_auth_failed() is False
+
+    def test_rate_limit_window(self, tmp_path):
+        a = self._auth(tmp_path, _creds())
+        assert not a.is_rate_limited()
+        a.mark_rate_limited(60)
+        assert a.is_rate_limited()
+
+    def test_build_auth_url(self):
+        url, verifier = CodexAuth.build_auth_url()
+        assert url.startswith("https://auth.openai.com/oauth/authorize?") and verifier
+
+
+class TestCodexAuthForceRefresh:
+    def _auth(self, tmp_path, creds):
+        p = tmp_path / "creds.json"
+        p.write_text(json.dumps(creds))
+        return CodexAuth(str(p))
+
+    @pytest.mark.asyncio
+    async def test_stale_token_mismatch_is_noop_success(self, tmp_path):
+        a = self._auth(tmp_path, _creds(access="current"))
+        assert await a.force_refresh(stale_token="a-different-old-token") is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_success(self, tmp_path, monkeypatch):
+        a = self._auth(tmp_path, _creds(access="current"))
+
+        async def ok(creds):
+            a._credentials = _creds(access="new")
+        monkeypatch.setattr(a, "_refresh", ok)
+        assert await a.force_refresh(stale_token="current") is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_returns_false(self, tmp_path, monkeypatch):
+        a = self._auth(tmp_path, _creds())
+
+        async def boom(creds):
+            raise RuntimeError("refresh failed")
+        monkeypatch.setattr(a, "_refresh", boom)
+        assert await a.force_refresh() is False
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_load_failure_false(self, tmp_path):
+        a = CodexAuth(str(tmp_path / "missing.json"))  # _load raises
+        assert await a.force_refresh() is False
+
+
+class TestRefreshTransport:
+    def _auth(self, tmp_path, creds):
+        p = tmp_path / "creds.json"
+        p.write_text(json.dumps(creds))
+        return CodexAuth(str(p))
+
+    @pytest.mark.asyncio
+    async def test_refresh_success_extracts_jwt_claims(self, tmp_path, monkeypatch):
+        token = _jwt({"chatgpt_account_id": "acct-9", "email": "x@y.z",
+                      "chatgpt_plan_type": "pro"})
+        _FakeSession.response = _FakeResp(
+            200, json.dumps({"access_token": token, "refresh_token": "r2",
+                             "expires_in": 3600}).encode())
+        monkeypatch.setattr(ca.aiohttp, "ClientSession", _FakeSession)
+        a = self._auth(tmp_path, _creds(label="acct-label"))
+        await a._refresh(a._load())
+        saved = json.loads((tmp_path / "creds.json").read_text())
+        assert saved["access_token"] == token and saved["account_id"] == "acct-9"
+        assert saved["email"] == "x@y.z" and saved["plan_type"] == "pro"
+        assert saved["label"] == "acct-label"  # preserved
+
+    @pytest.mark.asyncio
+    async def test_refresh_http_error_raises(self, tmp_path, monkeypatch):
+        _FakeSession.response = _FakeResp(400, b"bad")
+        monkeypatch.setattr(ca.aiohttp, "ClientSession", _FakeSession)
+        a = self._auth(tmp_path, _creds())
+        with pytest.raises(RuntimeError, match="refresh failed"):
+            await a._refresh(a._load())
+
+    @pytest.mark.asyncio
+    async def test_refresh_no_token_raises(self, tmp_path):
+        a = self._auth(tmp_path, {"access_token": "t", "expires_at": 0})  # no refresh_token
+        with pytest.raises(RuntimeError, match="No refresh token"):
+            await a._refresh(a._load())
+
+    @pytest.mark.asyncio
+    async def test_refresh_falls_back_to_old_claims(self, tmp_path, monkeypatch):
+        # New JWT carries no claims → account_id/email/plan_type fall back to
+        # the previously-stored creds (lines 239-250).
+        _FakeSession.response = _FakeResp(
+            200, json.dumps({"access_token": _jwt({}), "expires_in": 3600}).encode())
+        monkeypatch.setattr(ca.aiohttp, "ClientSession", _FakeSession)
+        a = self._auth(tmp_path, _creds(account_id="old-acct", email="old@e.co",
+                                        plan_type="pro"))
+        await a._refresh(a._load())
+        saved = json.loads((tmp_path / "creds.json").read_text())
+        assert saved["account_id"] == "old-acct" and saved["email"] == "old@e.co"
+        assert saved["plan_type"] == "pro"
+
+
+class TestOAuthTransport:
+    @pytest.mark.asyncio
+    async def test_exchange_code_success_and_error(self, tmp_path, monkeypatch):
+        token = _jwt({"chatgpt_account_id": "acct", "email": "e@x.co",
+                      "chatgpt_plan_type": "pro"})
+        _FakeSession.response = _FakeResp(
+            200, json.dumps({"access_token": token, "refresh_token": "r",
+                             "expires_in": 3600}).encode())
+        monkeypatch.setattr(ca.aiohttp, "ClientSession", _FakeSession)
+        creds = await CodexAuth.exchange_code("code", "verifier")
+        assert creds["account_id"] == "acct" and creds["refresh_token"] == "r"
+
+        _FakeSession.response = _FakeResp(400, b"denied")
+        with pytest.raises(RuntimeError, match="exchange failed"):
+            await CodexAuth.exchange_code("code", "verifier")
+
+    @pytest.mark.asyncio
+    async def test_request_device_code_success_and_error(self, tmp_path, monkeypatch):
+        _FakeSession.response = _FakeResp(
+            200, json.dumps({"device_auth_id": "dev-1", "user_code": "AB-CD",
+                             "interval": 3}).encode())
+        monkeypatch.setattr(ca.aiohttp, "ClientSession", _FakeSession)
+        out = await CodexAuth.request_device_code()
+        assert out["device_auth_id"] == "dev-1" and out["interval"] == 3
+
+        _FakeSession.response = _FakeResp(500, b"boom")
+        with pytest.raises(RuntimeError, match="Device code request failed"):
+            await CodexAuth.request_device_code()
+
+
+# ── CodexAuthPool ────────────────────────────────────────────────────
+
+class TestPoolInit:
+    def test_missing_file_empty_pool(self, tmp_path):
+        assert CodexAuthPool(str(tmp_path / "none.json")).account_count == 0
+
+    def test_corrupt_file_empty_pool(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text("{ broken")
+        assert CodexAuthPool(str(p)).account_count == 0
+
+    def test_single_object_format(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps(_creds()))
+        assert CodexAuthPool(str(p)).account_count == 1
+
+    def test_list_format_creates_shadows(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([_creds(access="a0", account_id="0"),
+                                 _creds(access="a1", account_id="1")]))
+        pool = CodexAuthPool(str(p))
+        assert pool.account_count == 2
+        assert (tmp_path / "codex_auth_0.json").exists()
+        assert (tmp_path / "codex_auth_1.json").exists()
+
+    def test_shadow_newer_wins_over_canonical(self, tmp_path):
+        # The outage-fix path: a rotated shadow (newer expires_at) must win, and
+        # the canonical file gets pulled up to match — never the reverse.
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([_creds(access="stale", account_id="0", expires_at=100)]))
+        shadow = tmp_path / "codex_auth_0.json"
+        shadow.write_text(json.dumps(_creds(access="rotated", account_id="0",
+                                            expires_at=999)))
+        pool = CodexAuthPool(str(p))
+        assert pool.account_count == 1
+        # canonical rewritten to the rotated creds
+        assert json.loads(p.read_text())[0]["access_token"] == "rotated"
+
+    def test_skips_invalid_entries(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps(["nope", {"no_token": 1}, _creds(account_id="ok")]))
+        assert CodexAuthPool(str(p)).account_count == 1
+
+    def test_stale_shadow_files_removed(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([_creds(account_id="0")]))
+        stale = tmp_path / "codex_auth_1.json"
+        stale.write_text("{}")
+        CodexAuthPool(str(p))
+        assert not stale.exists()
+
+
+class TestPoolRotation:
+    def _pool(self, tmp_path, n=2):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([
+            _creds(access=f"a{i}", account_id=str(i)) for i in range(n)]))
+        return CodexAuthPool(str(p))
+
+    @pytest.mark.asyncio
+    async def test_acquire_returns_healthy_token(self, tmp_path):
+        pool = self._pool(tmp_path)
+        token, acct, idx = await pool.acquire()
+        assert token == "a0" and idx == 0
+
+    @pytest.mark.asyncio
+    async def test_acquire_rotates_past_rate_limited(self, tmp_path):
+        pool = self._pool(tmp_path)
+        pool._accounts[0].mark_rate_limited(60)
+        token, _, idx = await pool.acquire()
+        assert token == "a1" and idx == 1
+
+    @pytest.mark.asyncio
+    async def test_acquire_all_rate_limited_raises(self, tmp_path):
+        pool = self._pool(tmp_path)
+        for a in pool._accounts:
+            a.mark_rate_limited(60)
+        with pytest.raises(RuntimeError, match="rate-limited or"):
+            await pool.acquire()
+
+    @pytest.mark.asyncio
+    async def test_acquire_all_failed_raises_with_errors(self, tmp_path, monkeypatch):
+        pool = self._pool(tmp_path)
+        for a in pool._accounts:
+            async def boom():
+                raise RuntimeError("token boom")
+            monkeypatch.setattr(a, "get_access_token", boom)
+        with pytest.raises(RuntimeError, match="accounts failed"):
+            await pool.acquire()
+
+    @pytest.mark.asyncio
+    async def test_get_access_token_delegates(self, tmp_path):
+        assert await self._pool(tmp_path).get_access_token() == "a0"
+
+    @pytest.mark.asyncio
+    async def test_token_for_index_and_out_of_range(self, tmp_path):
+        pool = self._pool(tmp_path)
+        tok, acct = await pool.token_for(1)
+        assert tok == "a1" and acct == "1"
+        with pytest.raises(RuntimeError, match="out of range"):
+            await pool.token_for(99)
+
+    @pytest.mark.asyncio
+    async def test_mark_limited_rotates_when_current(self, tmp_path):
+        pool = self._pool(tmp_path)
+        await pool.mark_current_limited()
+        assert pool._current_index == 1
+
+    @pytest.mark.asyncio
+    async def test_mark_limited_out_of_range_noop(self, tmp_path):
+        pool = self._pool(tmp_path)
+        await pool.mark_limited(99)  # no raise
+        assert pool._current_index == 0
+
+    @pytest.mark.asyncio
+    async def test_mark_auth_failed_rotates_and_backs_off(self, tmp_path):
+        pool = self._pool(tmp_path)
+        assert await pool.mark_current_auth_failed() is True
+        assert pool._current_index == 1
+        assert pool._accounts[0].is_rate_limited()  # long backoff set
+
+    @pytest.mark.asyncio
+    async def test_mark_auth_failed_single_account_false(self, tmp_path):
+        pool = self._pool(tmp_path, n=1)
+        assert await pool.mark_current_auth_failed() is False
+
+    @pytest.mark.asyncio
+    async def test_invalidate_current(self, tmp_path):
+        pool = self._pool(tmp_path)
+        pool._accounts[0]._load()
+        await pool.invalidate_current()
+        assert pool._accounts[0]._credentials is None
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_delegates(self, tmp_path, monkeypatch):
+        pool = self._pool(tmp_path)
+
+        async def ok(stale):
+            return True
+        monkeypatch.setattr(pool._accounts[0], "force_refresh", ok)
+        assert await pool.force_refresh(0) is True
+        assert await pool.force_refresh(99) is False
+
+    @pytest.mark.asyncio
+    async def test_set_active_and_out_of_range(self, tmp_path):
+        pool = self._pool(tmp_path)
+        await pool.set_active(1)
+        assert pool._current_index == 1
+        with pytest.raises(ValueError, match="out of range"):
+            await pool.set_active(99)
+
+    def test_current_and_account_id(self, tmp_path):
+        pool = self._pool(tmp_path)
+        assert pool.current is pool._accounts[0]
+        assert pool.get_account_id() == "0"
+        assert pool.is_configured()
+
+    def test_current_empty_raises(self, tmp_path):
+        pool = CodexAuthPool(str(tmp_path / "none.json"))
+        assert pool.get_account_id() is None
+        with pytest.raises(RuntimeError, match="No Codex"):
+            _ = pool.current
+
+    @pytest.mark.asyncio
+    async def test_reload_sync_and_async(self, tmp_path):
+        pool = self._pool(tmp_path, n=2)
+        pool.reload()
+        assert pool.account_count == 2
+        assert await pool.reload_async() == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_pool_ops_are_safe_noops(self, tmp_path):
+        pool = CodexAuthPool(str(tmp_path / "none.json"))
+        await pool.mark_current_limited()
+        await pool.mark_limited(0)
+        await pool.invalidate_current()
+        assert await pool.mark_current_auth_failed() is False
+        assert await pool.mark_auth_failed(0) is False
+        assert await pool.force_refresh(0) is False
+
+    def test_canonical_sync_mirrors_to_canonical_file(self, tmp_path):
+        # A per-account _save() must mirror back into the canonical list file
+        # (the on_save hook wired at init) — the mechanism that keeps single-use
+        # refresh tokens consistent across restarts.
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([_creds(access="a0", account_id="0"),
+                                 _creds(access="a1", account_id="1")]))
+        pool = CodexAuthPool(str(p))
+        pool._accounts[1]._save(_creds(access="rotated", account_id="1"))
+        assert json.loads(p.read_text())[1]["access_token"] == "rotated"
+
+    def test_canonical_sync_ignores_out_of_range(self, tmp_path):
+        # If the canonical file shrank, an index past its end is a safe no-op.
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([_creds(account_id="0")]))
+        pool = CodexAuthPool(str(p))
+        sync = pool._canonical_sync(5)  # index beyond the 1-entry file
+        sync(_creds(access="x"))  # no raise, no write
+        assert len(json.loads(p.read_text())) == 1

--- a/tests/test_openai_codex_client.py
+++ b/tests/test_openai_codex_client.py
@@ -1,0 +1,354 @@
+"""Coverage for CodexChatClient conversion + auth adapters (RFC-006 P2 ≥85%).
+
+Targets the pure request/response converters (internal → Codex Responses API
+format), token estimation, the tool-cache, and the CodexAuthPool-vs-bare-auth
+adapter branches. Network streaming is exercised separately where cheap.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.llm.openai_codex import CodexChatClient
+
+
+class _BareAuth:
+    """Minimal single-account auth (not a CodexAuthPool)."""
+
+    def __init__(self):
+        self.marked = False
+        self.refreshed = False
+
+    async def get_access_token(self):
+        return "tok"
+
+    def get_account_id(self):
+        return "acct"
+
+    def mark_rate_limited(self):
+        self.marked = True
+
+    async def mark_current_auth_failed(self):
+        return False
+
+    async def force_refresh(self, stale):
+        self.refreshed = True
+        return True
+
+
+def _client(auth=None):
+    return CodexChatClient(auth=auth or _BareAuth(), model="gpt-5.5", max_tokens=1000)
+
+
+class TestConvertMessages:
+    def test_plain_string_roles(self):
+        c = _client()
+        out = c._convert_messages([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "yo"},
+        ])
+        assert out[0]["content"][0]["type"] == "input_text"
+        assert out[1]["content"][0]["type"] == "output_text"
+
+    def test_unknown_role_maps_to_user(self):
+        out = _client()._convert_messages([{"role": "tool", "content": "x"}])
+        assert out[0]["role"] == "user"
+
+    def test_list_content_text_and_tool_blocks(self):
+        out = _client()._convert_messages([{"role": "user", "content": [
+            {"type": "text", "text": "hello"},
+            {"type": "tool_use", "name": "grep"},
+            {"type": "tool_result", "content": "found it"},
+        ]}])
+        joined = out[0]["content"][0]["text"]
+        assert "hello" in joined and "[Used tool: grep]" in joined
+        assert "[Tool result: found it]" in joined
+
+    def test_tool_result_list_content_summarized(self):
+        out = _client()._convert_messages([{"role": "user", "content": [
+            {"type": "tool_result", "content": [{"type": "text", "text": "abc"}]},
+        ]}])
+        assert "[Tool result: abc]" in out[0]["content"][0]["text"]
+
+    def test_image_block_builds_multimodal(self):
+        out = _client()._convert_messages([{"role": "user", "content": [
+            {"type": "text", "text": "look"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png",
+                                         "data": "AAAA"}},
+        ]}])
+        types = [b["type"] for b in out[0]["content"]]
+        assert "input_text" in types and "input_image" in types
+
+    def test_empty_and_non_str_skipped(self):
+        out = _client()._convert_messages([
+            {"role": "user", "content": []},          # empty list → skip
+            {"role": "user", "content": 12345},       # non-str/list → skip
+            {"role": "user", "content": "kept"},
+        ])
+        assert len(out) == 1 and out[0]["content"][0]["text"] == "kept"
+
+
+class TestConvertMessagesWithTools:
+    def test_string_content(self):
+        out = _client()._convert_messages_with_tools([{"role": "user", "content": "hi"}])
+        assert out[0]["type"] == "message" and out[0]["content"][0]["type"] == "input_text"
+
+    def test_tool_use_flushes_text_and_builds_function_call(self):
+        out = _client()._convert_messages_with_tools([{"role": "assistant", "content": [
+            {"type": "text", "text": "thinking"},
+            {"type": "tool_use", "id": "call-1", "name": "grep", "input": {"q": "x"}},
+        ]}])
+        assert out[0]["type"] == "message"  # flushed text
+        assert out[1]["type"] == "function_call" and out[1]["call_id"] == "call-1"
+        assert json.loads(out[1]["arguments"]) == {"q": "x"}
+
+    def test_tool_result_becomes_function_output(self):
+        out = _client()._convert_messages_with_tools([{"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "call-1", "content": "done"},
+        ]}])
+        assert out[0]["type"] == "function_call_output"
+        assert out[0]["call_id"] == "call-1" and out[0]["output"] == "done"
+
+    def test_tool_result_list_and_nonstring_content(self):
+        out = _client()._convert_messages_with_tools([{"role": "user", "content": [
+            {"type": "tool_result", "content": [{"type": "text", "text": "a"},
+                                                {"type": "text", "text": "b"}]},
+        ]}])
+        assert out[0]["output"] == "a b"
+        out2 = _client()._convert_messages_with_tools([{"role": "user", "content": [
+            {"type": "tool_result", "content": {"weird": 1}},
+        ]}])
+        assert "weird" in out2[0]["output"]
+
+    def test_image_block(self):
+        out = _client()._convert_messages_with_tools([{"role": "user", "content": [
+            {"type": "image", "source": {"type": "base64", "data": "ZZ"}},
+        ]}])
+        assert out[0]["content"][0]["type"] == "input_image"
+
+    def test_non_dict_block_and_non_list_content_skipped(self):
+        out = _client()._convert_messages_with_tools([
+            {"role": "user", "content": ["not-a-dict-block"]},
+            {"role": "user", "content": 999},
+            {"role": "user", "content": ""},
+        ])
+        assert out == []
+
+
+class TestToolsAndEstimation:
+    def test_convert_tools_format(self):
+        out = CodexChatClient._convert_tools([
+            {"name": "grep", "description": "search", "input_schema": {"type": "object"}}])
+        assert out[0] == {"type": "function", "name": "grep", "description": "search",
+                          "parameters": {"type": "object"}}
+
+    def test_convert_tools_defaults(self):
+        out = CodexChatClient._convert_tools([{"name": "bare"}])
+        assert out[0]["parameters"] == {"type": "object", "properties": {}}
+
+    def test_convert_tools_cached_identity(self):
+        c = _client()
+        tools = [{"name": "t"}]
+        first = c._convert_tools_cached(tools)
+        assert c._convert_tools_cached(tools) is first  # cache hit, same object
+        assert c._convert_tools_cached([{"name": "t"}]) is not first  # new list → reconvert
+
+    def test_estimate_body_input_tokens(self):
+        body = {"instructions": "sys", "input": [
+            {"content": [{"text": "hello"}], "arguments": "args", "output": "out"}]}
+        assert CodexChatClient._estimate_body_input_tokens(body) >= 1
+        assert CodexChatClient._estimate_body_input_tokens({}) == 1
+
+
+class TestMetadataAndHeaders:
+    def test_provider_and_model(self):
+        c = _client()
+        assert c.provider_name == "codex" and c.model_name == "gpt-5.5"
+
+    def test_auth_headers_with_and_without_account(self):
+        h = CodexChatClient._auth_headers("t", "acct")
+        assert h["Authorization"] == "Bearer t" and h["ChatGPT-Account-Id"] == "acct"
+        assert "ChatGPT-Account-Id" not in CodexChatClient._auth_headers("t", None)
+
+    def test_pool_metrics_no_session(self):
+        m = _client().get_pool_metrics()
+        assert m["http_pool_active_connections"] == 0
+        assert m["http_pool_max_connections"] == 10
+        assert _client().pool_stats()["http_pool_total_requests"] == 0
+
+    @pytest.mark.asyncio
+    async def test_close_without_session_is_safe(self):
+        await _client().close()  # no session → no error
+
+
+class _FakeContent:
+    """Async byte-line iterator standing in for resp.content."""
+
+    def __init__(self, lines):
+        self._lines = [ln.encode() if isinstance(ln, str) else ln for ln in lines]
+
+    def __aiter__(self):
+        async def gen():
+            for ln in self._lines:
+                yield ln
+        return gen()
+
+
+class _FakeResp:
+    def __init__(self, lines):
+        self.content = _FakeContent(lines)
+
+
+def _sse(event: dict) -> str:
+    return f"data: {json.dumps(event)}"
+
+
+class TestReadStream:
+    @pytest.mark.asyncio
+    async def test_deltas_concatenated(self):
+        resp = _FakeResp([
+            _sse({"type": "response.output_text.delta", "delta": "hel"}),
+            _sse({"type": "response.output_text.delta", "delta": "lo"}),
+            "data: [DONE]",
+        ])
+        assert await _client()._read_stream(resp) == "hello"
+
+    @pytest.mark.asyncio
+    async def test_done_text_used_when_no_deltas(self):
+        resp = _FakeResp([_sse({"type": "response.output_text.done", "text": "final"})])
+        assert await _client()._read_stream(resp) == "final"
+
+    @pytest.mark.asyncio
+    async def test_completed_fallback_and_ignored_noise(self):
+        resp = _FakeResp([
+            "ignored non-data line",
+            "data: not-json",
+            _sse({"type": "response.completed", "response": {"output": [
+                {"type": "message", "content": [{"text": "from-completed"}]}]}}),
+        ])
+        assert await _client()._read_stream(resp) == "from-completed"
+
+    @pytest.mark.asyncio
+    async def test_failed_event_raises(self):
+        from src.llm.openai_codex import CodexStreamError
+        resp = _FakeResp([_sse({"type": "response.failed", "error": "quota"})])
+        with pytest.raises(CodexStreamError, match="response.failed"):
+            await _client()._read_stream(resp)
+
+    @pytest.mark.asyncio
+    async def test_incomplete_returns_partial(self):
+        resp = _FakeResp([
+            _sse({"type": "response.output_text.delta", "delta": "partial"}),
+            _sse({"type": "response.incomplete",
+                  "response": {"incomplete_details": {"reason": "max_tokens"}}}),
+        ])
+        assert await _client()._read_stream(resp) == "partial"
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_returns_empty(self):
+        assert await _client()._read_stream(_FakeResp([])) == ""
+
+
+class TestReadToolStream:
+    @pytest.mark.asyncio
+    async def test_streamed_function_call(self):
+        resp = _FakeResp([
+            _sse({"type": "response.output_item.added", "output_index": 0,
+                  "item": {"type": "function_call", "call_id": "c1", "name": "grep"}}),
+            _sse({"type": "response.function_call_arguments.delta",
+                  "output_index": 0, "delta": '{"q":'}),
+            _sse({"type": "response.function_call_arguments.delta",
+                  "output_index": 0, "delta": '"x"}'}),
+            _sse({"type": "response.function_call_arguments.done", "output_index": 0}),
+        ])
+        out = await _client()._read_tool_stream(resp)
+        assert out.stop_reason == "tool_use"
+        assert out.tool_calls[0].name == "grep" and out.tool_calls[0].input == {"q": "x"}
+
+    @pytest.mark.asyncio
+    async def test_text_only_is_end_turn(self):
+        resp = _FakeResp([_sse({"type": "response.output_text.delta", "delta": "hi"})])
+        out = await _client()._read_tool_stream(resp)
+        assert out.text == "hi" and out.stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_malformed_args_flagged(self):
+        resp = _FakeResp([
+            _sse({"type": "response.output_item.added", "output_index": 0,
+                  "item": {"type": "function_call", "call_id": "c1", "name": "grep"}}),
+            _sse({"type": "response.function_call_arguments.delta",
+                  "output_index": 0, "delta": "{not json"}),
+            _sse({"type": "response.function_call_arguments.done", "output_index": 0}),
+        ])
+        out = await _client()._read_tool_stream(resp)
+        assert out.tool_calls[0].parse_error and "malformed" in out.tool_calls[0].parse_error
+
+    @pytest.mark.asyncio
+    async def test_output_item_done_finalizes_unstreamed_call(self):
+        resp = _FakeResp([
+            _sse({"type": "response.output_item.added", "output_index": 0,
+                  "item": {"type": "function_call", "call_id": "c2", "name": "ls"}}),
+            _sse({"type": "response.output_item.done", "output_index": 0,
+                  "item": {"type": "function_call", "arguments": '{"path":"/"}'}}),
+        ])
+        out = await _client()._read_tool_stream(resp)
+        assert out.tool_calls[0].id == "c2" and out.tool_calls[0].input == {"path": "/"}
+
+    @pytest.mark.asyncio
+    async def test_completed_fallback_function_call(self):
+        resp = _FakeResp([
+            _sse({"type": "response.completed", "response": {"output": [
+                {"type": "function_call", "call_id": "c3", "name": "cat",
+                 "arguments": '{"f":"x"}'}]}}),
+        ])
+        out = await _client()._read_tool_stream(resp)
+        assert out.tool_calls[0].id == "c3" and out.tool_calls[0].name == "cat"
+
+    @pytest.mark.asyncio
+    async def test_tool_stream_failed_raises(self):
+        from src.llm.openai_codex import CodexStreamError
+        resp = _FakeResp([_sse({"type": "error", "message": "boom"})])
+        with pytest.raises(CodexStreamError):
+            await _client()._read_tool_stream(resp)
+
+    @pytest.mark.asyncio
+    async def test_tool_stream_incomplete_reason(self):
+        resp = _FakeResp([
+            _sse({"type": "response.output_text.delta", "delta": "part"}),
+            _sse({"type": "response.incomplete", "response": {}}),
+        ])
+        out = await _client()._read_tool_stream(resp)
+        assert out.stop_reason == "incomplete" and out.text == "part"
+
+
+class TestAuthAdapters:
+    @pytest.mark.asyncio
+    async def test_bare_auth_adapters(self):
+        auth = _BareAuth()
+        c = _client(auth)
+        assert await c._acquire_auth() == ("tok", "acct", 0)
+        assert await c._token_for(0) == ("tok", "acct")
+        await c._mark_limited(0)
+        assert auth.marked
+        assert await c._mark_auth_failed(0) is False
+        assert await c._force_refresh(0, "stale") is True and auth.refreshed
+
+    @pytest.mark.asyncio
+    async def test_pool_auth_adapters(self, tmp_path):
+        from src.llm.codex_auth import CodexAuthPool
+
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([
+            {"access_token": "a0", "refresh_token": "r", "expires_at": 9_999_999_999,
+             "account_id": "0"},
+            {"access_token": "a1", "refresh_token": "r", "expires_at": 9_999_999_999,
+             "account_id": "1"},
+        ]))
+        c = _client(CodexAuthPool(str(p)))
+        token, acct, idx = await c._acquire_auth()
+        assert token == "a0" and idx == 0
+        tok1, _ = await c._token_for(1)
+        assert tok1 == "a1"
+        await c._mark_limited(0)  # marks account 0
+        assert await c._mark_auth_failed(1) is True  # rotate off, other available


### PR DESCRIPTION
The security-adjacent wave — the token-rotation subsystem that caused the June outages, and the provider that consumes it.

## Coverage movement (ceremony: improved 3, decreased 0)

| File | Before | After |
|---|---|---|
| `llm/codex_auth.py` | 54% | **93%** |
| `llm/openai_codex.py` | 61% | **85%** |

Total repo coverage (reported): **68.6% → 69.6%**.

## What's driven

- **codex_auth**: the full CodexAuth token lifecycle (load/save/on-save propagation, refresh-on-expiry, force_refresh stale/success/fail), the `_refresh` transport with faked aiohttp (JWT claim extraction + old-claim fallback, HTTP error, missing-token), OAuth exchange + device-code. And the crown: **CodexAuthPool** — the shadow-vs-canonical "newest wins" `_init_accounts` that *is* the outage fix, round-robin `acquire` with rate-limit rotation and all-failed/all-limited surfacing, `mark_auth_failed` backoff, the `_canonical_sync` mirror, every empty-pool guard.
- **openai_codex**: the internal→Responses-API message/tool converters (text/image/tool_use/tool_result, role mapping, multimodal), token estimation, identity-cached tool conversion, the pool-vs-bare auth adapters, and **both SSE stream readers through a fake byte-line response** — deltas, done-text, completed fallback, terminal-failure raise, incomplete-partial, and full function-call assembly (streamed args, malformed-JSON flagging, `output_item.done` finalize, completed-event fallback).

## Ledger

**Empty.** No bugs — the rotation and streaming logic behaved exactly as pinned. The June-outage fix in `_init_accounts` holds up under direct test.

## Reviewer note

`process_manager.py` baseline set to `missing=21` (its stable full-suite value; a P1 regen had captured a luckier 17-miss run). The lines are stable error-handler branches — not environment-sensitive — and the missing-count **ceiling** tolerates better runs, so this is the conservative (safe) direction. Flagging it explicitly per the store.py lesson.

## Verification

Suite **6,402 passed / 4 skipped** (+85) · ruff clean · mypy 0 · coverage gate green on the ratcheted baseline (self-consistent across 3 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3