### PR TITLE
RFC-006 P3: core singles — skill_manager 28→78, handlers/state 21→93

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -960,9 +960,9 @@
   "statements": 109
  },
  "src/tools/handlers/state.py": {
-  "covered": 62,
-  "missing": 239,
-  "percent": 20.6,
+  "covered": 281,
+  "missing": 20,
+  "percent": 93.36,
   "statements": 301
  },
  "src/tools/handlers/system.py": {
@@ -1038,15 +1038,15 @@
   "statements": 165
  },
  "src/tools/skill_context.py": {
-  "covered": 76,
-  "missing": 132,
-  "percent": 36.54,
+  "covered": 88,
+  "missing": 120,
+  "percent": 42.31,
   "statements": 208
  },
  "src/tools/skill_manager.py": {
-  "covered": 199,
-  "missing": 511,
-  "percent": 28.03,
+  "covered": 553,
+  "missing": 157,
+  "percent": 77.89,
   "statements": 710
  },
  "src/tools/ssh.py": {

--- a/tests/test_skill_manager_coverage.py
+++ b/tests/test_skill_manager_coverage.py
@@ -1,0 +1,324 @@
+"""Coverage for skill_manager (RFC-006 P3 — 28→75%).
+
+Two layers: the module-level pure helpers (dependency-safety guard against
+pip-install RCE, config-schema validation, static AST extractors) and the
+SkillManager lifecycle (create/edit/delete/enable/disable/config/validate)
+against a tmp skills dir with a mock executor.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.tools.skill_manager import (
+    SkillManager,
+    SkillMetadata,
+    _extract_dependencies_from_source,
+    _extract_skill_name_from_source,
+    _parse_package_name,
+    apply_defaults,
+    is_safe_dependency_spec,
+    validate_config,
+    validate_config_value,
+)
+
+
+def _skill_code(name="demo", deps=None, description="a demo skill", config_schema=None):
+    defn = {
+        "name": name,
+        "description": description,
+        "input_schema": {"type": "object", "properties": {}},
+    }
+    if deps is not None:
+        defn["dependencies"] = deps
+    if config_schema is not None:
+        defn["config_schema"] = config_schema
+    return (
+        f"SKILL_DEFINITION = {defn!r}\n\n"
+        "async def execute(inp, context):\n"
+        "    return 'ok'\n"
+    )
+
+
+# ── dependency-safety guard (security-critical) ──────────────────────
+
+class TestIsSafeDependencySpec:
+    @pytest.mark.parametrize("spec", [
+        "requests", "requests>=2.0", "Pillow[jpeg]", "numpy==1.26.0", "pkg~=1.2",
+    ])
+    def test_safe_specs_allowed(self, spec):
+        assert is_safe_dependency_spec(spec) is True
+
+    @pytest.mark.parametrize("spec", [
+        "",                                      # empty
+        "pkg @ https://evil/x.tar.gz",           # PEP 508 direct ref
+        "git+https://github.com/x/y",            # VCS
+        "https://evil/pkg.tar.gz",               # bare URL
+        "./local/path",                          # local path
+        "-e .",                                  # pip option
+        "pkg; os.system('rm -rf /')",            # env marker / chaining
+        "pkg with space",                        # whitespace
+        "..\\..\\evil",                          # backslash path
+    ])
+    def test_unsafe_specs_rejected(self, spec):
+        assert is_safe_dependency_spec(spec) is False
+
+    def test_parse_package_name(self):
+        assert _parse_package_name("requests>=2.0") == "requests"
+        assert _parse_package_name("Pillow[jpeg]") == "Pillow"
+        assert _parse_package_name("@bad") == ""
+
+
+# ── config-schema validation ─────────────────────────────────────────
+
+class TestConfigValidation:
+    def test_type_checks(self):
+        assert validate_config_value("f", {"type": "string"}, 5) is not None
+        assert validate_config_value("f", {"type": "integer"}, True) is not None  # bool≠int
+        assert validate_config_value("f", {"type": "number"}, "x") is not None
+        assert validate_config_value("f", {"type": "boolean"}, 1) is not None
+        assert validate_config_value("f", {"type": "string"}, "ok") is None
+
+    def test_enum_constraint(self):
+        schema = {"type": "string", "enum": ["a", "b"]}
+        assert validate_config_value("f", schema, "c") is not None
+        assert validate_config_value("f", schema, "a") is None
+
+    def test_numeric_bounds(self):
+        schema = {"type": "integer", "minimum": 1, "maximum": 10}
+        assert validate_config_value("f", schema, 0) is not None
+        assert validate_config_value("f", schema, 11) is not None
+        assert validate_config_value("f", schema, 5) is None
+
+    def test_string_length_bounds(self):
+        schema = {"type": "string", "minLength": 2, "maxLength": 4}
+        assert validate_config_value("f", schema, "x") is not None
+        assert validate_config_value("f", schema, "toolong") is not None
+        assert validate_config_value("f", schema, "ok") is None
+
+    def test_validate_config_required_and_unknown(self):
+        schema = {"properties": {"a": {"type": "string"}}, "required": ["a", "b"]}
+        errs = validate_config(schema, {"a": "x", "c": 1})
+        assert any("Missing required field 'b'" in e for e in errs)
+        assert any("Unknown field 'c'" in e for e in errs)
+
+    def test_required_with_default_not_flagged(self):
+        schema = {"properties": {"a": {"type": "string", "default": "d"}}, "required": ["a"]}
+        assert validate_config(schema, {}) == []
+
+    def test_apply_defaults(self):
+        schema = {"properties": {"a": {"default": 1}, "b": {"default": 2}}}
+        assert apply_defaults(schema, {"b": 9}) == {"a": 1, "b": 9}
+
+
+# ── static AST extractors ────────────────────────────────────────────
+
+class TestAstExtractors:
+    def test_extract_name(self):
+        assert _extract_skill_name_from_source(_skill_code("mine")) == "mine"
+
+    def test_extract_dependencies(self):
+        code = _skill_code(deps=["requests", "numpy"])
+        assert _extract_dependencies_from_source(code) == ["requests", "numpy"]
+
+    def test_extract_from_syntax_error_is_empty(self):
+        assert _extract_skill_name_from_source("def (:::") == ""
+        assert _extract_dependencies_from_source("def (:::") == []
+
+    def test_extract_missing_definition(self):
+        assert _extract_skill_name_from_source("X = 1") == ""
+        assert _extract_dependencies_from_source("X = 1") == []
+
+
+# ── SkillMetadata ────────────────────────────────────────────────────
+
+class TestSkillMetadata:
+    def test_from_valid_definition(self):
+        meta, diags = SkillMetadata.from_definition({
+            "name": "demo", "version": "1.2.3", "author": "aaron",
+            "tags": ["util"], "dependencies": ["requests"],
+        })
+        assert meta.version == "1.2.3" and meta.tags == ["util"]
+        assert meta.dependencies == ["requests"]
+        assert not any(d.level == "error" for d in diags)
+
+    def test_bad_field_types_produce_warnings(self):
+        meta, diags = SkillMetadata.from_definition({
+            "version": 123, "author": [], "tags": "notalist",
+        })
+        # bad types are ignored with warnings, defaults kept
+        assert meta.version == "0.0.0"
+        assert any(d.level == "warn" for d in diags)
+
+
+# ── SkillManager lifecycle ───────────────────────────────────────────
+
+@pytest.fixture
+def manager(tmp_path):
+    return SkillManager(str(tmp_path / "skills"), tool_executor=MagicMock())
+
+
+class TestSkillManagerLifecycle:
+    def test_create_show_and_duplicate(self, manager):
+        assert "created and loaded" in manager.create_skill("demo", _skill_code("demo"))
+        assert manager.has_skill("demo")
+        assert "already exists" in manager.create_skill("demo", _skill_code("demo"))
+
+    def test_create_name_mismatch_rejected(self, manager):
+        # SKILL_DEFINITION.name must match the filename
+        out = manager.create_skill("wrongfile", _skill_code("realname"))
+        assert "doesn't match filename" in out
+        assert not manager.has_skill("wrongfile")
+
+    def test_create_broken_code_rejected(self, manager):
+        out = manager.create_skill("broken", "def (:::")
+        assert "failed to load" in out
+
+    def test_edit_reloads(self, manager):
+        manager.create_skill("demo", _skill_code("demo", description="v1"))
+        out = manager.edit_skill("demo", _skill_code("demo", description="v2"))
+        assert "updated and reloaded" in out
+
+    def test_edit_missing(self, manager):
+        assert "not found" in manager.edit_skill("ghost", _skill_code("ghost"))
+
+    def test_edit_broken_reverts(self, manager):
+        manager.create_skill("demo", _skill_code("demo"))
+        out = manager.edit_skill("demo", "def (:::")
+        assert "Reverted" in out and manager.has_skill("demo")  # still usable
+
+    def test_enable_disable_lifecycle(self, manager):
+        manager.create_skill("demo", _skill_code("demo"))
+        assert manager.is_enabled("demo")
+        assert "disabled" in manager.disable_skill("demo")
+        assert not manager.is_enabled("demo")
+        assert "already disabled" in manager.disable_skill("demo")
+        assert "enabled" in manager.enable_skill("demo")
+        assert "already enabled" in manager.enable_skill("demo")
+
+    def test_disable_survives_reload(self, tmp_path):
+        d = str(tmp_path / "skills")
+        m1 = SkillManager(d, tool_executor=MagicMock())
+        m1.create_skill("demo", _skill_code("demo"))
+        m1.disable_skill("demo")
+        # A fresh manager reads the persisted .disabled.json
+        m2 = SkillManager(d, tool_executor=MagicMock())
+        assert not m2.is_enabled("demo")
+
+    def test_delete(self, manager):
+        manager.create_skill("demo", _skill_code("demo"))
+        assert "deleted" in manager.delete_skill("demo")
+        assert not manager.has_skill("demo")
+        assert "not found" in manager.delete_skill("demo")
+
+    def test_invalid_name_rejected(self, manager):
+        assert manager.create_skill("bad name!", _skill_code("bad name!")) != ""
+        assert not manager.has_skill("bad name!")
+
+    def test_list_skills_and_get_info(self, manager):
+        manager.create_skill("demo", _skill_code("demo"))
+        listed = manager.list_skills()
+        assert any(s["name"] == "demo" for s in listed)
+        info = manager.get_skill_info("demo")
+        assert info and info["name"] == "demo"
+        assert manager.get_skill_info("ghost") is None
+
+    def test_get_tool_definitions_excludes_disabled(self, manager):
+        manager.create_skill("demo", _skill_code("demo"))
+        assert any(t["name"] == "demo" for t in manager.get_tool_definitions())
+        manager.disable_skill("demo")
+        assert not any(t["name"] == "demo" for t in manager.get_tool_definitions())
+
+
+class TestSkillConfig:
+    _SCHEMA = {"type": "object",
+               "properties": {"level": {"type": "integer", "default": 1}}}
+
+    def test_set_and_get_config(self, tmp_path):
+        m = SkillManager(str(tmp_path / "skills"), tool_executor=MagicMock())
+        m.create_skill("demo", _skill_code("demo", config_schema=self._SCHEMA))
+        assert m.set_skill_config("demo", {"level": 5}) == []
+        assert m.get_skill_config("demo")["level"] == 5
+
+    def test_set_config_validation_error(self, tmp_path):
+        m = SkillManager(str(tmp_path / "skills"), tool_executor=MagicMock())
+        m.create_skill("demo", _skill_code("demo", config_schema=self._SCHEMA))
+        errs = m.set_skill_config("demo", {"level": "not-an-int"})
+        assert errs and any("integer" in e for e in errs)
+
+
+class TestExecuteExportStatus:
+    @pytest.mark.asyncio
+    async def test_execute_runs_skill(self, manager):
+        code = ("SKILL_DEFINITION = {'name': 'echo', 'description': 'd', "
+                "'input_schema': {'type': 'object', 'properties': {}}}\n"
+                "async def execute(inp, context):\n"
+                "    return f\"got {inp.get('x')}\"\n")
+        manager.create_skill("echo", code)
+        assert await manager.execute("echo", {"x": 42}) == "got 42"
+
+    @pytest.mark.asyncio
+    async def test_execute_missing_and_disabled(self, manager):
+        assert "not found" in await manager.execute("ghost", {})
+        manager.create_skill("demo", _skill_code("demo"))
+        manager.disable_skill("demo")
+        assert "disabled" in await manager.execute("demo", {})
+
+    @pytest.mark.asyncio
+    async def test_execute_error_is_caught(self, manager):
+        code = ("SKILL_DEFINITION = {'name': 'boom', 'description': 'd', "
+                "'input_schema': {'type': 'object', 'properties': {}}}\n"
+                "async def execute(inp, context):\n"
+                "    raise ValueError('kaboom')\n")
+        manager.create_skill("boom", code)
+        out = await manager.execute("boom", {})
+        assert "Skill error" in out and "kaboom" in out
+        # stats recorded even on error
+        assert manager._skills["boom"].total_executions == 1
+
+    def test_export_skill(self, manager):
+        manager.create_skill("demo", _skill_code("demo"))
+        result = manager.export_skill("demo")
+        assert isinstance(result, tuple)
+        blob, fname = result
+        assert b"SKILL_DEFINITION" in blob and fname == "demo.py"
+        assert "not found" in manager.export_skill("ghost")
+
+    def test_skill_status_report(self, manager):
+        manager.create_skill("demo", _skill_code("demo", description="a demo skill"))
+        status = manager.skill_status("demo")
+        assert "Skill: demo" in status and "a demo skill" in status
+        assert "not found" in manager.skill_status("ghost")
+
+    def test_check_dependencies(self, manager):
+        # A skill declaring an already-installed dep reports it satisfied.
+        manager.create_skill("dep", _skill_code("dep", deps=["pytest"]))
+        result = manager.check_dependencies("dep")
+        assert isinstance(result, dict)
+
+
+class TestValidateSkillCode:
+    def _mgr(self, tmp_path):
+        return SkillManager(str(tmp_path / "skills"), tool_executor=MagicMock())
+
+    def test_valid_code_passes(self, tmp_path):
+        res = self._mgr(tmp_path).validate_skill_code(_skill_code("demo"))
+        assert res["valid"] is True
+
+    def test_missing_execute_flagged(self, tmp_path):
+        code = "SKILL_DEFINITION = {'name': 'x', 'description': 'd', 'input_schema': {}}\n"
+        res = self._mgr(tmp_path).validate_skill_code(code)
+        assert res["valid"] is False
+        assert any("execute" in e for e in res["errors"])
+
+    def test_syntax_error_flagged(self, tmp_path):
+        res = self._mgr(tmp_path).validate_skill_code("def (:::")
+        assert res["valid"] is False
+
+    def test_non_async_execute_flagged(self, tmp_path):
+        code = ("SKILL_DEFINITION = {'name': 'x', 'description': 'd', 'input_schema': {}}\n"
+                "def execute(inp, context):\n    return 'x'\n")
+        res = self._mgr(tmp_path).validate_skill_code(code)
+        # non-async execute is a warning, not a hard error
+        assert any("async" in w for w in res["warnings"])

--- a/tests/test_state_handlers.py
+++ b/tests/test_state_handlers.py
@@ -1,0 +1,212 @@
+"""Coverage for StateTools — memory_manage + manage_list (RFC-006 P3, ≥85%).
+
+Drives the real handler bodies via a StateTools wired to tmp-file-backed
+memory (in-dict) and lists (real json). memory_manage bounds prompt bloat
+via the LRU-by-write cap; manage_list is the grocery/list CRUD with ownership.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.tools.handlers.state import MEMORY_MAX_KEYS_PER_SECTION, StateTools
+
+
+@pytest.fixture
+def tools(tmp_path):
+    mem = {}
+    memory_path = tmp_path / "memory.json"
+    deps = SimpleNamespace(
+        memory_path=lambda: memory_path,
+        memory_lock=lambda: asyncio.Lock(),
+        lists_lock=lambda: asyncio.Lock(),
+    )
+    st = StateTools.__new__(StateTools)
+    st._deps = deps
+    st._load_all_memory = lambda: json.loads(json.dumps(mem))  # deep copy snapshot
+    def _save(all_mem):
+        mem.clear()
+        mem.update(all_mem)
+    st._save_all_memory = _save
+    return st
+
+
+class TestMemoryManage:
+    @pytest.mark.asyncio
+    async def test_missing_action(self, tools):
+        assert "requires an 'action'" in await tools._handle_memory_manage({})
+
+    @pytest.mark.asyncio
+    async def test_save_get_personal_and_global(self, tools):
+        await tools._handle_memory_manage(
+            {"action": "save", "key": "k", "value": "v"}, user_id="u1")
+        got = await tools._handle_memory_manage({"action": "get", "key": "k"}, user_id="u1")
+        assert "personal" in got and "v" in got
+        await tools._handle_memory_manage(
+            {"action": "save", "scope": "global", "key": "g", "value": "gv"})
+        got_g = await tools._handle_memory_manage({"action": "get", "key": "g"})
+        assert "global" in got_g and "gv" in got_g
+
+    @pytest.mark.asyncio
+    async def test_save_requires_key_and_value(self, tools):
+        assert "required" in await tools._handle_memory_manage({"action": "save", "key": "k"})
+
+    @pytest.mark.asyncio
+    async def test_get_missing_key_and_no_key(self, tools):
+        assert "'key' is required" in await tools._handle_memory_manage({"action": "get"})
+        assert "No note found" in await tools._handle_memory_manage(
+            {"action": "get", "key": "absent"})
+
+    @pytest.mark.asyncio
+    async def test_list_empty_then_populated(self, tools):
+        assert "No notes" in await tools._handle_memory_manage({"action": "list"})
+        await tools._handle_memory_manage(
+            {"action": "save", "scope": "global", "key": "g", "value": "gv"})
+        await tools._handle_memory_manage(
+            {"action": "save", "key": "p", "value": "pv"}, user_id="u1")
+        listing = await tools._handle_memory_manage({"action": "list"}, user_id="u1")
+        assert "Global notes" in listing and "Your personal notes" in listing
+
+    @pytest.mark.asyncio
+    async def test_delete_personal_global_and_absent(self, tools):
+        await tools._handle_memory_manage(
+            {"action": "save", "key": "k", "value": "v"}, user_id="u1")
+        assert "Deleted personal" in await tools._handle_memory_manage(
+            {"action": "delete", "key": "k"}, user_id="u1")
+        await tools._handle_memory_manage(
+            {"action": "save", "scope": "global", "key": "g", "value": "gv"})
+        assert "Deleted global" in await tools._handle_memory_manage(
+            {"action": "delete", "key": "g"})
+        assert "No note found" in await tools._handle_memory_manage(
+            {"action": "delete", "key": "ghost"})
+        assert "'key' is required" in await tools._handle_memory_manage({"action": "delete"})
+
+    @pytest.mark.asyncio
+    async def test_cap_evicts_oldest(self, tools):
+        for i in range(MEMORY_MAX_KEYS_PER_SECTION + 3):
+            await tools._handle_memory_manage(
+                {"action": "save", "scope": "global", "key": f"k{i}", "value": str(i)})
+        # first-written keys evicted; the just-written one survives
+        last = await tools._handle_memory_manage(
+            {"action": "get", "key": f"k{MEMORY_MAX_KEYS_PER_SECTION + 2}"})
+        assert "No note found" not in last
+        assert "No note found" in await tools._handle_memory_manage({"action": "get", "key": "k0"})
+
+    @pytest.mark.asyncio
+    async def test_save_without_user_falls_to_global(self, tools):
+        r = await tools._handle_memory_manage({"action": "save", "key": "k", "value": "v"})
+        assert "global note" in r
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tools):
+        assert "Unknown memory action" in await tools._handle_memory_manage(
+            {"action": "frobnicate"})
+
+
+class TestManageList:
+    async def _add(self, tools, items, name="grocery", **kw):
+        return await tools._handle_manage_list(
+            {"action": "add", "list_name": name, "items": items, **kw})
+
+    @pytest.mark.asyncio
+    async def test_add_show_and_dedup(self, tools):
+        await self._add(tools, ["Milk", "Eggs"])
+        again = await self._add(tools, ["milk", "Bread"])
+        assert "Already on the list" in again and "Bread" in again
+        shown = await tools._handle_manage_list({"action": "show", "list_name": "grocery"})
+        assert "Milk" in shown and "Eggs" in shown and "Bread" in shown
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, tools):
+        assert "No lists exist" in await tools._handle_manage_list({"action": "list_all"})
+        await self._add(tools, ["Milk"])
+        allv = await tools._handle_manage_list({"action": "list_all"})
+        assert "grocery" in allv and "1 items" in allv
+
+    @pytest.mark.asyncio
+    async def test_remove_and_not_found(self, tools):
+        await self._add(tools, ["Milk", "Eggs"])
+        r = await tools._handle_manage_list(
+            {"action": "remove", "list_name": "grocery", "items": ["Milk", "Ghost"]})
+        assert "Removed" in r and "Not found: Ghost" in r
+
+    @pytest.mark.asyncio
+    async def test_mark_done_and_undone(self, tools):
+        await self._add(tools, ["Milk"])
+        done = await tools._handle_manage_list(
+            {"action": "mark_done", "list_name": "grocery", "items": ["Milk"]})
+        assert "Marked done: Milk" in done
+        undone = await tools._handle_manage_list(
+            {"action": "mark_undone", "list_name": "grocery", "items": ["Milk"]})
+        assert "Marked undone: Milk" in undone
+
+    @pytest.mark.asyncio
+    async def test_clear(self, tools):
+        await self._add(tools, ["Milk", "Eggs"])
+        cleared = await tools._handle_manage_list({"action": "clear", "list_name": "grocery"})
+        assert "Cleared 2 item(s)" in cleared
+        assert "already empty" in await tools._handle_manage_list(
+            {"action": "clear", "list_name": "grocery"})
+
+    @pytest.mark.asyncio
+    async def test_show_empty_and_missing(self, tools):
+        assert "is empty" in await tools._handle_manage_list(
+            {"action": "show", "list_name": "nope"})
+        assert "list_name is required" in await tools._handle_manage_list({"action": "show"})
+
+    @pytest.mark.asyncio
+    async def test_personal_ownership_isolation(self, tools):
+        # u1 creates a personal list; u2 cannot see or access it.
+        await tools._handle_manage_list(
+            {"action": "add", "list_name": "secret", "items": ["x"], "owner": "personal"},
+            user_id="u1")
+        denied = await tools._handle_manage_list(
+            {"action": "show", "list_name": "secret"}, user_id="u2")
+        assert "don't have access" in denied
+        allv = await tools._handle_manage_list({"action": "list_all"}, user_id="u2")
+        assert "secret" not in allv
+
+    @pytest.mark.asyncio
+    async def test_remove_and_markdone_on_missing_list(self, tools):
+        assert "doesn't exist" in await tools._handle_manage_list(
+            {"action": "remove", "list_name": "nope", "items": ["x"]})
+        assert "doesn't exist" in await tools._handle_manage_list(
+            {"action": "mark_done", "list_name": "nope", "items": ["x"]})
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tools):
+        await self._add(tools, ["Milk"])
+        assert "Unknown action" in await tools._handle_manage_list(
+            {"action": "frobnicate", "list_name": "grocery"})
+
+
+class TestListMigrationAndFormat:
+    def test_migrates_old_grocery_file(self, tools, tmp_path):
+        old = tmp_path / "grocery_list.json"
+        old.write_text(json.dumps({"items": [
+            {"name": "Milk", "added_by": "u1", "added_at": "2026-01-01T00:00:00"}]}))
+        lists = tools._load_lists()
+        assert "grocery" in lists and lists["grocery"]["items"][0]["name"] == "Milk"
+
+    def test_load_lists_no_path(self):
+        st = StateTools.__new__(StateTools)
+        st._deps = SimpleNamespace(memory_path=lambda: None)
+        assert st._load_lists() == {}
+
+    def test_format_list_with_done_and_timestamp(self):
+        out = StateTools._format_list("grocery", {"items": [
+            {"name": "Milk", "done": True, "added_by": "u1", "added_at": "2026-01-02T00:00:00"},
+            {"name": "Eggs", "done": False},
+        ]})
+        assert "~~Milk~~" in out and "Jan 02" in out and "Eggs" in out
+
+    def test_format_list_bad_timestamp_ignored(self):
+        out = StateTools._format_list("g", {"items": [
+            {"name": "X", "added_at": "not-a-date"}]})
+        assert "X" in out  # no crash on unparseable timestamp
+
+    def test_format_empty(self):
+        assert "is empty" in StateTools._format_list("g", {"items": []})


### PR DESCRIPTION
Two high-value single-file wins.

## Coverage movement (ceremony: improved 3, decreased 0)

| File | Before | After |
|---|---|---|
| `tools/handlers/state.py` | 21% | **93%** |
| `tools/skill_manager.py` | 28% | **78%** |

Total repo coverage (reported): **69.6% → 71.7%**.

## What's driven

- **handlers/state**: `memory_manage` (get/list/save/delete, scope routing, the LRU-by-write cap + eviction that bounds prompt bloat) and `manage_list` (add/dedup, show, remove, mark done/undone, clear, list_all, **personal-vs-shared ownership isolation**, old `grocery_list.json` migration, `_format_list` rendering).
- **skill_manager**: the security-critical **`is_safe_dependency_spec`** (rejects the PEP 508 direct-ref / VCS / URL / path / pip-option / env-marker specs that would run an attacker's `setup.py` at install), config-schema validation, static AST name/dep extractors, the full lifecycle (create/edit/delete with name-match + revert-on-broken, enable/disable **persisted across reload**, config get/set/validate, list/info/tool-defs), **end-to-end skill `execute`** (success/error/disabled/missing with stats recording), export, status, deps.

## Ledger

**Empty.** No bugs — the code matched the pinned expectations. I did correct four *test-authoring* assumptions mid-write (SkillMetadata holds version/tags, not name; non-async execute is a warning not a hard error; `repr()` emits single quotes so a double-quote string-replace no-op'd) — the source was right, my first guesses weren't.

## Verification

Suite **6,477 passed / 4 skipped** (+75) · ruff clean · mypy 0 · coverage gate green on the ratcheted baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3