### PR TITLE
fix: serialize audit HMAC-chain writes under a persist lock

### DIFF
--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from collections import deque
 from collections.abc import Callable
@@ -54,6 +55,16 @@ class AuditLogger:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._event_callback: Callable | None = None
         self._signer: AuditSigner | None = AuditSigner(hmac_key) if hmac_key else None
+        # Serializes every operation that reads/mutates the signer's chain
+        # state or rotates the active file. The HMAC chain records ORDER: each
+        # entry's _prev_hmac is the previous entry's _hmac. sign() advances that
+        # running hash, so sign→write must be atomic w.r.t. other persists —
+        # otherwise two concurrent audited actions sign in one order and write
+        # in another, and verify sees the file out of chain-order (they invented
+        # await so we could race ourselves in one thread). Invariant: _persist,
+        # _maybe_rotate (as called from persist), and initialize_chain all hold
+        # this lock.
+        self._persist_lock = asyncio.Lock()
         self._classify_failures = classify_failures
         self._result_cap = result_cap
         self._tool_input_cap = tool_input_cap
@@ -63,7 +74,9 @@ class AuditLogger:
     def _maybe_rotate(self) -> None:
         """Rotate audit.jsonl → .1 → .2 … once it exceeds max_bytes.
 
-        Called before each append. Bounds total growth to roughly
+        Must be called with _persist_lock held (it resets the signer's chain
+        state; rotation + first-entry-signing must be atomic). Called before
+        each append. Bounds total growth to roughly
         max_bytes * (max_files + 1). The HMAC chain (if enabled) starts fresh in
         the new current file — the signer's prev-hash is reset to GENESIS after
         rotation, so verify_integrity() (which reads the current file from
@@ -141,16 +154,23 @@ class AuditLogger:
         being written becomes the first line of the fresh file and its
         _prev_hmac is GENESIS (the signer is reset in _maybe_rotate). Signing
         after rotation was the bug: the first post-rotation entry chained to the
-        old file and verify_integrity() failed."""
-        self._maybe_rotate()
-        if self._signer:
-            self._signer.sign(entry)
-        line = json.dumps(entry, default=str) + "\n"
-        try:
-            async with aiofiles.open(self.path, "a") as f:
-                await f.write(line)
-        except Exception as e:
-            log.error("Failed to write audit log: %s", e)
+        old file and verify_integrity() failed.
+
+        Rotate → sign → append run under _persist_lock so the chain's write
+        order matches its sign order (see __init__). The event fan-out is a
+        best-effort side effect and runs AFTER the lock — the signed append has
+        already durably happened, so a slow or failing callback can neither
+        stall other persists nor affect the persisted result."""
+        async with self._persist_lock:
+            self._maybe_rotate()
+            if self._signer:
+                self._signer.sign(entry)
+            line = json.dumps(entry, default=str) + "\n"
+            try:
+                async with aiofiles.open(self.path, "a") as f:
+                    await f.write(line)
+            except Exception as e:
+                log.error("Failed to write audit log: %s", e)
         if self._event_callback:
             try:
                 await self._event_callback(entry)
@@ -485,27 +505,31 @@ class AuditLogger:
         return await self._collect_matches(_match, limit)
 
     async def initialize_chain(self) -> None:
-        """Read the last signed entry to resume the HMAC chain state."""
+        """Read the last signed entry to resume the HMAC chain state.
+
+        Holds _persist_lock: it mutates the signer's chain state, and must not
+        race a persist if startup overlaps with the first served requests."""
         if not self._signer or not self.path.exists():
             return
-        try:
-            async with aiofiles.open(self.path) as f:
-                lines = await f.readlines()
-        except Exception as exc:
-            log.error("Failed to read audit log for chain init: %s", exc)
-            return
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
+        async with self._persist_lock:
             try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            prev = entry.get("_hmac")
-            if prev:
-                self._signer.prev_hmac = prev
-            return
+                async with aiofiles.open(self.path) as f:
+                    lines = await f.readlines()
+            except Exception as exc:
+                log.error("Failed to read audit log for chain init: %s", exc)
+                return
+            for line in reversed(lines):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                prev = entry.get("_hmac")
+                if prev:
+                    self._signer.prev_hmac = prev
+                return
 
     async def verify_integrity(self) -> dict:
         """Verify the HMAC chain of the audit log.

--- a/tests/test_audit_persist_concurrency.py
+++ b/tests/test_audit_persist_concurrency.py
@@ -1,0 +1,98 @@
+"""Regression tests for the audit-chain concurrency fix (2026-07-07).
+
+AuditLogger._persist signed an entry (advancing the shared signer's running
+chain hash) and then wrote it across an ``await`` with no lock, so two
+concurrent audited actions signed in one order and wrote in another — the file
+landed out of chain-order and verify_integrity() reported valid=False with zero
+tampering. The fix serializes rotate→sign→write under _persist_lock.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.audit.logger import AuditLogger
+from src.audit.signer import AuditSigner, verify_log
+
+
+async def _hammer(logger, n):
+    import asyncio
+
+    async def one(i):
+        await logger.log_execution(
+            user_id=f"u{i}", user_name="U", channel_id="c", tool_name="t",
+            tool_input={"i": i}, approved=True, result_summary="ok",
+            execution_time_ms=1)
+    await asyncio.gather(*(one(i) for i in range(n)))
+
+
+class TestOrderingMechanism:
+    async def test_out_of_order_signed_entries_fail_verify(self, tmp_path):
+        # Deterministic proof of the failure MODE: two individually-valid
+        # signed entries, written to disk in the REVERSE of their sign order,
+        # break file-order verification even though each HMAC is correct.
+        signer = AuditSigner("k")
+        a = signer.sign({"seq": 1})   # signed first
+        b = signer.sign({"seq": 2})   # signed second (chains to a)
+        p = tmp_path / "audit.jsonl"
+        # write b BEFORE a — the reordering the race produced
+        p.write_text(json.dumps(b) + "\n" + json.dumps(a) + "\n")
+        result = await verify_log(p, "k")
+        assert result["valid"] is False  # out-of-order signed entries caught
+
+    async def test_in_order_signed_entries_verify(self, tmp_path):
+        signer = AuditSigner("k")
+        a = signer.sign({"seq": 1})
+        b = signer.sign({"seq": 2})
+        p = tmp_path / "audit.jsonl"
+        p.write_text(json.dumps(a) + "\n" + json.dumps(b) + "\n")
+        assert (await verify_log(p, "k"))["valid"] is True
+
+
+class TestPersistLock:
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_stay_chain_valid(self, tmp_path):
+        # 64 concurrent audited actions must produce a verifiable chain.
+        logger = AuditLogger(path=str(tmp_path / "audit.jsonl"), hmac_key="k")
+        await _hammer(logger, 64)
+        res = await logger.verify_integrity()
+        assert res["valid"] is True and res["verified"] == 64
+
+    @pytest.mark.asyncio
+    async def test_lock_is_load_bearing(self, tmp_path, monkeypatch):
+        # Same concurrency, lock swapped for a no-op context: the chain breaks.
+        # This is the deterministic "sans lock fails / with lock passes" proof —
+        # the lock is the only variable between this and the test above.
+        logger = AuditLogger(path=str(tmp_path / "audit.jsonl"), hmac_key="k")
+
+        class _NoLock:
+            def __call__(self):  # allow `async with logger._persist_lock:`
+                return self
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(logger, "_persist_lock", _NoLock())
+        await _hammer(logger, 64)
+        res = await logger.verify_integrity()
+        assert res["valid"] is False  # without the lock, concurrency reorders
+
+
+class TestRotationUnderLock:
+    @pytest.mark.asyncio
+    async def test_rotation_first_entry_still_verifies(self, tmp_path):
+        # Rotation resets the signer to GENESIS; the first entry of the new file
+        # must chain from GENESIS and verify. Tiny max_bytes forces a rotation
+        # mid-run; the invariant (rotate+sign atomic under the lock) must hold.
+        logger = AuditLogger(path=str(tmp_path / "audit.jsonl"), hmac_key="k",
+                             max_bytes=200, max_files=3)
+        await _hammer(logger, 40)
+        # the CURRENT file (post-rotation) must verify from genesis
+        res = await logger.verify_integrity()
+        assert res["valid"] is True
+        # a rotated file was produced
+        assert (tmp_path / "audit.jsonl.1").exists()


### PR DESCRIPTION
The audit HMAC chain — tamper-evidence shipped in v3.49.0 — silently breaks under concurrent writes. `/api/audit/verify` returns `valid=false` with **zero tampering**. Found on the live install during v3.54.0 post-deploy verification (25 breaks, all clustered on high-concurrency timestamps).

## Root cause

`AuditLogger._persist` signs an entry (advancing the **shared** signer's running chain hash) and then writes it across an `await`, with no lock. Two concurrent audited actions sign in one order and write in another: each entry stays individually HMAC-valid, but the file lands **out of chain-order**, so `verify` — which walks file order — breaks at every reordered pair. Pre-existing since v3.49.0; not caused by any recent release.

## Fix

An `asyncio.Lock` held across the chain-critical section — rotate + sign + serialize + write — so disk order always matches sign order. **Invariant:** every operation that reads/mutates the signer's `prev_hmac` or rotates the active file runs under it, so `initialize_chain` takes it too (startup overlap with the first served requests would otherwise race). The event-callback fan-out moved **outside** the lock — the signed append has already durably happened; a slow or failing WebSocket callback can neither stall other persists nor affect the result.

## Proof (deterministic, per review)

- **Reproduced**: 64 concurrent `log_execution` → `valid=False, first_bad=4` before; `valid=True, verified=64` after.
- **+5 tests**: ordering mechanism (out-of-order signed entries fail verify / in-order pass) · concurrency regression (64 concurrent → valid) · **load-bearing proof** (same run with the lock swapped for a no-op context → invalid — the deterministic sans-lock-fails/with-lock-passes comparison Odin required) · rotation-under-load (tiny `max_bytes` forces a mid-run rotation; the new file's first entry still verifies from genesis).

## Out of scope (ops decision)

The **25 existing historical breaks** on `/opt/odin` persist until the log rotates past them or the chain is re-baselined — a remediation call for Aaron, orthogonal to this go-forward code fix.

## Verification

Suite **6,521 passed / 4 skipped** (+5) · ruff clean · mypy 0 · lint/type/coverage gates all new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCWoxMmuTNWWWnjJ9wrg3