### PR TITLE
test: RFC-006 P4-continuation CONT-1 — web route coverage

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1122,9 +1122,9 @@
   "statements": 75
  },
  "src/web/api/agents_loops.py": {
-  "covered": 31,
-  "missing": 119,
-  "percent": 20.67,
+  "covered": 148,
+  "missing": 2,
+  "percent": 98.67,
   "statements": 150
  },
  "src/web/api/codex_admin.py": {
@@ -1140,15 +1140,15 @@
   "statements": 297
  },
  "src/web/api/integrations.py": {
-  "covered": 120,
-  "missing": 146,
-  "percent": 45.11,
+  "covered": 266,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 266
  },
  "src/web/api/knowledge_mem.py": {
-  "covered": 118,
-  "missing": 131,
-  "percent": 47.39,
+  "covered": 247,
+  "missing": 2,
+  "percent": 99.2,
   "statements": 249
  },
  "src/web/api/llm_admin.py": {
@@ -1206,9 +1206,9 @@
   "statements": 131
  },
  "src/web/websocket.py": {
-  "covered": 105,
-  "missing": 122,
-  "percent": 46.26,
+  "covered": 200,
+  "missing": 27,
+  "percent": 88.11,
   "statements": 227
  }
 }

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -1,6 +1,6 @@
 # RFC-006: Test-Coverage Campaign (ratchet gate + prioritized waves)
 
-Status: R2 — COMPLETE (campaign shipped through P4b; results in §6b). Plan of record was Odin-approved R1 (§6a).  Remaining P4-continuation + P5 deferred by design.
+Status: R3 — CONT-1 COMPLETE (campaign shipped through P4b in §6b; P4-continuation CONT-1 in §6c). Plan of record was Odin-approved R1 (§6a).  CONT-2 + P5 deferred by design.
 Campaign branch: `coverage/rfc006` (created after plan approval).
 Predecessors: RFC-005 (type-safety ratchet) is the template — a fail-closed CI ratchet plus incremental waves, security/high-value first. Unlike RFC-005, coverage waves add TESTS, not annotations: they can and will surface real bugs. Bug **fixes** are out-of-band (§5).
 
@@ -93,7 +93,28 @@ Required amendments, all adopted: **B1** ratchet redesigned to per-file missed-c
 
 **COV ledger: EMPTY.** Tests were written against never-walked authorization, credential-rotation, memory, skill, and admin-route code — every path behaved exactly as the tests pinned correct behavior. The gate's first act was catching its *own* nondeterminism (config `.env` branch + `store.py` exception-branch flake), both fixed deterministically, not by loosening the ratchet. Two genuine hygiene finds (relative-`Path("config.yml")` test hazard; a duplicate-named shadowed test) were fixed as they surfaced.
 
-**Deliberately deferred (a P4-continuation campaign, whenever there's appetite):** `web/api/config_admin.py` and `llm_admin.py` to ≥85, plus `knowledge_mem`/`agents_loops`/`integrations`/`websocket`, and P5 (discord native tools). These are large multi-registrar route surfaces; Odin endorsed partial-per-file, and the ratchet holds every gain as the permanent floor while they wait.
+**Deliberately deferred (a P4-continuation campaign, whenever there's appetite):** `web/api/config_admin.py` and `llm_admin.py` to ≥85 (CONT-2), plus `knowledge_mem`/`agents_loops`/`integrations`/`websocket` (CONT-1, done — §6c), and P5 (discord native tools). These are large multi-registrar route surfaces; Odin endorsed partial-per-file, and the ratchet holds every gain as the permanent floor while they wait.
+
+## 6c. R3 — P4-continuation CONT-1 (2026-07-07)
+
+Picks up the §6b deferred web-route surfaces. Four files, one PR, Odin-reviewed, coverage-gated.
+
+**Total line coverage 72.9% → 74.7%** (whole repo, reported). Suite 6,516 → 6,606 (+90 tests). mypy stayed 0, ruff clean.
+
+| File | Start → End |
+|---|---|
+| `web/api/integrations.py` | 45% → **100%** |
+| `web/api/knowledge_mem.py` | 47% → **99%** |
+| `web/api/agents_loops.py` | 21% → **99%** |
+| `web/websocket.py` | 46% → **88%** |
+
+**Method (per Odin's wave advisory — real interfaces, faked boundaries):** `knowledge_mem` drives a real `KnowledgeStore` (temp sqlite, FTS-only via `embedder=None`) and a real `ConversationReflector` (temp learned.json) with real round-tripping memory persistence — only embeddings faked. `integrations` fakes every remote service (MCP / Slack / issue-tracker / Grafana / webhooks): request parsing, validation, delegation — never the network. `agents_loops` uses real route dispatch with faked loop/agent/process runtime boundaries (no real loops started). `websocket` uses aiohttp's real ws test client for the `handle` message loop and `_handle_chat`; broadcast/close/tail helpers driven directly with hashable fake sockets; autouse `chdir(tmp_path)` isolates the relative `./data/audit.jsonl` tail read.
+
+**Uncovered by design:** the two `_iteration_cb` runtime closures in `agents_loops` (would require starting real loops — Odin: "don't worship the green bar"); `websocket`'s 1 s-poll log-tail loop (timing-heavy) plus a few deep auth/CLOSE branches; two dead-defensive `except` / `_safe_int_param` fallback lines in `knowledge_mem`.
+
+**COV ledger: EMPTY.** Every failing test during authoring was a *test-setup* error the production code corrected me on — dedup-skipped identical ingest, non-numeric `channel_id` → `int()` raise, `_validate_string` being length-only, `_safe_int_param` gracefully falling back (not 400), `SimpleNamespace` unhashable inside a socket set. No real bugs surfaced; no `xfail`s written.
+
+**Scope discipline:** the ratchet was reverted for three files my tests *incidentally* lifted (`knowledge/store.py`, `learning/reflector.py`, `web/api_common.py`) — kept at their looser ceilings so this PR's baseline diff is exactly its four target files, and to avoid locking a tighter number on `store.py` (past coverage nondeterminism). Those gains are real and claimable by a later targeted ratchet.
 
 ## 7. Risks / discipline
 

--- a/tests/test_web_api_agents_loops.py
+++ b/tests/test_web_api_agents_loops.py
@@ -1,0 +1,258 @@
+"""Route coverage for web/api/agents_loops.py (RFC-006 P4-continuation, CONT-1).
+
+Drives the loop / agent / process admin routes through the real aiohttp route
+layer. Runtime boundaries (loop_manager.start_loop, agent_manager.kill,
+process_registry.kill) are faked — per review, we validate request parsing,
+delegation, and response shaping, not real loop/process startup.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.web.api.agents_loops import register_agents, register_loops, register_processes
+
+
+def _app(*registrars, bot):
+    routes = web.RouteTableDef()
+    for reg in registrars:
+        reg(routes, bot)
+    app = web.Application()
+    app.router.add_routes(routes)
+    return app
+
+
+def _bare_bot():
+    """A bot with no agent/process managers — exercises the defensive fallbacks."""
+    return type("B", (), {})()
+
+
+def _loop_info(**kw):
+    base = dict(goal="watch X", mode="notify", interval_seconds=60,
+                stop_condition=None, max_iterations=50, channel_id="c1",
+                requester_id="web-api", requester_name="Web API",
+                iteration_count=2, last_trigger=1.0, created_at=1.0,
+                status="running", _iteration_history=[{"n": 1}, {"n": 2}])
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _agent_info(**kw):
+    base = dict(label="worker", goal="do it", status="running",
+                state=SimpleNamespace(value="running"), channel_id="c1",
+                requester_name="U", iteration_count=1, tools_used=["grep"],
+                created_at=1.0, ended_at=None, result="", error="",
+                recovery_attempts=0, depth=0, parent_id=None, children_ids=[],
+                _sm=SimpleNamespace(history_as_dicts=lambda: []))
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class TestLoops:
+    @pytest.mark.asyncio
+    async def test_list_loops(self):
+        bot = MagicMock()
+        bot.loop_manager._loops = {"L1": _loop_info()}
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            body = await (await c.get("/api/loops")).json()
+            assert body[0]["id"] == "L1" and body[0]["goal"] == "watch X"
+            assert len(body[0]["iteration_history"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_start_loop_validation(self):
+        bot = MagicMock()
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            assert (await c.post("/api/loops", json={})).status == 400  # no goal
+            assert (await c.post("/api/loops",
+                                 json={"goal": "g"})).status == 400  # no channel_id
+
+    @pytest.mark.asyncio
+    async def test_start_loop_channel_not_found(self):
+        bot = MagicMock()
+        bot.get_channel.return_value = None
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            r = await c.post("/api/loops", json={"goal": "g", "channel_id": "999"})
+            assert r.status == 404
+
+    @pytest.mark.asyncio
+    async def test_start_loop_goal_too_long(self):
+        bot = MagicMock()
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            r = await c.post("/api/loops", json={"goal": "g" * 5000, "channel_id": "1"})
+            assert r.status == 400
+
+    @pytest.mark.asyncio
+    async def test_start_loop_non_numeric_channel(self):
+        bot = MagicMock()
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            # int("abc") raises → channel resolves to None → 404
+            r = await c.post("/api/loops", json={"goal": "g", "channel_id": "abc"})
+            assert r.status == 404
+
+    @pytest.mark.asyncio
+    async def test_start_loop_success(self):
+        bot = MagicMock()
+        bot.get_channel.return_value = MagicMock()
+        bot.loop_manager.start_loop.return_value = "loop-123"
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            r = await c.post("/api/loops", json={"goal": "watch", "channel_id": "1"})
+            assert r.status == 201 and (await r.json())["loop_id"] == "loop-123"
+
+    @pytest.mark.asyncio
+    async def test_start_loop_manager_error(self):
+        bot = MagicMock()
+        bot.get_channel.return_value = MagicMock()
+        bot.loop_manager.start_loop.return_value = "Error: too many loops"
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            assert (await c.post("/api/loops",
+                                 json={"goal": "g", "channel_id": "1"})).status == 400
+
+    @pytest.mark.asyncio
+    async def test_stop_loop_found_and_missing(self):
+        bot = MagicMock()
+        bot.loop_manager.stop_loop.side_effect = ["Stopped loop.", "Loop not found."]
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            assert (await c.delete("/api/loops/L1")).status == 200
+            assert (await c.delete("/api/loops/L1")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_restart_missing_loop(self):
+        bot = MagicMock()
+        bot.loop_manager._loops = {}
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            assert (await c.post("/api/loops/ghost/restart")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_restart_success(self):
+        bot = MagicMock()
+        bot.loop_manager._loops = {"L1": _loop_info(status="running", channel_id="123")}
+        bot.get_channel.return_value = MagicMock()
+        bot.loop_manager.start_loop.return_value = "loop-new"
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            r = await c.post("/api/loops/L1/restart")
+            assert r.status == 201
+            body = await r.json()
+            assert body["old_id"] == "L1" and body["new_id"] == "loop-new"
+            bot.loop_manager.stop_loop.assert_called_once_with("L1")  # stopped first
+
+    @pytest.mark.asyncio
+    async def test_restart_channel_gone(self):
+        bot = MagicMock()
+        bot.loop_manager._loops = {"L1": _loop_info(status="stopped")}
+        bot.get_channel.return_value = None
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            assert (await c.post("/api/loops/L1/restart")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_restart_manager_error(self):
+        bot = MagicMock()
+        bot.loop_manager._loops = {"L1": _loop_info(status="running", channel_id="123")}
+        bot.get_channel.return_value = MagicMock()
+        bot.loop_manager.start_loop.return_value = "Error: too many loops"
+        async with TestClient(TestServer(_app(register_loops, bot=bot))) as c:
+            assert (await c.post("/api/loops/L1/restart")).status == 400
+
+
+class TestAgents:
+    @pytest.mark.asyncio
+    async def test_list_agents(self):
+        bot = MagicMock()
+        bot.agent_manager._agents = {"A1": _agent_info()}
+        async with TestClient(TestServer(_app(register_agents, bot=bot))) as c:
+            body = await (await c.get("/api/agents")).json()
+            assert body[0]["id"] == "A1" and body[0]["label"] == "worker"
+            assert body[0]["state"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_list_agents_no_manager(self):
+        bot = MagicMock()
+        bot.agent_manager._agents = "not-a-dict"
+        async with TestClient(TestServer(_app(register_agents, bot=bot))) as c:
+            assert await (await c.get("/api/agents")).json() == []
+
+    @pytest.mark.asyncio
+    async def test_kill_agent_found_and_missing(self):
+        bot = MagicMock()
+        bot.agent_manager._agents = {"A1": _agent_info()}
+        bot.agent_manager.kill.side_effect = ["Killed agent.", "Agent not found."]
+        async with TestClient(TestServer(_app(register_agents, bot=bot))) as c:
+            assert (await c.delete("/api/agents/A1")).status == 200
+            assert (await c.delete("/api/agents/A1")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_children_lineage_descendants(self):
+        bot = MagicMock()
+        bot.agent_manager.get_children.return_value = [{"id": "c"}]
+        bot.agent_manager.get_lineage.return_value = ["root", "A1"]
+        bot.agent_manager.get_descendants.return_value = ["A2"]
+        async with TestClient(TestServer(_app(register_agents, bot=bot))) as c:
+            children = await (await c.get("/api/agents/A1/children")).json()
+            lineage = await (await c.get("/api/agents/A1/lineage")).json()
+            descendants = await (await c.get("/api/agents/A1/descendants")).json()
+            assert children[0]["id"] == "c"
+            assert lineage["lineage"] == ["root", "A1"]
+            assert descendants["descendants"] == ["A2"]
+
+    @pytest.mark.asyncio
+    async def test_kill_agent_non_dict_registry(self):
+        bot = MagicMock()
+        bot.agent_manager._agents = "not-a-dict"  # raise-AttributeError guard → 404
+        async with TestClient(TestServer(_app(register_agents, bot=bot))) as c:
+            assert (await c.delete("/api/agents/A1")).status == 404
+
+    @pytest.mark.asyncio
+    async def test_no_agent_manager_fallbacks(self):
+        # A bot with no agent_manager attribute at all exercises the defensive
+        # AttributeError guards: list → [], kill → 404, tree routes → 503.
+        async with TestClient(TestServer(_app(register_agents, bot=_bare_bot()))) as c:
+            assert await (await c.get("/api/agents")).json() == []
+            assert (await c.delete("/api/agents/A1")).status == 404
+            assert (await c.get("/api/agents/A1/children")).status == 503
+            assert (await c.get("/api/agents/A1/lineage")).status == 503
+            assert (await c.get("/api/agents/A1/descendants")).status == 503
+
+
+class TestProcesses:
+    def _proc(self, **kw):
+        base = dict(command="tail -f log", host="localhost", status="running",
+                    exit_code=None, start_time=1.0,
+                    output_buffer=["line1\n", "line2\n", "line3\n", "line4\n"])
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    @pytest.mark.asyncio
+    async def test_list_processes(self):
+        bot = MagicMock()
+        bot.tool_executor._process_registry._processes = {1: self._proc()}
+        async with TestClient(TestServer(_app(register_processes, bot=bot))) as c:
+            body = await (await c.get("/api/processes")).json()
+            assert body[0]["pid"] == 1 and body[0]["command"] == "tail -f log"
+            assert body[0]["output_preview"] == ["line2", "line3", "line4"]
+
+    @pytest.mark.asyncio
+    async def test_list_processes_no_registry(self):
+        bot = MagicMock()
+        bot.tool_executor._process_registry = None
+        async with TestClient(TestServer(_app(register_processes, bot=bot))) as c:
+            assert await (await c.get("/api/processes")).json() == []
+
+    @pytest.mark.asyncio
+    async def test_kill_process(self):
+        bot = MagicMock()
+        reg = MagicMock()
+        reg.kill = AsyncMock(return_value="Killed process 5.")
+        bot.tool_executor._process_registry = reg
+        async with TestClient(TestServer(_app(register_processes, bot=bot))) as c:
+            assert (await c.delete("/api/processes/5")).status == 200
+            assert (await c.delete("/api/processes/notanint")).status == 400
+
+    @pytest.mark.asyncio
+    async def test_kill_process_no_registry(self):
+        bot = MagicMock()
+        bot.tool_executor._process_registry = None
+        async with TestClient(TestServer(_app(register_processes, bot=bot))) as c:
+            assert (await c.delete("/api/processes/5")).status == 404

--- a/tests/test_web_api_integrations.py
+++ b/tests/test_web_api_integrations.py
@@ -1,0 +1,300 @@
+"""Route coverage for web/api/integrations.py (RFC-006 P4-continuation, CONT-1).
+
+Per Odin's advisory: fake the remote services hard. These tests validate request
+parsing, validation, and delegation/response shaping for MCP / Slack / issue
+tracker / Grafana alerts / outbound webhooks — never the network. Each service
+is a faked object; the "disabled" path is simply the attribute being absent.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.web.api.integrations import (
+    register_grafana_alerts,
+    register_issue_tracker,
+    register_mcp_servers,
+    register_outbound_webhooks,
+    register_slack,
+)
+
+
+def _app(*registrars, bot):
+    routes = web.RouteTableDef()
+    for reg in registrars:
+        reg(routes, bot)
+    app = web.Application()
+    app.router.add_routes(routes)
+    return app
+
+
+def _bot(**attrs):
+    """A plain bot object — unset service attrs read as None (the disabled path)."""
+    bot = type("B", (), {})()
+    for k, v in attrs.items():
+        setattr(bot, k, v)
+    return bot
+
+
+# --------------------------------------------------------------------------- #
+# MCP servers
+# --------------------------------------------------------------------------- #
+class TestMcpServers:
+    async def test_disabled_503(self):
+        async with TestClient(TestServer(_app(register_mcp_servers, bot=_bot()))) as c:
+            assert (await c.get("/api/mcp/servers")).status == 503
+            assert (await c.get("/api/mcp/servers/x/tools")).status == 503
+            assert (await c.post("/api/mcp/servers", json={"name": "x"})).status == 503
+            assert (await c.delete("/api/mcp/servers/x")).status == 503
+
+    async def test_list_and_tools(self):
+        conn = SimpleNamespace(tools=[{"name": "ping", "description": "d"}])
+        mgr = MagicMock()
+        mgr.get_status.return_value = [{"name": "srv", "connected": True}]
+        mgr.get_server.side_effect = lambda n: conn if n == "srv" else None
+        bot = _bot(mcp_manager=mgr)
+        async with TestClient(TestServer(_app(register_mcp_servers, bot=bot))) as c:
+            assert (await (await c.get("/api/mcp/servers")).json())["servers"][0]["name"] == "srv"
+            body = await (await c.get("/api/mcp/servers/srv/tools")).json()
+            assert body["tools"][0]["original_name"] == "ping"
+            assert (await c.get("/api/mcp/servers/ghost/tools")).status == 404
+
+    async def test_add_success_and_validation_and_error(self):
+        mgr = MagicMock()
+        mgr.add_server = AsyncMock(return_value={"name": "srv", "tools": 3})
+        bot = _bot(mcp_manager=mgr, tool_catalog=MagicMock())
+        async with TestClient(TestServer(_app(register_mcp_servers, bot=bot))) as c:
+            r = await c.post("/api/mcp/servers", json={"name": "srv", "command": "run"})
+            assert r.status == 201
+            bot.tool_catalog.invalidate.assert_called_once()
+            assert (await c.post("/api/mcp/servers", json={})).status == 400  # no name
+            mgr.add_server.side_effect = RuntimeError("boom")
+            assert (await c.post("/api/mcp/servers", json={"name": "y"})).status == 400
+
+    async def test_remove_success_and_error(self):
+        mgr = MagicMock()
+        mgr.remove_server = AsyncMock()
+        bot = _bot(mcp_manager=mgr, tool_catalog=MagicMock())
+        async with TestClient(TestServer(_app(register_mcp_servers, bot=bot))) as c:
+            assert (await c.delete("/api/mcp/servers/srv")).status == 200
+            mgr.remove_server.side_effect = RuntimeError("nope")
+            assert (await c.delete("/api/mcp/servers/srv")).status == 404
+
+
+# --------------------------------------------------------------------------- #
+# Slack
+# --------------------------------------------------------------------------- #
+class TestSlack:
+    def _notifier(self):
+        n = MagicMock()
+        n.get_status.return_value = {"channel": "#ops"}
+        n.send = AsyncMock(return_value=True)
+        n.send_formatted = AsyncMock(return_value=True)
+        return n
+
+    async def test_status_disabled_and_enabled(self):
+        async with TestClient(TestServer(_app(register_slack, bot=_bot()))) as c:
+            assert (await (await c.get("/api/slack/status")).json())["enabled"] is False
+        bot = _bot(health_server=SimpleNamespace(slack_notifier=self._notifier()))
+        async with TestClient(TestServer(_app(register_slack, bot=bot))) as c:
+            body = await (await c.get("/api/slack/status")).json()
+            assert body["enabled"] is True and body["channel"] == "#ops"
+
+    async def test_test_endpoint(self):
+        async with TestClient(TestServer(_app(register_slack, bot=_bot()))) as c:
+            assert (await c.post("/api/slack/test", json={})).status == 503
+        bot = _bot(health_server=SimpleNamespace(slack_notifier=self._notifier()))
+        async with TestClient(TestServer(_app(register_slack, bot=bot))) as c:
+            r = await c.post("/api/slack/test", json={"message": "hi"})
+            assert r.status == 200 and (await r.json())["sent"] is True
+            # tolerates a non-JSON body (defaults to {})
+            assert (await c.post("/api/slack/test", data="not json")).status == 200
+
+    async def test_send_plain_and_formatted(self):
+        notifier = self._notifier()
+        bot = _bot(health_server=SimpleNamespace(slack_notifier=notifier))
+        async with TestClient(TestServer(_app(register_slack, bot=bot))) as c:
+            assert (await c.post("/api/slack/send", data="bad")).status == 400
+            assert (await c.post("/api/slack/send", json={})).status == 400  # no text
+            assert (await c.post("/api/slack/send", json={"text": "hello"})).status == 200
+            notifier.send.assert_awaited()
+            assert (await c.post("/api/slack/send",
+                                 json={"text": "warn", "severity": "critical"})).status == 200
+            notifier.send_formatted.assert_awaited()
+
+    async def test_send_disabled(self):
+        async with TestClient(TestServer(_app(register_slack, bot=_bot()))) as c:
+            assert (await c.post("/api/slack/send", json={"text": "x"})).status == 503
+
+
+# --------------------------------------------------------------------------- #
+# Issue tracker
+# --------------------------------------------------------------------------- #
+class TestIssueTracker:
+    def _client(self):
+        cl = MagicMock()
+        cl.get_status.return_value = {"provider": "linear"}
+        cl.execute = AsyncMock(return_value={"id": "ISS-1"})
+        return cl
+
+    async def test_status(self):
+        async with TestClient(TestServer(_app(register_issue_tracker, bot=_bot()))) as c:
+            assert (await (await c.get("/api/issues/status")).json())["enabled"] is False
+        bot = _bot(_issue_tracker_client=self._client())
+        async with TestClient(TestServer(_app(register_issue_tracker, bot=bot))) as c:
+            assert (await (await c.get("/api/issues/status")).json())["provider"] == "linear"
+
+    async def test_execute(self):
+        async with TestClient(TestServer(_app(register_issue_tracker, bot=_bot()))) as c:
+            assert (await c.post("/api/issues/execute", json={"action": "x"})).status == 503
+        bot = _bot(_issue_tracker_client=self._client())
+        async with TestClient(TestServer(_app(register_issue_tracker, bot=bot))) as c:
+            assert (await c.post("/api/issues/execute", data="bad")).status == 400
+            assert (await c.post("/api/issues/execute", json={})).status == 400  # no action
+            r = await c.post("/api/issues/execute", json={"action": "list_issues"})
+            assert r.status == 200 and (await r.json())["ok"] is True
+            bot._issue_tracker_client.execute.side_effect = ValueError("bad action")
+            assert (await c.post("/api/issues/execute", json={"action": "z"})).status == 400
+
+    async def test_create(self):
+        async with TestClient(TestServer(_app(register_issue_tracker, bot=_bot()))) as c:
+            assert (await c.post("/api/issues/create", json={"title": "t"})).status == 503
+        bot = _bot(_issue_tracker_client=self._client())
+        async with TestClient(TestServer(_app(register_issue_tracker, bot=bot))) as c:
+            assert (await c.post("/api/issues/create", data="bad")).status == 400
+            assert (await c.post("/api/issues/create", json={})).status == 400  # no title
+            r = await c.post("/api/issues/create", json={"title": "Fix bug"})
+            assert r.status == 201 and (await r.json())["ok"] is True
+            bot._issue_tracker_client.execute.side_effect = ValueError("nope")
+            assert (await c.post("/api/issues/create", json={"title": "x"})).status == 400
+
+
+# --------------------------------------------------------------------------- #
+# Grafana alerts
+# --------------------------------------------------------------------------- #
+class TestGrafanaAlerts:
+    def _handler(self):
+        h = MagicMock()
+        h.get_status.return_value = {"rules": 2}
+        h.alert_history = [{"n": 1}, {"n": 2}, {"n": 3}]
+        h.get_rules_list.return_value = [{"id": "r1"}]
+        h.get_remediations_list.return_value = [{"id": "rem1"}]
+        h.remove_rule.return_value = True
+        return h
+
+    async def test_status_and_disabled(self):
+        async with TestClient(TestServer(_app(register_grafana_alerts, bot=_bot()))) as c:
+            assert (await (await c.get("/api/grafana-alerts/status")).json())["enabled"] is False
+            assert (await c.get("/api/grafana-alerts/history")).status == 503
+            assert (await c.get("/api/grafana-alerts/rules")).status == 503
+            assert (await c.post("/api/grafana-alerts/rules", json={})).status == 503
+            assert (await c.delete("/api/grafana-alerts/rules/r1")).status == 503
+            assert (await c.get("/api/grafana-alerts/remediations")).status == 503
+
+    async def test_enabled_reads(self):
+        bot = _bot(health_server=SimpleNamespace(grafana_handler=self._handler()))
+        async with TestClient(TestServer(_app(register_grafana_alerts, bot=bot))) as c:
+            assert (await (await c.get("/api/grafana-alerts/status")).json())["rules"] == 2
+            hist = await (await c.get("/api/grafana-alerts/history?limit=2")).json()
+            assert hist["total"] == 3 and len(hist["alerts"]) == 2
+            rules = await (await c.get("/api/grafana-alerts/rules")).json()
+            assert rules["rules"][0]["id"] == "r1"
+            rems = await (await c.get("/api/grafana-alerts/remediations")).json()
+            assert rems["remediations"][0]["id"] == "rem1"
+
+    async def test_add_rule(self):
+        handler = self._handler()
+        bot = _bot(health_server=SimpleNamespace(grafana_handler=handler))
+        async with TestClient(TestServer(_app(register_grafana_alerts, bot=bot))) as c:
+            assert (await c.post("/api/grafana-alerts/rules", data="bad")).status == 400
+            # missing name_pattern → 400
+            assert (await c.post("/api/grafana-alerts/rules", json={"id": "r1"})).status == 400
+            r = await c.post("/api/grafana-alerts/rules",
+                             json={"id": "r1", "name_pattern": "CPU.*", "remediation_goal": "go"})
+            assert r.status == 201 and (await r.json())["rule"] == "r1"
+            handler.add_rule.assert_called_once()
+            # a rule the handler rejects surfaces as 400
+            handler.add_rule.side_effect = ValueError("duplicate rule id")
+            assert (await c.post("/api/grafana-alerts/rules",
+                                 json={"id": "r2", "name_pattern": "Mem.*"})).status == 400
+
+    async def test_delete_rule(self):
+        handler = self._handler()
+        bot = _bot(health_server=SimpleNamespace(grafana_handler=handler))
+        async with TestClient(TestServer(_app(register_grafana_alerts, bot=bot))) as c:
+            assert (await c.delete("/api/grafana-alerts/rules/r1")).status == 200
+            handler.remove_rule.return_value = False
+            assert (await c.delete("/api/grafana-alerts/rules/ghost")).status == 404
+
+
+# --------------------------------------------------------------------------- #
+# Outbound webhooks
+# --------------------------------------------------------------------------- #
+class TestOutboundWebhooks:
+    def _dispatcher(self):
+        d = MagicMock()
+        d.get_status.return_value = {"count": 1}
+        target = MagicMock()
+        target.to_dict.return_value = {"id": "wh1", "name": "hook"}
+        d.register.return_value = target
+        d.update.return_value = target
+        d.unregister.return_value = True
+        d.send_test_event = AsyncMock(return_value=target)
+        d.stats.as_dict.return_value = {"sent": 5}
+        return d, target
+
+    async def test_disabled_503(self):
+        async with TestClient(TestServer(_app(register_outbound_webhooks, bot=_bot()))) as c:
+            assert (await c.get("/api/outbound-webhooks")).status == 503
+            assert (await c.post("/api/outbound-webhooks", json={})).status == 503
+            assert (await c.put("/api/outbound-webhooks/x", json={})).status == 503
+            assert (await c.delete("/api/outbound-webhooks/x")).status == 503
+            assert (await c.post("/api/outbound-webhooks/x/test")).status == 503
+            assert (await c.get("/api/outbound-webhooks/stats")).status == 503
+
+    async def test_list_and_stats(self):
+        d, _ = self._dispatcher()
+        bot = _bot(outbound_webhook_dispatcher=d)
+        async with TestClient(TestServer(_app(register_outbound_webhooks, bot=bot))) as c:
+            assert (await (await c.get("/api/outbound-webhooks")).json())["count"] == 1
+            assert (await (await c.get("/api/outbound-webhooks/stats")).json())["sent"] == 5
+
+    async def test_create(self):
+        d, _ = self._dispatcher()
+        bot = _bot(outbound_webhook_dispatcher=d)
+        async with TestClient(TestServer(_app(register_outbound_webhooks, bot=bot))) as c:
+            assert (await c.post("/api/outbound-webhooks", data="bad")).status == 400
+            # name is length-validated (max 128); an over-long name is rejected
+            assert (await c.post("/api/outbound-webhooks",
+                                 json={"name": "n" * 200})).status == 400
+            r = await c.post("/api/outbound-webhooks",
+                             json={"name": "hook", "url": "https://example.test/x"})
+            assert r.status == 201 and (await r.json())["id"] == "wh1"
+            # dispatcher rejecting the target (e.g. bad url) surfaces as 400
+            d.register.side_effect = ValueError("bad url")
+            assert (await c.post("/api/outbound-webhooks", json={"name": "hook2"})).status == 400
+
+    async def test_update(self):
+        d, _ = self._dispatcher()
+        bot = _bot(outbound_webhook_dispatcher=d)
+        async with TestClient(TestServer(_app(register_outbound_webhooks, bot=bot))) as c:
+            assert (await c.put("/api/outbound-webhooks/wh1", data="bad")).status == 400
+            assert (await c.put("/api/outbound-webhooks/wh1", json={"name": "new"})).status == 200
+            d.update.return_value = None
+            assert (await c.put("/api/outbound-webhooks/ghost", json={})).status == 404
+            d.update.side_effect = ValueError("bad")
+            assert (await c.put("/api/outbound-webhooks/wh1", json={})).status == 400
+
+    async def test_delete_and_test(self):
+        d, _ = self._dispatcher()
+        bot = _bot(outbound_webhook_dispatcher=d)
+        async with TestClient(TestServer(_app(register_outbound_webhooks, bot=bot))) as c:
+            assert (await c.delete("/api/outbound-webhooks/wh1")).status == 200
+            d.unregister.return_value = False
+            assert (await c.delete("/api/outbound-webhooks/ghost")).status == 404
+            assert (await c.post("/api/outbound-webhooks/wh1/test")).status == 200
+            d.send_test_event = AsyncMock(return_value=None)
+            assert (await c.post("/api/outbound-webhooks/ghost/test")).status == 404

--- a/tests/test_web_api_knowledge_mem.py
+++ b/tests/test_web_api_knowledge_mem.py
@@ -1,0 +1,295 @@
+"""Route coverage for web/api/knowledge_mem.py (RFC-006 P4-continuation, CONT-1).
+
+Per Odin's advisory: drive the real route handlers against real store / memory /
+reflector interfaces backed by temp storage. Embeddings are the only external
+boundary faked (``bot.embedder = None`` → the store runs FTS-only), so the
+knowledge routes exercise real ingest / version / dedup / merge machinery.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.knowledge.store import KnowledgeStore
+from src.learning.reflector import ConversationReflector
+from src.web.api.knowledge_mem import (
+    register_knowledge,
+    register_learned_context,
+    register_memory_notes,
+)
+
+
+def _app(*registrars, bot):
+    routes = web.RouteTableDef()
+    for reg in registrars:
+        reg(routes, bot)
+    app = web.Application()
+    app.router.add_routes(routes)
+    return app
+
+
+async def _ingest(client, source, content):
+    return await client.post("/api/knowledge", json={"source": source, "content": content})
+
+
+# --------------------------------------------------------------------------- #
+# Knowledge — real store, temp db, FTS-only (embedder=None)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def store(tmp_path):
+    s = KnowledgeStore(tmp_path / "kb.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def kbot(store):
+    bot = type("B", (), {})()
+    bot.knowledge = store
+    bot.embedder = None
+    return bot
+
+
+class TestKnowledgeUnavailable:
+    """Every knowledge route short-circuits to 503 when the store is down."""
+
+    async def test_all_routes_503(self):
+        bot = type("B", (), {})()
+        bot.knowledge = None
+        async with TestClient(TestServer(_app(register_knowledge, bot=bot))) as c:
+            assert (await c.get("/api/knowledge")).status == 503
+            assert (await _ingest(c, "s", "c")).status == 503
+            assert (await c.delete("/api/knowledge/s")).status == 503
+            assert (await c.post("/api/knowledge/s/reingest")).status == 503
+            assert (await c.get("/api/knowledge/search?q=x")).status == 503
+            assert (await c.get("/api/knowledge/s/chunks")).status == 503
+            assert (await c.get("/api/knowledge/duplicates")).status == 503
+            assert (await c.post("/api/knowledge/merge", json={})).status == 503
+            assert (await c.get("/api/knowledge/s/versions")).status == 503
+            assert (await c.get("/api/knowledge/s/versions/1")).status == 503
+            assert (await c.post("/api/knowledge/s/versions/1/restore")).status == 503
+            assert (await c.get("/api/knowledge/s/versions/1/diff/2")).status == 503
+            assert (await c.post("/api/knowledge/import", json={"items": []})).status == 503
+
+
+class TestKnowledgeCrud:
+    async def test_ingest_list_delete_roundtrip(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            r = await _ingest(c, "doc.md", "hello world alpha")
+            assert r.status == 201 and (await r.json())["chunks"] >= 1
+
+            sources = await (await c.get("/api/knowledge")).json()
+            assert any(s["source"] == "doc.md" for s in sources)
+
+            r = await c.delete("/api/knowledge/doc.md")
+            assert r.status == 200 and (await r.json())["chunks_removed"] >= 1
+            assert (await c.delete("/api/knowledge/doc.md")).status == 404
+
+    async def test_ingest_validation(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            assert (await c.post("/api/knowledge", json={})).status == 400  # no source/content
+            # an over-long source name fails validation
+            assert (await _ingest(c, "x" * 5000, "c")).status == 400
+
+    async def test_reingest(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            await _ingest(c, "d.md", "some content here")
+            r = await c.post("/api/knowledge/d.md/reingest")
+            assert r.status == 200 and (await r.json())["source"] == "d.md"
+            assert (await c.post("/api/knowledge/ghost.md/reingest")).status == 404
+
+    async def test_search(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            await _ingest(c, "d.md", "pangolins are scaly mammals")
+            r = await c.get("/api/knowledge/search?q=pangolins")
+            assert r.status == 200 and isinstance(await r.json(), list)
+            assert (await c.get("/api/knowledge/search?q=")).status == 400
+            # a non-integer limit gracefully falls back to the default (no 400)
+            assert (await c.get("/api/knowledge/search?q=x&limit=notanint")).status == 200
+
+    async def test_chunks(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            await _ingest(c, "d.md", "chunk body text")
+            r = await c.get("/api/knowledge/d.md/chunks")
+            assert r.status == 200 and len(await r.json()) >= 1
+            assert (await c.get("/api/knowledge/ghost.md/chunks")).status == 404
+
+
+class TestKnowledgeDedupMerge:
+    async def test_duplicates_and_merge(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            # Distinct content so both sources actually persist (identical content
+            # would be dedup-skipped on the second ingest and never stored).
+            await _ingest(c, "a.md", "alpha body content one")
+            await _ingest(c, "b.md", "beta body content two")
+
+            dups = await (await c.get("/api/knowledge/duplicates")).json()
+            assert "exact" in dups and "near" in dups
+            # threshold parse fallback (bad value ignored, no crash)
+            assert (await c.get("/api/knowledge/duplicates?threshold=oops")).status == 200
+
+            r = await c.post("/api/knowledge/merge",
+                             json={"keep_source": "a.md", "remove_source": "b.md"})
+            assert r.status == 200 and (await r.json())["kept"] == "a.md"
+
+    async def test_merge_validation(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            assert (await c.post("/api/knowledge/merge", data="not json")).status == 400
+            assert (await c.post("/api/knowledge/merge", json={"keep_source": "a"})).status == 400
+            r = await c.post("/api/knowledge/merge",
+                             json={"keep_source": "ghost", "remove_source": "also"})
+            assert r.status == 404
+
+
+class TestKnowledgeVersions:
+    async def test_versions_lifecycle(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            await _ingest(c, "v.md", "first version body")
+            await _ingest(c, "v.md", "second version body changed")
+
+            versions = await (await c.get("/api/knowledge/v.md/versions")).json()
+            assert len(versions) >= 2
+
+            r = await c.get("/api/knowledge/v.md/versions/1")
+            assert r.status == 200 and (await r.json())["version"] == 1
+            assert (await c.get("/api/knowledge/v.md/versions/999")).status == 404
+
+            r = await c.post("/api/knowledge/v.md/versions/1/restore")
+            assert r.status == 200 and (await r.json())["status"] == "restored"
+            assert (await c.post("/api/knowledge/v.md/versions/999/restore")).status == 404
+
+            r = await c.get("/api/knowledge/v.md/versions/1/diff/2")
+            assert r.status == 200
+            assert (await c.get("/api/knowledge/v.md/versions/1/diff/999")).status == 404
+
+
+class TestKnowledgeImport:
+    async def test_import_batch(self, kbot, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "one.md").write_text("imported document body one")
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            r = await c.post("/api/knowledge/import", json={"items": [
+                {"type": "directory", "path": str(docs), "pattern": "**/*.md"},
+                {"type": "url", "url": ""},  # missing url → recorded as failure
+            ]})
+            assert r.status == 200
+            body = await r.json()
+            assert body["total"] == 2 and body["succeeded"] >= 1 and body["failed"] >= 1
+
+    async def test_import_validation(self, kbot):
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            assert (await c.post("/api/knowledge/import", data="bad")).status == 400
+            assert (await c.post("/api/knowledge/import", json={"items": "notalist"})).status == 400
+
+
+# --------------------------------------------------------------------------- #
+# Memory notes — real round-tripping backing (load→mutate→save contract)
+# --------------------------------------------------------------------------- #
+def _memory_bot(initial=None):
+    """A bot whose tool_executor persists memory through real copy semantics."""
+    backing: dict[str, dict[str, str]] = {"global": {}}
+    if initial:
+        backing.update({k: dict(v) for k, v in initial.items()})
+
+    def load():
+        return {k: dict(v) for k, v in backing.items()}
+
+    def save(data):
+        backing.clear()
+        backing.update({k: dict(v) for k, v in data.items()})
+
+    bot = type("B", (), {})()
+    bot.tool_executor = type("E", (), {})()
+    bot.tool_executor._load_all_memory = load
+    bot.tool_executor._save_all_memory = save
+    bot._backing = backing
+    return bot
+
+
+class TestMemoryNotes:
+    async def test_list(self):
+        bot = _memory_bot({"global": {"a": "1", "b": "2"}, "user_5": {"x": "9"}})
+        async with TestClient(TestServer(_app(register_memory_notes, bot=bot))) as c:
+            body = await (await c.get("/api/memory")).json()
+            assert body["global"]["count"] == 2 and set(body["global"]["keys"]) == {"a", "b"}
+            assert body["user_5"]["count"] == 1
+
+    async def test_get(self):
+        bot = _memory_bot({"global": {"a": "hello"}})
+        async with TestClient(TestServer(_app(register_memory_notes, bot=bot))) as c:
+            r = await c.get("/api/memory/global/a")
+            assert r.status == 200 and (await r.json())["value"] == "hello"
+            assert (await c.get("/api/memory/global/missing")).status == 404
+
+    async def test_set_persists(self):
+        bot = _memory_bot()
+        async with TestClient(TestServer(_app(register_memory_notes, bot=bot))) as c:
+            assert (await c.put("/api/memory/global/k", json={"value": "v"})).status == 200
+            assert (await c.put("/api/memory/global/k", json={})).status == 400  # no value
+            # writing to a scope that doesn't exist yet creates it
+            assert (await c.put("/api/memory/user_9/greeting", json={"value": "hi"})).status == 200
+        assert bot._backing["global"]["k"] == "v"  # real persistence
+        assert bot._backing["user_9"]["greeting"] == "hi"
+
+    async def test_delete_persists(self):
+        bot = _memory_bot({"global": {"gone": "soon"}})
+        async with TestClient(TestServer(_app(register_memory_notes, bot=bot))) as c:
+            assert (await c.delete("/api/memory/global/gone")).status == 200
+            assert (await c.delete("/api/memory/global/gone")).status == 404
+        assert "gone" not in bot._backing["global"]
+
+    async def test_bulk_delete(self):
+        bot = _memory_bot({"global": {"a": "1", "b": "2", "c": "3"}})
+        async with TestClient(TestServer(_app(register_memory_notes, bot=bot))) as c:
+            assert (await c.post("/api/memory/bulk-delete", data="bad")).status == 400
+            assert (await c.post("/api/memory/bulk-delete", json={"entries": []})).status == 400
+            r = await c.post("/api/memory/bulk-delete", json={"entries": [
+                {"scope": "global", "key": "a"},
+                {"scope": "global", "key": "c"},
+                {"scope": "nope", "key": "z"},  # skipped
+            ]})
+            assert r.status == 200 and (await r.json())["count"] == 2
+        assert set(bot._backing["global"]) == {"b"}
+
+
+# --------------------------------------------------------------------------- #
+# Learned context — real reflector, temp learned.json
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def learned_bot(tmp_path):
+    path = tmp_path / "learned.json"
+    path.write_text(json.dumps({
+        "version": 2,
+        "last_reflection": "2026-07-07T00:00:00+00:00",
+        "entries": [
+            {"key": "e1", "category": "operational", "content": "first lesson"},
+            {"key": "e2", "category": "correction", "content": "second lesson"},
+        ],
+    }))
+    bot = type("B", (), {})()
+    bot.reflector = ConversationReflector(str(path))
+    return bot
+
+
+class TestLearnedContext:
+    async def test_list(self, learned_bot):
+        async with TestClient(TestServer(_app(register_learned_context, bot=learned_bot))) as c:
+            body = await (await c.get("/api/learned")).json()
+            assert body["count"] == 2 and len(body["entries"]) == 2
+
+    async def test_delete(self, learned_bot):
+        async with TestClient(TestServer(_app(register_learned_context, bot=learned_bot))) as c:
+            assert (await c.delete("/api/learned/e1")).status == 200
+            assert (await c.delete("/api/learned/e1")).status == 404
+
+    async def test_update(self, learned_bot):
+        async with TestClient(TestServer(_app(register_learned_context, bot=learned_bot))) as c:
+            r = await c.put("/api/learned/e2",
+                            json={"content": "revised", "category": "preference"})
+            assert r.status == 200 and (await r.json())["content"] == "revised"
+            assert (await c.put("/api/learned/ghost", json={"content": "x"})).status == 404
+            assert (await c.put("/api/learned/e2", data="not json")).status == 400

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,0 +1,283 @@
+"""Coverage for web/websocket.py (RFC-006 P4-continuation, CONT-1 optional).
+
+Odin green-lit websocket "only if tractable with real websocket client tests" —
+aiohttp's ws test client makes the ``handle`` message loop and ``_handle_chat``
+paths fully drivable end-to-end. The broadcast / close / tail helpers are
+exercised directly on the manager with fake sockets. ``process_web_chat`` (the
+one real external boundary) is patched; a chdir(tmp_path) autouse fixture keeps
+``_tail_logs``' relative ./data/audit.jsonl read isolated.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.web.websocket import WebSocketManager, setup_websocket
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+
+def _bot():
+    return SimpleNamespace(name="odin")
+
+
+def _client(*, api_token="", web_config=None, session_manager=None):
+    app = web.Application()
+    if session_manager is not None:
+        app["session_manager"] = session_manager
+    manager = setup_websocket(app, _bot(), api_token=api_token, web_config=web_config)
+    return TestClient(TestServer(app)), manager
+
+
+CHAT_RESULT = {"response": "hi there", "tools_used": ["grep"], "is_error": False}
+
+
+# --------------------------------------------------------------------------- #
+# handle() — the real message loop
+# --------------------------------------------------------------------------- #
+class TestHandleLoop:
+    async def test_subscribe_unsubscribe_ping_unknown(self):
+        client, _ = _client()
+        async with client:
+            async with client.ws_connect("/api/ws") as ws:
+                await ws.send_json({"subscribe": "events"})
+                assert (await ws.receive_json())["channel"] == "events"
+                await ws.send_json({"unsubscribe": "events"})
+                assert (await ws.receive_json())["type"] == "unsubscribed"
+                await ws.send_json({"type": "ping", "ts": 42})
+                pong = await ws.receive_json()
+                assert pong["type"] == "pong" and pong["ts"] == 42
+                await ws.send_json({"whatever": 1})
+                assert "unknown command" in (await ws.receive_json())["error"]
+
+    async def test_invalid_json(self):
+        client, _ = _client()
+        async with client:
+            async with client.ws_connect("/api/ws") as ws:
+                await ws.send_str("{not json")
+                assert "invalid JSON" in (await ws.receive_json())["error"]
+
+    async def test_subscribe_logs_streams_tail(self):
+        # _tail_logs reads ./data/audit.jsonl (relative → isolated by chdir)
+        from pathlib import Path
+        data = Path("data")
+        data.mkdir()
+        (data / "audit.jsonl").write_text('{"a":1}\n{"a":2}\n')
+        client, _ = _client()
+        async with client:
+            async with client.ws_connect("/api/ws") as ws:
+                await ws.send_json({"subscribe": "logs"})
+                # tail lines + the subscribed confirmation arrive (order not fixed)
+                seen = {(await ws.receive_json())["type"] for _ in range(3)}
+                assert "log" in seen and "subscribed" in seen
+                await ws.send_json({"unsubscribe": "logs"})
+
+
+class TestAuth:
+    async def test_rejects_without_token(self):
+        client, _ = _client(api_token="s3cret")
+        async with client:
+            async with client.ws_connect("/api/ws") as ws:
+                await ws.receive()  # server closes with code 4001
+                assert ws.closed
+
+    async def test_accepts_matching_token(self):
+        client, _ = _client(api_token="s3cret")
+        async with client:
+            async with client.ws_connect("/api/ws?token=s3cret") as ws:
+                await ws.send_json({"type": "ping", "ts": 1})
+                assert (await ws.receive_json())["type"] == "pong"
+
+    async def test_accepts_session_manager_token(self):
+        # web_config present (auth on), api_token empty → session_manager validates
+        sm = SimpleNamespace(validate=lambda t: t == "good", get_identity=lambda t: None)
+        client, _ = _client(web_config=SimpleNamespace(), session_manager=sm)
+        async with client:
+            async with client.ws_connect("/api/ws?token=good") as ws:
+                await ws.send_json({"type": "ping", "ts": 1})
+                assert (await ws.receive_json())["type"] == "pong"
+
+
+# --------------------------------------------------------------------------- #
+# _handle_chat — validation, rate limit, delegation, error shaping
+# --------------------------------------------------------------------------- #
+class TestChat:
+    async def test_chat_success(self):
+        client, _ = _client()
+        with patch("src.web.websocket.process_web_chat",
+                   new=AsyncMock(return_value=CHAT_RESULT)):
+            async with client:
+                async with client.ws_connect("/api/ws") as ws:
+                    await ws.send_json({"type": "chat", "content": "hello"})
+                    resp = await ws.receive_json()
+                    assert resp["type"] == "chat_response"
+                    assert resp["content"] == "hi there" and resp["tools_used"] == ["grep"]
+
+    async def test_chat_with_files(self):
+        result = {**CHAT_RESULT, "files": [{"name": "out.txt"}]}
+        client, _ = _client()
+        with patch("src.web.websocket.process_web_chat",
+                   new=AsyncMock(return_value=result)):
+            async with client:
+                async with client.ws_connect("/api/ws") as ws:
+                    await ws.send_json({"type": "chat", "content": "make a file"})
+                    resp = await ws.receive_json()
+                    assert resp["files"] == [{"name": "out.txt"}]
+
+    async def test_chat_empty_and_too_long(self):
+        client, _ = _client()
+        async with client:
+            async with client.ws_connect("/api/ws") as ws:
+                await ws.send_json({"type": "chat", "content": "   "})
+                assert (await ws.receive_json())["type"] == "chat_error"
+                await ws.send_json({"type": "chat", "content": "x" * 40000})
+                assert (await ws.receive_json())["type"] == "chat_error"
+
+    async def test_chat_rate_limit(self):
+        client, _ = _client()
+        with patch("src.web.websocket.process_web_chat",
+                   new=AsyncMock(return_value=CHAT_RESULT)):
+            async with client:
+                async with client.ws_connect("/api/ws") as ws:
+                    last: dict = {}
+                    for _ in range(11):
+                        await ws.send_json({"type": "chat", "content": "ping"})
+                        last = await ws.receive_json()
+                    assert last["type"] == "chat_error" and "rate limit" in last["error"]
+
+    async def test_chat_timeout(self):
+        client, _ = _client()
+        with patch("src.web.websocket.process_web_chat",
+                   new=AsyncMock(side_effect=TimeoutError())):
+            async with client:
+                async with client.ws_connect("/api/ws") as ws:
+                    await ws.send_json({"type": "chat", "content": "slow"})
+                    resp = await ws.receive_json()
+                    assert resp["type"] == "chat_error" and "timed out" in resp["error"]
+
+    async def test_chat_generic_error_scrubbed(self):
+        client, _ = _client()
+        with patch("src.web.websocket.process_web_chat",
+                   new=AsyncMock(side_effect=RuntimeError("kaboom"))):
+            async with client:
+                async with client.ws_connect("/api/ws") as ws:
+                    await ws.send_json({"type": "chat", "content": "boom"})
+                    resp = await ws.receive_json()
+                    assert resp["type"] == "chat_error" and "kaboom" in resp["error"]
+
+
+# --------------------------------------------------------------------------- #
+# broadcast / close / identity helpers — direct with fake sockets
+# --------------------------------------------------------------------------- #
+class _FakeWS:
+    """A hashable (identity) stand-in socket for the broadcast/close/tail helpers.
+
+    (SimpleNamespace can't be used — it defines __eq__ so it's unhashable and
+    the manager keeps sockets in sets.)
+    """
+
+    def __init__(self, **kw):
+        self.closed = False
+        self.send_json = AsyncMock()
+        self.close = AsyncMock()
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _fake_ws(**kw):
+    return _FakeWS(**kw)
+
+
+class TestBroadcastAndClose:
+    async def test_broadcast_event_to_subscribers(self):
+        mgr = WebSocketManager(_bot())
+        good = _fake_ws()
+        dead = _fake_ws()
+        dead.send_json = AsyncMock(side_effect=ConnectionError())
+        mgr._event_subscribers.update({good, dead})
+        mgr._clients.update({good, dead})
+        await mgr.broadcast_event({"kind": "test"})
+        good.send_json.assert_awaited_once()
+        # a socket that errors on send is pruned from the subscriber set
+        assert dead not in mgr._event_subscribers
+
+    async def test_broadcast_no_subscribers_is_noop(self):
+        mgr = WebSocketManager(_bot())
+        await mgr.broadcast_event({"kind": "test"})  # no raise, early return
+
+    async def test_close_by_user_id(self):
+        mgr = WebSocketManager(_bot())
+        match = _fake_ws(_odin_identity=SimpleNamespace(user_id="u1"))
+        other = _fake_ws(_odin_identity=SimpleNamespace(user_id="u2"))
+        mgr._clients.update({match, other})
+        closed = await mgr.close_by_user_id("u1")
+        assert closed == 1
+        match.close.assert_awaited_once()
+        assert match not in mgr._clients and other in mgr._clients
+
+    async def test_close_by_user_id_none_match(self):
+        mgr = WebSocketManager(_bot())
+        mgr._clients.add(_fake_ws(_odin_identity=SimpleNamespace(user_id="uX")))
+        assert await mgr.close_by_user_id("nobody") == 0
+
+    async def test_close_by_user_id_swallows_close_error(self):
+        mgr = WebSocketManager(_bot())
+        ws = _fake_ws(_odin_identity=SimpleNamespace(user_id="u1"))
+        ws.close = AsyncMock(side_effect=RuntimeError("already closed"))
+        mgr._clients.add(ws)
+        assert await mgr.close_by_user_id("u1") == 1  # error swallowed, still pruned
+        assert ws not in mgr._clients
+
+    def test_client_count(self):
+        mgr = WebSocketManager(_bot())
+        mgr._clients.update({_fake_ws(), _fake_ws()})
+        assert mgr.client_count == 2
+
+
+class TestTailLogs:
+    async def test_tail_sends_existing_lines(self):
+        from pathlib import Path
+        data = Path("data")
+        data.mkdir()
+        (data / "audit.jsonl").write_text('{"a":1}\n{"a":2}\n{"a":3}\n')
+        mgr = WebSocketManager(_bot())
+        ws = _fake_ws()
+        # ws is not in _log_subscribers → the poll loop exits after the tail send
+        await mgr._tail_logs(ws)
+        assert ws.send_json.await_count == 3
+
+    async def test_tail_no_file_is_safe(self):
+        mgr = WebSocketManager(_bot())
+        ws = _fake_ws()
+        await mgr._tail_logs(ws)  # ./data/audit.jsonl absent → no send, no raise
+        ws.send_json.assert_not_awaited()
+
+    def test_resolve_identity_via_session_manager(self):
+        ident = SimpleNamespace(user_id="u1")
+        sm = SimpleNamespace(validate=lambda t: True, get_identity=lambda t: ident)
+        mgr = WebSocketManager(_bot(), session_manager=sm)
+        assert mgr._resolve_identity("tok") is ident
+
+    def test_resolve_identity_via_token_manager(self):
+        ident = SimpleNamespace(user_id="u1")
+        tm = SimpleNamespace(resolve=lambda t: ident)
+        request = SimpleNamespace(app={"token_manager": tm})
+        mgr = WebSocketManager(_bot())
+        assert mgr._resolve_identity("tok", request) is ident
+
+    def test_resolve_identity_via_web_config(self):
+        ident = SimpleNamespace(user_id="u2")
+        wc = SimpleNamespace(resolve_api_identity=lambda t: ident)
+        mgr = WebSocketManager(_bot(), web_config=wc)
+        assert mgr._resolve_identity("tok") is ident
+
+    def test_resolve_identity_returns_none(self):
+        mgr = WebSocketManager(_bot())
+        assert mgr._resolve_identity("tok") is None


### PR DESCRIPTION
Picks up the four deferred web-route surfaces from the coverage plan's §6b backlog (`docs/plans/coverage-plan.md`). One PR, purely additive tests + a scoped baseline ratchet — **no `src/` changes, no behaviour change.**

## Coverage lifts

| File | Start → End |
|---|---|
| `web/api/integrations.py` | 45% → **100%** |
| `web/api/knowledge_mem.py` | 47% → **99%** |
| `web/api/agents_loops.py` | 21% → **99%** |
| `web/websocket.py` | 46% → **88%** |

Whole-repo line coverage **72.9% → 74.7%**; suite **+90 tests** (6,516 → 6,606). mypy 0, ruff clean, all four CI gates green.

## Method — real interfaces, faked boundaries

- **knowledge_mem**: real `KnowledgeStore` on a temp sqlite db (FTS-only via `embedder=None`), real `ConversationReflector` (temp learned.json), real round-tripping memory persistence. Only embeddings faked. Exercises real ingest / search / versions / dedup / merge / import.
- **integrations**: every remote service (MCP / Slack / issue-tracker / Grafana / webhooks) faked hard — validates request parsing, validation, and delegation, never the network.
- **agents_loops**: real route dispatch with faked loop/agent/process **runtime** boundaries — no real loops or processes started.
- **websocket**: aiohttp's real ws test client drives the `handle` message loop and `_handle_chat` (subscribe/ping/chat/rate-limit/timeout/error); broadcast/close/tail helpers driven directly with hashable fake sockets. Autouse `chdir(tmp_path)` isolates the relative `./data/audit.jsonl` tail read.

## Uncovered by design

The two `_iteration_cb` runtime closures in `agents_loops` (would require starting real loops); `websocket`'s 1 s-poll log-tail loop (timing-heavy) and a couple of deep auth/CLOSE branches; two dead-defensive fallback lines in `knowledge_mem`.

## Discipline

- **COV ledger empty** — every failing test while authoring was a *test-setup* error the production code corrected (dedup-skipped identical ingest, non-numeric channel_id, length-only `_validate_string`, graceful `_safe_int_param` fallback, unhashable `SimpleNamespace` in a set). No real bugs; no `xfail`s.
- **Scoped ratchet** — `coverage-baseline.json` is tightened for exactly these four files. Three files my tests incidentally lifted (`knowledge/store.py`, `learning/reflector.py`, `web/api_common.py`) were kept at their looser ceilings, so the baseline diff matches this PR's stated scope and no tighter number is locked on `store.py` (past coverage nondeterminism).

Plan-of-record results: `docs/plans/coverage-plan.md` §6c.