### PR TITLE
test: RFC-006 P5 — discord native-tool coverage

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -216,27 +216,27 @@
   "statements": 2
  },
  "src/discord/native_tools/agents_tasks.py": {
-  "covered": 111,
-  "missing": 210,
-  "percent": 34.58,
+  "covered": 304,
+  "missing": 17,
+  "percent": 94.7,
   "statements": 321
  },
  "src/discord/native_tools/channel_ops.py": {
-  "covered": 17,
-  "missing": 96,
-  "percent": 15.04,
+  "covered": 113,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 113
  },
  "src/discord/native_tools/knowledge.py": {
-  "covered": 20,
-  "missing": 97,
-  "percent": 17.09,
+  "covered": 117,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 117
  },
  "src/discord/native_tools/media.py": {
-  "covered": 21,
-  "missing": 145,
-  "percent": 12.65,
+  "covered": 166,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 166
  },
  "src/discord/native_tools/registry.py": {
@@ -246,9 +246,9 @@
   "statements": 89
  },
  "src/discord/native_tools/scheduling.py": {
-  "covered": 57,
-  "missing": 67,
-  "percent": 45.97,
+  "covered": 124,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 124
  },
  "src/discord/native_tools/skills_tools.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -1,6 +1,6 @@
 # RFC-006: Test-Coverage Campaign (ratchet gate + prioritized waves)
 
-Status: R3 — CONT-1 + CONT-2 COMPLETE (campaign shipped through P4b in §6b; P4-continuation CONT-1 in §6c, CONT-2 in §6d — all six deferred web-route surfaces now covered). Plan of record was Odin-approved R1 (§6a).  Only P5 (discord native tools) remains deferred.
+Status: R3 — CONT-1 + CONT-2 + P5 COMPLETE (campaign shipped through P4b in §6b; P4-continuation CONT-1 §6c, CONT-2 §6d, P5 discord native tools §6e). Plan of record was Odin-approved R1 (§6a). All deferred surfaces now covered.
 Campaign branch: `coverage/rfc006` (created after plan approval).
 Predecessors: RFC-005 (type-safety ratchet) is the template — a fail-closed CI ratchet plus incremental waves, security/high-value first. Unlike RFC-005, coverage waves add TESTS, not annotations: they can and will surface real bugs. Bug **fixes** are out-of-band (§5).
 
@@ -134,6 +134,28 @@ Suite **+90 tests**; mypy 0, ruff clean.
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
 **End state:** the six web-route surfaces the §6b campaign deferred are now 88–100% covered; the coverage-no-drop ratchet holds each as a permanent floor. Only P5 (discord native tools) remains deferred.
+
+## 6e. R3 — P5 discord native tools (2026-07-07)
+
+The last deferred surface: the five Discord-native tool domain handlers (`src/discord/native_tools/`). One PR, Odin-reviewed, coverage-gated.
+
+| File | Start → End |
+|---|---|
+| `native_tools/channel_ops.py` | 15% → **100%** |
+| `native_tools/knowledge.py` | 17% → **100%** |
+| `native_tools/media.py` | 13% → **100%** |
+| `native_tools/scheduling.py` | 46% → **100%** |
+| `native_tools/agents_tasks.py` | 34% → **95%** |
+
+Suite **+103 tests**; mypy 0, ruff clean.
+
+**Method:** each domain `*Tools` class is constructed directly with faked deps and its `_handle_*` methods driven with crafted inputs; the handlers return plain strings (or `analyze_image`'s `__image_block__` marker dict). Every external boundary is faked hard — `discord.Forbidden/NotFound/HTTPException` are real exceptions raised from mocks; no gateway, no network (aiohttp sessions + `getaddrinfo` faked), no SSH subprocess (`create_subprocess_exec` faked), no ComfyUI, no browser. For `agents_tasks`, the runtime is fully neutralized: `run_background_task` is patched, and the loop/agent/bridge managers are mocks — **no real task, loop, or agent ever executes.**
+
+**Uncovered by design (`agents_tasks`, 17 lines = 95%):** exactly the inner `_iteration_cb` / `_tool_exec_cb` / `_codex_followup` / `_run` closures that only execute inside a live loop or spawned agent. Per Odin's standing advisory ("don't start real loops/agents just to worship the green bar"), these are left to the loop/agent integration paths, not driven synthetically.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
+**Campaign end state:** whole-repo line coverage **67.0% → ~78%** across RFC-006 (P0–P5); the four CI ratchets (lint / types / coverage / suite) hold every gain. The web-API, web-admin, and native-tool surfaces are now 88–100% covered.
 
 ## 7. Risks / discipline
 

--- a/tests/test_native_agents_tasks.py
+++ b/tests/test_native_agents_tasks.py
@@ -1,0 +1,330 @@
+"""Coverage for src/discord/native_tools/agents_tasks.py (RFC-006 P5).
+
+The fifth, largest native-tool domain: background-task delegation, autonomous
+loops, agent spawn/collect, and the loop-agent bridge. Every runtime boundary is
+faked — managers, the loop runner, the LLM gateway, and run_background_task —
+so no real task/loop/agent ever executes (Odin's rule: don't start real runtime
+just to green the bar). The inner iteration/tool callbacks only run under real
+execution and are intentionally not driven here; we cover the handler bodies:
+validation, setup, the launch call, and response shaping.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.discord.background_task import MAX_STEPS
+from src.discord.native_tools.agents_tasks import AgentTaskDeps, AgentTaskTools
+
+
+def _cfg(tools_enabled=True):
+    return SimpleNamespace(
+        tools=SimpleNamespace(enabled=tools_enabled, tool_timeouts={}),
+        agents=SimpleNamespace(max_nesting_depth=2, hard_max_iterations=300,
+                               max_iterations=120, scheduled_max_iterations=180,
+                               final_warning_iterations=[20, 10, 5, 1]),
+    )
+
+
+def _deps(**ov):
+    d: dict[str, Any] = dict(
+        get_config=lambda: _cfg(),
+        llm_gateway=SimpleNamespace(active_client=object()),
+        channel_state=SimpleNamespace(background_tasks={}, background_tasks_max=50),
+        tool_executor=MagicMock(),
+        skill_manager=MagicMock(),
+        get_knowledge_store=lambda: MagicMock(),
+        embedder=None,
+        audit=MagicMock(),
+        agent_manager=MagicMock(),
+        loop_manager=MagicMock(),
+        loop_agent_bridge=MagicMock(),
+        agent_trajectory_saver=None,
+        get_context_compressor=lambda: None,
+        tool_loop=MagicMock(),
+        turn_recorder=SimpleNamespace(_emit_lifecycle_event=AsyncMock()),
+        prompt_builder=SimpleNamespace(build_full_prompt=lambda **k: "SYS"),
+        tool_catalog=SimpleNamespace(merged_definitions=lambda: [{"name": "web_search"}]),
+    )
+    d.update(ov)
+    return AgentTaskDeps(**d)
+
+
+def _tools(**ov):
+    return AgentTaskTools(_deps(**ov))
+
+
+def _message(cid=42, uid=7):
+    return SimpleNamespace(channel=SimpleNamespace(id=cid), author=SimpleNamespace(id=uid))
+
+
+def _task(status="running", results=None, steps=None, tid="T1", desc="job"):
+    return SimpleNamespace(
+        task_id=tid, description=desc, status=status,
+        steps=steps or [{"tool_name": "x"}], results=results or [], cancel=MagicMock())
+
+
+# --------------------------------------------------------------------------- #
+# delegate_task
+# --------------------------------------------------------------------------- #
+class TestDelegateTask:
+    async def test_validation(self):
+        t = _tools()
+        msg = _message()
+        assert "No steps" in await t._handle_delegate_task(msg, {"steps": []})
+        assert "Too many steps" in await t._handle_delegate_task(
+            msg, {"steps": [{"tool_name": "x"}] * (MAX_STEPS + 1)})
+        assert "must have 'tool_name'" in await t._handle_delegate_task(
+            msg, {"steps": [{"no_tool": 1}]})
+        assert "missing 'command'" in await t._handle_delegate_task(
+            msg, {"steps": [{"tool_name": "run_command", "tool_input": {}}]})
+
+    async def test_success_launches(self):
+        t = _tools()
+        msg = _message()
+        with patch("src.discord.native_tools.agents_tasks.run_background_task",
+                   new=AsyncMock()):
+            out = await t._handle_delegate_task(
+                msg, {"description": "deploy", "steps": [{"tool_name": "web_search"}]})
+            await asyncio.sleep(0)  # let the fire-and-forget _run() settle
+        assert "Background task started" in out and "deploy" in out
+        assert len(t._channel_state.background_tasks) == 1
+
+    async def test_prunes_old_completed(self):
+        deps = _deps()
+        deps.channel_state.background_tasks_max = 1
+        deps.channel_state.background_tasks = {
+            "old1": _task(status="completed"), "old2": _task(status="completed")}
+        t = AgentTaskTools(deps)
+        with patch("src.discord.native_tools.agents_tasks.run_background_task",
+                   new=AsyncMock()):
+            await t._handle_delegate_task(_message(), {"steps": [{"tool_name": "web_search"}]})
+            await asyncio.sleep(0)
+        # pruned down to the cap + the new one
+        assert len(deps.channel_state.background_tasks) <= 2
+
+
+# --------------------------------------------------------------------------- #
+# list_tasks / cancel_task
+# --------------------------------------------------------------------------- #
+class TestListCancelTasks:
+    def test_list_empty(self):
+        assert "No background tasks" in _tools()._handle_list_tasks()
+
+    def test_list_overview(self):
+        deps = _deps()
+        r_ok = SimpleNamespace(status="ok", index=0, description="s", elapsed_ms=5, output="done")
+        deps.channel_state.background_tasks = {"T1": _task(results=[r_ok])}
+        out = AgentTaskTools(deps)._handle_list_tasks()
+        assert "`T1`" in out and "1 ok" in out
+
+    def test_list_detail_and_missing(self):
+        deps = _deps()
+        r = SimpleNamespace(status="error", index=1, description="step", elapsed_ms=9, output="")
+        deps.channel_state.background_tasks = {"T1": _task(results=[r])}
+        t = AgentTaskTools(deps)
+        out = t._handle_list_tasks({"task_id": "T1"})
+        assert "job" in out and "(no output)" in out
+        assert "No task found" in t._handle_list_tasks({"task_id": "ghost"})
+
+    def test_list_detail_truncates(self):
+        deps = _deps()
+        big = SimpleNamespace(status="ok", index=0, description="s",
+                              elapsed_ms=1, output="x" * 4000)
+        deps.channel_state.background_tasks = {"T1": _task(results=[big])}
+        out = AgentTaskTools(deps)._handle_list_tasks({"task_id": "T1"})
+        assert "truncated" in out
+
+    def test_cancel(self):
+        deps = _deps()
+        deps.channel_state.background_tasks = {"T1": _task(status="running")}
+        t = AgentTaskTools(deps)
+        assert "No task found" in t._handle_cancel_task({"task_id": "ghost"})
+        assert "Cancellation requested" in t._handle_cancel_task({"task_id": "T1"})
+        deps.channel_state.background_tasks["T2"] = _task(status="completed", tid="T2")
+        assert "is not running" in t._handle_cancel_task({"task_id": "T2"})
+
+
+# --------------------------------------------------------------------------- #
+# loops
+# --------------------------------------------------------------------------- #
+class TestLoops:
+    def test_start_loop_validation_and_error(self):
+        t = _tools()
+        assert "'goal' is required" in t._handle_start_loop(_message(), {})
+        t._loop_manager.start_loop.return_value = "Error: too many loops"
+        assert "Error" in t._handle_start_loop(_message(), {"goal": "watch"})
+
+    async def test_start_loop_success(self):
+        t = _tools()
+        t._loop_manager.start_loop.return_value = "loop123"
+        out = t._handle_start_loop(_message(), {"goal": "watch the logs", "interval_seconds": 30})
+        await asyncio.sleep(0)  # let lifecycle fire-and-forget settle
+        assert "loop123" in out and "mode=notify" in out
+
+    async def test_stop_loop(self):
+        t = _tools()
+        assert "'loop_id' is required" in t._handle_stop_loop({})
+        t._loop_manager.stop_loop.return_value = "Loop stopped."
+        assert "stopped" in t._handle_stop_loop({"loop_id": "L1"})
+        await asyncio.sleep(0)
+
+    def test_list_loops(self):
+        t = _tools()
+        t._loop_manager.list_loops.return_value = "1 loop"
+        assert t._handle_list_loops() == "1 loop"
+
+
+# --------------------------------------------------------------------------- #
+# spawn_agent
+# --------------------------------------------------------------------------- #
+class TestSpawnAgent:
+    async def test_validation(self):
+        assert "required" in await _tools()._handle_spawn_agent(_message(), {"label": "a"})
+        t = _tools(llm_gateway=SimpleNamespace(active_client=None))
+        assert "not available" in await t._handle_spawn_agent(
+            _message(), {"label": "a", "goal": "g"})
+
+    async def test_success(self):
+        t = _tools()
+        t._agent_manager.spawn.return_value = "agent-1"
+        t._agent_manager._agents = {}
+        out = await t._handle_spawn_agent(_message(), {"label": "worker", "goal": "do it"})
+        assert "spawned" in out and "agent-1" in out
+
+    async def test_spawn_error_returned(self):
+        t = _tools()
+        t._agent_manager.spawn.return_value = "Error: nesting too deep"
+        t._agent_manager._agents = {}
+        assert "Error" in await t._handle_spawn_agent(
+            _message(), {"label": "w", "goal": "g"})
+
+    async def test_nested_with_parent_and_compressor(self):
+        cc = SimpleNamespace(max_context_chars=500000, keep_recent_iterations=20)
+        t = _tools(get_context_compressor=lambda: cc)
+        t._agent_manager.spawn.return_value = "child-1"
+        t._agent_manager._agents = {"parent-1": SimpleNamespace(depth=0)}
+        out = await t._handle_spawn_agent(
+            _message(), {"label": "child", "goal": "sub", "parent_id": "parent-1"})
+        assert "depth 1" in out
+
+    async def test_scheduled_spawn_uses_higher_budget(self):
+        t = _tools()
+        t._agent_manager.spawn.return_value = "agent-s"
+        t._agent_manager._agents = {}
+        out = await t._handle_spawn_agent(
+            _message(), {"label": "s", "goal": "g", "_scheduled": True})
+        assert "spawned" in out
+
+
+# --------------------------------------------------------------------------- #
+# simple agent handlers
+# --------------------------------------------------------------------------- #
+class TestAgentHandlers:
+    def test_send_to_agent(self):
+        t = _tools()
+        assert "'agent_id' is required" in t._handle_send_to_agent({})
+        assert "'message' is required" in t._handle_send_to_agent({"agent_id": "a"})
+        t._agent_manager.send.return_value = "sent"
+        assert t._handle_send_to_agent({"agent_id": "a", "message": "hi"}) == "sent"
+
+    def test_list_agents(self):
+        t = _tools()
+        t._agent_manager.list.return_value = []
+        assert "No agents running" in t._handle_list_agents(_message())
+        t._agent_manager.list.return_value = [
+            {"id": "a1", "label": "w", "status": "running",
+             "iteration_count": 3, "runtime_seconds": 12}]
+        out = t._handle_list_agents(_message())
+        assert "Agents (1)" in out and "`a1`" in out
+
+    def test_kill_agent(self):
+        t = _tools()
+        assert "'agent_id' is required" in t._handle_kill_agent({})
+        t._agent_manager.kill.return_value = "killed"
+        assert t._handle_kill_agent({"agent_id": "a"}) == "killed"
+
+    def test_get_agent_results(self):
+        t = _tools()
+        assert "'agent_id' is required" in t._handle_get_agent_results({})
+        t._agent_manager.get_results.return_value = None
+        assert "not found" in t._handle_get_agent_results({"agent_id": "a"})
+        t._agent_manager.get_results.return_value = {
+            "status": "running", "label": "w", "iteration_count": 2, "runtime_seconds": 5}
+        assert "still running" in t._handle_get_agent_results({"agent_id": "a"})
+        t._agent_manager.get_results.return_value = {
+            "status": "failed", "label": "w", "iteration_count": 4, "runtime_seconds": 9,
+            "tools_used": ["grep"], "result": "x" * 2000, "error": "boom"}
+        out = t._handle_get_agent_results({"agent_id": "a"})
+        assert "failed" in out and "Result:" in out and "Error: boom" in out
+        assert "..." in out  # long result truncated
+
+    async def test_wait_for_agents(self):
+        t = _tools()
+        assert "required" in await t._handle_wait_for_agents({})
+        assert "must be a list" in await t._handle_wait_for_agents({"agent_ids": "notalist"})
+        t._agent_manager.wait_for_agents = AsyncMock(return_value={
+            "a1": {"status": "completed", "label": "w", "result": "x" * 1000}})
+        out = await t._handle_wait_for_agents({"agent_ids": ["a1"], "timeout": 10})
+        assert "`a1`" in out and "..." in out  # long content truncated at 800
+
+    async def test_collect_agent_result_helper(self):
+        t = _tools()
+        t._agent_manager.wait_for_agents = AsyncMock(return_value={
+            "a1": {"status": "failed", "label": "worker", "runtime_seconds": 5,
+                   "iteration_count": 3, "tools_used": ["grep"], "result": "x" * 2000,
+                   "error": "crashed"}})
+        text, raw = await t._collect_agent_result("a1")
+        assert "worker" in text and raw["status"] == "failed"
+        assert raw["empty_result"] is False and "..." in text  # long result truncated
+        assert "Error: crashed" in text
+
+
+# --------------------------------------------------------------------------- #
+# loop-agent bridge
+# --------------------------------------------------------------------------- #
+class TestLoopAgentBridge:
+    def _running_loop(self):
+        return SimpleNamespace(status="running", iteration_count=2, goal="g",
+                               requester_id="u1", requester_name="U")
+
+    async def test_spawn_loop_agents_validation(self):
+        t = _tools()
+        assert "'loop_id' is required" in await t._handle_spawn_loop_agents(_message(), {})
+        assert "'tasks' list is required" in await t._handle_spawn_loop_agents(
+            _message(), {"loop_id": "L1"})
+        t._loop_manager._loops = {}
+        assert "not found" in await t._handle_spawn_loop_agents(
+            _message(), {"loop_id": "L1", "tasks": ["t"]})
+        t._loop_manager._loops = {"L1": SimpleNamespace(status="stopped")}
+        assert "not running" in await t._handle_spawn_loop_agents(
+            _message(), {"loop_id": "L1", "tasks": ["t"]})
+
+    async def test_spawn_loop_agents_no_client(self):
+        t = _tools(llm_gateway=SimpleNamespace(active_client=None))
+        t._loop_manager._loops = {"L1": self._running_loop()}
+        assert "not available" in await t._handle_spawn_loop_agents(
+            _message(), {"loop_id": "L1", "tasks": ["t"]})
+
+    async def test_spawn_loop_agents_success_and_errors(self):
+        t = _tools()
+        t._loop_manager._loops = {"L1": self._running_loop()}
+        t._loop_agent_bridge.spawn_agents_for_loop.return_value = ["ag1", "Error: bad"]
+        out = await t._handle_spawn_loop_agents(
+            _message(), {"loop_id": "L1", "tasks": ["a", "b"]})
+        assert "Spawned 1 agent(s): ag1" in out and "Errors: Error: bad" in out
+
+    async def test_collect_loop_agents(self):
+        t = _tools()
+        assert "'loop_id' is required" in await t._handle_collect_loop_agents({})
+        t._loop_manager._loops = {}
+        assert "not found" in await t._handle_collect_loop_agents({"loop_id": "L1"})
+        t._loop_manager._loops = {"L1": self._running_loop()}
+        t._loop_agent_bridge.wait_and_collect = AsyncMock(return_value=[])
+        assert "No agents to collect" in await t._handle_collect_loop_agents({"loop_id": "L1"})
+        t._loop_agent_bridge.wait_and_collect = AsyncMock(return_value=[{"id": "a1"}])
+        t._loop_agent_bridge.format_agent_results_for_context.return_value = "formatted"
+        assert await t._handle_collect_loop_agents(
+            {"loop_id": "L1", "agent_ids": ["a1"]}) == "formatted"

--- a/tests/test_native_channel_ops.py
+++ b/tests/test_native_channel_ops.py
@@ -1,0 +1,228 @@
+"""Coverage for src/discord/native_tools/channel_ops.py (RFC-006 P5).
+
+Drives the Discord-native channel-op handlers (purge / read / react / poll /
+set-permission) directly on ChannelOpsTools with faked discord objects. No
+gateway is touched — messages, channels, and discord.Forbidden/NotFound are all
+fakes; the handlers return plain strings we assert on.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+from src.discord.native_tools.channel_ops import ChannelOpsTools
+
+
+def _forbidden():
+    return discord.Forbidden(
+        SimpleNamespace(status=403, reason="Forbidden"), "denied")  # type: ignore[arg-type]
+
+
+def _not_found():
+    return discord.NotFound(
+        SimpleNamespace(status=404, reason="Not Found"), "missing")  # type: ignore[arg-type]
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        self._it = iter(self._items)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _hist_msg(content="hi", author="alice", bot=False, attachments=(), embeds=()):
+    return SimpleNamespace(
+        created_at=SimpleNamespace(strftime=lambda fmt: "12:00:00"),
+        author=SimpleNamespace(display_name=author, bot=bot),
+        content=content, attachments=list(attachments), embeds=list(embeds),
+    )
+
+
+def _channel(history_msgs=None, cid=42):
+    ch = MagicMock()
+    ch.id = cid
+    ch.purge = AsyncMock(return_value=[object(), object()])
+    ch.send = AsyncMock()
+    ch.fetch_message = AsyncMock()
+    if history_msgs is not None:
+        ch.history = lambda limit=10: _AsyncIter(history_msgs)
+    return ch
+
+
+def _message(channel=None, mid=7):
+    msg = MagicMock()
+    msg.id = mid
+    msg.channel = channel or _channel()
+    return msg
+
+
+def _tools(get_channel=None):
+    return ChannelOpsTools(
+        sessions=MagicMock(),
+        permissions=MagicMock(),
+        get_channel=get_channel or (lambda cid: None),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# purge
+# --------------------------------------------------------------------------- #
+class TestPurge:
+    async def test_success_resets_session(self):
+        t = _tools()
+        msg = _message()
+        out = await t._handle_purge(msg, {"count": 5})
+        assert "Deleted 2 messages" in out
+        t.sessions.reset.assert_called_once_with(str(msg.channel.id))
+
+    async def test_forbidden(self):
+        t = _tools()
+        msg = _message()
+        msg.channel.purge = AsyncMock(side_effect=_forbidden())
+        assert "don't have permission" in await t._handle_purge(msg, {})
+
+    async def test_generic_error(self):
+        t = _tools()
+        msg = _message()
+        msg.channel.purge = AsyncMock(side_effect=RuntimeError("boom"))
+        assert "Failed to purge" in await t._handle_purge(msg, {})
+
+
+# --------------------------------------------------------------------------- #
+# read_channel
+# --------------------------------------------------------------------------- #
+class TestReadChannel:
+    async def test_reads_and_formats(self):
+        embed = SimpleNamespace(title="T", description="D" * 300)
+        msgs = [
+            _hist_msg("hello", "alice"),
+            _hist_msg("", "botty", bot=True,
+                      attachments=[SimpleNamespace(filename="a.png")], embeds=[embed]),
+        ]
+        t = _tools()
+        msg = _message(channel=_channel(history_msgs=msgs))
+        out = await t._handle_read_channel(msg, {"limit": 10})
+        assert "2 messages read" in out
+        assert "alice" in out and "[BOT]" in out
+        assert "[attachment: a.png]" in out and "[embed:" in out
+
+    async def test_resolve_by_channel_id(self):
+        ch = _channel(history_msgs=[_hist_msg("yo")])
+        t = _tools(get_channel=lambda cid: ch)
+        out = await t._handle_read_channel(_message(), {"channel_id": "99"})
+        assert "1 messages read" in out
+
+    async def test_channel_id_not_found(self):
+        t = _tools(get_channel=lambda cid: None)
+        out = await t._handle_read_channel(_message(), {"channel_id": "99"})
+        assert "not found or not accessible" in out
+
+    async def test_no_channel_context(self):
+        t = _tools()
+        msg = SimpleNamespace(channel=None)
+        assert "No channel context" in await t._handle_read_channel(msg, {})
+
+    async def test_no_messages(self):
+        t = _tools()
+        msg = _message(channel=_channel(history_msgs=[]))
+        assert "No messages found" in await t._handle_read_channel(msg, {})
+
+    async def test_forbidden_and_error(self):
+        t = _tools()
+        ch = MagicMock()
+        ch.history = MagicMock(side_effect=_forbidden())
+        assert "Permission denied" in await t._handle_read_channel(
+            SimpleNamespace(channel=ch), {})
+        ch.history = MagicMock(side_effect=RuntimeError("x"))
+        assert "Failed to read channel" in await t._handle_read_channel(
+            SimpleNamespace(channel=ch), {})
+
+
+# --------------------------------------------------------------------------- #
+# add_reaction
+# --------------------------------------------------------------------------- #
+class TestAddReaction:
+    async def test_missing_emoji(self):
+        assert "'emoji' is required" in await _tools()._handle_add_reaction(_message(), {})
+
+    async def test_success_resolves_this(self):
+        t = _tools()
+        msg = _message()
+        target = MagicMock()
+        target.add_reaction = AsyncMock()
+        msg.channel.fetch_message = AsyncMock(return_value=target)
+        out = await t._handle_add_reaction(msg, {"emoji": "👍", "message_id": "this"})
+        assert out == "Reaction added."
+        msg.channel.fetch_message.assert_awaited_once_with(int(msg.id))
+
+    async def test_not_found_forbidden_error(self):
+        t = _tools()
+        msg = _message()
+        msg.channel.fetch_message = AsyncMock(side_effect=_not_found())
+        assert "not found" in await t._handle_add_reaction(msg, {"emoji": "x", "message_id": "5"})
+        msg.channel.fetch_message = AsyncMock(side_effect=_forbidden())
+        assert "Permission denied" in await t._handle_add_reaction(
+            msg, {"emoji": "x", "message_id": "5"})
+        msg.channel.fetch_message = AsyncMock(side_effect=RuntimeError("e"))
+        assert "Failed to add reaction" in await t._handle_add_reaction(
+            msg, {"emoji": "x", "message_id": "5"})
+
+
+# --------------------------------------------------------------------------- #
+# create_poll
+# --------------------------------------------------------------------------- #
+class TestCreatePoll:
+    async def test_validation(self):
+        t = _tools()
+        assert "required" in await t._handle_create_poll(_message(), {"question": "q"})
+        assert "maximum of 10" in await t._handle_create_poll(
+            _message(), {"question": "q", "options": [str(i) for i in range(11)]})
+
+    async def test_success(self):
+        t = _tools()
+        msg = _message()
+        out = await t._handle_create_poll(
+            msg, {"question": "Pick", "options": ["a", "b"], "duration_hours": 5})
+        assert out == "Poll created."
+        msg.channel.send.assert_awaited_once()
+
+    async def test_send_error(self):
+        t = _tools()
+        msg = _message()
+        msg.channel.send = AsyncMock(side_effect=RuntimeError("nope"))
+        assert "Failed to create poll" in await t._handle_create_poll(
+            msg, {"question": "q", "options": ["a"]})
+
+
+# --------------------------------------------------------------------------- #
+# set_permission
+# --------------------------------------------------------------------------- #
+class TestSetPermission:
+    async def test_denied_for_non_admin(self):
+        t = _tools()
+        t.permissions.is_admin.return_value = False
+        assert "Permission denied" in await t._handle_set_permission(
+            "u1", {"user_id": "u2", "tier": "user"})
+
+    async def test_success(self):
+        t = _tools()
+        t.permissions.is_admin.return_value = True
+        t.permissions.async_set_tier = AsyncMock()
+        out = await t._handle_set_permission("admin", {"user_id": "u2", "tier": "admin"})
+        assert "set to **admin**" in out
+
+    async def test_invalid_tier(self):
+        t = _tools()
+        t.permissions.is_admin.return_value = True
+        t.permissions.async_set_tier = AsyncMock(side_effect=ValueError("bad tier"))
+        assert "bad tier" in await t._handle_set_permission(
+            "admin", {"user_id": "u2", "tier": "nope"})

--- a/tests/test_native_knowledge.py
+++ b/tests/test_native_knowledge.py
@@ -1,0 +1,153 @@
+"""Coverage for src/discord/native_tools/knowledge.py (RFC-006 P5).
+
+Drives the knowledge/history/audit-search handlers on KnowledgeTools with faked
+store / sessions / audit boundaries. The store is a fake with controlled return
+shapes so the formatting branches are exercised precisely; BulkImporter is
+patched for the bulk path.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.discord.native_tools.knowledge import KnowledgeTools
+
+
+def _tools(store=None, sessions=None, audit=None):
+    return KnowledgeTools(
+        sessions=sessions or MagicMock(),
+        get_knowledge_store=lambda: store,
+        embedder=object(),
+        audit=audit or MagicMock(),
+    )
+
+
+def _store():
+    s = MagicMock()
+    s.search_hybrid = AsyncMock(return_value=[])
+    s.ingest = AsyncMock(return_value=3)
+    s.delete_source_async = AsyncMock(return_value=2)
+    return s
+
+
+class TestSearchHistory:
+    async def test_requires_query(self):
+        assert "query is required" in await _tools()._handle_search_history({})
+
+    async def test_no_results(self):
+        s = MagicMock()
+        s.search_history = AsyncMock(return_value=[])
+        assert "No past conversations" in await _tools(sessions=s)._handle_search_history(
+            {"query": "x"})
+
+    async def test_formats_results(self):
+        s = MagicMock()
+        s.search_history = AsyncMock(return_value=[
+            {"timestamp": 1_700_000_000, "type": "user", "content": "line\nbreak"},
+        ])
+        out = await _tools(sessions=s)._handle_search_history({"query": "q"})
+        assert "Found 1 result(s)" in out and "(user)" in out
+
+
+class TestSearchKnowledge:
+    async def test_store_unavailable(self):
+        assert "not available" in await _tools(store=None)._handle_search_knowledge({"query": "q"})
+
+    async def test_requires_query(self):
+        assert "query is required" in await _tools(store=_store())._handle_search_knowledge({})
+
+    async def test_no_results(self):
+        assert "No knowledge base results" in await _tools(
+            store=_store())._handle_search_knowledge({"query": "q"})
+
+    async def test_formats_results(self):
+        s = _store()
+        s.search_hybrid = AsyncMock(return_value=[
+            {"source": "doc.md", "score": 0.9, "content": "body\ntext"},
+        ])
+        out = await _tools(store=s)._handle_search_knowledge({"query": "q"})
+        assert "[doc.md]" in out and "score: 0.9" in out
+
+
+class TestIngest:
+    async def test_store_unavailable(self):
+        assert "not available" in await _tools(store=None)._handle_ingest_document({}, "web")
+
+    async def test_requires_source_and_content(self):
+        assert "required" in await _tools(store=_store())._handle_ingest_document(
+            {"source": "s"}, "web")
+
+    async def test_zero_chunks(self):
+        s = _store()
+        s.ingest = AsyncMock(return_value=0)
+        out = await _tools(store=s)._handle_ingest_document(
+            {"source": "s", "content": "c"}, "web")
+        assert "Failed to ingest" in out
+
+    async def test_success(self):
+        out = await _tools(store=_store())._handle_ingest_document(
+            {"source": "s", "content": "c"}, "web")
+        assert "Ingested 's'" in out and "3 chunks" in out
+
+
+class TestBulkIngest:
+    async def test_store_unavailable(self):
+        assert "not available" in await _tools(store=None)._handle_bulk_ingest({}, "web")
+
+    async def test_requires_items(self):
+        assert "required" in await _tools(store=_store())._handle_bulk_ingest(
+            {"items": "notalist"}, "web")
+
+    async def test_success(self):
+        batch = MagicMock(succeeded=1, failed=1, skipped=0, results=[
+            {"status": "ok", "source": "a", "chunks": 2, "error": None},
+            {"status": "error", "source": "b", "chunks": 0, "error": "bad"},
+        ])
+        importer = MagicMock()
+        importer.import_batch = AsyncMock(return_value=batch)
+        with patch("src.knowledge.importer.BulkImporter", return_value=importer):
+            out = await _tools(store=_store())._handle_bulk_ingest(
+                {"items": [{"type": "url"}]}, "web")
+        assert "1 succeeded, 1 failed" in out and "[OK] a (2 chunks)" in out and "[ERROR] b" in out
+
+
+class TestListDelete:
+    def test_list_unavailable_empty_and_formatted(self):
+        assert "not available" in _tools(store=None)._handle_list_knowledge()
+        s = _store()
+        s.list_sources = MagicMock(return_value=[])
+        assert "empty" in _tools(store=s)._handle_list_knowledge()
+        s.list_sources = MagicMock(return_value=[
+            {"source": "d.md", "chunks": 4, "uploader": "u", "ingested_at": "2026-07-07T00:00:00"},
+        ])
+        out = _tools(store=s)._handle_list_knowledge()
+        assert "1 document(s), 4 total chunks" in out and "**d.md**" in out
+
+    async def test_delete_paths(self):
+        assert "not available" in await _tools(store=None)._handle_delete_knowledge({})
+        assert "'source' is required" in await _tools(store=_store())._handle_delete_knowledge({})
+        s = _store()
+        s.delete_source_async = AsyncMock(return_value=0)
+        assert "No document found" in await _tools(store=s)._handle_delete_knowledge(
+            {"source": "x"})
+        out = await _tools(store=_store())._handle_delete_knowledge({"source": "x"})
+        assert "Deleted 'x'" in out and "2 chunks removed" in out
+
+
+class TestSearchAudit:
+    async def test_no_results(self):
+        a = MagicMock()
+        a.search = AsyncMock(return_value=[])
+        assert "No audit log entries" in await _tools(audit=a)._handle_search_audit({})
+
+    async def test_formats_entries(self):
+        a = MagicMock()
+        a.search = AsyncMock(return_value=[
+            {"timestamp": "2026-07-07T12:00:00Z", "tool_name": "run_command",
+             "user_name": "aaron", "approved": True, "execution_time_ms": 12,
+             "result_summary": "ok"},
+            {"timestamp": "2026-07-07T12:01:00Z", "tool_name": "x",
+             "user_name": "u", "approved": False, "error": "boom"},
+        ])
+        out = await _tools(audit=a)._handle_search_audit(
+            {"has_error": 1, "min_duration_ms": "5", "limit": 5})
+        assert "2 entries" in out and "run_command" in out and "ERROR: boom" in out

--- a/tests/test_native_media.py
+++ b/tests/test_native_media.py
@@ -1,0 +1,297 @@
+"""Coverage for src/discord/native_tools/media.py (RFC-006 P5).
+
+Drives the media/file handlers on MediaTools with every external boundary faked
+hard: no browser, no SSH subprocess, no aiohttp fetch, no ComfyUI. discord.File
+is real (BytesIO), channel.send is an AsyncMock; the handlers return strings (or
+the __image_block__ marker dict for analyze_image).
+"""
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+from src.discord.native_tools.media import MediaTools
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+def _http_exc(status=500):
+    return discord.HTTPException(
+        SimpleNamespace(status=status, reason="err"), "msg")  # type: ignore[arg-type]
+
+
+def _config(comfy_enabled=True):
+    return SimpleNamespace(
+        comfyui=SimpleNamespace(enabled=comfy_enabled, url="http://localhost:8188",
+                                default_checkpoint="sd.safetensors"),
+        tools=SimpleNamespace(ssh_key_path="/k", ssh_known_hosts_path="/kh"),
+    )
+
+
+def _executor(resolve=("1.2.3.4", "root", "linux"), exec_ret=(0, "")):
+    ex = MagicMock()
+    ex._resolve_host = MagicMock(return_value=resolve)
+    ex._exec_command = AsyncMock(return_value=exec_ret)
+    return ex
+
+
+def _tools(config=None, browser_manager=None, tool_executor=None):
+    return MediaTools(
+        get_config=lambda: config or _config(),
+        browser_manager=browser_manager,
+        tool_executor=tool_executor or _executor(),
+    )
+
+
+def _message():
+    m = MagicMock()
+    m.channel.send = AsyncMock()
+    return m
+
+
+class _Resp:
+    def __init__(self, status=200, ct="image/png", data=PNG):
+        self.status = status
+        self.headers = {"Content-Type": ct}
+        self._data = data
+
+    async def read(self):
+        return self._data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Session:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def get(self, *a, **k):
+        return self._resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class TestDetectImageType:
+    def test_all_formats(self):
+        assert MediaTools._detect_image_type(PNG) == "image/png"
+        assert MediaTools._detect_image_type(b"\xff\xd8abc") == "image/jpeg"
+        assert MediaTools._detect_image_type(b"GIF89a") == "image/gif"
+        assert MediaTools._detect_image_type(b"RIFF" + b"\x00" * 4 + b"WEBP") == "image/webp"
+        assert MediaTools._detect_image_type(b"nope1234") is None
+
+
+class TestBrowserScreenshot:
+    async def test_disabled(self):
+        assert "not enabled" in await _tools()._handle_browser_screenshot(_message(), {})
+
+    async def test_success_and_error(self):
+        t = _tools(browser_manager=MagicMock())
+        msg = _message()
+        with patch("src.tools.browser.handle_browser_screenshot",
+                   new=AsyncMock(return_value=("shot taken", PNG))):
+            assert await t._handle_browser_screenshot(msg, {}) == "shot taken"
+            msg.channel.send.assert_awaited_once()
+        with patch("src.tools.browser.handle_browser_screenshot",
+                   new=AsyncMock(side_effect=RuntimeError("x"))):
+            assert "failed" in await t._handle_browser_screenshot(msg, {})
+
+
+class TestGenerateFile:
+    async def test_success(self):
+        msg = _message()
+        out = await _tools()._handle_generate_file(
+            msg, {"filename": "a.txt", "content": "hello", "caption": "cap"})
+        assert "`a.txt`" in out and "5 bytes" in out
+        msg.channel.send.assert_awaited_once()
+
+    async def test_send_failure(self):
+        msg = _message()
+        msg.channel.send = AsyncMock(side_effect=RuntimeError("nope"))
+        assert "Failed to post file" in await _tools()._handle_generate_file(
+            msg, {"content": "x"})
+
+
+class TestPostFile:
+    async def test_validation_and_unknown_host(self):
+        assert "required" in await _tools()._handle_post_file(_message(), {"host": "h"})
+        t = _tools(tool_executor=_executor(resolve=None))
+        assert "Unknown or disallowed host" in await t._handle_post_file(
+            _message(), {"host": "h", "path": "/p"})
+
+    async def test_local_read(self, tmp_path):
+        f = tmp_path / "f.bin"
+        f.write_bytes(b"data")
+        msg = _message()
+        with patch("src.tools.ssh.is_local_address", return_value=True):
+            out = await _tools()._handle_post_file(msg, {"host": "localhost", "path": str(f)})
+        assert "Posted `f.bin`" in out
+
+    async def test_local_missing_and_errors(self, tmp_path):
+        with patch("src.tools.ssh.is_local_address", return_value=True):
+            assert "File not found" in await _tools()._handle_post_file(
+                _message(), {"host": "localhost", "path": str(tmp_path / "nope")})
+            with patch("builtins.open", side_effect=PermissionError):
+                assert "Permission denied" in await _tools()._handle_post_file(
+                    _message(), {"host": "localhost", "path": "/p"})
+            with patch("builtins.open", side_effect=OSError("io")):
+                assert "Failed to read file" in await _tools()._handle_post_file(
+                    _message(), {"host": "localhost", "path": "/p"})
+
+    async def test_remote_ssh(self, tmp_path):
+        b64 = base64.b64encode(b"remote-bytes")
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b64, b""))
+        proc.returncode = 0
+        with patch("src.tools.ssh.is_local_address", return_value=False), \
+             patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+            out = await _tools()._handle_post_file(
+                _message(), {"host": "srv", "path": "/etc/x"})
+        assert "Posted `x`" in out
+
+    async def test_remote_ssh_failure(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b"denied"))
+        proc.returncode = 1
+        with patch("src.tools.ssh.is_local_address", return_value=False), \
+             patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+            assert "Failed to fetch file" in await _tools()._handle_post_file(
+                _message(), {"host": "srv", "path": "/p"})
+
+    async def test_remote_timeout_and_generic_error(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(side_effect=TimeoutError())
+        with patch("src.tools.ssh.is_local_address", return_value=False), \
+             patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+            assert "timed out" in await _tools()._handle_post_file(
+                _message(), {"host": "srv", "path": "/p"})
+        proc.communicate = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch("src.tools.ssh.is_local_address", return_value=False), \
+             patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+            assert "Failed to fetch file" in await _tools()._handle_post_file(
+                _message(), {"host": "srv", "path": "/p"})
+
+    async def test_empty_file(self, tmp_path):
+        empty = tmp_path / "empty.bin"
+        empty.write_bytes(b"")
+        with patch("src.tools.ssh.is_local_address", return_value=True):
+            assert "not found or empty" in await _tools()._handle_post_file(
+                _message(), {"host": "localhost", "path": str(empty)})
+
+    async def test_too_large(self, tmp_path):
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"\x00" * (25 * 1024 * 1024 + 1))
+        with patch("src.tools.ssh.is_local_address", return_value=True):
+            out = await _tools()._handle_post_file(
+                _message(), {"host": "localhost", "path": str(big)})
+        assert "too large" in out
+
+    async def test_discord_http_error(self, tmp_path):
+        f = tmp_path / "f.bin"
+        f.write_bytes(b"data")
+        msg = _message()
+        msg.channel.send = AsyncMock(side_effect=_http_exc())
+        with patch("src.tools.ssh.is_local_address", return_value=True):
+            assert "Failed to upload to Discord" in await _tools()._handle_post_file(
+                msg, {"host": "localhost", "path": str(f)})
+
+
+class TestAnalyzeImage:
+    async def test_url_scheme_and_ssrf(self):
+        assert "http://" in await _tools()._handle_analyze_image(_message(), {"url": "ftp://x"})
+        with patch("src.tools.url_safety.is_url_blocked", return_value=True):
+            assert "URL blocked" in await _tools()._handle_analyze_image(
+                _message(), {"url": "http://169.254.169.254"})
+
+    async def test_url_fetch_variants(self):
+        with patch("src.tools.url_safety.is_url_blocked", return_value=False):
+            with patch("aiohttp.ClientSession", return_value=_Session(_Resp(status=404))):
+                assert "HTTP 404" in await _tools()._handle_analyze_image(
+                    _message(), {"url": "http://ok/img"})
+            with patch("aiohttp.ClientSession",
+                       return_value=_Session(_Resp(ct="text/html"))):
+                assert "does not point to an image" in await _tools()._handle_analyze_image(
+                    _message(), {"url": "http://ok/x"})
+            with patch("aiohttp.ClientSession", return_value=_Session(_Resp())):
+                out = await _tools()._handle_analyze_image(
+                    _message(), {"url": "http://ok/img", "prompt": "what?"})
+                assert isinstance(out, dict) and "__image_block__" in out
+                assert out["__prompt__"] == "what?"
+            with patch("aiohttp.ClientSession", side_effect=RuntimeError("neterr")):
+                assert "Failed to fetch image" in await _tools()._handle_analyze_image(
+                    _message(), {"url": "http://ok/x"})
+
+    async def test_host_path(self):
+        ex = _executor(exec_ret=(0, base64.b64encode(PNG).decode()))
+        out = await _tools(tool_executor=ex)._handle_analyze_image(
+            _message(), {"host": "srv", "path": "/img.png"})
+        assert isinstance(out, dict) and "__image_block__" in out
+
+    async def test_host_path_errors(self):
+        assert "Unknown or disallowed host" in await _tools(
+            tool_executor=_executor(resolve=None))._handle_analyze_image(
+                _message(), {"host": "h", "path": "/p"})
+        assert "Failed to read image" in await _tools(
+            tool_executor=_executor(exec_ret=(1, "err")))._handle_analyze_image(
+                _message(), {"host": "srv", "path": "/p"})
+
+    async def test_host_path_decode_error_and_empty(self):
+        # malformed base64 (wrong padding) from the host → decode raises → handled
+        assert "Failed to decode" in await _tools(
+            tool_executor=_executor(exec_ret=(0, "YQ")))._handle_analyze_image(
+                _message(), {"host": "s", "path": "/p"})
+        # empty output decodes to no bytes
+        assert "No image data" in await _tools(
+            tool_executor=_executor(exec_ret=(0, "")))._handle_analyze_image(
+                _message(), {"host": "s", "path": "/p"})
+
+    async def test_neither_source(self):
+        assert "Provide either" in await _tools()._handle_analyze_image(_message(), {})
+
+    async def test_size_and_format_limits(self):
+        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (5 * 1024 * 1024)
+        ex = _executor(exec_ret=(0, base64.b64encode(big).decode()))
+        assert "exceeds 5MB" in await _tools(tool_executor=ex)._handle_analyze_image(
+            _message(), {"host": "s", "path": "/p"})
+        ex2 = _executor(exec_ret=(0, base64.b64encode(b"notanimage!!").decode()))
+        assert "Unsupported image format" in await _tools(tool_executor=ex2)._handle_analyze_image(
+            _message(), {"host": "s", "path": "/p"})
+
+
+class TestGenerateImage:
+    async def test_disabled_and_no_prompt(self):
+        disabled = _tools(config=_config(comfy_enabled=False))
+        assert "disabled" in await disabled._handle_generate_image(_message(), {"prompt": "x"})
+        assert "required" in await _tools()._handle_generate_image(_message(), {})
+
+    async def test_success(self):
+        client = MagicMock()
+        client.generate = AsyncMock(return_value=PNG)
+        msg = _message()
+        with patch("src.tools.comfyui.ComfyUIClient", return_value=client):
+            out = await _tools()._handle_generate_image(
+                msg, {"prompt": "a cat", "width": 99999, "height": 10})
+            assert "Image generated and posted" in out
+            msg.channel.send.assert_awaited_once()
+
+    async def test_generation_failed_and_http_error(self):
+        client = MagicMock()
+        client.generate = AsyncMock(return_value=None)
+        with patch("src.tools.comfyui.ComfyUIClient", return_value=client):
+            assert "generation failed" in await _tools()._handle_generate_image(
+                _message(), {"prompt": "x"})
+        client.generate = AsyncMock(return_value=PNG)
+        msg = _message()
+        msg.channel.send = AsyncMock(side_effect=_http_exc())
+        with patch("src.tools.comfyui.ComfyUIClient", return_value=client):
+            assert "Failed to upload generated" in await _tools()._handle_generate_image(
+                msg, {"prompt": "x"})

--- a/tests/test_native_scheduling.py
+++ b/tests/test_native_scheduling.py
@@ -1,0 +1,165 @@
+"""Coverage for src/discord/native_tools/scheduling.py (RFC-006 P5).
+
+Exercises the creation-time payload validation (reminder / check / workflow) and
+the schedule CRUD handlers on SchedulingTools with a faked scheduler. parse_time
+is patched for determinism.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.discord.native_tools.scheduling import SchedulingTools
+
+
+def _tools(scheduler=None):
+    return SchedulingTools(scheduler=scheduler or MagicMock())
+
+
+def _message():
+    return SimpleNamespace(
+        channel=SimpleNamespace(id=42), author=SimpleNamespace(id=7))
+
+
+class TestValidatePayload:
+    def test_reminder_requires_message(self):
+        t = _tools()
+        assert t._validate_schedule_payload({"action": "reminder"}) is not None
+        assert t._validate_schedule_payload({"action": "reminder", "message": "hi"}) is None
+
+    def test_check_tool_name_and_command_shortcut(self):
+        t = _tools()
+        assert "requires 'tool_name'" in t._validate_schedule_payload({"action": "check"})
+        # command shortcut backfills tool_name + tool_input
+        inp: dict[str, Any] = {"action": "check", "command": "uname -r"}
+        assert t._validate_schedule_payload(inp) is None
+        assert inp["tool_name"] == "run_command"
+        assert inp["tool_input"]["command"] == "uname -r"
+
+    def test_check_missing_tool_input(self):
+        t = _tools()
+        assert "requires 'tool_input'" in t._validate_schedule_payload(
+            {"action": "check", "tool_name": "some_tool"})
+
+    def test_check_tool_input_from_single_step(self):
+        t = _tools()
+        inp = {"action": "check", "tool_name": "run_command",
+               "steps": [{"tool_input": {"command": "ls"}}]}
+        assert t._validate_schedule_payload(inp) is None
+        assert inp["tool_input"] == {"command": "ls"}
+
+    def test_workflow_validation(self):
+        t = _tools()
+        assert "non-empty 'steps'" in t._validate_schedule_payload({"action": "workflow"})
+        assert "must be an object" in t._validate_schedule_payload(
+            {"action": "workflow", "steps": ["notadict"]})
+        assert "missing 'tool_name'" in t._validate_schedule_payload(
+            {"action": "workflow", "steps": [{}]})
+        assert "non-empty" in t._validate_schedule_payload(
+            {"action": "workflow", "steps": [{"tool_name": "run_command", "tool_input": {}}]})
+        assert t._validate_schedule_payload(
+            {"action": "workflow",
+             "steps": [{"tool_name": "run_command", "tool_input": {"command": "ls"}}]}) is None
+
+    def test_extract_from_steps_edge_cases(self):
+        t = _tools()
+        assert t._extract_tool_input_from_steps({"steps": None}) is None
+        assert t._extract_tool_input_from_steps(  # two populated → ambiguous → None
+            {"steps": [{"tool_input": {"a": 1}}, {"tool_input": {"b": 2}}]}) is None
+
+
+class TestScheduleTask:
+    async def test_validation_error(self):
+        out = await _tools()._handle_schedule_task(_message(), {"action": "reminder"})
+        assert "Failed to create schedule" in out
+
+    async def test_success_variants(self):
+        sched = MagicMock()
+        sched.add = AsyncMock(return_value={
+            "id": "S1", "description": "d", "trigger": {"webhook": "x"}})
+        out = await _tools(sched)._handle_schedule_task(
+            _message(), {"action": "reminder", "message": "m", "trigger": {"webhook": "x"}})
+        assert "webhook-triggered" in out and "S1" in out
+
+        sched.add = AsyncMock(return_value={
+            "id": "S2", "description": "d", "cron": "* * * * *", "next_run": "soon"})
+        out = await _tools(sched)._handle_schedule_task(
+            _message(), {"action": "reminder", "message": "m"})
+        assert "recurring" in out and "Next run: soon" in out
+
+        sched.add = AsyncMock(return_value={"id": "S3", "description": "d"})
+        out = await _tools(sched)._handle_schedule_task(
+            _message(), {"action": "reminder", "message": "m"})
+        assert "one-time" in out
+
+    async def test_value_error_and_generic(self):
+        sched = MagicMock()
+        sched.add = AsyncMock(side_effect=ValueError("bad cron"))
+        out = await _tools(sched)._handle_schedule_task(
+            _message(), {"action": "reminder", "message": "m"})
+        assert "Failed to create schedule: bad cron" in out
+        sched.add = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await _tools(sched)._handle_schedule_task(
+            _message(), {"action": "reminder", "message": "m"})
+        assert "Error creating schedule" in out
+
+
+class TestListSchedules:
+    def test_empty(self):
+        sched = MagicMock()
+        sched.list_all.return_value = []
+        assert "No scheduled tasks" in _tools(sched)._handle_list_schedules()
+
+    def test_formats_all_types(self):
+        sched = MagicMock()
+        sched.list_all.return_value = [
+            {"id": "A", "description": "trig", "trigger": {"webhook": "x"}},
+            {"id": "B", "description": "cronjob", "cron": "* * * * *", "paused": True},
+            {"id": "C", "description": "once"},
+        ]
+        out = _tools(sched)._handle_list_schedules()
+        assert "3" in out and "trigger:" in out and "cron `* * * * *`" in out
+        assert "[PAUSED]" in out and "one-time" in out
+
+
+class TestUpdateSchedule:
+    async def test_requires_id_and_fields(self):
+        assert "'schedule_id' is required" in await _tools()._handle_update_schedule({})
+        assert "no fields to update" in await _tools()._handle_update_schedule(
+            {"schedule_id": "S1"})
+
+    async def test_paused_must_be_bool(self):
+        assert "must be a boolean" in await _tools()._handle_update_schedule(
+            {"schedule_id": "S1", "paused": "yes"})
+
+    async def test_value_error_not_found_and_success(self):
+        sched = MagicMock()
+        sched.update = AsyncMock(side_effect=ValueError("bad"))
+        assert "Error: bad" in await _tools(sched)._handle_update_schedule(
+            {"schedule_id": "S1", "description": "d"})
+        sched.update = AsyncMock(return_value=None)
+        assert "not found" in await _tools(sched)._handle_update_schedule(
+            {"schedule_id": "S1", "paused": True})
+        sched.update = AsyncMock(return_value={"id": "S1"})
+        assert "Updated schedule S1" in await _tools(sched)._handle_update_schedule(
+            {"schedule_id": "S1", "cron": "* * * * *", "trigger": {"webhook": "x"}})
+
+
+class TestDeleteAndParse:
+    async def test_delete(self):
+        sched = MagicMock()
+        sched.delete = AsyncMock(return_value=True)
+        assert "Deleted schedule S1" in await _tools(sched)._handle_delete_schedule(
+            {"schedule_id": "S1"})
+        sched.delete = AsyncMock(return_value=False)
+        assert "not found" in await _tools(sched)._handle_delete_schedule(
+            {"schedule_id": "S1"})
+
+    def test_parse_time(self):
+        t = _tools()
+        assert "'expression' is required" in t._handle_parse_time({})
+        with patch("src.tools.time_parser.parse_time", return_value="2026-07-07T14:00"):
+            assert "→ 2026-07-07T14:00" in t._handle_parse_time({"expression": "in 2 hours"})
+        with patch("src.tools.time_parser.parse_time", side_effect=ValueError("nope")):
+            assert "Error: nope" in t._handle_parse_time({"expression": "gibberish"})


### PR DESCRIPTION
Covers the **last** deferred surface in the coverage plan: the five Discord-native tool domain handlers in `src/discord/native_tools/`. Additive tests + a scoped baseline ratchet — **no `src/` changes.**

## Coverage lifts

| File | Start → End |
|---|---|
| `native_tools/channel_ops.py` | 15% → **100%** |
| `native_tools/knowledge.py` | 17% → **100%** |
| `native_tools/media.py` | 13% → **100%** |
| `native_tools/scheduling.py` | 46% → **100%** |
| `native_tools/agents_tasks.py` | 34% → **95%** |

Whole-repo line coverage **76.5% → 78.7%**; suite **+103 tests**. mypy 0, ruff clean, all four CI gates green.

## Method — fake every boundary hard

Each domain `*Tools` class is built with faked deps and its `_handle_*` methods driven directly; handlers return plain strings (or `analyze_image`'s `__image_block__` marker dict). No real runtime is ever touched:

- **discord**: `Forbidden` / `NotFound` / `HTTPException` are real exceptions raised from mocks; channels/messages are fakes.
- **media**: no network (aiohttp session + `getaddrinfo` faked), no SSH (`create_subprocess_exec` faked), no ComfyUI, no browser.
- **agents_tasks**: runtime neutralized — `run_background_task` patched, loop/agent/bridge managers mocked. **No real task, loop, or agent executes.**

## Uncovered by design

`agents_tasks` sits at 95% — the 17 uncovered lines are exactly the inner `_iteration_cb` / `_tool_exec_cb` / `_codex_followup` / `_run` closures that only run inside a live loop or spawned agent. Per your standing advisory ("don't start real loops/agents just to worship the green bar"), those are left to the loop/agent integration paths rather than driven synthetically.

## Discipline

- **COV ledger empty** — no real bugs; no `xfail`s.
- **Scoped ratchet** — `coverage-baseline.json` tightened for exactly these five files; incidental gains on other modules reverted to their looser ceilings.

This closes out the RFC-006 continuation: web-API, web-admin, and native-tool surfaces are all now 88–100% covered. Plan-of-record results: `docs/plans/coverage-plan.md` §6e.