### PR TITLE
test: RFC-006 P6 — tool handlers + time parser coverage

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -930,9 +930,9 @@
   "statements": 64
  },
  "src/tools/handlers/coding.py": {
-  "covered": 8,
-  "missing": 130,
-  "percent": 5.8,
+  "covered": 138,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 138
  },
  "src/tools/handlers/comms.py": {
@@ -954,9 +954,9 @@
   "statements": 110
  },
  "src/tools/handlers/files_docs.py": {
-  "covered": 18,
-  "missing": 91,
-  "percent": 16.51,
+  "covered": 109,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 109
  },
  "src/tools/handlers/state.py": {
@@ -1068,9 +1068,9 @@
   "statements": 157
  },
  "src/tools/time_parser.py": {
-  "covered": 12,
-  "missing": 96,
-  "percent": 11.11,
+  "covered": 108,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 108
  },
  "src/tools/tool_text.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -1,6 +1,6 @@
 # RFC-006: Test-Coverage Campaign (ratchet gate + prioritized waves)
 
-Status: R3 — CONT-1 + CONT-2 + P5 COMPLETE (campaign shipped through P4b in §6b; P4-continuation CONT-1 §6c, CONT-2 §6d, P5 discord native tools §6e). Plan of record was Odin-approved R1 (§6a). All deferred surfaces now covered.
+Status: R3 — CONT-1/CONT-2/P5/P6 COMPLETE (campaign shipped through P4b §6b; continuation CONT-1 §6c, CONT-2 §6d, P5 native tools §6e, P6 handlers+parsers §6f). Plan of record was Odin-approved R1 (§6a). Post-campaign coverage sweeps continue opportunistically on the lowest-coverage tractable modules while the ratchet holds every gain.
 Campaign branch: `coverage/rfc006` (created after plan approval).
 Predecessors: RFC-005 (type-safety ratchet) is the template — a fail-closed CI ratchet plus incremental waves, security/high-value first. Unlike RFC-005, coverage waves add TESTS, not annotations: they can and will surface real bugs. Bug **fixes** are out-of-band (§5).
 
@@ -156,6 +156,22 @@ Suite **+103 tests**; mypy 0, ruff clean.
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
 **Campaign end state:** whole-repo line coverage **67.0% → ~78%** across RFC-006 (P0–P5); the four CI ratchets (lint / types / coverage / suite) hold every gain. The web-API, web-admin, and native-tool surfaces are now 88–100% covered.
+
+## 6f. R3 — P6 tool handlers + parsers (2026-07-07)
+
+Post-P5 sweep of the next-lowest-coverage tractable modules. One PR, Odin-reviewed, coverage-gated.
+
+| File | Start → End |
+|---|---|
+| `tools/time_parser.py` | 11% → **100%** |
+| `tools/handlers/coding.py` | 6% → **100%** |
+| `tools/handlers/files_docs.py` | 17% → **100%** |
+
+Suite **+51 tests**; mypy 0, ruff clean.
+
+**Method:** `time_parser` is pure logic driven with an injected fixed `now` (a Wednesday noon UTC) — fully deterministic, no wall clock. The two handler domains are built via `HandlerBase.__new__` with only the deps each method touches (the P3 state-handler pattern); every boundary faked — no SSH (`_exec_command`/`_run_on_host` AsyncMocks), no network (aiohttp faked), no PDF library (`fitz` is not installed here, so it's injected as a fake `sys.modules` entry), and the command governor is a mock.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
 ## 7. Risks / discipline
 

--- a/tests/test_handlers_coding.py
+++ b/tests/test_handlers_coding.py
@@ -1,0 +1,177 @@
+"""Coverage for src/tools/handlers/coding.py (RFC-006 P6).
+
+CodingTools.claude_code drives a `claude` CLI over SSH; _parse_claude_stream_json
+is pure stream-json summarization. Built via __new__ with only the deps the two
+methods touch (config, resolve_host, exec_command, output_streamer). No SSH runs:
+_exec_command is an AsyncMock.
+"""
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from src.tools.handlers.coding import CodingTools
+
+
+def _cfg(host="", user="claude"):
+    return SimpleNamespace(claude_code_host=host, claude_code_user=user)
+
+
+def _tools(config=None, resolve=("1.2.3.4", "root", "linux"), exec_ret=(0, "result"),
+           streamer=None):
+    t = CodingTools.__new__(CodingTools)
+    t._deps = SimpleNamespace(  # type: ignore[assignment]  # __new__ bypasses HandlerDeps typing
+        config=lambda: config if config is not None else _cfg(),
+        output_streamer=lambda: streamer,
+    )
+    t._resolve_host = lambda host: resolve
+    t._exec_command = AsyncMock(return_value=exec_ret)
+    return t
+
+
+def _base_inp(**kw):
+    inp = {"working_directory": "/repo", "prompt": "do a thing"}
+    inp.update(kw)
+    return inp
+
+
+class TestClaudeCode:
+    async def test_no_host_configured(self):
+        t = _tools(config=_cfg(host=""))
+        assert "not configured" in await t._handle_claude_code(_base_inp())
+
+    async def test_unknown_host(self):
+        t = _tools(config=_cfg(host="srv"), resolve=None)
+        assert "Unknown or disallowed host" in await t._handle_claude_code(_base_inp())
+
+    async def test_allow_edits_requires_user(self):
+        t = _tools(config=_cfg(host="srv", user=""))
+        assert "claude_code_user not configured" in await t._handle_claude_code(
+            _base_inp(allow_edits=True))
+
+    async def test_success(self):
+        result_json = json.dumps({"type": "result", "result": "all done", "num_turns": 1})
+        t = _tools(config=_cfg(host="srv"), exec_ret=(0, result_json))
+        out = await t._handle_claude_code(_base_inp())
+        assert "all done" in out
+
+    async def test_failure_exit_code(self):
+        t = _tools(config=_cfg(host="srv"), exec_ret=(1, "boom"))
+        assert "Claude Code failed (exit 1)" in await t._handle_claude_code(_base_inp())
+
+    async def test_allow_edits_su_path(self):
+        result_json = json.dumps({"type": "result", "result": "edited"})
+        t = _tools(config=_cfg(host="srv", user="claude"), exec_ret=(0, result_json))
+        out = await t._handle_claude_code(
+            _base_inp(allow_edits=True, allowed_tools="Edit,Write"))
+        assert "edited" in out
+        # the executed command wraps in `su - claude`
+        assert "su - claude" in t._exec_command.call_args.args[1]
+
+    async def test_allow_edits_already_claude_user(self):
+        # running as the claude user already → no `su -` wrapper
+        result_json = json.dumps({"type": "result", "result": "ok"})
+        t = _tools(config=_cfg(host="srv", user="claude"), exec_ret=(0, result_json))
+        with patch.dict(os.environ, {"USER": "claude"}):
+            await t._handle_claude_code(_base_inp(allow_edits=True))
+        assert "su - " not in t._exec_command.call_args.args[1]
+
+    async def test_output_streaming(self):
+        finish = AsyncMock()
+        streamer = SimpleNamespace(
+            is_enabled=lambda tool: True,
+            create_callback=lambda tool, channel_id: (None, (lambda s: None), finish),
+        )
+        result_json = json.dumps({"type": "result", "result": "streamed"})
+        t = _tools(config=_cfg(host="srv"), exec_ret=(0, result_json), streamer=streamer)
+        out = await t._handle_claude_code(_base_inp())
+        assert "streamed" in out
+        finish.assert_awaited_once()
+
+    async def test_streaming_finish_error_swallowed(self):
+        streamer = SimpleNamespace(
+            is_enabled=lambda tool: True,
+            create_callback=lambda tool, channel_id: (
+                None, (lambda s: None), AsyncMock(side_effect=RuntimeError("x"))),
+        )
+        result_json = json.dumps({"type": "result", "result": "ok"})
+        t = _tools(config=_cfg(host="srv"), exec_ret=(0, result_json), streamer=streamer)
+        assert "ok" in await t._handle_claude_code(_base_inp())  # finish error swallowed
+
+    async def test_max_output_truncation(self):
+        big = json.dumps({"type": "result", "result": "x" * 8000})
+        t = _tools(config=_cfg(host="srv"), exec_ret=(0, big))
+        out = await t._handle_claude_code(_base_inp(max_output_chars=1000))
+        assert "[... truncated ...]" in out
+
+
+class TestParseStreamJson:
+    def test_no_activity_returns_raw(self):
+        # No tool calls, no cost → returns the raw output verbatim
+        text, activity = CodingTools._parse_claude_stream_json("plain text\nno json here")
+        assert text == "plain text\nno json here" and activity == ""
+
+    def test_ignores_blank_and_bad_json(self):
+        raw = "\n  \nnot-json\n" + json.dumps({"type": "result", "result": "ok",
+                                               "total_cost_usd": 0.01, "num_turns": 2})
+        text, activity = CodingTools._parse_claude_stream_json(raw)
+        assert text == "ok" and "Turns: 2" in activity and "$0.0100" in activity
+
+    def test_tool_activity_all_kinds(self):
+        lines = [
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "a.py"}},
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "a.py"}},  # dup
+                {"type": "tool_use", "name": "Edit",
+                 "input": {"file_path": "b.py", "old_string": "x", "new_string": "y"}},
+                {"type": "tool_use", "name": "Write",
+                 "input": {"file_path": "c.py", "content": "hello"}},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}},
+                {"type": "tool_use", "name": "Grep", "input": {"pattern": "TODO"}},
+            ]}},
+            {"type": "result", "result": "summary", "total_cost_usd": 0.5,
+             "num_turns": 3, "duration_ms": 4500},
+        ]
+        raw = "\n".join(json.dumps(x) for x in lines)
+        text, activity = CodingTools._parse_claude_stream_json(raw)
+        assert text == "summary"
+        assert "Files read: a.py" in activity  # dedup → single entry
+        assert "b.py:" in activity and "c.py (5 chars)" in activity
+        assert "$ ls -la" in activity and "Grep: TODO" in activity
+
+    def test_truncates_long_lists(self):
+        content = []
+        for i in range(15):
+            content.append({"type": "tool_use", "name": "Read",
+                            "input": {"file_path": f"f{i}.py"}})
+        for i in range(12):
+            content.append({"type": "tool_use", "name": "Edit",
+                            "input": {"file_path": f"e{i}.py",
+                                      "old_string": "a", "new_string": "b"}})
+        for i in range(12):
+            content.append({"type": "tool_use", "name": "Bash",
+                            "input": {"command": f"cmd{i}"}})
+        lines = [
+            {"type": "assistant", "message": {"content": content}},
+            {"type": "result", "result": "r", "total_cost_usd": 0.1},
+        ]
+        raw = "\n".join(json.dumps(x) for x in lines)
+        _, activity = CodingTools._parse_claude_stream_json(raw)
+        assert "+5 more" in activity      # reads capped at 10
+        assert "+4 more" in activity      # edits capped at 8
+        assert "(+4 more)" in activity    # commands capped at 8
+
+    def test_activity_truncated_at_2000(self):
+        # 10 long read paths push the activity summary past the 2000-char cap
+        content = [{"type": "tool_use", "name": "Read",
+                    "input": {"file_path": f"/very/long/path/{i}/" + "x" * 200}}
+                   for i in range(10)]
+        lines = [
+            {"type": "assistant", "message": {"content": content}},
+            {"type": "result", "result": "r", "total_cost_usd": 0.1},
+        ]
+        raw = "\n".join(json.dumps(x) for x in lines)
+        _, activity = CodingTools._parse_claude_stream_json(raw)
+        assert activity.endswith("...") and len(activity) == 2000

--- a/tests/test_handlers_files_docs.py
+++ b/tests/test_handlers_files_docs.py
@@ -1,0 +1,188 @@
+"""Coverage for src/tools/handlers/files_docs.py (RFC-006 P6).
+
+read_file / write_file run shell over _run_on_host (AsyncMock — no host touched);
+_parse_page_range is pure logic; analyze_pdf's fitz (PyMuPDF, not installed here)
+is injected as a fake module and aiohttp is faked, so no PDF library, network, or
+SSH is required.
+"""
+from __future__ import annotations
+
+import base64
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.tools.handlers.files_docs import FilesDocsTools
+
+
+def _tools(run_ret="file contents", govern=(True, "", None),
+           resolve=("1.2.3.4", "root", "linux"), exec_ret=(0, "")):
+    t = FilesDocsTools.__new__(FilesDocsTools)
+    t._run_on_host = AsyncMock(return_value=run_ret)
+    t._govern_command = MagicMock(return_value=govern)
+    t._resolve_host = lambda host: resolve
+    t._exec_command = AsyncMock(return_value=exec_ret)
+    return t
+
+
+# --- fake fitz + aiohttp -------------------------------------------------- #
+class _FakeDoc:
+    def __init__(self, pages):
+        self._pages = pages
+        self.page_count = len(pages)
+
+    def __getitem__(self, i):
+        return SimpleNamespace(get_text=lambda: self._pages[i])
+
+    def close(self):
+        pass
+
+
+def _fake_fitz(pages=None, error=None):
+    def _open(**kw):
+        if error:
+            raise error
+        return _FakeDoc(pages if pages is not None else ["page one text"])
+    return SimpleNamespace(open=_open)
+
+
+class _Resp:
+    def __init__(self, status=200, data=b"%PDF-1.4 fake"):
+        self.status = status
+        self._data = data
+
+    async def read(self):
+        return self._data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Session:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def get(self, *a, **k):
+        return self._resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class TestReadFile:
+    async def test_validation(self):
+        assert "'path' is required" in await _tools()._handle_read_file({"host": "h"})
+        assert "'host' is required" in await _tools()._handle_read_file({"path": "/p"})
+
+    async def test_success_and_bad_lines(self):
+        t = _tools()
+        out = await t._handle_read_file({"path": "/etc/x", "host": "h", "lines": "notanint"})
+        assert out == "file contents"
+        assert "head -n 200" in t._run_on_host.call_args.args[1]  # bad → default 200
+        await t._handle_read_file({"path": "/etc/x", "host": "h", "lines": 5000})
+        assert "head -n 1000" in t._run_on_host.call_args.args[1]  # clamped to 1000
+
+
+class TestWriteFile:
+    async def test_validation(self):
+        assert "'path' is required" in await _tools()._handle_write_file(
+            {"host": "h", "content": "c"})
+        assert "'content' is required" in await _tools()._handle_write_file(
+            {"path": "/p", "host": "h"})
+        assert "'host' is required" in await _tools()._handle_write_file(
+            {"path": "/p", "content": "c"})
+
+    async def test_governor_denies(self):
+        t = _tools(govern=(False, "DENIED: sensitive path", None))
+        out = await t._handle_write_file({"path": "/etc/passwd", "host": "h", "content": "x"})
+        assert out == "DENIED: sensitive path"
+
+    async def test_success_encodes_content(self):
+        t = _tools()
+        out = await t._handle_write_file({"path": "/tmp/f", "host": "h", "content": "hello"})
+        assert out == "file contents"
+        # content is base64-encoded into the command
+        assert base64.b64encode(b"hello").decode() in t._run_on_host.call_args.args[1]
+
+
+class TestParsePageRange:
+    def test_range_single_and_fallbacks(self):
+        f = FilesDocsTools._parse_page_range
+        assert f("2-4", 10) == [1, 2, 3]
+        assert f("3", 10) == [2]
+        assert f("99", 10) == list(range(10))       # out of range → all
+        assert f("a-b", 10) == list(range(10))       # unparseable range → all
+        assert f("notanint", 10) == list(range(10))  # unparseable single → all
+
+
+class TestAnalyzePdf:
+    async def test_url_scheme_and_ssrf(self):
+        assert "http://" in await _tools()._handle_analyze_pdf({"url": "ftp://x"})
+        with patch("src.tools.url_safety.is_url_blocked", return_value=True):
+            assert "blocked URL" in await _tools()._handle_analyze_pdf(
+                {"url": "http://169.254.169.254/x"})
+
+    async def test_url_success_and_http_error(self):
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["hello pdf"])}), \
+             patch("src.tools.url_safety.is_url_blocked", return_value=False):
+            with patch("aiohttp.ClientSession", return_value=_Session(_Resp(200))):
+                out = await _tools()._handle_analyze_pdf({"url": "http://ok/doc.pdf"})
+                assert "Page 1" in out and "hello pdf" in out
+            with patch("aiohttp.ClientSession", return_value=_Session(_Resp(404))):
+                assert "HTTP 404" in await _tools()._handle_analyze_pdf(
+                    {"url": "http://ok/doc.pdf"})
+            with patch("aiohttp.ClientSession", side_effect=RuntimeError("neterr")):
+                assert "Failed to fetch PDF" in await _tools()._handle_analyze_pdf(
+                    {"url": "http://ok/doc.pdf"})
+
+    async def test_host_path(self):
+        b64 = base64.b64encode(b"%PDF fake").decode()
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["from host"])}):
+            t = _tools(exec_ret=(0, b64))
+            out = await t._handle_analyze_pdf({"host": "srv", "path": "/doc.pdf"})
+            assert "from host" in out
+
+    async def test_host_path_errors(self):
+        with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
+            assert "Unknown or disallowed host" in await _tools(
+                resolve=None)._handle_analyze_pdf({"host": "h", "path": "/p"})
+            assert "Failed to read PDF from host" in await _tools(
+                exec_ret=(1, "denied"))._handle_analyze_pdf({"host": "s", "path": "/p"})
+            # malformed base64 (wrong padding) → decode raises → handled
+            assert "Failed to decode PDF" in await _tools(
+                exec_ret=(0, "YQ"))._handle_analyze_pdf({"host": "s", "path": "/p"})
+
+    async def test_neither_source(self):
+        with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
+            assert "Provide either" in await _tools()._handle_analyze_pdf({})
+
+    async def test_open_failure(self):
+        b64 = base64.b64encode(b"garbage").decode()
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(error=RuntimeError("bad pdf"))}):
+            assert "Failed to open PDF" in await _tools(
+                exec_ret=(0, b64))._handle_analyze_pdf({"host": "s", "path": "/p"})
+
+    async def test_page_selection_and_empty(self):
+        b64 = base64.b64encode(b"x").decode()
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["one", "two", "three"])}):
+            out = await _tools(exec_ret=(0, b64))._handle_analyze_pdf(
+                {"host": "s", "path": "/p", "pages": "2"})
+            assert "Page 2" in out and "two" in out and "Page 1" not in out
+        # a 0-page doc yields no parts → empty result → the no-text fallback
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=[])}):
+            out = await _tools(exec_ret=(0, b64))._handle_analyze_pdf(
+                {"host": "s", "path": "/p"})
+            assert "no extractable text" in out
+
+    async def test_truncation(self):
+        b64 = base64.b64encode(b"x").decode()
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["x" * 13000])}):
+            out = await _tools(exec_ret=(0, b64))._handle_analyze_pdf(
+                {"host": "s", "path": "/p"})
+            assert "truncated" in out

--- a/tests/test_time_parser.py
+++ b/tests/test_time_parser.py
@@ -1,0 +1,132 @@
+"""Coverage for src/tools/time_parser.py (RFC-006 P6).
+
+Pure-logic natural-language time parsing. Every test injects an explicit ``now``
+(a fixed Wednesday noon UTC) so results are fully deterministic — no wall clock.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.tools import time_parser
+from src.tools.time_parser import (
+    _next_weekday,
+    _parse_time_of_day,
+    parse_time,
+    set_default_timezone,
+)
+
+# 2026-03-18 is a Wednesday.
+NOW = datetime(2026, 3, 18, 12, 0, tzinfo=ZoneInfo("UTC"))
+
+
+class TestParseTimeOfDay:
+    def test_12_hour(self):
+        assert _parse_time_of_day("9am") == (9, 0)
+        assert _parse_time_of_day("9:30pm") == (21, 30)
+        assert _parse_time_of_day("12am") == (0, 0)   # midnight
+        assert _parse_time_of_day("12pm") == (12, 0)  # noon
+
+    def test_24_hour(self):
+        assert _parse_time_of_day("17:00") == (17, 0)
+        assert _parse_time_of_day("09:30") == (9, 30)
+
+    def test_bare_hour_is_none(self):
+        assert _parse_time_of_day("9") is None
+
+
+class TestNextWeekday:
+    def test_wraps_to_next_week(self):
+        # NOW is Wednesday (2). Next Wednesday is +7 days.
+        assert _next_weekday(NOW, 2).day == 25
+        # Next Friday (4) is +2 days.
+        assert _next_weekday(NOW, 4).day == 20
+
+
+class TestRelative:
+    def test_in_units(self):
+        assert parse_time("in 30 minutes", NOW).startswith("2026-03-18T12:30")
+        assert parse_time("in 2 hours", NOW).startswith("2026-03-18T14:00")
+        assert parse_time("in 1 day", NOW).startswith("2026-03-19T12:00")
+
+    def test_in_unknown_unit(self):
+        with pytest.raises(ValueError, match="Unknown time unit"):
+            parse_time("in 5 fortnights", NOW)
+
+
+class TestTomorrowToday:
+    def test_tomorrow_default_and_timed(self):
+        assert parse_time("tomorrow", NOW).startswith("2026-03-19T09:00")
+        assert parse_time("tomorrow at 3pm", NOW).startswith("2026-03-19T15:00")
+
+    def test_tomorrow_bad_time(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time("tomorrow at bogus", NOW)
+
+    def test_today_timed_and_requires_time(self):
+        assert parse_time("today at 5pm", NOW).startswith("2026-03-18T17:00")
+        with pytest.raises(ValueError, match="requires a time"):
+            parse_time("today", NOW)
+
+    def test_today_bad_time(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time("today at nope", NOW)
+
+
+class TestWeekdays:
+    def test_next_dayname(self):
+        assert parse_time("next Monday", NOW).startswith("2026-03-23T09:00")
+        assert parse_time("next Monday at 3pm", NOW).startswith("2026-03-23T15:00")
+
+    def test_next_dayname_bad_time(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time("next Monday at zzz", NOW)
+
+    def test_bare_dayname(self):
+        assert parse_time("friday", NOW).startswith("2026-03-20T09:00")
+        assert parse_time("friday at 10am", NOW).startswith("2026-03-20T10:00")
+
+    def test_bare_dayname_bad_time(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time("friday at ???", NOW)
+
+
+class TestAtAndBareTime:
+    def test_at_future_today(self):
+        assert parse_time("at 5pm", NOW).startswith("2026-03-18T17:00")
+
+    def test_at_past_rolls_to_tomorrow(self):
+        # 9am is before NOW (noon) → tomorrow
+        assert parse_time("at 9am", NOW).startswith("2026-03-19T09:00")
+
+    def test_at_bad_time(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time("at half-past-something", NOW)
+
+    def test_bare_time_future_and_past(self):
+        assert parse_time("5pm", NOW).startswith("2026-03-18T17:00")
+        assert parse_time("9am", NOW).startswith("2026-03-19T09:00")  # past → tomorrow
+
+    def test_unparseable(self):
+        with pytest.raises(ValueError, match="Cannot parse time expression"):
+            parse_time("sometime next century", NOW)
+
+
+class TestDefaults:
+    def test_now_none_uses_wall_clock(self):
+        # No now → uses the module default tz; just assert it produces ISO output.
+        out = parse_time("in 1 hour")
+        assert "T" in out and out.count(":") >= 2
+
+    def test_naive_now_gets_tz(self):
+        naive = datetime(2026, 3, 18, 12, 0)  # no tzinfo
+        assert parse_time("in 1 hour", naive).startswith("2026-03-18T13:00")
+
+    def test_set_default_timezone(self):
+        try:
+            set_default_timezone("America/New_York")
+            assert time_parser._default_tz.key == "America/New_York"
+        finally:
+            set_default_timezone("UTC")  # restore


### PR DESCRIPTION
A post-P5 sweep of the next-lowest-coverage tractable modules. Additive tests + a scoped baseline ratchet — **no `src/` changes.**

## Coverage lifts

| File | Start → End |
|---|---|
| `tools/time_parser.py` | 11% → **100%** |
| `tools/handlers/coding.py` | 6% → **100%** |
| `tools/handlers/files_docs.py` | 17% → **100%** |

Whole-repo line coverage **78.7% → 79.9%**; suite **+51 tests**. mypy 0, ruff clean, all four CI gates green.

## Method

- **time_parser** is pure logic — every test injects a fixed `now` (a Wednesday noon UTC), so results are fully deterministic with no wall clock.
- **coding / files_docs** are `HandlerBase` domains built via `__new__` with only the deps each method touches (the P3 state-handler pattern). Every boundary is faked: no SSH (`_exec_command` / `_run_on_host` AsyncMocks), no network (aiohttp faked), no PDF library (`fitz` isn't installed here, so it's injected as a fake `sys.modules` entry), governor mocked. The pure `_parse_claude_stream_json` and `_parse_page_range` helpers are exercised directly across all their branches.

## Discipline

- **COV ledger empty** — no real bugs; no `xfail`s.
- **Scoped ratchet** — baseline tightened for exactly these three files; incidental gains on other modules reverted to their looser ceilings.

Plan-of-record results: `docs/plans/coverage-plan.md` §6f.