### PR TITLE
test: RFC-006 P11 — safe tier-1 (llm_gateway, observability, sessions_chat)

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -204,9 +204,9 @@
   "statements": 400
  },
  "src/discord/llm_gateway.py": {
-  "covered": 65,
-  "missing": 109,
-  "percent": 37.36,
+  "covered": 173,
+  "missing": 1,
+  "percent": 99.43,
   "statements": 174
  },
  "src/discord/native_tools/__init__.py": {
@@ -1158,9 +1158,9 @@
   "statements": 396
  },
  "src/web/api/observability.py": {
-  "covered": 149,
-  "missing": 83,
-  "percent": 64.22,
+  "covered": 222,
+  "missing": 10,
+  "percent": 95.69,
   "statements": 232
  },
  "src/web/api/schedules_api.py": {
@@ -1182,9 +1182,9 @@
   "statements": 88
  },
  "src/web/api/sessions_chat.py": {
-  "covered": 208,
-  "missing": 95,
-  "percent": 68.65,
+  "covered": 288,
+  "missing": 15,
+  "percent": 95.05,
   "statements": 303
  },
  "src/web/api/skills_api.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -240,6 +240,24 @@ Suite **+40 tests**; mypy 0, ruff clean.
 
 With P10 the clearly-tractable modules are covered. The remaining low-coverage gated files all wrap infrastructure that can't be faked without either heavy harnesses or real side effects: `health/server.py` (large aiohttp server + middleware), `monitoring/watcher.py` (live metric-poll loops), `search/vectorstore.py` (sqlite-vec extension), `discord/llm_gateway.py` + `discord/wiring.py` (provider lifecycle / composition root), `discord/client.py` (the gateway lifecycle), `discord/intake_pipeline.py` and `tools/background_task.py` (real message/loop execution). These are the "returns get very difficult" tier — meaningful coverage there needs integration-style harnesses, not the boundary-faking pattern that carried P0–P10, and several would risk real side effects to exercise. The coverage-no-drop ratchet holds every gain (whole-repo **67.0% → ~82%**) as a permanent floor; further waves here are a deliberate future decision, not low-hanging fruit.
 
+## 6l. R3 — P11 safe tier-1, round 1 (2026-07-07)
+
+First safe pass into the "harder" tier — the files whose dangerous paths are shallow enough to stub airtight (no real execution, network, or gateway). Aaron's directive for this round: do all the work solo, one final PR, Odin reviews only that PR. (The genuinely dangerous files — `background_task`, `discord/client`, `watcher` — are deferred to a future Incus-sandboxed round, since this desktop *hosts* live Odin and localhost is a destructible target.)
+
+| File | Start → End |
+|---|---|
+| `discord/llm_gateway.py` | 37% → **99%** |
+| `web/api/observability.py` | 64% → **96%** |
+| `web/api/sessions_chat.py` | 69% → **94%** |
+
+Suite **+46 tests**; mypy 0, ruff clean.
+
+**Method / safety:** `llm_gateway` — the provider client classes (`CodexChatClient`/`OllamaClient`/`KimiClient`/`CodexAuthPool`) are patched so reloads build fakes (no real tokens, no network, no health-check hits a server), and the deferred-close `call_later` is stubbed so nothing schedules on a live loop. `observability` — all read-only stat routes with a faked bot; the file-reading aggregates (`context`/`failure`/affordances) are patched so no real trajectory/audit file is touched. `sessions_chat` — chat/execute go through the patched `process_web_chat` seam (never a real LLM call); session + trajectory routes use a faked store/saver. **Residual uncovered = the unreachable `except ValueError` branches around `_safe_int_param` (it swallows, never raises) and a couple of `.resolve()` path-escape / auth-configured-identity branches.**
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
+**Deferred (still safe, next round):** `learning/reflector`, `sessions/manager`, `scheduler` (validation/matching subset), `intake_pipeline` — intricate logic that deserves careful treatment, not a rushed tack-on.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -1,0 +1,255 @@
+"""Coverage for src/discord/llm_gateway.py (RFC-006 P11, safe tier-1).
+
+LLMGateway owns provider resolution, live reloads, runtime switching, and the
+guarded call_with_tools path. SAFE by construction: the provider client classes
+(CodexChatClient/OllamaClient/KimiClient/CodexAuthPool) are patched so reloads
+build fakes — no real tokens, no network, no health-check calls hit a server.
+The deferred-close call_later is stubbed so nothing is scheduled on a live loop.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.discord.llm_gateway import LLMGateway
+
+
+def _cfg(active="codex", codex_enabled=True, ollama_enabled=False,
+         kimi_enabled=False, kimi_key=""):
+    return SimpleNamespace(
+        llm_provider=SimpleNamespace(active_provider=active),
+        openai_codex=SimpleNamespace(enabled=codex_enabled, credentials_path="/creds",
+                                     model="gpt-5.5", max_tokens=8000),
+        ollama=SimpleNamespace(enabled=ollama_enabled, base_url="http://localhost:11434",
+                               model="qwen", max_tokens=4096, timeout=300, api_key=""),
+        kimi=SimpleNamespace(enabled=kimi_enabled, api_key=kimi_key,
+                             model="kimi-k2", max_tokens=4096, timeout=300),
+    )
+
+
+def _gw(config=None, codex=None, ollama=None, kimi=None,
+        guard=None, router=None, aux=None, cost=None):
+    return LLMGateway(
+        get_config=lambda: config if config is not None else _cfg(),
+        codex_client=codex, ollama_client=ollama, kimi_client=kimi,
+        subsystem_guard=guard, model_router=router, auxiliary_llm_client=aux,
+        cost_tracker=cost, sessions=MagicMock(), reflector=MagicMock(),
+    )
+
+
+class TestActiveClientAndCallbacks:
+    def test_active_client_resolution(self):
+        codex, ollama, kimi = object(), object(), object()
+        assert _gw(_cfg("codex"), codex, ollama, kimi).active_client is codex
+        assert _gw(_cfg("ollama"), codex, ollama, kimi).active_client is ollama
+        assert _gw(_cfg("kimi"), codex, ollama, kimi).active_client is kimi
+        # ollama active but not configured → falls back to codex
+        assert _gw(_cfg("ollama"), codex, None, kimi).active_client is codex
+
+    def test_wire_callbacks(self):
+        gw = _gw(codex=object())
+        gw.wire_callbacks()
+        gw.sessions.set_compaction_fn.assert_called_once()
+        gw.reflector.set_text_fn.assert_called_once()
+
+    async def test_callbacks_execute(self):
+        client = SimpleNamespace(chat=AsyncMock(return_value="summary"))
+        gw = _gw(codex=client)
+        gw.wire_callbacks()
+        compaction_fn = gw.sessions.set_compaction_fn.call_args.args[0]
+        assert await compaction_fn([{"role": "user", "content": "x"}], "sys") == "summary"
+        reflection_fn = gw.reflector.set_text_fn.call_args.args[0]
+        assert await reflection_fn([], "sys") == "summary"
+
+    async def test_callbacks_raise_without_client(self):
+        gw = _gw(codex=None)  # no active client
+        gw.wire_callbacks()
+        compaction = gw.sessions.set_compaction_fn.call_args.args[0]
+        reflection = gw.reflector.set_text_fn.call_args.args[0]
+        with pytest.raises(RuntimeError, match="No LLM provider"):
+            await compaction([], "s")
+        with pytest.raises(RuntimeError, match="No LLM provider"):
+            await reflection([], "s")
+
+
+class TestReloadCodex:
+    async def test_disabled(self):
+        gw = _gw(_cfg(codex_enabled=False), codex=object())
+        r = await gw.reload_codex_inner()
+        assert r["configured"] is False and gw.codex_client is None
+
+    async def test_existing_auth_pool_reloads(self):
+        from src.discord.llm_gateway import CodexAuthPool
+        pool = MagicMock(spec=CodexAuthPool)
+        pool.reload_async = AsyncMock(return_value=3)
+        client = SimpleNamespace(auth=pool)
+        gw = _gw(codex=client)
+        r = await gw.reload_codex_inner()
+        assert r["reloaded"] is True and r["accounts"] == 3
+
+    async def test_creates_new_client(self):
+        pool = MagicMock()
+        pool.is_configured.return_value = True
+        pool._accounts = [1, 2]
+        with patch("src.discord.llm_gateway.CodexAuthPool", return_value=pool), \
+             patch("src.discord.llm_gateway.CodexChatClient", return_value=MagicMock()):
+            gw = _gw(codex=None)
+            r = await gw.reload_codex_inner()
+        assert r["created"] is True and r["accounts"] == 2
+
+    async def test_credentials_missing(self):
+        pool = MagicMock()
+        pool.is_configured.return_value = False
+        with patch("src.discord.llm_gateway.CodexAuthPool", return_value=pool):
+            r = await _gw(codex=None).reload_codex_inner()
+        assert r["configured"] is False and "credentials" in r["reason"]
+
+    async def test_reload_wrapper_holds_lock(self):
+        gw = _gw(_cfg(codex_enabled=False), codex=object())
+        assert (await gw.reload_codex())["configured"] is False
+
+
+class TestReloadOllamaKimi:
+    async def test_ollama_disabled_closes_old(self):
+        old = SimpleNamespace(close=AsyncMock())
+        gw = _gw(_cfg(ollama_enabled=False), ollama=old)
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "call_later") as cl:  # record deferred close, don't schedule
+            r = await gw.reload_ollama_inner()
+        assert r["configured"] is False and gw.ollama_client is None
+        assert cl.called  # old client's close was scheduled
+
+    async def test_ollama_constructs(self):
+        with patch("src.discord.llm_gateway.OllamaClient",
+                   return_value=SimpleNamespace(health_check=AsyncMock(return_value={"ok": 1}),
+                                                close=AsyncMock())):
+            gw = _gw(_cfg(ollama_enabled=True))
+            r = await gw.reload_ollama_inner()
+            assert r["configured"] is True
+            wrapped = await gw.reload_ollama()  # wrapper adds health
+            assert wrapped["health"] == {"ok": 1}
+
+    async def test_kimi_disabled_and_no_key(self):
+        gw = _gw(_cfg(kimi_enabled=False))
+        assert (await gw.reload_kimi_inner())["configured"] is False
+        gw2 = _gw(_cfg(kimi_enabled=True, kimi_key=""))
+        r = await gw2.reload_kimi_inner()
+        assert r["configured"] is False and "api_key" in r["reason"]
+
+    async def test_kimi_disabled_closes_old(self):
+        old = SimpleNamespace(close=AsyncMock())
+        gw = _gw(_cfg(kimi_enabled=False), kimi=old)
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "call_later") as cl:
+            r = await gw.reload_kimi_inner()
+        assert r["configured"] is False and gw.kimi_client is None and cl.called
+
+    async def test_kimi_constructs(self):
+        with patch("src.discord.llm_gateway.KimiClient",
+                   return_value=SimpleNamespace(health_check=AsyncMock(return_value={"h": 1}),
+                                                close=AsyncMock())):
+            gw = _gw(_cfg(kimi_enabled=True, kimi_key="k"))
+            assert (await gw.reload_kimi_inner())["configured"] is True
+            assert (await gw.reload_kimi())["health"] == {"h": 1}
+
+
+class TestSwitchProvider:
+    async def test_unknown_and_unconfigured(self):
+        gw = _gw()
+        assert "error" in await gw.switch_provider("bogus")
+        assert "Codex not configured" in (await _gw(codex=None).switch_provider("codex"))["error"]
+        assert "Ollama not configured" in (
+            await _gw(codex=object()).switch_provider("ollama"))["error"]
+        assert "Kimi not configured" in (
+            await _gw(codex=object()).switch_provider("kimi"))["error"]
+
+    async def test_switch_success(self):
+        cfg = _cfg("codex", ollama_enabled=True)
+        gw = _gw(cfg, codex=object(), ollama=SimpleNamespace(model="qwen"))
+        r = await gw.switch_provider("ollama")
+        assert r["active_provider"] == "ollama" and r["model"] == "qwen"
+        assert cfg.llm_provider.active_provider == "ollama"
+
+    async def test_switch_waits_for_inflight(self):
+        cfg = _cfg("codex", ollama_enabled=True)
+        gw = _gw(cfg, codex=object(), ollama=SimpleNamespace(model="qwen"))
+        gw.inflight_requests = 1  # never drops → loop runs its full budget
+        with patch("asyncio.sleep", new=AsyncMock()):
+            r = await gw.switch_provider("ollama")
+        assert r["active_provider"] == "ollama"
+
+
+class TestCallWithTools:
+    async def test_no_client_and_switching(self):
+        gw = _gw(codex=None)
+        with pytest.raises(RuntimeError, match="No LLM provider"):
+            await gw.call_with_tools(messages=[], system="s", tools=[])
+        gw2 = _gw(codex=object())
+        gw2.switching = True
+        with pytest.raises(RuntimeError, match="switch in progress"):
+            await gw2.call_with_tools(messages=[], system="s", tools=[])
+
+    async def test_subsystem_guard_blocks(self):
+        guard = MagicMock()
+        guard.check.return_value = "circuit open"
+        gw = _gw(codex=object(), guard=guard)
+        with pytest.raises(RuntimeError, match="subsystem unavailable"):
+            await gw.call_with_tools(messages=[], system="s", tools=[])
+
+    async def test_success_records_cost(self):
+        resp = SimpleNamespace(input_tokens=10, output_tokens=5)
+        client = SimpleNamespace(chat_with_tools=AsyncMock(return_value=resp), model="gpt-5.5")
+        guard = MagicMock()
+        guard.check.return_value = None
+        cost = MagicMock()
+        gw = _gw(codex=client, guard=guard, cost=cost)
+        out = await gw.call_with_tools(messages=[], system="s", tools=[], user_id="u")
+        assert out is resp
+        guard.record_success.assert_called_once()
+        cost.record.assert_called_once()
+        assert gw.inflight_requests == 0  # decremented in finally
+
+    async def test_failure_records_and_raises(self):
+        client = SimpleNamespace(chat_with_tools=AsyncMock(side_effect=RuntimeError("api")))
+        guard = MagicMock()
+        guard.check.return_value = None
+        gw = _gw(codex=client, guard=guard)
+        with pytest.raises(RuntimeError, match="api"):
+            await gw.call_with_tools(messages=[], system="s", tools=[])
+        guard.record_failure.assert_called_once()
+        assert gw.inflight_requests == 0
+
+    async def test_model_router_cheap_path(self):
+        strong = SimpleNamespace(chat_with_tools=AsyncMock(), model="gpt-5.5")
+        aux_resp = SimpleNamespace(input_tokens=1, output_tokens=1)
+        aux = SimpleNamespace(chat_with_tools=AsyncMock(return_value=aux_resp), model="cheap")
+        router = MagicMock()
+        router.route = AsyncMock(return_value=SimpleNamespace(
+            use_strong=False, intent=SimpleNamespace(value="chat"), confidence=0.9))
+        gw = _gw(codex=strong, router=router, aux=aux)
+        out = await gw.call_with_tools(messages=[], system="s", tools=[], user_message="hi")
+        assert out is aux_resp  # routed to the cheap auxiliary client
+        aux.chat_with_tools.assert_awaited_once()
+
+    async def test_cost_record_exception_non_fatal(self):
+        resp = SimpleNamespace(input_tokens=1, output_tokens=1)
+        client = SimpleNamespace(chat_with_tools=AsyncMock(return_value=resp), model="m")
+        guard = MagicMock()
+        guard.check.return_value = None
+        cost = MagicMock()
+        cost.record.side_effect = RuntimeError("cost boom")
+        gw = _gw(codex=client, guard=guard, cost=cost)
+        # cost tracking failure must not break the call
+        assert await gw.call_with_tools(messages=[], system="s", tools=[]) is resp
+
+    async def test_router_exception_uses_strong(self):
+        resp = SimpleNamespace(input_tokens=0, output_tokens=0)
+        strong = SimpleNamespace(chat_with_tools=AsyncMock(return_value=resp), model="gpt-5.5")
+        router = MagicMock()
+        router.route = AsyncMock(side_effect=RuntimeError("route boom"))
+        gw = _gw(codex=strong, router=router, aux=SimpleNamespace())
+        out = await gw.call_with_tools(messages=[], system="s", tools=[], user_message="hi")
+        assert out is resp  # router failure is non-fatal → strong client used

--- a/tests/test_web_api_observability.py
+++ b/tests/test_web_api_observability.py
@@ -1,0 +1,204 @@
+"""Coverage for src/web/api/observability.py (RFC-006 P11, safe tier-1).
+
+All read-only stat/audit routes (+ one PUT for tool timeouts) through the real
+aiohttp route layer with a faked bot. SAFE: every route delegates to a bot
+subsystem; file-reading aggregates (context/failure/affordances) are patched, so
+nothing touches real trajectory/audit files.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.config.schema import Config
+from src.web.api import observability as obs
+
+
+def _app(*registrars, bot):
+    routes = web.RouteTableDef()
+    for reg in registrars:
+        reg(routes, bot)
+    app = web.Application()
+    app.router.add_routes(routes)
+    return app
+
+
+def _bot():
+    bot = MagicMock()
+    bot.config = Config(discord={"token": "x"})
+    a = bot.audit
+    a.count_by_tool = AsyncMock(return_value={"run_command": 5})
+    a.search = AsyncMock(return_value=[{"tool_name": "t", "error": "boom"}, {"tool_name": "u"}])
+    a.search_diffs = AsyncMock(return_value=[{"d": 1}])
+    a.verify_integrity = AsyncMock(return_value={"valid": True})
+    a.search_logs = AsyncMock(return_value=[{"l": 1}])
+    a.get_log_stats = AsyncMock(return_value={"total": 3})
+    a.search_by_risk = AsyncMock(return_value=[{"r": 1}])
+    ex = bot.tool_executor
+    ex.risk_stats.get_summary.return_value = {"risk": 1}
+    ex.risk_stats.get_recent.return_value = [{"e": 1}]
+    ex.command_governor.stats.get_summary.return_value = {"g": 1}
+    ex.recovery_stats.get_summary.return_value = {"rec": 1}
+    ex.recovery_stats.get_recent.return_value = []
+    ex.freshness_stats.get_summary.return_value = {"f": 1}
+    ex.freshness_stats.get_recent.return_value = []
+    ex.validation_stats.as_dict.return_value = {"v": 1}
+    bot.executor.bulkheads.get_all_metrics.return_value = {"b": 1}
+    bot.cost_tracker.get_totals.return_value = {"c": 1}
+    bot.cost_tracker.get_summary.return_value = {"c": 2}
+    bot.compression_stats.as_dict.return_value = {"comp": 1}
+    bot.model_router.get_metrics.return_value = {"m": 1}
+    bot.subsystem_guard.get_status.return_value = {"s": 1}
+    return bot
+
+
+class TestToolsMeta:
+    async def test_list_and_stats_and_timeouts(self):
+        bot = _bot()
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(obs, "get_tool_definitions",
+                       lambda: [{"name": "t", "description": "d", "is_core": True}])
+            async with TestClient(TestServer(_app(obs.register_tools_meta, bot=bot))) as c:
+                assert (await (await c.get("/api/tools")).json())[0]["name"] == "t"
+                assert (await (await c.get("/api/tools/stats")).json())["run_command"] == 5
+                assert "default_timeout" in await (await c.get("/api/tools/timeouts")).json()
+
+    async def test_set_timeouts(self):
+        bot = _bot()
+        async with TestClient(TestServer(_app(obs.register_tools_meta, bot=bot))) as c:
+            assert (await c.put("/api/tools/timeouts", data="bad")).status == 400
+            assert (await c.put("/api/tools/timeouts", json=[1])).status == 400
+            assert (await c.put("/api/tools/timeouts",
+                                json={"overrides": "notdict"})).status == 400
+            assert (await c.put("/api/tools/timeouts",
+                                json={"overrides": {"t": -1}})).status == 400
+            assert (await c.put("/api/tools/timeouts",
+                                json={"default_timeout": 0})).status == 400
+            r = await c.put("/api/tools/timeouts",
+                            json={"overrides": {"t": 30}, "default_timeout": 60})
+            assert r.status == 200 and (await r.json())["default_timeout"] == 60
+
+
+class TestBulkheadsAndAggregates:
+    async def test_bulkheads(self):
+        bot = _bot()
+        async with TestClient(TestServer(_app(obs.register_bulkheads, bot=bot))) as c:
+            assert (await (await c.get("/api/tools/bulkheads")).json())["b"] == 1
+        bot.executor = None
+        async with TestClient(TestServer(_app(obs.register_bulkheads, bot=bot))) as c:
+            assert (await c.get("/api/tools/bulkheads")).status == 503
+
+    async def test_aggregates(self):
+        bot = _bot()
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("src.observability.aggregates.context_aggregates",
+                       lambda d, w: {"ctx": w})
+            mp.setattr("src.observability.aggregates.failure_aggregates",
+                       lambda p, w: {"fail": w})
+            async with TestClient(TestServer(_app(obs.register_aggregates, bot=bot))) as c:
+                assert (await (await c.get(
+                    "/api/observability/context?window=5")).json())["ctx"] == 5
+                # non-integer window falls back to the 24h default
+                assert (await (await c.get(
+                    "/api/observability/context?window=abc")).json())["ctx"] == 24
+                assert (await (await c.get(
+                    "/api/observability/failures")).json())["fail"] == 24
+                assert (await (await c.get("/api/usage/totals")).json())["c"] == 1
+        # disabled prompt-budget → 503
+        bot.config.observability.prompt_budget_accounting = False
+        async with TestClient(TestServer(_app(obs.register_aggregates, bot=bot))) as c:
+            assert (await c.get("/api/observability/context")).status == 503
+        bot.cost_tracker = None
+        async with TestClient(TestServer(_app(obs.register_aggregates, bot=bot))) as c:
+            assert (await c.get("/api/usage/totals")).status == 503
+
+
+class TestAuditAndLogs:
+    async def test_audit(self):
+        bot = _bot()
+        async with TestClient(TestServer(_app(obs.register_audit_log, bot=bot))) as c:
+            # error_only filter keeps only the entry with an error field
+            body = await (await c.get("/api/audit?error_only=true&tool=t")).json()
+            assert len(body) == 1 and body[0]["error"] == "boom"
+            assert (await (await c.get("/api/audit/diffs")).json())["count"] == 1
+            assert (await c.get("/api/audit/verify")).status == 200
+        bot.audit.verify_integrity = AsyncMock(return_value={"valid": False})
+        async with TestClient(TestServer(_app(obs.register_audit_log, bot=bot))) as c:
+            assert (await c.get("/api/audit/verify")).status == 409
+
+    async def test_logs(self):
+        bot = _bot()
+        async with TestClient(TestServer(_app(obs.register_log_search, bot=bot))) as c:
+            assert (await c.get("/api/logs/search?level=bogus")).status == 400
+            assert (await (await c.get(
+                "/api/logs/search?level=error&q=x")).json())["count"] == 1
+            assert (await (await c.get("/api/logs/stats")).json())["total"] == 3
+
+
+class TestExecutorStats:
+    async def test_risk_recovery_freshness_validation(self):
+        bot = _bot()
+        regs = (obs.register_risk_classification, obs.register_recovery_stats,
+                obs.register_branch_freshness, obs.register_validation_stats)
+        async with TestClient(TestServer(_app(*regs, bot=bot))) as c:
+            assert (await (await c.get("/api/risk/stats")).json())["risk"] == 1
+            assert (await (await c.get("/api/risk/recent")).json())["entries"][0]["e"] == 1
+            assert (await (await c.get("/api/governor/stats")).json())["g"] == 1
+            assert (await (await c.get("/api/audit/risk?level=high")).json())["count"] == 1
+            assert (await (await c.get("/api/recovery/stats")).json())["rec"] == 1
+            assert "entries" in await (await c.get("/api/recovery/recent")).json()
+            assert (await (await c.get("/api/freshness/stats")).json())["f"] == 1
+            assert "entries" in await (await c.get("/api/freshness/recent")).json()
+            assert (await (await c.get("/api/validation/stats")).json())["v"] == 1
+
+    async def test_executor_unavailable_503(self):
+        bot = _bot()
+        bot.tool_executor = None
+        regs = (obs.register_risk_classification, obs.register_recovery_stats,
+                obs.register_branch_freshness, obs.register_validation_stats)
+        async with TestClient(TestServer(_app(*regs, bot=bot))) as c:
+            for path in ("/api/risk/stats", "/api/risk/recent", "/api/governor/stats",
+                         "/api/recovery/stats", "/api/recovery/recent",
+                         "/api/freshness/stats", "/api/freshness/recent",
+                         "/api/validation/stats"):
+                assert (await c.get(path)).status == 503
+
+    async def test_governor_missing(self):
+        bot = _bot()
+        bot.tool_executor.command_governor = None
+        async with TestClient(TestServer(
+                _app(obs.register_risk_classification, bot=bot))) as c:
+            assert (await c.get("/api/governor/stats")).status == 503
+
+
+class TestMiscStats:
+    async def test_affordances_compression_routing_usage_degradation(self):
+        bot = _bot()
+        regs = (obs.register_affordances, obs.register_compression_stats,
+                obs.register_routing_stats, obs.register_usage_cost,
+                obs.register_degradation)
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("src.tools.affordances.all_affordances", lambda: [{"tool": "t"}])
+            async with TestClient(TestServer(_app(*regs, bot=bot))) as c:
+                assert (await (await c.get("/api/affordances")).json())["affordances"]
+                assert (await (await c.get("/api/compression/stats")).json())["comp"] == 1
+                assert (await (await c.get("/api/routing/stats")).json())["m"] == 1
+                assert (await (await c.get("/api/usage")).json())["c"] == 2
+                assert (await (await c.get("/api/subsystems/status")).json())["s"] == 1
+
+    async def test_misc_unavailable_503(self):
+        bot = _bot()
+        bot.compression_stats = None
+        bot.model_router = None
+        bot.cost_tracker = None
+        bot.subsystem_guard = None
+        regs = (obs.register_compression_stats, obs.register_routing_stats,
+                obs.register_usage_cost, obs.register_degradation)
+        async with TestClient(TestServer(_app(*regs, bot=bot))) as c:
+            assert (await c.get("/api/compression/stats")).status == 503
+            assert (await c.get("/api/routing/stats")).status == 503
+            assert (await c.get("/api/usage")).status == 503
+            assert (await c.get("/api/subsystems/status")).status == 503

--- a/tests/test_web_api_sessions_chat.py
+++ b/tests/test_web_api_sessions_chat.py
@@ -1,0 +1,218 @@
+"""Coverage for src/web/api/sessions_chat.py (RFC-006 P11, safe tier-1).
+
+Chat/execute routes (through the `process_web_chat` seam — patched, never a real
+LLM call) plus the session read/export/delete CRUD with a faked bot.sessions.
+SAFE: no LLM, no real session store, no network.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.config.schema import Config
+from src.web.api.sessions_chat import (
+    register_agent_trajectories,
+    register_chat,
+    register_sessions,
+    register_trajectories,
+)
+
+
+def _app(*registrars, bot):
+    routes = web.RouteTableDef()
+    for reg in registrars:
+        reg(routes, bot)
+    app = web.Application()
+    app.router.add_routes(routes)
+    return app
+
+
+def _msg(role="user", content="hi", ts=1.0, uid="u"):
+    return SimpleNamespace(role=role, content=content, timestamp=ts, user_id=uid)
+
+
+def _session(messages=None, summary=""):
+    return SimpleNamespace(messages=messages if messages is not None else [_msg()],
+                           estimated_tokens=10, last_active=1.0, created_at=1.0,
+                           summary=summary, last_user_id="u")
+
+
+def _bot():
+    bot = MagicMock()
+    bot.api_token_manager = None  # dev mode → admin gate allows
+    bot.config = Config(discord={"token": "x"})
+    s = bot.sessions
+    s.items_snapshot.return_value = [("web:u:session:1", _session([_msg(content="x" * 200)]))]
+    s.get_session_token_usage.return_value = {"total": 100}
+    s.get_activity_metrics.return_value = {"active": 1}
+    s.search_history = AsyncMock(return_value=[{"r": 1}])
+    s.get.return_value = _session()
+    s.exists.return_value = True
+    s.token_budget = 64000
+    s.reset_many.return_value = 3
+    return bot
+
+
+_CHAT_OK = {"response": "hello", "tools_used": ["grep"], "is_error": False, "files": []}
+
+
+class TestChat:
+    async def test_validation(self):
+        async with TestClient(TestServer(_app(register_chat, bot=_bot()))) as c:
+            assert (await c.post("/api/chat", data="bad")).status == 400
+            assert (await c.post("/api/chat", json={})).status == 400  # no content
+            assert (await c.post("/api/chat", json={"content": "x" * 40000})).status == 400
+            assert (await c.post("/api/chat",
+                                 json={"content": "hi", "session_id": "bad id!"})).status == 400
+
+    async def test_success_and_error_and_session(self):
+        with patch("src.web.api.process_web_chat", new=AsyncMock(return_value=_CHAT_OK)):
+            async with TestClient(TestServer(_app(register_chat, bot=_bot()))) as c:
+                r = await c.post("/api/chat", json={"content": "hi", "session_id": "s1"})
+                assert r.status == 200
+                body = await r.json()
+                assert body["response"] == "hello" and body["session_id"] == "s1"
+        err = {**_CHAT_OK, "is_error": True, "files": [{"name": "f"}]}
+        with patch("src.web.api.process_web_chat", new=AsyncMock(return_value=err)):
+            async with TestClient(TestServer(_app(register_chat, bot=_bot()))) as c:
+                r = await c.post("/api/chat", json={"content": "hi"})
+                assert r.status == 502 and (await r.json())["files"]
+
+
+class TestExecute:
+    async def test_validation_and_success(self):
+        with patch("src.web.api.process_web_chat", new=AsyncMock(return_value=_CHAT_OK)):
+            async with TestClient(TestServer(_app(register_chat, bot=_bot()))) as c:
+                assert (await c.post("/api/execute", data="bad")).status == 400
+                assert (await c.post("/api/execute", json={})).status == 400  # no prompt
+                assert (await c.post("/api/execute",
+                                     json={"prompt": "x" * 40000})).status == 400
+                r = await c.post("/api/execute", json={"prompt": "do it"})
+                assert r.status == 200 and (await r.json())["source"] == "web_api"
+
+
+class TestSessionsCrud:
+    async def test_list_and_stats_and_search(self):
+        async with TestClient(TestServer(_app(register_sessions, bot=_bot()))) as c:
+            listed = await (await c.get("/api/sessions")).json()
+            assert listed[0]["channel_id"] == "web:u:session:1"
+            assert listed[0]["preview"][0]["content"].endswith("...")  # long msg truncated
+            assert (await (await c.get("/api/sessions/token-usage")).json())["total"] == 100
+            assert (await (await c.get("/api/sessions/activity")).json())["active"] == 1
+            assert (await c.get("/api/sessions/search")).status == 400  # no q
+            s = await (await c.get("/api/sessions/search?q=hi&after=1&before=2")).json()
+            assert s["count"] == 1
+
+    async def test_get_export_delete(self):
+        bot = _bot()
+        bot.sessions.get.return_value = _session(summary="a running summary")
+        async with TestClient(TestServer(_app(register_sessions, bot=bot))) as c:
+            body = await (await c.get("/api/sessions/web:u:session:1")).json()
+            assert body["token_budget"] == 64000 and len(body["messages"]) == 1
+            # export json + text (text includes the summary header)
+            assert (await c.get("/api/sessions/c1/export")).status == 200
+            txt = await c.get("/api/sessions/c1/export?format=text")
+            text_body = await txt.text()
+            assert txt.status == 200 and "MESSAGES" in text_body.upper()
+            assert "running summary" in text_body
+            assert (await c.delete("/api/sessions/c1")).status == 200
+            bot.sessions.get.return_value = None
+            assert (await c.get("/api/sessions/gone")).status == 404
+            bot.sessions.exists.return_value = False
+            assert (await c.delete("/api/sessions/gone")).status == 404
+
+    async def test_clear_bulk(self):
+        async with TestClient(TestServer(_app(register_sessions, bot=_bot()))) as c:
+            assert (await c.post("/api/sessions/clear-bulk", data="bad")).status == 400
+            empty = await c.post("/api/sessions/clear-bulk", json={"channel_ids": []})
+            assert empty.status == 400
+            r = await c.post("/api/sessions/clear-bulk", json={"channel_ids": ["a", "b", "c"]})
+            assert r.status == 200 and (await r.json())["count"] == 3
+
+    async def test_non_admin_access(self):
+        # inject a non-admin identity via an app middleware, exercising the
+        # own-session filter / access-denied branches
+        bot = _bot()
+        ident = SimpleNamespace(tier="user", user_id="alice", username="A", allowed_tools=None)
+
+        @web.middleware
+        async def _inject(request, handler):
+            # the handlers read the attribute form via getattr(request, "_api_identity")
+            request._api_identity = ident  # type: ignore[attr-defined]
+            return await handler(request)
+
+        routes = web.RouteTableDef()
+        register_sessions(routes, bot)
+        app = web.Application(middlewares=[_inject])
+        app.router.add_routes(routes)
+        async with TestClient(TestServer(app)) as c:
+            # own session (alice) not in snapshot → filtered out → empty list
+            assert await (await c.get("/api/sessions")).json() == []
+            # accessing someone else's session → 403
+            assert (await c.get("/api/sessions/web:bob:session:1")).status == 403
+
+
+def _saver(tmp_path, count=2):
+    s = MagicMock()
+    s.directory = tmp_path
+    s.count = count
+    s.list_files = AsyncMock(return_value=["a.jsonl"])
+    s.read_file = AsyncMock(return_value=[{"e": 1}])
+    s.find_by_message_id = AsyncMock(return_value={"m": 1})
+    s.find_by_agent_id = AsyncMock(return_value={"a": 1})
+    s.search = AsyncMock(return_value=[{"r": 1}])
+    return s
+
+
+class TestTrajectories:
+    async def test_all(self, tmp_path):
+        bot = _bot()
+        bot.trajectory_saver = _saver(tmp_path)
+        async with TestClient(TestServer(_app(register_trajectories, bot=bot))) as c:
+            assert (await (await c.get("/api/trajectories")).json())["count"] == 2
+            assert (await (await c.get("/api/trajectories/a.jsonl")).json())["count"] == 1
+            assert (await c.get("/api/trajectories/bad.txt")).status == 400  # bad ext
+            assert (await c.get("/api/trajectories/..%2Fx.jsonl")).status == 400  # traversal
+            assert (await (await c.get(
+                "/api/trajectories/message/m1")).json())["entry"]["m"] == 1
+            assert (await (await c.get(
+                "/api/trajectories/search/query?errors_only=1")).json())["count"] == 1
+            bot.trajectory_saver.find_by_message_id = AsyncMock(return_value=None)
+            assert (await c.get("/api/trajectories/message/gone")).status == 404
+
+    async def test_unavailable_503(self):
+        bot = _bot()
+        bot.trajectory_saver = None
+        async with TestClient(TestServer(_app(register_trajectories, bot=bot))) as c:
+            assert (await c.get("/api/trajectories")).status == 503
+            assert (await c.get("/api/trajectories/a.jsonl")).status == 503
+            assert (await c.get("/api/trajectories/message/m")).status == 503
+            assert (await c.get("/api/trajectories/search/query")).status == 503
+
+
+class TestAgentTrajectories:
+    async def test_all(self, tmp_path):
+        bot = _bot()
+        bot.agent_trajectory_saver = _saver(tmp_path)
+        async with TestClient(TestServer(_app(register_agent_trajectories, bot=bot))) as c:
+            assert (await (await c.get("/api/agent-trajectories")).json())["count"] == 2
+            assert (await (await c.get(
+                "/api/agent-trajectories/agent/ag1")).json())["entry"]["a"] == 1
+            assert (await (await c.get(
+                "/api/agent-trajectories/search/query")).json())["count"] == 1
+            assert (await (await c.get("/api/agent-trajectories/a.jsonl")).json())["count"] == 1
+            assert (await c.get("/api/agent-trajectories/bad.txt")).status == 400
+            bot.agent_trajectory_saver.find_by_agent_id = AsyncMock(return_value=None)
+            assert (await c.get("/api/agent-trajectories/agent/gone")).status == 404
+
+    async def test_unavailable_503(self):
+        bot = _bot()
+        bot.agent_trajectory_saver = None
+        async with TestClient(TestServer(_app(register_agent_trajectories, bot=bot))) as c:
+            assert (await c.get("/api/agent-trajectories")).status == 503
+            assert (await c.get("/api/agent-trajectories/agent/a")).status == 503
+            assert (await c.get("/api/agent-trajectories/search/query")).status == 503
+            assert (await c.get("/api/agent-trajectories/a.jsonl")).status == 503


### PR DESCRIPTION
First safe pass into the harder tier — files whose dangerous paths are shallow enough to stub airtight (no real execution, network, or gateway). Additive tests + a scoped baseline ratchet — **no `src/` changes.**

The genuinely dangerous files (`background_task`, `discord/client`, `watcher`) are **deferred to a future Incus-sandboxed round** — this desktop hosts live Odin and localhost is a destructible target, so those need a containment layer beyond mocking.

## Coverage lifts

| File | Start → End |
|---|---|
| `discord/llm_gateway.py` | 37% → **99%** |
| `web/api/observability.py` | 64% → **96%** |
| `web/api/sessions_chat.py` | 69% → **94%** |

Whole-repo line coverage **82.1% → 83.1%**; suite **+46 tests**. mypy 0, ruff clean, all four CI gates green.

## Method / safety

- **llm_gateway** — the provider client classes (`CodexChatClient`/`OllamaClient`/`KimiClient`/`CodexAuthPool`) are patched so reloads build fakes: no real tokens, no network, no health-check hits a server. The deferred-close `call_later` is stubbed so nothing schedules on a live loop.
- **observability** — all read-only stat/audit routes with a faked bot; the file-reading aggregates (`context`/`failure`/affordances) are patched so no real trajectory/audit file is touched.
- **sessions_chat** — chat/execute go through the patched `process_web_chat` seam (**never a real LLM call**); session + trajectory routes use a faked store/saver.

Residual uncovered = the unreachable `except ValueError` branches around `_safe_int_param` (it swallows, never raises) plus a couple of `.resolve()` path-escape / auth-configured-identity branches.

## Discipline

- **COV ledger empty** — no real bugs; no `xfail`s.
- **Scoped ratchet** — baseline tightened for exactly these three files.

**Still safe, next round:** `learning/reflector`, `sessions/manager`, `scheduler` (validation subset), `intake_pipeline` — intricate logic that deserves careful treatment rather than a rushed tack-on.

Plan-of-record results: `docs/plans/coverage-plan.md` §6l.