### PR TITLE
test: RFC-006 P15 — ollama transport + config validators + audit read paths

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -48,10 +48,10 @@
   "statements": 60
  },
  "src/audit/logger.py": {
-  "covered": 245,
-  "missing": 52,
-  "percent": 82.49,
-  "statements": 297
+  "covered": 274,
+  "missing": 27,
+  "percent": 91.03,
+  "statements": 301
  },
  "src/audit/signer.py": {
   "covered": 71,
@@ -66,9 +66,9 @@
   "statements": 30
  },
  "src/config/schema.py": {
-  "covered": 506,
-  "missing": 59,
-  "percent": 89.56,
+  "covered": 564,
+  "missing": 1,
+  "percent": 99.82,
   "statements": 565
  },
  "src/constants.py": {
@@ -444,9 +444,9 @@
   "statements": 151
  },
  "src/llm/ollama.py": {
-  "covered": 112,
-  "missing": 65,
-  "percent": 63.28,
+  "covered": 172,
+  "missing": 5,
+  "percent": 97.18,
   "statements": 177
  },
  "src/llm/openai_codex.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -306,6 +306,25 @@ The session manager, driven against a **real** `SessionManager` (not a mocked on
 
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
+## 6p. R3 — P15 ollama transport + config validators + audit read paths (2026-07-07)
+
+Three unrelated safe files in one PR, Odin-reviewed. Whole-repo 83.6% → **84.1%**.
+
+| File | Start → End |
+|---|---|
+| `llm/ollama.py` | 63.3% → **97.2%** (missing 65 → 5) |
+| `config/schema.py` | 89.6% → **99.8%** (missing 59 → 1) |
+| `audit/logger.py` | 82.5% → **91.0%** (missing 52 → 27) |
+
+**Method / safety.**
+- *ollama* — the HTTP transport (`_request_with_retry` success / retryable-5xx-then-success / retry-exhausted / non-retryable-status / `ClientError`-then-success / `ClientError`-exhausted, with `asyncio.sleep` patched so retries don't wall-clock), `chat`/`chat_with_tools`, `health_check` (exact-model / base-name-prefix / non-200 / exception), `_headers`, and the real `_get_session`/`close` lifecycle. The only faked boundary is a queue-backed fake `aiohttp` session — **no real network.**
+- *config/schema* — every out-of-range field validator's raise arm (parametrized), `_substitute_env_vars` (required / default / missing-raises), `load_config`'s success path plus all four `SystemExit` arms (env-missing, bad-YAML, non-mapping, validation-failure) against tmp files, and `WebConfig.resolve_api_identity` (listed-token + single-token fallback). Pure + tmp-file reads.
+- *audit/logger* — real `AuditLogger` on a tmp jsonl: entries written via the logger's own `log_execution`/`log_web_action` (real `_persist`), then read back through `search`/`_match` (every filter: tool/user/host/keyword/date/status/has_error/min_duration/limit), `count_by_tool`, `get_log_stats`, `initialize_chain` (HMAC chain resumed by a second logger + `verify_integrity` green), and log rotation (tiny `max_bytes` → `.1` backup created). `_cap_tool_input` both arms. Real file I/O only.
+
+**Deliberately deferred:** ollama's few remaining defensive lines; the audit search-by-risk / diff-search / verify-integrity-failure edges (partly covered by the existing `test_audit_signing`/`test_audit_persist_concurrency` suites) — remaining 27 are lower-yield branch tails.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_audit_logger_search.py
+++ b/tests/test_audit_logger_search.py
@@ -1,0 +1,125 @@
+"""Coverage for src/audit/logger.py read/search/stats/rotation (RFC-006 P15, safe).
+
+Drives a REAL AuditLogger against a tmp jsonl path: entries are written via the
+logger's own log_execution/log_web_action (real _persist), then read back through
+search/_match (every filter), count_by_tool, get_log_stats, initialize_chain, and
+log rotation. SAFE: real file I/O in tmp only; no network, no tool dispatch.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.audit.logger import AuditLogger, _cap_tool_input
+
+
+@pytest.fixture
+def logger(tmp_path):
+    return AuditLogger(path=str(tmp_path / "audit.jsonl"))
+
+
+async def _exec(logger, **kw):
+    params = dict(user_id="u1", user_name="Alice", channel_id="c1",
+                  tool_name="run_command", tool_input={"host": "server"},
+                  approved=True, result_summary="ok", execution_time_ms=50)
+    params.update(kw)
+    await logger.log_execution(**params)
+
+
+class TestCapToolInput:
+    def test_small_passthrough(self):
+        inp = {"a": 1}
+        assert _cap_tool_input(inp, 4000) is inp
+
+    def test_oversized_truncated(self):
+        out = _cap_tool_input({"blob": "x" * 200}, 20)
+        assert isinstance(out, str) and out.startswith("<tool_input truncated")
+
+
+class TestSearchFilters:
+    async def test_each_filter(self, logger):
+        await _exec(logger, tool_name="run_command", user_name="Alice",
+                    tool_input={"host": "server"}, execution_time_ms=500)
+        await _exec(logger, tool_name="read_file", user_name="Bob",
+                    tool_input={"host": "playground"}, execution_time_ms=10,
+                    error="boom")
+        assert len(await logger.search()) == 2  # no filters → all
+        assert len(await logger.search(tool_name="read_file")) == 1
+        assert len(await logger.search(user="alice")) == 1          # case-insensitive
+        assert len(await logger.search(host="server")) == 1
+        assert len(await logger.search(keyword="playground")) == 1  # blob keyword
+        assert len(await logger.search(has_error=True)) == 1
+        assert len(await logger.search(min_duration_ms=100)) == 1   # only the 500ms one
+        assert await logger.search(limit=1) != []                   # limit honoured
+
+    async def test_date_filter_and_no_file(self, logger, tmp_path):
+        # missing file → empty
+        assert await AuditLogger(path=str(tmp_path / "absent.jsonl")).search() == []
+        await _exec(logger)
+        assert len(await logger.search(date="20")) == 1     # ISO year prefix matches
+        assert await logger.search(date="1999") == []       # no such day
+
+    async def test_status_filter_via_web_action(self, logger):
+        await logger.log_web_action(method="POST", path="/x", status=200)
+        assert len(await logger.search(status="200")) == 1
+        assert await logger.search(status="404") == []
+
+
+class TestCountAndStats:
+    async def test_count_by_tool(self, logger, tmp_path):
+        assert await AuditLogger(path=str(tmp_path / "absent.jsonl")).count_by_tool() == {}
+        await _exec(logger, tool_name="run_command")
+        await _exec(logger, tool_name="run_command")
+        await _exec(logger, tool_name="read_file")
+        counts = await logger.count_by_tool()
+        assert counts == {"run_command": 2, "read_file": 1}
+        assert list(counts)[0] == "run_command"  # most-used first
+
+    async def test_get_log_stats(self, logger):
+        await _exec(logger, tool_name="run_command")
+        await _exec(logger, tool_name="read_file", error="failed")
+        await logger.log_web_action(method="GET", path="/ui", status=200)
+        stats = await logger.get_log_stats()
+        assert stats["total"] == 3
+        assert stats["errors"] == 1
+        assert stats["tool_count"] == 2
+        assert stats["web_actions"] == 1
+        assert stats["tools"] == ["read_file", "run_command"]
+
+
+class TestLogWebAction:
+    async def test_success_and_error_entries(self, logger):
+        await logger.log_web_action(method="POST", path="/api/x", status=201,
+                                    ip="1.2.3.4", execution_time_ms=12,
+                                    user_id="u9", username="Nine", label="admin",
+                                    diff="- a\n+ b")
+        await logger.log_web_action(method="DELETE", path="/api/y", status=500)
+        entries = await logger.search()
+        by_path = {e["path"]: e for e in entries}
+        ok = by_path["/api/x"]
+        assert ok["success"] is True and ok["actor"] == "web:u9" and ok["label"] == "admin"
+        assert ok["diff"] == "- a\n+ b"
+        err = by_path["/api/y"]
+        assert err["success"] is False and err["error"] == "HTTP 500"
+
+
+class TestChainAndRotation:
+    async def test_initialize_chain_resumes(self, tmp_path):
+        key = "ab12" * 16  # 64-char hex HMAC key
+        path = str(tmp_path / "signed.jsonl")
+        first = AuditLogger(path=path, hmac_key=key)
+        await _exec(first, tool_name="run_command")
+        await _exec(first, tool_name="read_file")
+        # a fresh logger over the same file resumes the chain from the last entry
+        second = AuditLogger(path=path, hmac_key=key)
+        await second.initialize_chain()
+        await _exec(second, tool_name="list_dir")     # chains onto the resumed state
+        result = await second.verify_integrity()
+        assert result.get("valid") is True
+
+    async def test_rotation_creates_backup(self, tmp_path):
+        # tiny cap → the second persist rotates the first entry into .1
+        path = tmp_path / "rot.jsonl"
+        logger = AuditLogger(path=str(path), max_bytes=150, max_files=3)
+        await _exec(logger, result_summary="x" * 200)  # one entry already > cap
+        await _exec(logger, result_summary="y" * 200)  # triggers rotation
+        assert (tmp_path / "rot.jsonl.1").exists()

--- a/tests/test_config_schema_validators.py
+++ b/tests/test_config_schema_validators.py
@@ -1,0 +1,125 @@
+"""Coverage for src/config/schema.py validators + loader (RFC-006 P15, safe).
+
+Pure Pydantic field validators (the ``raise`` arms fire on out-of-range values),
+the ``${VAR}`` env-substitution helper, ``load_config``'s success + every
+SystemExit error arm (driven against tmp files), and ``WebConfig`` identity
+resolution. SAFE: pure validation + tmp-file reads only; no network, no LLM.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.schema import (
+    AgentsConfig,
+    ApiTokenIdentity,
+    BrowserConfig,
+    BulkheadConfig,
+    ConnectionPoolConfig,
+    KimiConfig,
+    RetryConfig,
+    ToolsConfig,
+    WebConfig,
+    _substitute_env_vars,
+    load_config,
+)
+
+
+class TestFieldValidators:
+    """Each out-of-range value trips its validator's raise arm."""
+
+    @pytest.mark.parametrize("factory", [
+        lambda: RetryConfig(max_retries=-1),
+        lambda: RetryConfig(base_delay=-1.0),
+        lambda: BulkheadConfig(ssh_max_concurrent=0),
+        lambda: BulkheadConfig(ssh_max_queued=-1),
+        lambda: AgentsConfig(max_iterations=0),
+        lambda: AgentsConfig(final_warning_iterations=[0]),
+        lambda: ConnectionPoolConfig(max_connections=0),
+        lambda: ConnectionPoolConfig(keepalive_timeout=-1.0),
+        lambda: ToolsConfig(command_timeout_seconds=0),
+        lambda: ToolsConfig(max_tool_iterations_chat=0),
+        lambda: KimiConfig(max_tokens=0),
+        lambda: BrowserConfig(default_timeout_ms=500),
+        lambda: WebConfig(port=0),
+        lambda: WebConfig(port=99999),
+    ])
+    def test_invalid_value_rejected(self, factory):
+        with pytest.raises(ValidationError):
+            factory()
+
+    def test_valid_values_accepted(self):
+        # the return arms (happy path) — construction succeeds
+        assert RetryConfig(max_retries=3, base_delay=0.5).max_retries == 3
+        assert ToolsConfig(command_timeout_seconds=30).command_timeout_seconds == 30
+        assert WebConfig(port=3002).port == 3002
+
+
+class TestResolveApiIdentity:
+    def test_matches_listed_token(self):
+        ident = ApiTokenIdentity(token="tok-listed", user_id="u1", username="U1",
+                                 tier="user", label="l1")
+        web = WebConfig(api_tokens=[ident])
+        assert web.resolve_api_identity("tok-listed") is ident
+        assert web.resolve_api_identity("wrong") is None
+
+    def test_falls_back_to_single_api_token(self):
+        web = WebConfig(api_token="tok-default")
+        got = web.resolve_api_identity("tok-default")
+        assert got is not None and got.user_id == "api-admin" and got.tier == "admin"
+        assert web.resolve_api_identity("nope") is None
+
+
+class TestSubstituteEnvVars:
+    def test_required_present(self, monkeypatch):
+        monkeypatch.setenv("ODIN_TEST_VAR", "resolved")
+        assert _substitute_env_vars("x=${ODIN_TEST_VAR}") == "x=resolved"
+
+    def test_optional_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ODIN_MISSING_VAR", raising=False)
+        assert _substitute_env_vars("x=${ODIN_MISSING_VAR:-fallback}") == "x=fallback"
+
+    def test_required_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("ODIN_MISSING_VAR", raising=False)
+        with pytest.raises(ValueError, match="not set"):
+            _substitute_env_vars("x=${ODIN_MISSING_VAR}")
+
+
+class TestLoadConfig:
+    def _write(self, tmp_path, text):
+        p = tmp_path / "config.yml"
+        p.write_text(text)
+        return p
+
+    def test_valid_config(self, tmp_path):
+        p = self._write(tmp_path, "discord:\n  token: abc\n")
+        cfg = load_config(p)
+        assert cfg.discord.token == "abc"
+
+    def test_env_substituted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ODIN_TOKEN_TEST", "from-env")
+        p = self._write(tmp_path, "discord:\n  token: ${ODIN_TOKEN_TEST}\n")
+        assert load_config(p).discord.token == "from-env"
+
+    def test_missing_env_var_is_systemexit(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ODIN_ABSENT", raising=False)
+        p = self._write(tmp_path, "discord:\n  token: ${ODIN_ABSENT}\n")
+        with pytest.raises(SystemExit, match="Configuration error"):
+            load_config(p)
+
+    def test_bad_yaml_is_systemexit(self, tmp_path):
+        p = self._write(tmp_path, "discord: [unterminated\n")
+        with pytest.raises(SystemExit, match="Failed to parse"):
+            load_config(p)
+
+    def test_non_mapping_is_systemexit(self, tmp_path):
+        p = self._write(tmp_path, "- just\n- a\n- list\n")
+        with pytest.raises(SystemExit, match="empty or invalid"):
+            load_config(p)
+
+    def test_validation_failure_is_systemexit(self, tmp_path):
+        # tools.command_timeout_seconds=0 trips ToolsConfig's validator
+        p = self._write(tmp_path,
+                        "discord:\n  token: abc\ntools:\n  command_timeout_seconds: 0\n")
+        with pytest.raises(SystemExit, match="validation failed"):
+            load_config(p)

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,6 +1,9 @@
 """Tests for the Ollama LLM client."""
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
 import pytest
 
 from src.llm.ollama import OllamaClient
@@ -268,3 +271,177 @@ class TestConfigParsing:
         assert cfg.ollama.enabled is True
         assert cfg.ollama.model == "qwen2.5:14b"
         assert cfg.llm_provider.active_provider == "ollama"
+
+
+# --- HTTP transport (faked aiohttp session — no real network) ---
+
+
+class _FakeResp:
+    """Stands in for an aiohttp response context manager."""
+
+    def __init__(self, status=200, payload=None, text="", raise_on_enter=None):
+        self.status = status
+        self._payload = payload if payload is not None else {}
+        self._text = text
+        self._raise = raise_on_enter
+
+    async def __aenter__(self):
+        if self._raise is not None:
+            raise self._raise
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return self._text
+
+
+class _FakeSession:
+    """Pops a queued _FakeResp per request; records calls; never touches network."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.closed = False
+        self.calls: list = []
+
+    def post(self, url, json=None, headers=None):
+        self.calls.append(("post", url, json, headers))
+        return self._responses.pop(0)
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("get", url, headers))
+        return self._responses.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+def _client(**kw):
+    params = dict(base_url="http://localhost:11434", model="llama3.1:8b",
+                  max_tokens=256, max_retries=1, retry_base_delay=0.0,
+                  retry_max_delay=0.0)
+    params.update(kw)
+    return OllamaClient(**params)  # type: ignore[arg-type]  # test-helper kwargs merge
+
+
+class TestHeaders:
+    def test_without_and_with_api_key(self):
+        assert "Authorization" not in _client()._headers()
+        h = _client(api_key="sk-abc")._headers()
+        assert h["Authorization"] == "Bearer sk-abc"
+        assert h["Content-Type"] == "application/json"
+
+
+class TestSessionLifecycle:
+    async def test_get_session_creates_and_close(self):
+        c = _client()
+        session = await c._get_session()            # real ClientSession object, no network
+        assert session is await c._get_session()    # reused while open
+        assert c._session is not None
+        await c.close()
+        assert c._session is None                    # closed + cleared
+
+
+class TestRequestWithRetry:
+    async def test_success_first_try(self):
+        c = _client()
+        c._session = _FakeSession([_FakeResp(200, {"ok": 1})])  # type: ignore[assignment]
+        assert await c._request_with_retry({"model": "x"}) == {"ok": 1}
+        assert c._total_requests == 1
+
+    async def test_retryable_then_success(self):
+        c = _client(max_retries=2)
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(503, text="busy"), _FakeResp(200, {"ok": 2})])
+        with patch("src.llm.ollama.asyncio.sleep", new=AsyncMock()) as slept:
+            assert await c._request_with_retry({}) == {"ok": 2}
+        slept.assert_awaited()  # backed off before the retry
+
+    async def test_retryable_exhausted_raises(self):
+        c = _client(max_retries=1)
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(500, text="boom"), _FakeResp(500, text="boom")])
+        with patch("src.llm.ollama.asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(RuntimeError, match="500"):
+                await c._request_with_retry({})
+
+    async def test_non_retryable_status_raises(self):
+        c = _client()
+        c._session = _FakeSession([_FakeResp(400, text="bad request")])  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="400"):
+            await c._request_with_retry({})
+
+    async def test_client_error_then_success(self):
+        c = _client(max_retries=2)
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(raise_on_enter=aiohttp.ClientError("neterr")),
+            _FakeResp(200, {"ok": 3})])
+        with patch("src.llm.ollama.asyncio.sleep", new=AsyncMock()):
+            assert await c._request_with_retry({}) == {"ok": 3}
+
+    async def test_client_error_exhausted_raises(self):
+        c = _client(max_retries=1)
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(raise_on_enter=aiohttp.ClientError("neterr")),
+            _FakeResp(raise_on_enter=aiohttp.ClientError("neterr"))])
+        with patch("src.llm.ollama.asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(RuntimeError, match="connection error after"):
+                await c._request_with_retry({})
+
+
+class TestChatEndpoints:
+    async def test_chat_returns_content(self):
+        c = _client()
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(200, {"message": {"content": "hello there"}})])
+        assert await c.chat([{"role": "user", "content": "hi"}], "sys") == "hello there"
+        # body carried the converted messages + num_predict override honoured
+        _, url, body, _ = c._session.calls[0]  # type: ignore[union-attr]
+        assert url.endswith("/api/chat") and body["stream"] is False
+
+    async def test_chat_with_tools_parses_response(self):
+        c = _client()
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(200, {"message": {
+                "content": "",
+                "tool_calls": [{"function": {"name": "get_time", "arguments": {"tz": "utc"}}}],
+            }})])
+        resp = await c.chat_with_tools([{"role": "user", "content": "time?"}], "sys",
+                                       [{"name": "get_time", "description": "d",
+                                         "input_schema": {}}])
+        assert isinstance(resp, LLMResponse)
+        assert resp.stop_reason == "tool_use"
+        assert resp.tool_calls[0].name == "get_time"
+
+
+class TestHealthCheck:
+    async def test_healthy_with_exact_model(self):
+        c = _client(model="llama3.1:8b")
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(200, {"models": [{"name": "llama3.1:8b"}]})])
+        r = await c.health_check()
+        assert r["healthy"] is True and r["model_available"] is True
+
+    async def test_healthy_with_base_name_match(self):
+        c = _client(model="llama3.1:8b")
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(200, {"models": [{"name": "llama3.1:70b"}]})])
+        r = await c.health_check()
+        assert r["healthy"] is True and r["model_available"] is True  # base-name prefix match
+
+    async def test_non_200_unhealthy(self):
+        c = _client()
+        c._session = _FakeSession([_FakeResp(500, text="down")])  # type: ignore[assignment]
+        r = await c.health_check()
+        assert r["healthy"] is False and "500" in r["error"]
+
+    async def test_exception_unhealthy(self):
+        c = _client()
+        c._session = _FakeSession([  # type: ignore[assignment]
+            _FakeResp(raise_on_enter=aiohttp.ClientError("refused"))])
+        r = await c.health_check()
+        assert r["healthy"] is False and "refused" in r["error"]


### PR DESCRIPTION
Test-only wave (RFC-006 P15). Three unrelated **safe** files, one PR. No \`src\` changes.

## Coverage (whole-repo 83.6% → 84.1%)

| File | Start → End |
|---|---|
| \`llm/ollama.py\` | 63.3% → **97.2%** (missing 65 → 5) |
| \`config/schema.py\` | 89.6% → **99.8%** (missing 59 → 1) |
| \`audit/logger.py\` | 82.5% → **91.0%** (missing 52 → 27) |

## Method / safety (real interfaces, faked boundaries only)

- **ollama** — HTTP transport via a queue-backed fake \`aiohttp\` session (no real network), \`asyncio.sleep\` patched so the retry matrix does not wall-clock: \`_request_with_retry\` (success / retryable-5xx-then-success / retry-exhausted / non-retryable-status / \`ClientError\`-then-success / \`ClientError\`-exhausted), \`chat\`/\`chat_with_tools\`, \`health_check\` (exact / base-name-prefix / non-200 / exception), \`_headers\`, real \`_get_session\`/\`close\`.
- **config/schema** — every field-validator raise arm (parametrized), \`_substitute_env_vars\`, \`load_config\` success + all four \`SystemExit\` arms (env-missing / bad-YAML / non-mapping / validation-failure) against tmp files, \`WebConfig.resolve_api_identity\`. Pure + tmp reads.
- **audit/logger** — real \`AuditLogger\` on a tmp jsonl: entries written via its own \`log_execution\`/\`log_web_action\` (real \`_persist\`), read back through \`search\`/\`_match\` (all filters), \`count_by_tool\`, \`get_log_stats\`, \`initialize_chain\` (+\`verify_integrity\` green), log rotation, \`_cap_tool_input\`. Real file I/O only.

## Deferred (honest boundary)

ollama defensive tails; audit search-by-risk / diff-search / verify-failure edges (partly covered by existing \`test_audit_signing\`/\`test_audit_persist_concurrency\`).

## Gates (local)

- coverage-gate: findings=0 (baseline ratchet scoped to exactly the 3 target entries)
- lint-gate: new=0 · type-gate: new=0
- suite: 7128 passed, 4 skipped

**COV ledger: EMPTY** — no product bugs surfaced.