### PR TITLE
test: RFC-006 P16 — email client MIME/IMAP/SMTP + health checker probes

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -318,9 +318,9 @@
   "statements": 3
  },
  "src/health/checker.py": {
-  "covered": 226,
-  "missing": 42,
-  "percent": 84.33,
+  "covered": 268,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 268
  },
  "src/health/grafana_alerts.py": {
@@ -900,9 +900,9 @@
   "statements": 268
  },
  "src/tools/email_client.py": {
-  "covered": 179,
-  "missing": 52,
-  "percent": 77.49,
+  "covered": 210,
+  "missing": 21,
+  "percent": 90.91,
   "statements": 231
  },
  "src/tools/executor.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -325,6 +325,23 @@ Three unrelated safe files in one PR, Odin-reviewed. Whole-repo 83.6% → **84.1
 
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
+## 6q. R3 — P16 email client + health checker (2026-07-07)
+
+Two safe files in one PR, Odin-reviewed. Whole-repo 84.1% → **84.4%**.
+
+| File | Start → End |
+|---|---|
+| `tools/email_client.py` | 77.5% → **90.9%** (missing 52 → 21) |
+| `health/checker.py` | 84.3% → **100.0%** (missing 42 → 0) |
+
+**Method / safety.**
+- *email_client* — pure MIME parsing (`_extract_body`: multipart-plain / multipart-html-only / no-text-body / single-part / empty / truncation; `_decode_header_value`: empty + encoded-bytes) plus SMTP send and IMAP search/read/list with `smtplib.SMTP` / `imaplib.IMAP4_SSL` **faked** (a queue-backed fake conn / context-manager server): happy paths, the Gmail `X-GM-RAW` branch, non-OK / UID-not-found / connect-failure error arms, password redaction, and attachment-outside-allowed-dir / not-a-file guards. **No real SMTP/IMAP, no network** — only constructed in-memory messages.
+- *health/checker* — the provider-configured paths of `check_ollama`/`check_kimi` (all three circuit-breaker states + the error arm) driven with real *un-connected* `OllamaClient`/`KimiClient` objects (breaker-state inspection + `pool_stats` only, no request), `check_codex`'s lazy-`None`-session branch, the exception arms of `check_browser`/`check_loops`/`check_agents` (probe raises → "down"), and `check_all`'s crashed-checker handling (a patched raising checker → recorded as down, overall unhealthy). Fake `bot` namespaces; no network, no LLM call.
+
+**Deliberately deferred:** email_client's remaining 21 lines are attachment-encoding sub-branches and a few provider-quirk tails — lower-yield, left for a future pass.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_email_client_paths.py
+++ b/tests/test_email_client_paths.py
@@ -1,0 +1,225 @@
+"""Coverage for src/tools/email_client.py body-extraction + IMAP/SMTP paths
+(RFC-006 P16, safe).
+
+Pure MIME parsing (``_extract_body`` every branch, ``_decode_header_value``) plus
+the SMTP send and IMAP search/read/list flows with ``smtplib.SMTP`` /
+``imaplib.IMAP4_SSL`` faked — including the connect-fail, non-OK, and not-found
+error arms. SAFE: no real SMTP/IMAP connection, no network; only constructed
+in-memory email messages and faked transport objects.
+"""
+from __future__ import annotations
+
+import email as email_lib
+from unittest.mock import patch
+
+import pytest
+
+from src.tools import email_client as ec
+
+_HDR = b"From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Hi there\r\n\r\n"
+
+
+class TestPureHelpers:
+    def test_decode_header_value(self):
+        assert ec._decode_header_value(None) == ""            # empty guard
+        assert ec._decode_header_value("plain subject") == "plain subject"
+        assert ec._decode_header_value("=?utf-8?q?caf=C3=A9?=") == "café"  # bytes branch
+
+    def test_extract_body_multipart_plain(self):
+        msg = email_lib.message_from_string(
+            "Content-Type: multipart/alternative; boundary=b\r\n\r\n"
+            "--b\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nplain part\r\n--b--\r\n")
+        assert ec._extract_body(msg, 5000) == "plain part"
+
+    def test_extract_body_multipart_html_only(self):
+        msg = email_lib.message_from_string(
+            "Content-Type: multipart/alternative; boundary=b\r\n\r\n"
+            "--b\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<p>hi</p>\r\n--b--\r\n")
+        out = ec._extract_body(msg, 5000)
+        assert out.startswith("[HTML content]") and "<p>hi</p>" in out
+
+    def test_extract_body_multipart_none(self):
+        msg = email_lib.message_from_string(
+            "Content-Type: multipart/mixed; boundary=b\r\n\r\n"
+            "--b\r\nContent-Type: image/png\r\n"
+            "Content-Disposition: attachment; filename=x.png\r\n\r\nBLOB\r\n--b--\r\n")
+        assert ec._extract_body(msg, 5000) == "[no text body found]"
+
+    def test_extract_body_singlepart_and_empty(self):
+        body = email_lib.message_from_string("Content-Type: text/plain\r\n\r\nhello world")
+        assert ec._extract_body(body, 5000) == "hello world"
+        empty = email_lib.message_from_string("Subject: x\r\n\r\n")
+        assert ec._extract_body(empty, 5000) == "[empty message]"
+
+    def test_extract_body_truncation(self):
+        big = email_lib.message_from_string("Content-Type: text/plain\r\n\r\n" + "z" * 100)
+        out = ec._extract_body(big, 10)
+        assert out.startswith("z" * 10) and "truncated at 10 chars" in out
+
+
+class _FakeIMAP:
+    """Minimal imaplib.IMAP4_SSL stand-in — no socket, records logout."""
+
+    def __init__(self, *, search=("OK", [b""]), fetch_map=None):
+        self._search = search
+        self._fetch_map = fetch_map or {}
+        self.logged_out = False
+
+    def login(self, user, password):
+        return ("OK", [b"ok"])
+
+    def select(self, folder, readonly=False):
+        return ("OK", [b"1"])
+
+    def uid(self, command, *args):
+        if command == "SEARCH":
+            return self._search
+        # FETCH
+        uid = args[0]
+        return self._fetch_map.get(uid, ("NO", [None]))
+
+    def logout(self):
+        self.logged_out = True
+
+
+def _imap_patch(fake):
+    return patch("imaplib.IMAP4_SSL", return_value=fake)
+
+
+class TestSearchEmail:
+    def test_returns_summaries(self):
+        fake = _FakeIMAP(search=("OK", [b"1"]),
+                         fetch_map={b"1": ("OK", [(b"1 (RFC822.HEADER", _HDR)])})
+        with _imap_patch(fake):
+            out = ec.search_email(imap_host="imap.example.com", imap_port=993,
+                                  username="u", password="p", query="hi")
+        assert out[0]["subject"] == "Hi there" and fake.logged_out
+
+    def test_gmail_uses_xgmraw(self):
+        fake = _FakeIMAP(search=("OK", [b"1"]),
+                         fetch_map={b"1": ("OK", [(b"1 (RFC822.HEADER", _HDR)])})
+        with _imap_patch(fake), patch.object(fake, "uid", wraps=fake.uid) as spy:
+            ec.search_email(imap_host="imap.gmail.com", imap_port=993,
+                            username="u", password="p", query='is:unread')
+        assert any("X-GM-RAW" in str(c.args) for c in spy.call_args_list)
+
+    def test_non_ok_search_returns_empty(self):
+        with _imap_patch(_FakeIMAP(search=("NO", [b""]))):
+            assert ec.search_email(imap_host="imap.example.com", imap_port=993,
+                                   username="u", password="p", query="x") == []
+
+    def test_connect_failure_raises_redacted(self):
+        with patch("imaplib.IMAP4_SSL", side_effect=OSError("bad secret-pw here")):
+            with pytest.raises(RuntimeError, match="IMAP connect failed"):
+                ec.search_email(imap_host="h", imap_port=1, username="u",
+                                password="secret-pw", query="x")
+
+
+class TestReadEmail:
+    def test_reads_full_message(self):
+        raw = _HDR + b"body here"
+        fake = _FakeIMAP(fetch_map={"7": ("OK", [(b"7 (RFC822", raw)])})
+        with _imap_patch(fake):
+            out = ec.read_email(imap_host="imap.example.com", imap_port=993,
+                                username="u", password="p", uid="7")
+        assert out["subject"] == "Hi there" and "body" in out and fake.logged_out
+
+    def test_uid_not_found_raises(self):
+        with _imap_patch(_FakeIMAP(fetch_map={})):  # FETCH returns ("NO", [None])
+            with pytest.raises(ValueError, match="not found"):
+                ec.read_email(imap_host="imap.example.com", imap_port=993,
+                              username="u", password="p", uid="404")
+
+    def test_connect_failure_raises(self):
+        with patch("imaplib.IMAP4_SSL", side_effect=OSError("nope")):
+            with pytest.raises(RuntimeError, match="IMAP connect failed"):
+                ec.read_email(imap_host="h", imap_port=1, username="u",
+                              password="p", uid="1")
+
+
+class TestListRecent:
+    def test_lists_with_flags_and_size(self):
+        raw = _HDR
+        meta = b"1 (RFC822.SIZE 2048 FLAGS (\\Seen))"
+        fake = _FakeIMAP(search=("OK", [b"1"]), fetch_map={b"1": ("OK", [(meta, raw)])})
+        with _imap_patch(fake):
+            out = ec.list_recent(imap_host="imap.example.com", imap_port=993,
+                                 username="u", password="p")
+        assert out[0]["size_bytes"] == 2048
+        assert out[0]["flags"] == ["\\Seen"]
+
+    def test_non_ok_returns_empty(self):
+        with _imap_patch(_FakeIMAP(search=("NO", [b""]))):
+            assert ec.list_recent(imap_host="imap.example.com", imap_port=993,
+                                  username="u", password="p") == []
+
+    def test_connect_failure_raises(self):
+        with patch("imaplib.IMAP4_SSL", side_effect=OSError("nope")):
+            with pytest.raises(RuntimeError, match="IMAP connect failed"):
+                ec.list_recent(imap_host="h", imap_port=1, username="u", password="p")
+
+
+class _FakeSMTP:
+    """smtplib.SMTP stand-in used as a context manager — records the send."""
+
+    def __init__(self, *a, **kw):
+        self.sent = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def starttls(self):
+        pass
+
+    def login(self, user, password):
+        pass
+
+    def sendmail(self, from_addr, recipients, body):
+        self.sent = (from_addr, recipients, body)
+
+
+class TestSendEmail:
+    def test_sends_with_reply_to(self):
+        fake = _FakeSMTP()
+        with patch("smtplib.SMTP", return_value=fake):
+            out = ec.send_email(smtp_host="smtp.example.com", smtp_port=587,
+                                username="u", password="p", from_address="me@example.com",
+                                to=["you@example.com"], cc=["c@example.com"],
+                                reply_to="reply@example.com", subject="Hi", body="hello")
+        assert out["status"] == "sent" and out["cc"] == ["c@example.com"]
+        assert fake.sent is not None and "reply@example.com" in fake.sent[2]
+
+    def test_no_recipients_raises(self):
+        with pytest.raises(ValueError, match="No recipients"):
+            ec.send_email(smtp_host="h", smtp_port=1, username="u", password="p",
+                          from_address="me@example.com", to=[], subject="s", body="b")
+
+    def test_smtp_failure_redacts_password(self):
+        with patch("smtplib.SMTP", side_effect=OSError("auth failed for topsecret")):
+            with pytest.raises(RuntimeError) as ei:
+                ec.send_email(smtp_host="h", smtp_port=1, username="u",
+                              password="topsecret", from_address="me@example.com",
+                              to=["you@example.com"], subject="s", body="b")
+        assert "topsecret" not in str(ei.value) and "[REDACTED]" in str(ei.value)
+
+    def test_attachment_outside_allowed_dir_raises(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_text("data")
+        with patch("smtplib.SMTP", return_value=_FakeSMTP()):
+            with pytest.raises(ValueError, match="outside allowed"):
+                ec.send_email(smtp_host="h", smtp_port=1, username="u", password="p",
+                              from_address="me@example.com", to=["you@example.com"],
+                              subject="s", body="b", attachments=[str(f)],
+                              allowed_dirs=["/some/other/dir"])
+
+    def test_attachment_not_a_file_raises(self, tmp_path):
+        with patch("smtplib.SMTP", return_value=_FakeSMTP()):
+            with pytest.raises(ValueError, match="not a file"):
+                ec.send_email(smtp_host="h", smtp_port=1, username="u", password="p",
+                              from_address="me@example.com", to=["you@example.com"],
+                              subject="s", body="b",
+                              attachments=[str(tmp_path / "missing.txt")],
+                              allowed_dirs=[str(tmp_path)])

--- a/tests/test_health_checker_paths.py
+++ b/tests/test_health_checker_paths.py
@@ -1,0 +1,128 @@
+"""Coverage for src/health/checker.py probe branches (RFC-006 P16, safe).
+
+The provider-configured paths of check_ollama/check_kimi (all circuit-breaker
+states + error arm), check_codex's lazy-session branch, and the exception arms
+of check_browser/check_loops/check_agents, plus check_all's crashed-checker
+handling. SAFE: fake bot namespaces + real (un-connected) Ollama/Kimi client
+objects — no network, no LLM call; only breaker-state inspection and pool_stats.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from src.health import checker
+from src.health.checker import (
+    check_agents,
+    check_all,
+    check_browser,
+    check_codex,
+    check_kimi,
+    check_loops,
+    check_ollama,
+)
+from src.llm.kimi import KimiClient
+from src.llm.ollama import OllamaClient
+
+
+def _bot(**kw) -> Any:
+    return SimpleNamespace(**kw)
+
+
+def _gw(**kw) -> Any:
+    return SimpleNamespace(llm_gateway=SimpleNamespace(**kw))
+
+
+class TestCheckOllama:
+    def _client(self, state):
+        c = OllamaClient(base_url="http://x", model="m")
+        c.breaker = SimpleNamespace(state=state)  # type: ignore[assignment]
+        return c
+
+    def test_closed_is_ok(self):
+        r = check_ollama(_gw(ollama_client=self._client("closed")))
+        assert r.status == "ok" and r.healthy is True
+
+    def test_open_is_down(self):
+        r = check_ollama(_gw(ollama_client=self._client("open")))
+        assert r.status == "down" and r.healthy is False
+
+    def test_half_open_is_degraded(self):
+        r = check_ollama(_gw(ollama_client=self._client("half_open")))
+        assert r.status == "degraded" and r.healthy is True
+
+    def test_error_probing(self):
+        c = self._client("closed")
+        c.pool_stats = MagicMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+        r = check_ollama(_gw(ollama_client=c))
+        assert r.status == "down" and "Error probing Ollama" in r.detail
+
+
+class TestCheckKimi:
+    def _client(self, state):
+        c = KimiClient(api_key="x", model="kimi-k2")
+        c.breaker = SimpleNamespace(state=state)  # type: ignore[assignment]
+        return c
+
+    def test_closed_is_ok(self):
+        r = check_kimi(_gw(kimi_client=self._client("closed")))
+        assert r.status == "ok" and r.healthy is True
+
+    def test_open_is_down(self):
+        r = check_kimi(_gw(kimi_client=self._client("open")))
+        assert r.status == "down"
+
+    def test_half_open_is_degraded(self):
+        r = check_kimi(_gw(kimi_client=self._client("half_open")))
+        assert r.status == "degraded"
+
+    def test_error_probing(self):
+        c = self._client("closed")
+        c.pool_stats = MagicMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+        r = check_kimi(_gw(kimi_client=c))
+        assert r.status == "down" and "Error probing Kimi" in r.detail
+
+
+class TestCheckCodexLazySession:
+    def test_none_session_is_ok_lazy(self):
+        codex = SimpleNamespace(breaker=SimpleNamespace(state="closed"),
+                                get_pool_metrics=lambda: {}, _session=None)
+        r = check_codex(_gw(codex_client=codex))
+        assert r.status == "ok" and "lazy" in r.detail
+
+
+class TestExceptionArms:
+    def test_browser_probe_error(self):
+        browser = SimpleNamespace(is_connected=MagicMock(side_effect=RuntimeError("x")))
+        executor = SimpleNamespace(_browser_manager=SimpleNamespace(_browser=browser))
+        r = check_browser(_bot(tool_executor=executor))
+        assert r.status == "down" and "Error" in r.detail
+
+    def test_loops_probe_error(self):
+        class _LM:
+            @property
+            def active_count(self):
+                raise RuntimeError("boom")
+        r = check_loops(_bot(loop_manager=_LM()))
+        assert r.status == "down"
+
+    def test_agents_probe_error(self):
+        class _A:
+            @property
+            def status(self):
+                raise RuntimeError("boom")
+        r = check_agents(_bot(agent_manager=SimpleNamespace(_agents={"a": _A()})))
+        assert r.status == "down"
+
+
+class TestCheckAllCrashedChecker:
+    def test_crashed_checker_recorded(self):
+        def _boom(bot):
+            raise RuntimeError("crashed")
+
+        with patch.object(checker, "_ALL_CHECKERS", [_boom]):
+            out = check_all(_bot())
+        comp = out["components"][0]
+        assert comp["status"] == "down" and "crashed" in comp["detail"]
+        assert out["overall"] == "unhealthy" and out["total"] == 1


### PR DESCRIPTION
Test-only wave (RFC-006 P16). Two **safe** files, one PR. No `src` changes.

## Coverage (whole-repo 84.1% → 84.4%)

| File | Start → End |
|---|---|
| `tools/email_client.py` | 77.5% → **90.9%** (missing 52 → 21) |
| `health/checker.py` | 84.3% → **100.0%** (missing 42 → 0) |

## Method / safety (real interfaces, faked boundaries only)

- **email_client** — pure MIME parsing (`_extract_body` every branch: multipart-plain / html-only / no-text-body / single-part / empty / truncation; `_decode_header_value`) plus SMTP send + IMAP search/read/list with `smtplib.SMTP` / `imaplib.IMAP4_SSL` **faked** (queue-backed fake conn / context-manager server): happy paths, Gmail `X-GM-RAW` branch, non-OK / UID-not-found / connect-failure arms, password redaction, attachment-outside-allowed-dir / not-a-file guards. **No real SMTP/IMAP, no network** — only in-memory messages.
- **health/checker** — `check_ollama`/`check_kimi` configured paths (all 3 circuit-breaker states + error arm) driven with real *un-connected* `OllamaClient`/`KimiClient` objects (breaker-state + `pool_stats` only, no request), `check_codex` lazy-`None`-session, the exception arms of `check_browser`/`check_loops`/`check_agents`, and `check_all`'s crashed-checker handling. Fake `bot` namespaces; no network, no LLM.

## Deferred

email_client attachment-encoding sub-branches (remaining 21) — lower-yield tails.

## Gates (local)

- coverage-gate: findings=0 (ratchet scoped to exactly the 2 target entries)
- lint-gate: new=0 · type-gate: new=0
- suite: 7162 passed, 4 skipped

**COV ledger: EMPTY** — no product bugs surfaced.
