### PR TITLE
test: RFC-006 P17 — web tools + channel config (both to 100%)

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -120,9 +120,9 @@
   "statements": 349
  },
  "src/discord/channel_config.py": {
-  "covered": 43,
-  "missing": 38,
-  "percent": 53.09,
+  "covered": 81,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 81
  },
  "src/discord/channel_logger.py": {
@@ -1086,9 +1086,9 @@
   "statements": 95
  },
  "src/tools/web.py": {
-  "covered": 47,
-  "missing": 51,
-  "percent": 47.96,
+  "covered": 98,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 98
  },
  "src/trajectories/__init__.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -342,6 +342,21 @@ Two safe files in one PR, Odin-reviewed. Whole-repo 84.1% → **84.4%**.
 
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
+## 6r. R3 — P17 web tools + channel config (2026-07-07)
+
+Two safe files to 100%, one PR, Odin-reviewed. Whole-repo 84.4% → **84.7%**.
+
+| File | Start → End |
+|---|---|
+| `tools/web.py` | 48.0% → **100.0%** (missing 51 → 0) |
+| `discord/channel_config.py` | 53.1% → **100.0%** (missing 38 → 0) |
+
+**Method / safety.**
+- *tools/web* — pure `_HTMLToText` (skip-tag + block-newline) and `_parse_ddg_results` (link/snippet extraction + `uddg=` redirect unwrap + no-results), plus `fetch_url`/`web_search` with `aiohttp.ClientSession` **faked** (queue-backed fake session/response) and the SSRF `is_url_blocked` guard patched: blocked-URL, HTML/JSON/text content types, non-200, truncation, `ClientError`, and generic-exception arms. **No real HTTP, no network.**
+- *discord/channel_config* — real `ChannelConfigManager` on a tmp JSON path: the channel > guild > global resolution ladder for `is_enabled`/`should_require_mention`/`should_respond_to_bots` (including `guild_id=None` skipping the guild layer), the set/get/clear mutators (None-values-skipped, clear removes), persistence round-trip via a second manager, and the corrupt-file load guard. Pure dict logic + tmp-file I/O.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -1,0 +1,93 @@
+"""Coverage for src/discord/channel_config.py (RFC-006 P17, safe).
+
+Real ChannelConfigManager against a tmp JSON path — the channel>guild>global
+resolution ladder for is_enabled / should_require_mention / should_respond_to_bots,
+the set/get/clear mutators, persistence round-trips, and the corrupt-file load
+guard. SAFE: pure dict logic + tmp-file I/O only; no network, no Discord.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.discord.channel_config import ChannelConfigManager
+
+
+@pytest.fixture
+def mgr(tmp_path):
+    return ChannelConfigManager(path=str(tmp_path / "channel_config.json"))
+
+
+class TestResolutionLadder:
+    def test_is_enabled_channel_over_guild_over_global(self, mgr):
+        assert mgr.is_enabled("g1", "c1", global_default=True) is True   # global fallback
+        mgr.set_guild_config("g1", enabled=False)
+        assert mgr.is_enabled("g1", "c1") is False                       # guild default
+        mgr.set_channel_config("c1", enabled=True)
+        assert mgr.is_enabled("g1", "c1") is True                        # channel override wins
+
+    def test_require_mention_ladder(self, mgr):
+        assert mgr.should_require_mention("g1", "c1", global_default=False) is False
+        mgr.set_guild_config("g1", require_mention=True)
+        assert mgr.should_require_mention("g1", "c9") is True             # guild
+        mgr.set_channel_config("c9", require_mention=False)
+        assert mgr.should_require_mention("g1", "c9") is False            # channel
+
+    def test_respond_to_bots_ladder(self, mgr):
+        assert mgr.should_respond_to_bots("g1", "c1") is False            # global default
+        mgr.set_guild_config("g1", respond_to_bots=True)
+        assert mgr.should_respond_to_bots("g1", "cX") is True             # guild
+        mgr.set_channel_config("cX", respond_to_bots=False)
+        assert mgr.should_respond_to_bots("g1", "cX") is False            # channel
+
+    def test_no_guild_id_uses_global(self, mgr):
+        # guild_id=None skips the guild layer entirely
+        assert mgr.is_enabled(None, "c1", global_default=True) is True
+        assert mgr.should_require_mention(None, "c1", global_default=True) is True
+
+
+class TestMutatorsAndPersistence:
+    def test_set_and_get(self, mgr):
+        got = mgr.set_guild_config("g1", enabled=True, require_mention=True, respond_to_bots=None)
+        assert got["enabled"] is True and got["require_mention"] is True
+        assert "respond_to_bots" not in got                     # None values are skipped
+        assert mgr.get_guild_config("g1")["enabled"] is True
+
+    def test_clear_channel_override(self, mgr):
+        mgr.set_channel_config("c1", enabled=False)
+        assert mgr.get_channel_config("c1") != {}
+        assert mgr.set_channel_config("c1", clear=True) == {}   # clear removes it
+        assert mgr.get_channel_config("c1") == {}
+
+    def test_get_all_snapshot(self, mgr):
+        mgr.set_guild_config("g1", enabled=True)
+        mgr.set_channel_config("c1", enabled=False)
+        snap = mgr.get_all()
+        assert "g1" in snap["guild_defaults"] and "c1" in snap["channel_overrides"]
+
+    def test_persistence_roundtrip(self, tmp_path):
+        p = str(tmp_path / "cc.json")
+        m = ChannelConfigManager(path=p)
+        m.set_guild_config("g1", require_mention=True)
+        m.set_channel_config("c1", enabled=False)
+        reloaded = ChannelConfigManager(path=p)                 # reads from disk
+        assert reloaded.get_guild_config("g1")["require_mention"] is True
+        assert reloaded.get_channel_config("c1")["enabled"] is False
+
+
+class TestLoad:
+    def test_load_existing_file(self, tmp_path):
+        p = tmp_path / "cc.json"
+        p.write_text(json.dumps({
+            "guild_defaults": {"g1": {"enabled": False}},
+            "channel_overrides": {},
+        }))
+        m = ChannelConfigManager(path=str(p))
+        assert m.is_enabled("g1", "cAny") is False
+
+    def test_corrupt_file_is_tolerated(self, tmp_path):
+        p = tmp_path / "cc.json"
+        p.write_text("{ this is not valid json")
+        m = ChannelConfigManager(path=str(p))                   # error caught, starts empty
+        assert m.get_all() == {"guild_defaults": {}, "channel_overrides": {}}

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -1,0 +1,137 @@
+"""Coverage for src/tools/web.py fetch/search/parse (RFC-006 P17, safe).
+
+Pure HTML→text conversion and DuckDuckGo result parsing, plus fetch_url and
+web_search with aiohttp.ClientSession FAKED (a queue-backed fake session/response)
+and the SSRF is_url_blocked guard patched. SAFE: no real HTTP request, no network;
+only in-memory HTML strings and faked transport. Covers the blocked-URL, non-200,
+network-error, and content-type branches.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import aiohttp
+
+from src.tools import web
+
+
+class _Resp:
+    """Fake aiohttp response context manager."""
+
+    def __init__(self, status=200, reason="OK", headers=None, body=""):
+        self.status = status
+        self.reason = reason
+        self.headers = headers or {}
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def text(self, errors="strict"):
+        return self._body
+
+
+class _Session:
+    """Fake aiohttp.ClientSession context manager; .get() returns a queued _Resp."""
+
+    def __init__(self, resp=None, raise_on_get=None):
+        self._resp = resp
+        self._raise = raise_on_get
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def get(self, url, **kw):
+        if self._raise is not None:
+            raise self._raise
+        return self._resp
+
+
+def _session_patch(session):
+    return patch("aiohttp.ClientSession", return_value=session)
+
+
+class TestHtmlToText:
+    def test_skips_script_keeps_block_text(self):
+        out = web._html_to_text(
+            "<script>var x=1;</script><style>.a{}</style><p>Hello</p><div>World</div>")
+        assert "Hello" in out and "World" in out
+        assert "var x" not in out and ".a{}" not in out  # script/style skipped
+
+
+class TestParseDdgResults:
+    def test_parses_links_snippets_and_uddg(self):
+        html = (
+            '<a class="result__a" href="https://example.com/page">Example <b>Title</b></a>'
+            '<td class="result__snippet">A useful snippet.</td>'
+            '<a class="result__a" '
+            'href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Freal.com%2Fx&rut=z">Second</a>'
+            '<td class="result__snippet">Second snippet.</td>'
+        )
+        out = web._parse_ddg_results(html, max_results=5)
+        assert "1. Example Title" in out and "https://example.com/page" in out
+        assert "A useful snippet." in out
+        assert "https://real.com/x" in out  # uddg redirect unwrapped
+
+    def test_no_results(self):
+        assert web._parse_ddg_results("<html>nothing here</html>", 5) == "No results found."
+
+
+class TestFetchUrl:
+    async def test_blocked_url(self):
+        with patch("src.tools.url_safety.is_url_blocked", return_value=True):
+            out = await web.fetch_url("http://169.254.169.254/latest/meta-data")
+        assert "blocked address" in out
+
+    async def test_html_success_and_json_and_text(self):
+        with patch("src.tools.url_safety.is_url_blocked", return_value=False):
+            with _session_patch(_Session(_Resp(
+                    headers={"Content-Type": "text/html"}, body="<p>hi there</p>"))):
+                assert "hi there" in await web.fetch_url("http://x")
+            with _session_patch(_Session(_Resp(
+                    headers={"Content-Type": "application/json"}, body='{"a":1}'))):
+                assert await web.fetch_url("http://x") == '{"a":1}'
+            with _session_patch(_Session(_Resp(
+                    headers={"Content-Type": "text/plain"}, body="plain text"))):
+                assert await web.fetch_url("http://x") == "plain text"
+
+    async def test_non_200_and_truncation(self):
+        with patch("src.tools.url_safety.is_url_blocked", return_value=False):
+            with _session_patch(_Session(_Resp(status=404, reason="Not Found"))):
+                assert "Error: HTTP 404: Not Found" in await web.fetch_url("http://x")
+            with _session_patch(_Session(_Resp(
+                    headers={"Content-Type": "text/plain"}, body="z" * 100))):
+                out = await web.fetch_url("http://x", max_chars=10)
+                assert out.startswith("z" * 10) and "truncated" in out
+
+    async def test_network_and_generic_errors(self):
+        with patch("src.tools.url_safety.is_url_blocked", return_value=False):
+            with _session_patch(_Session(raise_on_get=aiohttp.ClientError("neterr"))):
+                assert "network failure" in await web.fetch_url("http://x")
+            with _session_patch(_Session(raise_on_get=RuntimeError("boom"))):
+                assert "Error: boom" in await web.fetch_url("http://x")
+
+
+class TestWebSearch:
+    async def test_success_parses_results(self):
+        html = ('<a class="result__a" href="https://r.com">Res</a>'
+                '<td class="result__snippet">snip</td>')
+        with _session_patch(_Session(_Resp(body=html))):
+            out = await web.web_search("query")
+        assert "Res" in out and "https://r.com" in out
+
+    async def test_non_200(self):
+        with _session_patch(_Session(_Resp(status=503))):
+            assert "Search failed: HTTP 503" in await web.web_search("q")
+
+    async def test_network_and_generic_errors(self):
+        with _session_patch(_Session(raise_on_get=aiohttp.ClientError("neterr"))):
+            assert "Search error" in await web.web_search("q")
+        with _session_patch(_Session(raise_on_get=RuntimeError("boom"))):
+            assert "Error: boom" in await web.web_search("q")


### PR DESCRIPTION
Test-only wave (RFC-006 P17). Two **safe** files driven to **100%**, one PR. No `src` changes.

## Coverage (whole-repo 84.4% → 84.7%)

| File | Start → End |
|---|---|
| `tools/web.py` | 48.0% → **100.0%** (missing 51 → 0) |
| `discord/channel_config.py` | 53.1% → **100.0%** (missing 38 → 0) |

## Method / safety (real interfaces, faked boundaries only)

- **tools/web** — pure `_HTMLToText` (skip-tag + block-newline) and `_parse_ddg_results` (link/snippet extraction + `uddg=` redirect unwrap + no-results), plus `fetch_url`/`web_search` with `aiohttp.ClientSession` **faked** (queue-backed fake session/response) and the SSRF `is_url_blocked` guard patched: blocked-URL, HTML/JSON/text content types, non-200, truncation, `ClientError`, generic-exception arms. **No real HTTP, no network.**
- **discord/channel_config** — real `ChannelConfigManager` on a tmp JSON path: the channel > guild > global resolution ladder for `is_enabled`/`should_require_mention`/`should_respond_to_bots` (incl. `guild_id=None` skipping the guild layer), the set/get/clear mutators, persistence round-trip via a second manager, and the corrupt-file load guard. Pure dict logic + tmp-file I/O.

## Gates (local)

- coverage-gate: findings=0 (ratchet scoped to exactly the 2 target entries)
- lint-gate: new=0 · type-gate: new=0
- suite: 7182 passed, 4 skipped

**COV ledger: EMPTY** — no product bugs surfaced.
