### PR TITLE
test: RFC-006 P18 — planning store (gated 100%) + error handler (additive)

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -720,9 +720,9 @@
   "statements": 2
  },
  "src/planning/store.py": {
-  "covered": 62,
-  "missing": 39,
-  "percent": 61.39,
+  "covered": 101,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 101
  },
  "src/relevance.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -357,6 +357,21 @@ Two safe files to 100%, one PR, Odin-reviewed. Whole-repo 84.4% → **84.7%**.
 
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
+## 6s. R3 — P18 planning store + error handler (2026-07-07)
+
+One gated file to 100% plus additive coverage of an excluded surface, one PR, Odin-reviewed. Whole-repo 84.7% → **84.9%**.
+
+| File | Start → End | Gated? |
+|---|---|---|
+| `planning/store.py` | 61.4% → **100.0%** (missing 39 → 0) | yes — ratcheted |
+| `discord/helpers/error_handler.py` | 0% → **100.0%** | **no** — on the §3 EXCLUDES list; tests are additive |
+
+**Method / safety.**
+- *planning/store* — real `PlanStore` on a tmp JSON path: create/get_pending (most-recent-wins, user/channel scoping), `list_pending` filters, the `mark_executing`/`mark_completed`/`mark_cancelled` transitions (+ missing-plan no-ops), expiry pruning (`_prune_expired` flips pending→expired), persistence round-trip via a second store, the corrupt-file load guard, and the `ExecutionPlan` `is_expired`/`to_dict`/`from_dict` (unknown-key-filtering) helpers. Pure dataclass logic + tmp-file I/O.
+- *error_handler* — `handle_command_error` dispatch for every discord.py error type (MissingPermissions / BotMissingPermissions / MissingRequiredArgument / BadArgument / CommandOnCooldown / NoPrivateMessage / CommandNotFound-silent / CheckFailure / generic-unhandled) plus the `CommandInvokeError` unwrap, using real discord error objects + a fake ctx. **This file is on the coverage-gate EXCLUDES list ("discord.py error-event glue")**, so it is *not* ratcheted — the tests are additive regression coverage that improve whole-repo % without changing the gate's exclusion policy. (It proved cleanly unit-testable; if a future pass wants it gated, un-excluding it in `coverage_gate.py` is a one-line change — deferred here to keep the wave a pure test/baseline diff.)
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,76 @@
+"""Coverage for src/discord/helpers/error_handler.py (RFC-006 P18, safe).
+
+The command-error dispatcher — each discord.py error type maps to its
+user-friendly embed (or is silently ignored / logged). SAFE: real discord error
+objects + a fake ctx with an AsyncMock send; no gateway, no network.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from discord.ext import commands
+
+from src.discord.helpers.error_handler import handle_command_error
+
+
+def _ctx() -> Any:
+    return SimpleNamespace(send=AsyncMock(), command="mycmd")
+
+
+async def _run(error) -> Any:
+    ctx = _ctx()
+    await handle_command_error(ctx, error)
+    return ctx
+
+
+def _sent_text(ctx) -> str:
+    ctx.send.assert_awaited_once()
+    return ctx.send.await_args.kwargs["embed"].description or ""
+
+
+class TestHandleCommandError:
+    async def test_missing_permissions(self):
+        ctx = await _run(commands.MissingPermissions(["manage_guild"]))
+        assert "manage_guild" in _sent_text(ctx)
+
+    async def test_bot_missing_permissions(self):
+        ctx = await _run(commands.BotMissingPermissions(["send_messages"]))
+        assert "send_messages" in _sent_text(ctx)
+
+    async def test_missing_required_argument(self):
+        param = SimpleNamespace(name="amount", displayed_name="amount")
+        ctx = await _run(commands.MissingRequiredArgument(param))  # type: ignore[arg-type]
+        assert "amount" in _sent_text(ctx)
+
+    async def test_bad_argument(self):
+        ctx = await _run(commands.BadArgument("bad value here"))
+        assert "bad value here" in _sent_text(ctx)
+
+    async def test_cooldown(self):
+        cd = commands.Cooldown(1, 5.0)
+        ctx = await _run(commands.CommandOnCooldown(cd, 3.2, commands.BucketType.user))
+        assert "Cooldown" in _sent_text(ctx)
+
+    async def test_no_private_message(self):
+        ctx = await _run(commands.NoPrivateMessage())
+        assert "DMs" in _sent_text(ctx)
+
+    async def test_command_not_found_is_silent(self):
+        ctx = await _run(commands.CommandNotFound())
+        ctx.send.assert_not_called()   # unknown commands ignored
+
+    async def test_check_failure(self):
+        ctx = await _run(commands.CheckFailure())
+        assert "permission" in _sent_text(ctx)
+
+    async def test_unhandled_error_is_logged_and_generic(self):
+        ctx = await _run(RuntimeError("something weird"))  # type: ignore[arg-type]
+        assert "unexpected error" in _sent_text(ctx)
+
+    async def test_unwraps_command_invoke_error(self):
+        # CommandInvokeError wrapping a known error → unwrapped and handled
+        inner = commands.MissingPermissions(["administrator"])
+        ctx = await _run(commands.CommandInvokeError(inner))
+        assert "administrator" in _sent_text(ctx)

--- a/tests/test_planning_store.py
+++ b/tests/test_planning_store.py
@@ -1,0 +1,98 @@
+"""Coverage for src/planning/store.py (RFC-006 P18, safe).
+
+Real PlanStore against a tmp JSON path — create/get_pending/list_pending, the
+mark_* state transitions, expiry pruning, persistence round-trips, the
+corrupt-file load guard, and the ExecutionPlan dataclass helpers. SAFE: pure
+dataclass logic + tmp-file I/O only; no network, no execution.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.planning.store import ExecutionPlan, PlanStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return PlanStore(persist_path=str(tmp_path / "plans.json"))
+
+
+def _mk(store, **kw):
+    params = dict(user_id="u1", channel_id="c1", original_request="do X", summary="X")
+    params.update(kw)
+    return store.create(**params)
+
+
+class TestCreateAndQuery:
+    def test_create_and_get_pending(self, store):
+        p = _mk(store)
+        got = store.get_pending("u1", "c1")
+        assert got is not None and got.plan_id == p.plan_id
+        assert store.get_pending("u2", "c1") is None  # different user → none
+
+    def test_most_recent_pending_wins(self, store):
+        p1 = _mk(store)
+        p2 = _mk(store)
+        store._plans[p2.plan_id].created_at = store._plans[p1.plan_id].created_at + 100
+        assert store.get_pending("u1", "c1").plan_id == p2.plan_id
+
+    def test_list_pending_filters(self, store):
+        _mk(store, user_id="u1", channel_id="c1")
+        _mk(store, user_id="u1", channel_id="c2")
+        _mk(store, user_id="u2", channel_id="c1")
+        assert len(store.list_pending()) == 3
+        assert len(store.list_pending(user_id="u1")) == 2
+        assert len(store.list_pending(channel_id="c1")) == 2
+        assert len(store.list_pending(user_id="u1", channel_id="c1")) == 1
+
+
+class TestStateTransitions:
+    def test_mark_executing_completed_cancelled(self, store):
+        p = _mk(store)
+        assert store.mark_executing(p.plan_id) is True
+        assert store.mark_executing(p.plan_id) is False   # no longer pending
+        store.mark_completed(p.plan_id)
+        assert store._plans[p.plan_id].status == "completed"
+        p2 = _mk(store, channel_id="c2")
+        store.mark_cancelled(p2.plan_id)
+        assert store._plans[p2.plan_id].status == "cancelled"
+
+    def test_mark_missing_plan_is_noop(self, store):
+        assert store.mark_executing("nope") is False
+        store.mark_completed("nope")   # no raise
+        store.mark_cancelled("nope")   # no raise
+
+    def test_expired_is_pruned(self, store):
+        p = _mk(store, expiry_seconds=1)
+        store._plans[p.plan_id].expires_at = 1.0   # far in the past
+        assert store.get_pending("u1", "c1") is None
+        assert store._plans[p.plan_id].status == "expired"
+        assert store.list_pending() == []
+
+
+class TestPersistence:
+    def test_roundtrip(self, tmp_path):
+        path = str(tmp_path / "plans.json")
+        s1 = PlanStore(persist_path=path)
+        s1.create(user_id="u1", channel_id="c1", original_request="remember this", summary="X")
+        s2 = PlanStore(persist_path=path)   # reads from disk
+        got = s2.get_pending("u1", "c1")
+        assert got is not None and got.original_request == "remember this"
+
+    def test_corrupt_file_tolerated(self, tmp_path):
+        path = tmp_path / "plans.json"
+        path.write_text("{ not valid json")
+        s = PlanStore(persist_path=str(path))   # warning caught, starts empty
+        assert s.list_pending() == []
+
+
+class TestExecutionPlan:
+    def test_is_expired_and_dict_roundtrip(self):
+        p = ExecutionPlan(plan_id="p", user_id="u", channel_id="c",
+                          original_request="r", summary="s", expires_at=1.0)
+        assert p.is_expired() is True
+        d = p.to_dict()
+        assert d["plan_id"] == "p"
+        # from_dict filters unknown keys
+        restored = ExecutionPlan.from_dict({**d, "bogus_field": 123})
+        assert restored.plan_id == "p" and not hasattr(restored, "bogus_field")


### PR DESCRIPTION
Test-only wave (RFC-006 P18). No `src` changes.

## Coverage (whole-repo 84.7% → 84.9%)

| File | Start → End | Gated? |
|---|---|---|
| `planning/store.py` | 61.4% → **100.0%** (missing 39 → 0) | yes — ratcheted |
| `discord/helpers/error_handler.py` | 0% → **100.0%** | **no** — on the §3 EXCLUDES list; additive |

## Method / safety (real interfaces, faked boundaries only)

- **planning/store** — real `PlanStore` on a tmp JSON path: create/get_pending (most-recent-wins, user+channel scoping), `list_pending` filters, the `mark_executing`/`mark_completed`/`mark_cancelled` transitions (+ missing-plan no-ops), expiry pruning (pending→expired), persistence round-trip via a second store, the corrupt-file load guard, and the `ExecutionPlan` helpers (`is_expired`/`to_dict`/`from_dict` unknown-key filtering). Pure dataclass + tmp-file I/O.
- **error_handler** — `handle_command_error` dispatch for every discord.py error type + the `CommandInvokeError` unwrap, via real discord error objects + a fake ctx. **This file is on the coverage-gate `EXCLUDES` list** ("discord.py error-event glue"), so it is **not** ratcheted — these tests are additive regression coverage that lift whole-repo % without touching the gate's exclusion policy. (It turned out cleanly unit-testable; un-excluding it later is a one-line `coverage_gate.py` change, deliberately deferred to keep this wave a pure test/baseline diff.)

## Gates (local)

- coverage-gate: findings=0, gated-files=202 (error_handler correctly stays ungated); ratchet scoped to `planning/store` only
- lint-gate: new=0 · type-gate: new=0
- suite: 7201 passed, 4 skipped

**COV ledger: EMPTY** — no product bugs surfaced.
