### PR TITLE
test: RFC-006 P19 — FTS index + schedule history

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -738,9 +738,9 @@
   "statements": 3
  },
  "src/scheduler/history.py": {
-  "covered": 90,
-  "missing": 21,
-  "percent": 81.08,
+  "covered": 102,
+  "missing": 9,
+  "percent": 91.89,
   "statements": 111
  },
  "src/scheduler/scheduler.py": {
@@ -762,9 +762,9 @@
   "statements": 29
  },
  "src/search/fts.py": {
-  "covered": 123,
-  "missing": 28,
-  "percent": 81.46,
+  "covered": 151,
+  "missing": 0,
+  "percent": 100.0,
   "statements": 151
  },
  "src/search/hybrid.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -372,6 +372,21 @@ One gated file to 100% plus additive coverage of an excluded surface, one PR, Od
 
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
+## 6t. R3 — P19 FTS index + schedule history (2026-07-07)
+
+Two safe file-backed stores, one PR, Odin-reviewed. Whole-repo 84.9% → **85.1%**.
+
+| File | Start → End |
+|---|---|
+| `search/fts.py` | 81.5% → **100.0%** (missing 28 → 0) |
+| `scheduler/history.py` | 81.1% → **91.9%** (missing 21 → 9) |
+
+**Method / safety.**
+- *search/fts* — real `FullTextIndex` on a **tmp sqlite FTS5 db** (complements `test_fts_search.py`): the channel_id-filtered `search_sessions`/`search_channel_logs` branches, the knowledge index/search/`delete_knowledge_source`/`has_knowledge_chunk` cycle, `index_channel_messages` (content-filtering + empty-input guards) / `clear_channel_logs`, session re-index (delete-then-insert), and every `except` error arm — exercised by closing the connection so the sqlite op raises and is caught (returns False/[]/0). No network, no external service.
+- *scheduler/history* — real `ScheduleHistory` on a tmp JSONL: `record` (error truncation to 500 chars + retry field), `query` (schedule/status/limit filters + no-file guard), `stats` (empty + computed avg/last-run), `prune` (no-file, under-threshold no-op, excess-removal compaction, and the auto-prune-during-`record` path), plus the `aiofiles`-raises `except` arms (patched to `OSError`). Async file I/O in tmp only; the remaining 9 lines are the prune-write-failure tail.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_fts_channel_and_errors.py
+++ b/tests/test_fts_channel_and_errors.py
@@ -1,0 +1,87 @@
+"""Coverage for src/search/fts.py channel/knowledge/error paths (RFC-006 P19, safe).
+
+Complements test_fts_search.py: the channel_id-filtered session/channel-log
+search branches, the knowledge index/search/delete cycle, channel-log
+index/clear, empty-input guards, and every `except` error arm (exercised by
+closing the connection so the sqlite op raises and is caught). SAFE: real sqlite
+FTS5 in a tmp db; no network, no external service.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.search.fts import FullTextIndex
+
+
+@pytest.fixture
+def idx(tmp_path):
+    return FullTextIndex(str(tmp_path / "fts.db"))
+
+
+class TestSessions:
+    def test_channel_filtered_search(self, idx):
+        idx.index_session("s1", "alpha content here", "c1", 100.0)
+        idx.index_session("s2", "alpha content there", "c2", 200.0)
+        assert len(idx.search_sessions("alpha")) == 2
+        assert len(idx.search_sessions("alpha", channel_id="c1")) == 1   # channel filter
+        assert idx.search_sessions("alpha", channel_id="cX") == []
+        assert idx.has_session("s1") is True and idx.has_session("nope") is False
+
+    def test_reindex_replaces(self, idx):
+        idx.index_session("s1", "first version", "c1", 100.0)
+        idx.index_session("s1", "second version", "c1", 101.0)   # delete-then-insert
+        res = idx.search_sessions("second")
+        assert len(res) == 1 and "second" in res[0]["content"].lower()
+        assert idx.search_sessions("first") == []
+
+
+class TestKnowledge:
+    def test_index_search_delete(self, idx):
+        idx.index_knowledge_chunk("k1", "vector databases rock", "doc-a", 0)
+        idx.index_knowledge_chunk("k2", "vector search is fast", "doc-b", 1)
+        assert len(idx.search_knowledge("vector")) == 2
+        assert idx.has_knowledge_chunk("k1") is True
+        assert idx.delete_knowledge_source("doc-a") == 1     # one row removed
+        assert idx.has_knowledge_chunk("k1") is False
+        assert len(idx.search_knowledge("vector")) == 1
+
+
+class TestChannelLogs:
+    def test_index_search_clear(self, idx):
+        n = idx.index_channel_messages([
+            {"content": "hello world", "author": "alice", "channel_id": "c1", "ts": 1.0},
+            {"content": "goodbye world", "author": "bob", "channel_id": "c2", "ts": 2.0},
+            {"content": "", "author": "empty", "channel_id": "c1", "ts": 3.0},  # skipped
+        ])
+        assert n == 2                                          # empty content dropped
+        assert len(idx.search_channel_logs("world")) == 2
+        assert len(idx.search_channel_logs("world", channel_id="c1")) == 1
+        assert idx.clear_channel_logs() is True
+        assert idx.search_channel_logs("world") == []
+
+    def test_empty_inputs_are_guarded(self, idx):
+        assert idx.index_channel_messages([]) == 0
+        assert idx.index_channel_messages([{"author": "x"}]) == 0   # no content → 0
+        assert idx.search_channel_logs("") == []                    # empty query
+        assert idx.search_sessions("   ") == []                     # whitespace query
+        assert idx.search_knowledge("") == []
+
+
+class TestErrorBranches:
+    def test_closed_connection_returns_safe_defaults(self, idx):
+        idx.index_session("s1", "content", "c1", 1.0)
+        idx.index_knowledge_chunk("k1", "content", "src", 0)
+        idx.index_channel_messages([
+            {"content": "x", "author": "a", "channel_id": "c", "ts": 1.0}])
+        assert idx._conn is not None
+        idx._conn.close()   # every subsequent sqlite op raises → caught by except arms
+
+        assert idx.index_session("s2", "x", "c1", 1.0) is False
+        assert idx.search_sessions("content") == []
+        assert idx.index_knowledge_chunk("k2", "x", "s", 0) is False
+        assert idx.search_knowledge("content") == []
+        assert idx.delete_knowledge_source("src") == 0
+        assert idx.index_channel_messages([
+            {"content": "x", "author": "a", "channel_id": "c", "ts": 1.0}]) == 0
+        assert idx.search_channel_logs("x") == []
+        assert idx.clear_channel_logs() is False

--- a/tests/test_schedule_history.py
+++ b/tests/test_schedule_history.py
@@ -1,0 +1,108 @@
+"""Coverage for src/scheduler/history.py (RFC-006 P19, safe).
+
+Real ScheduleHistory against a tmp JSONL path — record (with error truncation +
+retry field), query (schedule/status/limit filters + no-file guard), stats
+(empty + computed), and prune (no-file, under-threshold no-op, excess removal,
+and the auto-prune-during-record path). SAFE: async file I/O in tmp only; no
+network, no scheduler execution.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.scheduler.history import ScheduleHistory
+
+
+@pytest.fixture
+def hist(tmp_path):
+    return ScheduleHistory(path=str(tmp_path / "history.jsonl"))
+
+
+async def _rec(hist, **kw):
+    params = dict(schedule_id="s1", description="d", action="a",
+                  status="success", duration_ms=10)
+    params.update(kw)
+    return await hist.record(**params)
+
+
+class TestRecordAndQuery:
+    async def test_record_and_filters(self, hist):
+        await _rec(hist, schedule_id="s1", status="success")
+        await _rec(hist, schedule_id="s1", status="failure")
+        await _rec(hist, schedule_id="s2", status="success")
+        assert len(await hist.query()) == 3                       # all
+        assert len(await hist.query("s1")) == 2                   # by schedule
+        assert len(await hist.query(status="success")) == 2       # by status
+        assert len(await hist.query("s1", status="failure")) == 1  # combined
+        assert len(await hist.query(limit=1)) == 1                # limit
+
+    async def test_error_truncated_and_retry_recorded(self, hist):
+        await _rec(hist, status="failure", error="x" * 600, retry_attempt=3)
+        entry = (await hist.query("s1"))[0]
+        assert len(entry["error"]) == 500 and entry["retry_attempt"] == 3
+
+    async def test_query_missing_file(self, tmp_path):
+        h = ScheduleHistory(path=str(tmp_path / "absent.jsonl"))
+        assert await h.query() == []
+
+
+class TestStats:
+    async def test_empty(self, hist):
+        s = await hist.stats("nope")
+        assert s["total_runs"] == 0 and s["last_run"] is None
+
+    async def test_computed(self, hist):
+        await _rec(hist, status="success", duration_ms=10)
+        await _rec(hist, status="failure", duration_ms=30)
+        s = await hist.stats("s1")
+        assert s["total_runs"] == 2 and s["successes"] == 1 and s["failures"] == 1
+        assert s["avg_duration_ms"] == 20 and s["last_run"] is not None
+
+
+class TestPrune:
+    async def test_no_file(self, tmp_path):
+        h = ScheduleHistory(path=str(tmp_path / "absent.jsonl"))
+        assert await h.prune() == 0
+
+    async def test_under_threshold_noop(self, hist):
+        await _rec(hist)
+        assert await hist.prune() == 0                            # <= MAX_TOTAL_ENTRIES
+
+    async def test_removes_excess(self, tmp_path):
+        h = ScheduleHistory(path=str(tmp_path / "h.jsonl"), max_entries_per_schedule=2)
+        for i in range(5):
+            await _rec(h, schedule_id="s1", duration_ms=i)
+        with patch("src.scheduler.history.MAX_TOTAL_ENTRIES", 3):
+            removed = await h.prune()                             # 5 rows, keep last 2
+        assert removed == 3
+        assert len(await h.query("s1")) == 2
+
+    async def test_auto_prune_during_record(self, tmp_path):
+        h = ScheduleHistory(path=str(tmp_path / "h.jsonl"), max_entries_per_schedule=1)
+        h._auto_prune_interval = 2                                # prune every 2 records
+        with patch("src.scheduler.history.MAX_TOTAL_ENTRIES", 1):
+            for i in range(4):
+                await _rec(h, schedule_id="s1", duration_ms=i)   # auto-prune fires mid-loop
+        # only the most-recent-per-schedule survives the compaction
+        assert len(await h.query("s1")) == 1
+
+
+class TestIOErrors:
+    """The defensive except arms — aiofiles.open raising is caught, not propagated."""
+
+    async def test_record_write_failure_swallowed(self, hist):
+        with patch("aiofiles.open", side_effect=OSError("disk full")):
+            entry = await _rec(hist)               # write fails, is logged, entry still returned
+        assert entry["schedule_id"] == "s1"
+
+    async def test_query_read_failure_returns_empty(self, hist):
+        await _rec(hist)                           # file now exists
+        with patch("aiofiles.open", side_effect=OSError("io error")):
+            assert await hist.query() == []
+
+    async def test_prune_read_failure_returns_zero(self, hist):
+        await _rec(hist)
+        with patch("aiofiles.open", side_effect=OSError("io error")):
+            assert await hist.prune() == 0


### PR DESCRIPTION
Test-only wave (RFC-006 P19). Two safe file-backed stores. No `src` changes.

## Coverage (whole-repo 84.9% → 85.1%)

| File | Start → End |
|---|---|
| `search/fts.py` | 81.5% → **100.0%** (missing 28 → 0) |
| `scheduler/history.py` | 81.1% → **91.9%** (missing 21 → 9) |

## Method / safety (real interfaces, faked boundaries only)

- **search/fts** — real `FullTextIndex` on a **tmp sqlite FTS5 db** (complements `test_fts_search.py`): the channel_id-filtered `search_sessions`/`search_channel_logs` branches, the knowledge index/search/`delete_knowledge_source`/`has_knowledge_chunk` cycle, `index_channel_messages` (content-filtering + empty-input guards) / `clear_channel_logs`, session re-index (delete-then-insert), and every `except` error arm — exercised by closing the connection so the sqlite op raises and is caught. No network, no external service.
- **scheduler/history** — real `ScheduleHistory` on a tmp JSONL: `record` (error truncation + retry field), `query` (schedule/status/limit filters + no-file guard), `stats` (empty + computed), `prune` (no-file / under-threshold / excess-removal / auto-prune-during-record), and the `aiofiles`-raises `except` arms (patched to `OSError`). Async file I/O in tmp only; remaining 9 lines are the prune-write-failure tail.

## Gates (local)

- coverage-gate: findings=0 (ratchet scoped to exactly the 2 target entries)
- lint-gate: new=0 · type-gate: new=0
- suite: 7219 passed, 4 skipped

**COV ledger: EMPTY** — no product bugs surfaced.
