### PR TITLE
test: RFC-006 P22 — codex admin routes (set_label/delete/device-poll edges)

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1128,9 +1128,9 @@
   "statements": 150
  },
  "src/web/api/codex_admin.py": {
-  "covered": 185,
-  "missing": 34,
-  "percent": 84.47,
+  "covered": 203,
+  "missing": 16,
+  "percent": 92.69,
   "statements": 219
  },
  "src/web/api/config_admin.py": {

--- a/docs/plans/coverage-plan.md
+++ b/docs/plans/coverage-plan.md
@@ -417,6 +417,20 @@ Two safe pure/bookkeeping surfaces, one PR, Odin-reviewed. Whole-repo 85.2% → 
 
 **COV ledger: EMPTY.** No real bugs; no `xfail`s.
 
+## 6w. R3 — P22 codex admin routes (2026-07-07)
+
+One web-route file, extending the existing `test_web_api_codex_admin.py` harness. One PR, Odin-reviewed. Whole-repo 85.3% → **85.4%**.
+
+| File | Start → End |
+|---|---|
+| `web/api/codex_admin.py` | 84.5% → **92.7%** (missing 34 → 16) |
+
+**Method / safety.** Drives the Codex OAuth admin routes through the real aiohttp route layer (`TestClient`/`TestServer`) with a real `CodexAuthPool` (or a pool-less bot for the file-only branches) — faking only network transport and the poll/refresh calls. New coverage: `set_label` / `delete_account` dict-index-0 + invalid-index + unreadable-file(500) branches, `refresh` exception→500, `activate` unconfigured→503, and the `device-poll` credential-merge branches (out-of-range save_index → append, dict-file promote-to-list, no-file fresh write). **No real Codex network, no token exchange** — the credentials file is a tmp fixture.
+
+**Deliberately deferred (16 lines):** the intricate defensive tail — the device-poll `except`-backup path (needs injected write-failure), the per-account status `except` (malformed account), the set_label shadow-update `except`, and the `pool.reload()` fallback (needs a pool lacking `reload_async`). Contrived failure-injection with mock-drift risk, low value.
+
+**COV ledger: EMPTY.** No real bugs; no `xfail`s.
+
 ## 7. Risks / discipline
 
 - **Coverage theater**: the §5 real-behavior rule + Odin review of every test are the guard. A test that would pass against a `pass` body is rejected.

--- a/tests/test_web_api_codex_admin.py
+++ b/tests/test_web_api_codex_admin.py
@@ -247,3 +247,102 @@ class TestAccountOps:
         path.unlink()
         async with TestClient(TestServer(_app(bot))) as c:
             assert (await c.delete("/api/codex/account/0")).status == 404
+
+
+def _bot_raw(tmp_path, content):
+    """Bot with an arbitrary creds-file content and no pool (codex_client=None),
+    isolating the file-manipulation branches of set_label / delete_account."""
+    creds_path = tmp_path / "codex.json"
+    creds_path.write_text(content)
+    bot = MagicMock()
+    bot.config.openai_codex.credentials_path = str(creds_path)
+    bot.llm_gateway.codex_client = None
+    return bot, creds_path
+
+
+class TestAccountOpsEdges:
+    @pytest.mark.asyncio
+    async def test_set_label_dict_file(self, tmp_path):
+        bot, path = _bot_raw(tmp_path, json.dumps(_creds(email="d@x.co")))   # single dict
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.put("/api/codex/account/0/label", json={"label": "solo"})
+            assert r.status == 200 and json.loads(path.read_text())["label"] == "solo"
+            assert (await c.put("/api/codex/account/1/label",
+                                json={"label": "x"})).status == 400          # invalid dict index
+
+    @pytest.mark.asyncio
+    async def test_set_label_unreadable_file(self, tmp_path):
+        bot, _ = _bot_raw(tmp_path, "{ not valid json")
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.put("/api/codex/account/0/label",
+                                json={"label": "x"})).status == 500          # read fails
+
+    @pytest.mark.asyncio
+    async def test_delete_dict_file(self, tmp_path):
+        bot, path = _bot_raw(tmp_path, json.dumps(_creds(email="d@x.co")))
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.delete("/api/codex/account/0")).status == 200     # dict-index-0
+            assert json.loads(path.read_text()) == []                        # cleared to []
+            path.write_text(json.dumps(_creds()))                            # reset to a dict
+            assert (await c.delete("/api/codex/account/1")).status == 400     # invalid dict index
+
+    @pytest.mark.asyncio
+    async def test_delete_unreadable_file(self, tmp_path):
+        bot, _ = _bot_raw(tmp_path, "{ broken")
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.delete("/api/codex/account/0")).status == 500     # read fails
+
+    @pytest.mark.asyncio
+    async def test_refresh_raises_500(self, tmp_path, monkeypatch):
+        bot, _ = _make_bot(tmp_path, accounts=1)
+        monkeypatch.setattr(ca.CodexAuth, "_refresh",
+                            AsyncMock(side_effect=RuntimeError("boom")))
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.post("/api/codex/account/0/refresh")).status == 500
+
+    @pytest.mark.asyncio
+    async def test_activate_unconfigured_503(self, tmp_path):
+        bot, _ = _make_bot(tmp_path, configured=False)
+        async with TestClient(TestServer(_app(bot))) as c:
+            assert (await c.post("/api/codex/account/0/activate")).status == 503
+
+
+class TestDevicePollMerge:
+    @pytest.mark.asyncio
+    async def test_out_of_range_save_index_appends(self, tmp_path, monkeypatch):
+        bot, path = _make_bot(tmp_path, accounts=1)
+        bot.llm_gateway.reload_codex = AsyncMock(return_value={"configured": True})
+        monkeypatch.setattr(ca.CodexAuth, "poll_device_auth",
+                            AsyncMock(return_value=_creds(access="oor", account_id="9")))
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.post("/api/codex/device-poll",
+                             json={"device_auth_id": "d", "user_code": "AB", "save_index": 5})
+            assert r.status == 200
+        data = json.loads(path.read_text())
+        assert len(data) == 2 and data[1]["access_token"] == "oor"       # appended, not replaced
+
+    @pytest.mark.asyncio
+    async def test_dict_file_with_save_index_promotes(self, tmp_path, monkeypatch):
+        bot, path = _bot_raw(tmp_path, json.dumps(_creds(email="orig@x.co")))  # dict file
+        bot.llm_gateway.reload_codex = AsyncMock(return_value={"configured": True})
+        monkeypatch.setattr(ca.CodexAuth, "poll_device_auth",
+                            AsyncMock(return_value=_creds(access="promoted")))
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.post("/api/codex/device-poll",
+                             json={"device_auth_id": "d", "user_code": "AB", "save_index": 0})
+            assert r.status == 200
+        data = json.loads(path.read_text())
+        assert isinstance(data, list) and len(data) == 2                 # [orig, new]
+
+    @pytest.mark.asyncio
+    async def test_no_file_writes_fresh(self, tmp_path, monkeypatch):
+        bot, path = _bot_raw(tmp_path, "")
+        path.unlink()                                                    # no creds file
+        bot.llm_gateway.reload_codex = AsyncMock(return_value={"configured": True})
+        monkeypatch.setattr(ca.CodexAuth, "poll_device_auth",
+                            AsyncMock(return_value=_creds(access="fresh")))
+        async with TestClient(TestServer(_app(bot))) as c:
+            r = await c.post("/api/codex/device-poll",
+                             json={"device_auth_id": "d", "user_code": "AB"})
+            assert r.status == 200
+        assert json.loads(path.read_text())[0]["access_token"] == "fresh"


### PR DESCRIPTION
Test-only wave (RFC-006 P22). One web-route file. No `src` changes.

## Coverage (whole-repo 85.3% → 85.4%)

| File | Start → End |
|---|---|
| `web/api/codex_admin.py` | 84.5% → **92.7%** (missing 34 → 16) |

## Method / safety

Extends the existing `test_web_api_codex_admin.py` harness — drives the Codex OAuth admin routes through the real aiohttp route layer (`TestClient`/`TestServer`) with a real `CodexAuthPool` (or a pool-less bot for file-only branches), faking only the network transport and the poll/refresh calls. New coverage:

- `set_label` / `delete_account`: dict-index-0, invalid-index, and unreadable-file(500) branches
- `refresh` exception → 500 · `activate` unconfigured → 503
- `device-poll` credential-merge: out-of-range `save_index` → append, dict-file promote-to-list, no-file fresh write

**No real Codex network, no token exchange** — the credentials file is a tmp fixture.

## Deferred (16 lines)

The intricate defensive tail — device-poll `except`-backup (needs injected write-failure), per-account status `except`, set_label shadow-update `except`, and the `pool.reload()` fallback (pool lacking `reload_async`). Contrived failure-injection, mock-drift risk, low value.

## Gates (local)

- coverage-gate: findings=0 (ratchet scoped to the one target file)
- lint-gate: new=0 · type-gate: new=0
- suite: 7269 passed, 4 skipped

**COV ledger: EMPTY** — no product bugs surfaced.
