### PR TITLE
feat(webui): add GPT-5.6 Sol and Terra to Codex model dropdown

### DIFF
--- a/ui/dist/assets/index-BM8KeBZG.js
+++ b/ui/dist/assets/index-BM8KeBZG.js
@@ -4817,6 +4817,8 @@ Please report this to https://github.com/markedjs/marked.`,e){const n="<p>An err
               <label class="text-xs text-gray-400">Model</label>
               <select v-model="codexForm.model" @change="saveCodexConfig"
                       class="w-full bg-gray-900 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-200">
+                <option value="gpt-5.6-sol">gpt-5.6-sol</option>
+                <option value="gpt-5.6-terra">gpt-5.6-terra</option>
                 <option value="gpt-5.5">gpt-5.5</option>
                 <option value="gpt-5">gpt-5</option>
                 <option value="gpt-5-mini">gpt-5-mini</option>

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Odin — Management</title>
-  <script type="module" crossorigin src="/ui/assets/index-CfoRYt0B.js"></script>
+  <script type="module" crossorigin src="/ui/assets/index-BM8KeBZG.js"></script>
   <link rel="stylesheet" crossorigin href="/ui/assets/index-DGHYqcAn.css">
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen" style="font-family: var(--hm-font-sans);">

--- a/ui/js/pages/llm-config.js
+++ b/ui/js/pages/llm-config.js
@@ -100,6 +100,8 @@ export default {
               <label class="text-xs text-gray-400">Model</label>
               <select v-model="codexForm.model" @change="saveCodexConfig"
                       class="w-full bg-gray-900 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-200">
+                <option value="gpt-5.6-sol">gpt-5.6-sol</option>
+                <option value="gpt-5.6-terra">gpt-5.6-terra</option>
                 <option value="gpt-5.5">gpt-5.5</option>
                 <option value="gpt-5">gpt-5</option>
                 <option value="gpt-5-mini">gpt-5-mini</option>


### PR DESCRIPTION
## What

Adds `gpt-5.6-sol` and `gpt-5.6-terra` as selectable Codex models in the WebUI LLM config page, listed newest-first ahead of `gpt-5.5`. Display order only — the form default remains `gpt-5.5`.

## Why

GPT-5.6 (Sol/Terra/Luna family) began staged preview rollout in late June 2026 and the Codex ChatGPT-auth backend now accepts Sol and Terra for account tiers that have access (verified with live requests; `served_model` confirmed from `response.completed` events). Luna is not served on this backend (404), so it is not included.

## Availability caveat (per design review)

GPT-5.6 availability is **account-tier dependent** during the preview: accounts without access receive a backend 400 ("model is not supported when using Codex with a ChatGPT account"). Sol currently has narrower tier availability than Terra. A 400 is not failover-eligible in the auth pool (only 429/401 rotate), so selecting a model an account cannot use surfaces as a request error — an informed-admin choice, same class as the existing `gpt-4.1`/`gpt-4o` options which this auth path also rejects.

## Scope

- UI-only: no backend change (`PUT /api/llm/codex/config` already accepts any model string, no server-side allowlist) and no test changes (the dropdown is not test-pinned).
- Strictly additive per design discussion — pruning the dead `gpt-4.1`/`gpt-4o` options is deliberately left to a possible follow-up.
- `ui/dist/` rebuilt via `npm run check` and committed (drift gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)