### PR TITLE
fix(llm): apply model/max_tokens to live Codex client on reload

### DIFF
--- a/src/discord/llm_gateway.py
+++ b/src/discord/llm_gateway.py
@@ -110,6 +110,17 @@ class LLMGateway:
             auth = getattr(self.codex_client, "auth", None)
             if isinstance(auth, CodexAuthPool):
                 count = await auth.reload_async()
+                # Config changes (model/max_tokens) must land on the live
+                # client too — it reads self.model per request, and without
+                # this a WebUI model switch only took effect after a restart.
+                if self.codex_client.model != config.openai_codex.model:
+                    log.info(
+                        "Codex model updated via live reload: %s -> %s",
+                        self.codex_client.model,
+                        config.openai_codex.model,
+                    )
+                self.codex_client.model = config.openai_codex.model
+                self.codex_client.max_tokens = config.openai_codex.max_tokens
                 return {"configured": True, "reloaded": True, "accounts": count}
 
         auth = CodexAuthPool(config.openai_codex.credentials_path)

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -85,10 +85,30 @@ class TestReloadCodex:
         from src.discord.llm_gateway import CodexAuthPool
         pool = MagicMock(spec=CodexAuthPool)
         pool.reload_async = AsyncMock(return_value=3)
-        client = SimpleNamespace(auth=pool)
+        client = SimpleNamespace(auth=pool, model="gpt-5.5", max_tokens=8000)
         gw = _gw(codex=client)
         r = await gw.reload_codex_inner()
         assert r["reloaded"] is True and r["accounts"] == 3
+
+    async def test_existing_client_gets_model_and_max_tokens_from_config(self):
+        """Regression: a reload after a config PUT must land model/max_tokens
+        on the LIVE client. The auth-pool branch used to return early without
+        applying them, so WebUI model switches silently no-opped until the
+        next restart while /api/llm/status kept reporting the old model."""
+        from src.discord.llm_gateway import CodexAuthPool
+        pool = MagicMock(spec=CodexAuthPool)
+        pool.reload_async = AsyncMock(return_value=3)
+        client = SimpleNamespace(auth=pool, model="gpt-5.5", max_tokens=8000)
+        cfg = _cfg()
+        cfg.openai_codex.model = "gpt-5.6-terra"
+        cfg.openai_codex.max_tokens = 4096
+        gw = _gw(cfg, codex=client)
+        r = await gw.reload_codex_inner()
+        assert r["reloaded"] is True
+        # same client object — auth pool, breaker, and session are preserved
+        assert gw.codex_client is client
+        assert client.model == "gpt-5.6-terra"
+        assert client.max_tokens == 4096
 
     async def test_creates_new_client(self):
         pool = MagicMock()


### PR DESCRIPTION
## What

`reload_codex_inner()`'s existing-client branch refreshed the auth pool and returned early — config changes (`model`, `max_tokens`) never reached the running client. A WebUI model switch (`PUT /api/llm/codex/config`) persisted to config and reported `status: updated`, but the live client kept sending its boot-time model until the next restart, and `/api/llm/status` `active_model` (truthfully) kept reporting the old one.

Found live while validating #218: switching the Codex model via the dropdown saved the config, but the next reply still went out on the previous model — journal shows the auth-pool reload line and no client rebuild.

## Fix

Mirror what the Ollama reload already does (apply current config on every reload), but surgically for Codex: assign `model` and `max_tokens` onto the existing client inside the auth-pool branch. The client reads `self.model` per request, so it takes effect on the next call while preserving the auth pool object (account pinning), circuit-breaker state, and the pooled session — no rebuild needed. Logs the transition when the model actually changes.

## Tests

- New regression test: existing-client reload with a changed config → same client object, `model`/`max_tokens` updated.
- The existing auth-pool-reload test fake gains the `model`/`max_tokens` attributes the real client contract has always had (it was under-specified).
- Full suite 7,242 passed / 4 skipped; ruff and mypy clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)