### PR TITLE
fix(self-update): correct repo root, clear stale metadata, trust pyproject for version

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,11 @@
 """Version management for Odin.
 
-Reads version from package metadata (installed via pip) with fallback
-to parsing pyproject.toml directly (development / uninstalled mode).
+Prefers pyproject.toml from the source tree (the service imports src/
+from the checkout, so that file describes the code actually running),
+falling back to installed package metadata for site-packages installs.
+Installed metadata can go stale after a self-update — a stale
+odin_bot.egg-info / dist-info kept reporting the previous version, so
+the updater re-offered the release it had already applied.
 """
 from __future__ import annotations
 
@@ -11,23 +15,8 @@ from pathlib import Path
 _FALLBACK_VERSION = "0.0.0-dev"
 
 
-def get_version() -> str:
-    """Return the Odin version string.
-
-    Resolution order:
-    1. importlib.metadata (works when installed via pip / .deb)
-    2. Parse pyproject.toml in the project root (development mode)
-    3. Fallback to "0.0.0-dev"
-    """
-    # Try installed package metadata first
-    try:
-        from importlib.metadata import version
-
-        return version("odin-bot")
-    except Exception:
-        pass
-
-    # Fallback: parse pyproject.toml directly
+def _version_from_pyproject() -> str | None:
+    """Version from the pyproject.toml next to the running source tree."""
     try:
         toml_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
         if toml_path.is_file():
@@ -37,5 +26,25 @@ def get_version() -> str:
                 return match.group(1)
     except Exception:
         pass
+    return None
 
-    return _FALLBACK_VERSION
+
+def _version_from_metadata() -> str | None:
+    """Version from installed package metadata (pip / .deb installs)."""
+    try:
+        from importlib.metadata import version
+
+        return version("odin-bot")
+    except Exception:
+        return None
+
+
+def get_version() -> str:
+    """Return the Odin version string.
+
+    Resolution order:
+    1. pyproject.toml in the project root — the code actually running
+    2. importlib.metadata — installed without a source checkout
+    3. Fallback to "0.0.0-dev"
+    """
+    return _version_from_pyproject() or _version_from_metadata() or _FALLBACK_VERSION

--- a/src/web/api/self_update.py
+++ b/src/web/api/self_update.py
@@ -15,6 +15,33 @@ from ...odin_log import get_logger
 log = get_logger("web.api")
 
 
+def _repo_root() -> str:
+    """Repo root = nearest ancestor of this module containing pyproject.toml.
+
+    Derived by marker rather than a fixed number of dirname hops: the
+    RFC-003 package split moved this module one level deeper
+    (src/web/api.py -> src/web/api/self_update.py) and the old 3-hop
+    derivation silently pointed base at <repo>/src — so the updater's
+    pip reinstall step never ran (src/.venv does not exist), config.yml
+    preservation joined the wrong directory, and the bot kept reporting
+    the pre-update version from stale package metadata.
+    """
+    import os
+
+    path = os.path.dirname(os.path.abspath(__file__))
+    for _ in range(8):
+        if os.path.isfile(os.path.join(path, "pyproject.toml")):
+            return path
+        parent = os.path.dirname(path)
+        if parent == path:
+            break
+        path = parent
+    # Fallback: historical layout, src/web/api/ is three levels below root
+    return os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+
+
 def register_self_update(routes: web.RouteTableDef, bot) -> None:
     """Self-Update (verbatim from the monolith)."""
     # ------------------------------------------------------------------
@@ -60,7 +87,7 @@ def register_self_update(routes: web.RouteTableDef, bot) -> None:
         except Exception:
             data = {}
         target = data.get("version", "latest")
-        base = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        base = _repo_root()
 
         # Resolve "latest" to actual release tag
         if target == "latest":
@@ -146,6 +173,14 @@ def register_self_update(routes: web.RouteTableDef, bot) -> None:
             # Restore user config files after update
             for fname, data in _backups.items():
                 open(os.path.join(base, fname), "wb").write(data)
+
+            # Stale build metadata (a leftover odin_bot.egg-info, e.g.
+            # root-owned from a manual install) can poison the reinstall and
+            # keep importlib.metadata reporting the previous version — the
+            # updater then re-offers the release it just applied.
+            egg_info = os.path.join(base, "odin_bot.egg-info")
+            if os.path.isdir(egg_info):
+                shutil.rmtree(egg_info, ignore_errors=True)
 
             # Install/update dependencies
             venv_pip = os.path.join(base, ".venv", "bin", "pip")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,8 @@
 """Tests for src/version.py."""
 from __future__ import annotations
 
-from src.version import get_version
+import src.version as version_mod
+from src.version import _version_from_pyproject, get_version
 
 
 class TestGetVersion:
@@ -22,3 +23,29 @@ class TestGetVersion:
         version = get_version()
         # Minimal check: contains at least one digit
         assert any(ch.isdigit() for ch in version)
+
+    def test_pyproject_helper_parses_real_file(self):
+        v = _version_from_pyproject()
+        assert v is not None and any(ch.isdigit() for ch in v)
+
+
+class TestResolutionOrder:
+    """Self-update regression: stale installed metadata (odin_bot.egg-info /
+    dist-info left at the previous version) must not mask the version of the
+    code actually running from the source checkout — the updater re-offered
+    the release it had already applied."""
+
+    def test_pyproject_wins_over_stale_metadata(self, monkeypatch):
+        monkeypatch.setattr(version_mod, "_version_from_metadata", lambda: "0.0.1-stale")
+        assert get_version() == version_mod._version_from_pyproject()
+        assert get_version() != "0.0.1-stale"
+
+    def test_metadata_fallback_when_no_pyproject(self, monkeypatch):
+        monkeypatch.setattr(version_mod, "_version_from_pyproject", lambda: None)
+        monkeypatch.setattr(version_mod, "_version_from_metadata", lambda: "9.9.9")
+        assert get_version() == "9.9.9"
+
+    def test_dev_fallback_when_nothing_available(self, monkeypatch):
+        monkeypatch.setattr(version_mod, "_version_from_pyproject", lambda: None)
+        monkeypatch.setattr(version_mod, "_version_from_metadata", lambda: None)
+        assert get_version() == "0.0.0-dev"

--- a/tests/test_web_api_self_update.py
+++ b/tests/test_web_api_self_update.py
@@ -160,3 +160,61 @@ class TestStopAllLoops:
             body = await (await c.post("/api/loops/stop-all")).json()
             assert body["result"] == "stopped 3 loops"
             bot.loop_manager.stop_loop.assert_called_once_with("all")
+
+
+class TestRepoRootAndMetadataHygiene:
+    """Regressions for the field report of self-update misreporting its
+    version: base pointed at <repo>/src after the RFC-003 package split
+    (pip reinstall silently skipped — src/.venv never exists), and stale
+    odin_bot.egg-info metadata kept get_version() on the old release."""
+
+    def test_repo_root_contains_pyproject(self):
+        import os
+
+        from src.web.api.self_update import _repo_root
+        root = _repo_root()
+        assert os.path.isfile(os.path.join(root, "pyproject.toml"))
+        # the old 3-dirname derivation landed here — never again
+        assert not root.rstrip(os.sep).endswith(os.sep + "src")
+
+    async def test_apply_pip_installs_repo_root_and_clears_egg_info(self):
+        import asyncio
+        import os
+
+        from src.web.api.self_update import _repo_root
+        loop = asyncio.get_running_loop()
+        root = _repo_root()
+        commands: list = []
+
+        def _capture(cmd, **kw):
+            commands.append(cmd)
+            return _run_ok(cmd, **kw)
+
+        def _exists(path):
+            # only the venv pip probe answers True so the install step runs
+            return path.endswith(os.path.join(".venv", "bin", "pip"))
+
+        def _isdir(path):
+            return path.endswith("odin_bot.egg-info")
+
+        with patch("subprocess.run", side_effect=_capture), \
+             patch("os.path.exists", side_effect=_exists), \
+             patch("os.path.isdir", side_effect=_isdir), \
+             patch("shutil.rmtree") as rmtree, \
+             patch("os.walk", return_value=[]), \
+             patch.object(loop, "call_later", lambda d, cb, *a: MagicMock()), \
+             patch("os.kill") as kill:
+            async with TestClient(TestServer(_app())) as c:
+                r = await c.post("/api/update/apply", json={"version": "v3.55.0"})
+                assert r.status == 200
+
+        # stale build metadata is removed from the REPO ROOT before install
+        rmtree.assert_called_once()
+        assert rmtree.call_args.args[0] == os.path.join(root, "odin_bot.egg-info")
+        # pip reinstall actually runs, against the repo root (not <repo>/src)
+        pip_suffix = os.path.join(".venv", "bin", "pip")
+        pip_cmds = [c for c in commands if c and str(c[0]).endswith(pip_suffix)]
+        assert pip_cmds, "pip reinstall step never ran"
+        assert pip_cmds[0][0] == os.path.join(root, ".venv", "bin", "pip")
+        assert pip_cmds[0][-1] == root
+        kill.assert_not_called()


### PR DESCRIPTION
## Field report

An external install used `/api/update/apply` to move between releases: the git update succeeded and the service restarted, but the bot kept reporting the previous version with the same update still on offer. Investigation on that box showed the source tree at the new tag while `odin_bot.egg-info/PKG-INFO` and the venv `dist-info` still carried the old version — which `get_version()` trusted first.

## Three compounding causes, all fixed

1. **`base` pointed at `<repo>/src`, not the repo root.** The RFC-003 package split moved this handler one directory deeper (`src/web/api.py` → `src/web/api/self_update.py`) and the 3-`dirname` derivation was never adjusted. `git -C` masked it (git walks up), so code updates appeared to work — but `<repo>/src/.venv/bin/pip` never exists, so **the pip reinstall step has silently skipped on every self-update since v3.47.0**, and config.yml/.env preservation joined the wrong directory. `base` is now derived by a pyproject.toml marker walk (`_repo_root()`), robust to future module moves, with the historical 4-hop fallback.

2. **Stale build metadata poisons reinstalls.** A leftover `odin_bot.egg-info` (e.g. root-owned from a manual install — this exact artifact has bitten the dev clone before) can keep `importlib.metadata` on the previous version. The updater now removes it before `pip install`.

3. **`get_version()` trusted installed metadata over the running code.** The service imports `src/` from the checkout, so stale metadata misreports the running version and the updater re-offers a release it already applied. Resolution order is now **pyproject.toml → importlib.metadata → dev fallback**, split into testable helpers. (Demonstrated locally: the dev clone's stale editable metadata says 3.44.1 while the tree is 3.57.0 — the old order returned the wrong one.)

## Tests

+6: `_repo_root()` contains pyproject.toml and is never `<repo>/src`; the apply flow pins pip actually running against the repo root with egg-info cleared first (mirrors the existing SIGTERM-safe harness — restart callback stubbed via the running loop's `call_later`, per the P7 lesson); version resolution order covering the stale-metadata scenario, metadata fallback, and dev fallback.

Suite 7,248 passed / 4 skipped; ruff and mypy clean. No route changes; no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)