### PR TITLE
docs: refresh openai_codex example (gpt-5.5, reasoning_effort)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,8 +69,9 @@ tools:
 ```yaml
 openai_codex:
   enabled: true
-  model: gpt-5.4                 # ChatGPT subscription path
+  model: gpt-5.5                 # ChatGPT subscription path
   max_tokens: 4096
+  reasoning_effort: medium       # none | minimal | low | medium | high | xhigh
   credentials_path: ./data/codex_auth.json
   retry:
     max_retries: 3


### PR DESCRIPTION
Follow-up to the #220 review advisory: `docs/configuration.md` still showed `model: gpt-5.4` and did not mention `reasoning_effort`. Aligns the example with the tracked `config.yml` template. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)