### PR TITLE
fix(llm): drop unsupported 'minimal' reasoning effort

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,7 +17,7 @@ openai_codex:
   model: gpt-5.5
   max_tokens: 4096
   # Reasoning effort sent with every main-provider request:
-  # none | minimal | low | medium | high | xhigh (backend default: medium)
+  # none | low | medium | high | xhigh (backend default: medium)
   reasoning_effort: medium
   credentials_path: ./data/codex_auth.json
   retry:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ openai_codex:
   enabled: true
   model: gpt-5.5                 # ChatGPT subscription path
   max_tokens: 4096
-  reasoning_effort: medium       # none | minimal | low | medium | high | xhigh
+  reasoning_effort: medium       # none | low | medium | high | xhigh
   credentials_path: ./data/codex_auth.json
   retry:
     max_retries: 3

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -279,7 +279,12 @@ class AuxiliaryLLMConfig(BaseModel):
     )
 
 
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+# "minimal" is deliberately absent: it sits in the Codex API's generic
+# parameter enum but every model on the ChatGPT-auth path rejects it at the
+# per-model capability layer ("Unsupported value ... Supported values are:
+# 'none', 'low', 'medium', 'high', and 'xhigh'"), which turns a saved value
+# into a deterministic per-request 400.
+ReasoningEffort = Literal["none", "low", "medium", "high", "xhigh"]
 # Single source of truth for runtime validation (Literal does not validate
 # direct attribute assignment — the web admin layer checks against this set).
 CODEX_REASONING_EFFORTS: frozenset[str] = frozenset(get_args(ReasoningEffort))
@@ -295,6 +300,21 @@ class OpenAICodexConfig(BaseModel):
     max_tokens: int = 4096
     reasoning_effort: ReasoningEffort = "medium"
     credentials_path: str = "./data/codex_auth.json"
+
+    @field_validator("reasoning_effort", mode="before")
+    @classmethod
+    def _coerce_legacy_reasoning_effort(cls, v):
+        # v3.58.0 briefly offered "minimal"; a config persisted with it must
+        # not brick startup after upgrading — degrade to the nearest value.
+        if v == "minimal":
+            import logging
+
+            logging.getLogger("odin.config").warning(
+                "reasoning_effort 'minimal' is not supported by any Codex "
+                "model on this auth path; using 'low' instead"
+            )
+            return "low"
+        return v
     retry: RetryConfig = RetryConfig()
     connection_pool: ConnectionPoolConfig = ConnectionPoolConfig()
     auxiliary: AuxiliaryLLMConfig = AuxiliaryLLMConfig()

--- a/tests/test_config_schema_validators.py
+++ b/tests/test_config_schema_validators.py
@@ -132,11 +132,18 @@ class TestCodexReasoningEffort:
 
     def test_all_enum_values_accepted(self):
         from src.config.schema import CODEX_REASONING_EFFORTS, OpenAICodexConfig
-        assert CODEX_REASONING_EFFORTS == {
-            "none", "minimal", "low", "medium", "high", "xhigh"
-        }
+        # "minimal" is deliberately excluded — every Codex model on this auth
+        # path rejects it per-request despite it appearing in the API's
+        # generic parameter enum.
+        assert CODEX_REASONING_EFFORTS == {"none", "low", "medium", "high", "xhigh"}
         for value in CODEX_REASONING_EFFORTS:
             assert OpenAICodexConfig(reasoning_effort=value).reasoning_effort == value
+
+    def test_legacy_minimal_coerces_to_low(self):
+        """A config persisted while v3.58.0 offered "minimal" must not brick
+        startup after upgrading — it degrades to "low" with a warning."""
+        from src.config.schema import OpenAICodexConfig
+        assert OpenAICodexConfig(reasoning_effort="minimal").reasoning_effort == "low"
 
     def test_invalid_value_rejected_at_load(self):
         import pydantic

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -275,6 +275,10 @@ class TestProviderConfig:
                                   "reasoning_effort": "banana"})
             assert r.status == 400
             assert "reasoning_effort" in (await r.json())["error"]
+            # "minimal" is grammar-valid upstream but unsupported by every
+            # model on this auth path — the PUT layer rejects it too
+            assert (await c.put("/api/llm/codex/config",
+                                json={"reasoning_effort": "minimal"})).status == 400
         # nothing mutated, nothing reloaded
         assert bot.config.openai_codex.reasoning_effort == "medium"
         assert bot.config.openai_codex.model != "changed-model"

--- a/ui/dist/assets/index-D9jgmWYV.js
+++ b/ui/dist/assets/index-D9jgmWYV.js
@@ -4836,7 +4836,6 @@ Please report this to https://github.com/markedjs/marked.`,e){const n="<p>An err
               <select v-model="codexForm.reasoning_effort" @change="saveCodexConfig"
                       class="w-full bg-gray-900 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-200">
                 <option value="none">None</option>
-                <option value="minimal">Minimal</option>
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Odin — Management</title>
-  <script type="module" crossorigin src="/ui/assets/index-DbKkb-cw.js"></script>
+  <script type="module" crossorigin src="/ui/assets/index-D9jgmWYV.js"></script>
   <link rel="stylesheet" crossorigin href="/ui/assets/index-DGHYqcAn.css">
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen" style="font-family: var(--hm-font-sans);">

--- a/ui/js/pages/llm-config.js
+++ b/ui/js/pages/llm-config.js
@@ -119,7 +119,6 @@ export default {
               <select v-model="codexForm.reasoning_effort" @change="saveCodexConfig"
                       class="w-full bg-gray-900 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-200">
                 <option value="none">None</option>
-                <option value="minimal">Minimal</option>
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>


### PR DESCRIPTION
## Field result

Setting **Minimal** in the new Reasoning dropdown made every request fail with a Codex 400 — `Unsupported value: 'minimal' is not supported with the 'gpt-5.6-sol' model. Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'.` — until the value was changed (one dropdown click, live reload). The bad value persists in config, so it's a deterministic per-request failure, not a transient.

## Root cause

The six-value enum shipped in #220 came from the API's own `invalid_value` error listing — but that's the **parameter grammar**, not per-model capability, which is validated separately per request. A complete probe of the effort×model matrix (6 values × gpt-5.5 / gpt-5.6-sol / gpt-5.6-terra) shows `minimal` is **rejected by all three models** on this auth path while the other five are accepted everywhere. Offering it was a landmine on every model.

## Fix

- `ReasoningEffort` Literal and `CODEX_REASONING_EFFORTS` drop `minimal` (single source — UI select, PUT validation, `docs/configuration.md`, and the config template comment all follow).
- **Legacy coercion**: a config persisted with `minimal` during the hours v3.58.0 offered it degrades to `low` with a warning at load instead of failing Pydantic validation and bricking startup.
- Tests: coercion pinned, PUT `minimal` → 400 asserted, enum test updated to the five-value set with the exclusion rationale in a comment.

If the backend ever adds per-model support for `minimal`, re-adding is a two-line change.

Suite 7,257 passed / 4 skipped; ruff + mypy clean; `npm run check` green with rebuilt `ui/dist` committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)