### PR TITLE
fix(llm): stream-appropriate Codex timeouts; plumb transport config for real

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,13 @@ openai_codex:
   # none | low | medium | high | xhigh (backend default: medium)
   reasoning_effort: medium
   credentials_path: ./data/codex_auth.json
+  # Streaming transport timeouts. request_timeout_seconds is a generous
+  # whole-request backstop (long high-effort reasoning turns stream past
+  # 10 minutes); stream_stall_timeout_seconds fails the stream fast when
+  # no bytes arrive for that long (dead connection) instead of waiting
+  # out the backstop.
+  request_timeout_seconds: 3600
+  stream_stall_timeout_seconds: 180
   retry:
     max_retries: 3
     base_delay: 1.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,8 @@ openai_codex:
   max_tokens: 4096
   reasoning_effort: medium       # none | low | medium | high | xhigh
   credentials_path: ./data/codex_auth.json
+  request_timeout_seconds: 3600  # whole-request backstop; long reasoning turns stream past 10 min
+  stream_stall_timeout_seconds: 180  # fail fast when no stream bytes arrive for this long
   retry:
     max_retries: 3
     base_delay: 1.0

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -300,6 +300,12 @@ class OpenAICodexConfig(BaseModel):
     max_tokens: int = 4096
     reasoning_effort: ReasoningEffort = "medium"
     credentials_path: str = "./data/codex_auth.json"
+    # Streaming transport timeouts: a generous whole-request backstop (long
+    # high-effort reasoning turns stream well past 10 minutes) plus a stall
+    # bound that fails a silent stream fast instead of waiting out the
+    # backstop. Both are read per request, so live reload picks them up.
+    request_timeout_seconds: int = 3600
+    stream_stall_timeout_seconds: int = 180
 
     @field_validator("reasoning_effort", mode="before")
     @classmethod
@@ -315,6 +321,21 @@ class OpenAICodexConfig(BaseModel):
             )
             return "low"
         return v
+
+    @field_validator("request_timeout_seconds")
+    @classmethod
+    def _request_timeout_bounds(cls, v):
+        if not 60 <= v <= 86400:
+            raise ValueError("request_timeout_seconds must be between 60 and 86400")
+        return v
+
+    @field_validator("stream_stall_timeout_seconds")
+    @classmethod
+    def _stream_stall_timeout_bounds(cls, v):
+        if not 10 <= v <= 3600:
+            raise ValueError("stream_stall_timeout_seconds must be between 10 and 3600")
+        return v
+
     retry: RetryConfig = RetryConfig()
     connection_pool: ConnectionPoolConfig = ConnectionPoolConfig()
     auxiliary: AuxiliaryLLMConfig = AuxiliaryLLMConfig()

--- a/src/discord/llm_gateway.py
+++ b/src/discord/llm_gateway.py
@@ -131,6 +131,15 @@ class LLMGateway:
                 self.codex_client.model = config.openai_codex.model
                 self.codex_client.max_tokens = config.openai_codex.max_tokens
                 self.codex_client.reasoning_effort = config.openai_codex.reasoning_effort
+                # Per-request transport values apply live; pool sizing is
+                # session-construction state and needs a client rebuild.
+                self.codex_client.request_timeout = config.openai_codex.request_timeout_seconds
+                self.codex_client.stream_stall_timeout = (
+                    config.openai_codex.stream_stall_timeout_seconds
+                )
+                self.codex_client.max_retries = config.openai_codex.retry.max_retries
+                self.codex_client.retry_base_delay = config.openai_codex.retry.base_delay
+                self.codex_client.retry_max_delay = config.openai_codex.retry.max_delay
                 return {"configured": True, "reloaded": True, "accounts": count}
 
         auth = CodexAuthPool(config.openai_codex.credentials_path)
@@ -142,6 +151,13 @@ class LLMGateway:
             model=config.openai_codex.model,
             max_tokens=config.openai_codex.max_tokens,
             reasoning_effort=config.openai_codex.reasoning_effort,
+            max_retries=config.openai_codex.retry.max_retries,
+            retry_base_delay=config.openai_codex.retry.base_delay,
+            retry_max_delay=config.openai_codex.retry.max_delay,
+            pool_max_connections=config.openai_codex.connection_pool.max_connections,
+            pool_keepalive_timeout=config.openai_codex.connection_pool.keepalive_timeout,
+            request_timeout=config.openai_codex.request_timeout_seconds,
+            stream_stall_timeout=config.openai_codex.stream_stall_timeout_seconds,
         )
         self.wire_callbacks()
         log.info("Codex client created via live reload (model: %s)", config.openai_codex.model)

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -286,6 +286,13 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
                 model=config.openai_codex.model,
                 max_tokens=config.openai_codex.max_tokens,
                 reasoning_effort=config.openai_codex.reasoning_effort,
+                max_retries=config.openai_codex.retry.max_retries,
+                retry_base_delay=config.openai_codex.retry.base_delay,
+                retry_max_delay=config.openai_codex.retry.max_delay,
+                pool_max_connections=config.openai_codex.connection_pool.max_connections,
+                pool_keepalive_timeout=config.openai_codex.connection_pool.keepalive_timeout,
+                request_timeout=config.openai_codex.request_timeout_seconds,
+                stream_stall_timeout=config.openai_codex.stream_stall_timeout_seconds,
             )
             log.info("Codex backend enabled (model: %s)", config.openai_codex.model)
         else:
@@ -424,6 +431,13 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
                     auth=aux_auth,
                     model=_aux.model,
                     max_tokens=_aux.max_tokens,
+                    max_retries=config.openai_codex.retry.max_retries,
+                    retry_base_delay=config.openai_codex.retry.base_delay,
+                    retry_max_delay=config.openai_codex.retry.max_delay,
+                    pool_max_connections=config.openai_codex.connection_pool.max_connections,
+                    pool_keepalive_timeout=config.openai_codex.connection_pool.keepalive_timeout,
+                    request_timeout=config.openai_codex.request_timeout_seconds,
+                    stream_stall_timeout=config.openai_codex.stream_stall_timeout_seconds,
                 )
                 auxiliary_llm_client = AuxiliaryLLMClient(
                     aux_client=aux_client,

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -499,7 +499,12 @@ class CodexChatClient:
         last_error = None
         token, account_id, acct_idx = await self._acquire_auth()
 
-        for attempt in range(self.max_retries):
+        # max_retries counts total attempts here (historical semantics: 3 ⇒
+        # three tries); clamp so a configured 0 means "one attempt, no
+        # retries" — the sibling providers' meaning — instead of "make no
+        # request at all", which would silently suppress every Codex call
+        # now that the retry config is actually plumbed.
+        for attempt in range(max(1, self.max_retries)):
             try:
                 async with session.post(
                     CODEX_API_URL,

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -16,6 +16,18 @@ log = get_logger("codex")
 
 CODEX_API_URL = "https://chatgpt.com/backend-api/codex/responses"
 
+# Streaming transport timeouts (config-overridable via the ctor).
+# request_timeout is a generous whole-request backstop — high-effort
+# reasoning turns legitimately stream past the old 600s total cap, which
+# killed healthy generations at exactly 10 minutes and burned a retry
+# re-generating them from scratch. stream_stall_timeout instead bounds
+# silence between socket reads: a healthy SSE stream delivers events
+# continuously, so a long gap means a dead connection that should fail
+# fast into the retry engine rather than waiting out the backstop.
+DEFAULT_REQUEST_TIMEOUT = 3600
+DEFAULT_STREAM_STALL_TIMEOUT = 180
+CONNECT_TIMEOUT = 30
+
 
 class CodexStreamError(RuntimeError):
     """The SSE stream reported a terminal failure event (response.failed / error)."""
@@ -35,6 +47,8 @@ class CodexChatClient:
         retry_max_delay: float = DEFAULT_MAX_DELAY,
         pool_max_connections: int = 10,
         pool_keepalive_timeout: int = 30,
+        request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+        stream_stall_timeout: int = DEFAULT_STREAM_STALL_TIMEOUT,
     ) -> None:
         self.auth = auth
         self.model = model
@@ -47,6 +61,8 @@ class CodexChatClient:
         self.retry_max_delay = retry_max_delay
         self.pool_max_connections = pool_max_connections
         self.pool_keepalive_timeout = pool_keepalive_timeout
+        self.request_timeout = request_timeout
+        self.stream_stall_timeout = stream_stall_timeout
         self.breaker = CircuitBreaker("codex_api")
         self._session: aiohttp.ClientSession | None = None
         self._total_requests: int = 0
@@ -489,7 +505,11 @@ class CodexChatClient:
                     CODEX_API_URL,
                     headers=self._auth_headers(token, account_id),
                     json=body,
-                    timeout=aiohttp.ClientTimeout(total=600),
+                    timeout=aiohttp.ClientTimeout(
+                        total=self.request_timeout,
+                        sock_connect=CONNECT_TIMEOUT,
+                        sock_read=self.stream_stall_timeout,
+                    ),
                 ) as resp:
                     if resp.status == 200:
                         try:
@@ -604,9 +624,9 @@ class CodexChatClient:
                     raise RuntimeError(f"Codex API error ({resp.status}): {error_body[:500]}")
 
             except (TimeoutError, aiohttp.ClientError) as e:
-                # asyncio.TimeoutError: the 600s total timeout can fire
-                # mid-stream; it is not an aiohttp.ClientError and previously
-                # escaped both the retry loop and breaker bookkeeping.
+                # asyncio.TimeoutError: the total/sock_read timeouts can fire
+                # mid-stream; TimeoutError is not an aiohttp.ClientError and
+                # previously escaped both the retry loop and breaker bookkeeping.
                 self.breaker.record_failure()
                 last_error = str(e) or type(e).__name__
                 if attempt < self.max_retries - 1:

--- a/tests/test_codex_reliability.py
+++ b/tests/test_codex_reliability.py
@@ -584,3 +584,31 @@ async def test_generic_401_forces_refresh_and_retries_same_account(tmp_path, mon
     assert refreshed == ["stale-tok"]
     # Same account retried — no rotation, no rate-limit marking.
     assert pool._accounts[0].is_rate_limited() is False
+
+
+# ---------------------------------------------------------------------------
+# max_retries=0 semantics (PR #225 activation regression)
+# ---------------------------------------------------------------------------
+
+async def test_zero_max_retries_still_makes_one_attempt(monkeypatch):
+    """max_retries=0 must mean "one attempt, no retries" — never "make no
+    request at all". RetryConfig accepts 0 and was inert before it was
+    plumbed from config; an unclamped range(0) would silently suppress
+    every Codex call and fail with "after 0 retries: None"."""
+    client = _client(max_retries=0)
+    session = FakeSession([FakeResp(200, sse_lines=TEXT_OK_SSE)])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    text = await client._stream_request({"model": "m"})
+    assert text == "hello"
+    assert session.calls == 1
+
+
+async def test_zero_max_retries_failure_raises_without_retry(monkeypatch):
+    client = _client(max_retries=0)
+    session = FakeSession([TimeoutError()])
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        await client._stream_request({"model": "m"})
+    assert session.calls == 1

--- a/tests/test_config_schema_validators.py
+++ b/tests/test_config_schema_validators.py
@@ -152,3 +152,33 @@ class TestCodexReasoningEffort:
         from src.config.schema import OpenAICodexConfig
         with _pytest.raises(pydantic.ValidationError):
             OpenAICodexConfig(reasoning_effort="banana")
+
+
+class TestCodexTransportTimeouts:
+    def test_defaults(self):
+        from src.config.schema import OpenAICodexConfig
+        cfg = OpenAICodexConfig()
+        assert cfg.request_timeout_seconds == 3600
+        assert cfg.stream_stall_timeout_seconds == 180
+
+    def test_request_timeout_bounds(self):
+        from src.config.schema import OpenAICodexConfig
+        with pytest.raises(ValidationError):
+            OpenAICodexConfig(request_timeout_seconds=59)
+        with pytest.raises(ValidationError):
+            OpenAICodexConfig(request_timeout_seconds=86401)
+        assert OpenAICodexConfig(request_timeout_seconds=60).request_timeout_seconds == 60
+        assert (
+            OpenAICodexConfig(request_timeout_seconds=86400).request_timeout_seconds == 86400
+        )
+
+    def test_stream_stall_timeout_bounds(self):
+        from src.config.schema import OpenAICodexConfig
+        with pytest.raises(ValidationError):
+            OpenAICodexConfig(stream_stall_timeout_seconds=9)
+        with pytest.raises(ValidationError):
+            OpenAICodexConfig(stream_stall_timeout_seconds=3601)
+        assert (
+            OpenAICodexConfig(stream_stall_timeout_seconds=10).stream_stall_timeout_seconds
+            == 10
+        )

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -23,7 +23,13 @@ def _cfg(active="codex", codex_enabled=True, ollama_enabled=False,
         llm_provider=SimpleNamespace(active_provider=active),
         openai_codex=SimpleNamespace(enabled=codex_enabled, credentials_path="/creds",
                                      model="gpt-5.5", max_tokens=8000,
-                                     reasoning_effort="medium"),
+                                     reasoning_effort="medium",
+                                     request_timeout_seconds=3600,
+                                     stream_stall_timeout_seconds=180,
+                                     retry=SimpleNamespace(max_retries=3, base_delay=1.0,
+                                                           max_delay=30.0),
+                                     connection_pool=SimpleNamespace(max_connections=10,
+                                                                     keepalive_timeout=30)),
         ollama=SimpleNamespace(enabled=ollama_enabled, base_url="http://localhost:11434",
                                model="qwen", max_tokens=4096, timeout=300, api_key=""),
         kimi=SimpleNamespace(enabled=kimi_enabled, api_key=kimi_key,
@@ -114,6 +120,59 @@ class TestReloadCodex:
         assert client.model == "gpt-5.6-terra"
         assert client.max_tokens == 4096
         assert client.reasoning_effort == "xhigh"
+
+    async def test_existing_client_gets_transport_values_from_config(self):
+        """Companion to the model/max_tokens reload fix: the per-request
+        transport values (timeouts, retry policy) must land on the LIVE
+        client too, so a config change applies without a restart."""
+        from src.discord.llm_gateway import CodexAuthPool
+        pool = MagicMock(spec=CodexAuthPool)
+        pool.reload_async = AsyncMock(return_value=3)
+        client = SimpleNamespace(auth=pool, model="gpt-5.5", max_tokens=8000,
+                                 reasoning_effort="medium",
+                                 request_timeout=3600, stream_stall_timeout=180,
+                                 max_retries=3, retry_base_delay=1.0,
+                                 retry_max_delay=30.0)
+        cfg = _cfg()
+        cfg.openai_codex.request_timeout_seconds = 7200
+        cfg.openai_codex.stream_stall_timeout_seconds = 90
+        cfg.openai_codex.retry = SimpleNamespace(max_retries=5, base_delay=0.5,
+                                                 max_delay=10.0)
+        gw = _gw(cfg, codex=client)
+        r = await gw.reload_codex_inner()
+        assert r["reloaded"] is True
+        assert client.request_timeout == 7200
+        assert client.stream_stall_timeout == 90
+        assert client.max_retries == 5
+        assert client.retry_base_delay == 0.5
+        assert client.retry_max_delay == 10.0
+
+    async def test_created_client_receives_transport_kwargs(self):
+        """A freshly created client must be constructed from the config's
+        transport values — the retry/connection_pool config sections were
+        previously documented but never plumbed (ctor defaults happened to
+        match, so the gap was invisible)."""
+        pool = MagicMock()
+        pool.is_configured.return_value = True
+        pool._accounts = [1]
+        captured = {}
+
+        def _fake_client(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("src.discord.llm_gateway.CodexAuthPool", return_value=pool), \
+             patch("src.discord.llm_gateway.CodexChatClient", side_effect=_fake_client):
+            gw = _gw(codex=None)
+            r = await gw.reload_codex_inner()
+        assert r["created"] is True
+        assert captured["request_timeout"] == 3600
+        assert captured["stream_stall_timeout"] == 180
+        assert captured["max_retries"] == 3
+        assert captured["retry_base_delay"] == 1.0
+        assert captured["retry_max_delay"] == 30.0
+        assert captured["pool_max_connections"] == 10
+        assert captured["pool_keepalive_timeout"] == 30
 
     async def test_creates_new_client(self):
         pool = MagicMock()

--- a/tests/test_openai_codex_client.py
+++ b/tests/test_openai_codex_client.py
@@ -7,6 +7,7 @@ adapter branches. Network streaming is exercised separately where cheap.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -410,3 +411,49 @@ class TestReasoningEffortBody:
                   "input_schema": {"type": "object", "properties": {}}}]
         await client.chat_with_tools([{"role": "user", "content": "hi"}], "sys", tools)
         assert "reasoning" not in captured
+
+
+class TestTransportTimeouts:
+    def test_ctor_defaults(self):
+        client = _client()
+        assert client.request_timeout == 3600
+        assert client.stream_stall_timeout == 180
+
+    async def test_post_receives_configured_timeouts(self, monkeypatch):
+        """The per-request ClientTimeout must be built from the configured
+        values with NO fixed total cap: the old hardcoded total=600 killed
+        healthy long reasoning streams at exactly 10 minutes, while a dead
+        stream waited out the full window instead of failing on the first
+        silent stretch (sock_read)."""
+        client = CodexChatClient(auth=_BareAuth(), model="m", max_tokens=10,
+                                 request_timeout=1234, stream_stall_timeout=56)
+        recorded = {}
+
+        class _CM:
+            async def __aenter__(self):
+                return SimpleNamespace(status=200)
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _Sess:
+            closed = False
+
+            def post(self, url, **kwargs):
+                recorded.update(kwargs)
+                return _CM()
+
+        async def _fake_session():
+            return _Sess()
+
+        monkeypatch.setattr(client, "_get_session", _fake_session)
+
+        async def _reader(resp):
+            return "ok"
+
+        result = await client._send_with_retries({}, _reader, lambda r: not r)
+        assert result == "ok"
+        t = recorded["timeout"]
+        assert t.total == 1234
+        assert t.sock_read == 56
+        assert t.sock_connect == 30


### PR DESCRIPTION
## Problem

`_send_with_retries` posts every Codex request with a hardcoded `ClientTimeout(total=600)`. Long high-effort reasoning turns (gpt-5.6 @ xhigh doing a large review) legitimately stream past 10 minutes, so the client kills a **healthy** stream at exactly 600s, records a breaker failure, and re-generates the whole turn from scratch — up to 3× ≈ 30 wasted minutes, then a user-visible "LLM API error". Journal forensics show attempt pairs spaced exactly 600s+backoff apart going back weeks (the biggest gpt-5.5 review turns already brushed this ceiling and survived on retry luck); at 5.6@xhigh it became a hard wall. Three consecutive deaths also open the circuit breaker.

The total cap is simultaneously **slow at its actual job**: a stream that stops delivering bytes waits out the remaining window (up to 10 min) instead of failing on the first silent stretch.

Separately: the `retry:` and `connection_pool:` config sections are documented in the tracked template and docs but were **never plumbed into the client** — every construction site passed only auth/model/max_tokens/reasoning_effort, so those knobs silently did nothing (the ctor defaults happen to match the documented values, which is why it was invisible).

## Fix

- Per-request timeout is now `ClientTimeout(total=request_timeout, sock_connect=30, sock_read=stream_stall_timeout)`:
  - **`request_timeout_seconds`** (default 3600, bounds 60–86400): generous whole-request backstop rather than a working limit.
  - **`stream_stall_timeout_seconds`** (default 180, bounds 10–3600): max silence between socket reads — a healthy SSE stream delivers events continuously, so a long gap means a dead connection that should fail fast into the existing retry engine.
- Both fields on `OpenAICodexConfig` with bounds validators; documented in the tracked `config.yml` template and `docs/configuration.md`.
- All three `CodexChatClient` construction sites (wiring main, wiring aux, gateway reload-create) now plumb the new timeouts **and** the existing `retry`/`connection_pool` values — the documented sections are real now. Zero behavior change at defaults.
- The gateway existing-client reload branch applies the per-request transport values (timeouts + retry policy) alongside model/max_tokens/reasoning_effort (same pattern as #219/#220); pool sizing is session-construction state and still requires a client rebuild (commented as such).

## Semantics changes to be aware of

- A turn that previously died at 600s now streams to completion (backstop 3600).
- A genuinely dead stream now fails in ≤180s instead of waiting out up to 600s.
- Time-to-first-byte is now also bounded by `sock_read` (180s) rather than sharing the 600s total — the SSE response opens within seconds in practice, so this is comfortably generous.

## Tests (+7 — suite 7,264 passed / 4 skipped; ruff 0; mypy 0)

- ClientTimeout shape pin: `post()` receives total/sock_read/sock_connect from ctor values.
- Ctor defaults (3600/180).
- Schema defaults + bounds validation for both fields.
- Gateway reload: existing client receives new transport values live.
- Gateway create: constructed client receives all plumbed transport kwargs (regression pin on the previously-inert plumbing).