### PR TITLE
feat(image): native OpenAI image generation, toggleable with ComfyUI

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -251,6 +251,22 @@ comfyui:
   enabled: true
   url: http://localhost:8188
 
+# Image generation backend selection.
+#   auto    (default): follow the active chat provider — on 'codex' use native
+#            OpenAI (ComfyUI is the pre-generation fallback); on any other
+#            provider use ComfyUI only. If neither is available the tool hides.
+#   openai : native OpenAI only (rides the current Codex auth; Codex-provider only).
+#   comfyui: ComfyUI only.
+image:
+  backend: auto
+  openai:
+    enabled: true          # kill switch for the native wire implementation
+    outer_model: gpt-5.5   # Responses model hosting the image tool (pinned, not the chat model)
+    image_model: gpt-image-2
+    # Only sizes probed against this private endpoint — widen after verifying each.
+    allowed_sizes: ["1024x1024"]
+    default_size: "1024x1024"
+
 # Web UI and API — all web configuration lives here (not in .env)
 web:
   enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,47 @@ Leave `cdp_url` empty to launch a local headless Chromium. Set to `ws://host:por
 
 Run `playwright install chromium` after installation.
 
+## Image Generation
+
+```yaml
+comfyui:
+  enabled: true
+  url: http://localhost:8188
+
+image:
+  backend: auto            # auto | openai | comfyui
+  openai:
+    enabled: true          # kill switch for the native wire implementation
+    outer_model: gpt-5.5   # Responses model hosting the image tool (pinned)
+    image_model: gpt-image-2
+    allowed_sizes: ["1024x1024"]
+    default_size: "1024x1024"
+```
+
+The `generate_image` tool can target two backends:
+
+- **Native OpenAI** — generates via the `image_generation` tool on the Codex
+  ChatGPT OAuth backend, riding the **same account Odin uses for chat** (no
+  separate auth; subscription-quota-backed, so it draws on that account's usage
+  limit). Available only while the active provider is `codex`.
+- **ComfyUI** — the local Stable-Diffusion backend (`comfyui.enabled`), which
+  also supports `negative`, `width`/`height`, and checkpoint `model`.
+
+`backend` selects between them:
+
+- `auto` (default) follows the active chat provider: on `codex`, native OpenAI
+  is used with ComfyUI as a pre-generation fallback; on any other provider,
+  ComfyUI only. A `negative`/`width`/`height`/`model` argument routes the
+  request to ComfyUI. If neither backend is available (e.g. Kimi with no
+  ComfyUI) the tool is hidden from the registry.
+- `openai` forces native OpenAI (ComfyUI-only arguments are rejected).
+- `comfyui` forces ComfyUI.
+
+`outer_model` is pinned here rather than following your chat model, so changing
+the chat model (Sol/Terra/…) never alters image generation. Only sizes listed in
+`allowed_sizes` are accepted — widen it only after verifying a size works against
+this private endpoint.
+
 ## Web Management UI
 
 ```yaml

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -596,6 +596,46 @@ class ComfyUIConfig(BaseModel):
     default_checkpoint: str = ""
 
 
+class ImageOpenAIConfig(BaseModel):
+    """Native OpenAI image generation over the Codex ChatGPT OAuth backend.
+
+    Rides the SAME CodexAuthPool / current account Odin uses for chat — no
+    separate auth, no per-token API billing (subscription-quota-backed). The
+    outer model is pinned here rather than inherited from the chat model so a
+    Sol/Terra/UI change can't silently alter image generation. Both models are
+    config-only allowlisted, never arbitrary strings from the tool call.
+    """
+
+    enabled: bool = True  # kill switch for the native wire implementation
+    outer_model: str = "gpt-5.5"  # Responses model that hosts the image tool
+    image_model: str = "gpt-image-2"  # the image_generation tool's model
+    # Only sizes actually probed against THIS private endpoint are allowed;
+    # widen after verifying each value (the Codex endpoint != public Images API).
+    allowed_sizes: list[str] = Field(default_factory=lambda: ["1024x1024"])
+    default_size: str = "1024x1024"
+    # Image-specific deadline (separate from chat). Progress events keep the
+    # read timer alive but must not defeat the total.
+    request_timeout_seconds: int = 180
+    connect_timeout_seconds: int = 30
+    stream_stall_timeout_seconds: int = 120
+    max_image_bytes: int = 16 * 1024 * 1024  # decoded-size safety cap
+
+
+class ImageConfig(BaseModel):
+    """Image-generation backend selection.
+
+    ``auto`` follows the active chat provider: on ``codex`` native OpenAI is the
+    default (ComfyUI is the toggle/pre-generation fallback), on any other
+    provider ComfyUI is the only option. ``openai`` / ``comfyui`` force one
+    backend. Availability is structural (selected backend configured), so a
+    cooling-down account or an offline ComfyUI does not make the tool appear or
+    disappear — only the provider/config selection does.
+    """
+
+    backend: Literal["auto", "openai", "comfyui"] = "auto"
+    openai: ImageOpenAIConfig = ImageOpenAIConfig()
+
+
 class ReactionTriggerConfig(BaseModel):
     enabled: bool = False
     channel_ids: list[str] = Field(default_factory=list)  # Empty = all channels
@@ -758,6 +798,7 @@ class Config(BaseModel):
     browser: BrowserConfig = BrowserConfig()
     permissions: PermissionsConfig = PermissionsConfig()
     comfyui: ComfyUIConfig = ComfyUIConfig()
+    image: ImageConfig = ImageConfig()
     web: WebConfig = WebConfig()
     attachments: AttachmentsConfig = AttachmentsConfig()
     personality: PersonalityConfig = PersonalityConfig()

--- a/src/discord/llm_gateway.py
+++ b/src/discord/llm_gateway.py
@@ -60,6 +60,10 @@ class LLMGateway:
         self.provider_lock = asyncio.Lock()
         self.inflight_requests = 0
         self.switching = False
+        # Called after a provider switch settles — wiring points it at the tool
+        # catalog's invalidate() so provider-gated tools (e.g. native image gen,
+        # available only on Codex) reappear/disappear on the next request.
+        self.on_provider_switch: Callable[[], None] | None = None
 
     # ---------- provider resolution ----------------------------------------
 
@@ -266,6 +270,8 @@ class LLMGateway:
 
                 self.get_config().llm_provider.active_provider = provider
                 self.wire_callbacks()
+                if self.on_provider_switch is not None:
+                    self.on_provider_switch()
             finally:
                 self.switching = False
 

--- a/src/discord/native_tools/media.py
+++ b/src/discord/native_tools/media.py
@@ -22,10 +22,18 @@ log = get_logger("discord")
 
 
 class MediaTools:
-    def __init__(self, *, get_config: Callable, browser_manager, tool_executor) -> None:
+    def __init__(
+        self,
+        *,
+        get_config: Callable,
+        browser_manager,
+        tool_executor,
+        image_selector=None,
+    ) -> None:
         self.get_config = get_config
         self.browser_manager = browser_manager
         self.tool_executor = tool_executor
+        self.image_selector = image_selector
 
     @staticmethod
     def _detect_image_type(data: bytes) -> str | None:
@@ -255,43 +263,40 @@ class MediaTools:
         }
 
     async def _handle_generate_image(self, message, inp: dict) -> str:
-        """Generate an image via ComfyUI and post as Discord attachment."""
-        config = self.get_config()
-        if not config.comfyui.enabled:
-            return "Image generation is disabled. Enable ComfyUI in config to use this tool."
+        """Generate an image via the selected backend and post as a Discord
+        attachment. The backend returns bytes; this tool layer owns Discord."""
+        from ...tools.image import ImageGenError
+
+        if self.image_selector is None:
+            return "Image generation is not available."
 
         prompt_text = inp.get("prompt", "")
         if not prompt_text:
             return "A 'prompt' describing the image is required."
 
-        negative = inp.get("negative", "")
-        width = inp.get("width", 1024)
-        height = inp.get("height", 1024)
-        model = inp.get("model", "")
-
-        # Clamp dimensions to reasonable range
-        width = max(64, min(2048, width))
-        height = max(64, min(2048, height))
-
-        from ...tools.comfyui import ComfyUIClient
-
-        client = ComfyUIClient(
-            config.comfyui.url, default_checkpoint=config.comfyui.default_checkpoint
-        )
-        image_bytes = await client.generate(
-            prompt=prompt_text,
-            negative=negative,
-            width=width,
-            height=height,
-            model=model,
-        )
-
-        if not image_bytes:
-            return "Image generation failed. ComfyUI may be unavailable or the request timed out."
+        try:
+            result = await self.image_selector.generate(
+                prompt=prompt_text,
+                size=inp.get("size"),
+                negative=inp.get("negative", ""),
+                model=inp.get("model", ""),
+                width=inp.get("width"),
+                height=inp.get("height"),
+            )
+        except ImageGenError as e:
+            # These messages are constructed to carry no payload/account data.
+            return f"Image generation failed: {e}"
+        except Exception:
+            # Never surface a raw provider payload; log without the body.
+            log.warning("image generation raised unexpectedly", exc_info=True)
+            return "Image generation failed unexpectedly."
 
         try:
-            file = discord.File(io.BytesIO(image_bytes), filename="generated.png")
+            file = discord.File(io.BytesIO(result.data), filename="generated.png")
             await message.channel.send(file=file)
-            return f"Image generated and posted ({len(image_bytes) / 1024:.1f} KB)."
+            return (
+                f"Image generated via {result.backend} ({result.image_model}, "
+                f"{result.width}x{result.height}, {len(result.data) / 1024:.1f} KB) and posted."
+            )
         except discord.HTTPException as e:
             return f"Failed to upload generated image to Discord: {e}"

--- a/src/discord/tool_catalog.py
+++ b/src/discord/tool_catalog.py
@@ -47,6 +47,13 @@ class ToolCatalog:
         issue_cfg = getattr(config, "issue_tracker", None)
         if not issue_cfg or not issue_cfg.enabled:
             builtin = [t for t in builtin if t["name"] != "issue_tracker"]
+        # generate_image: visible only when a backend is structurally available —
+        # native (Codex provider + creds) OR ComfyUI configured, per image.backend.
+        # So Kimi with no ComfyUI hides it entirely.
+        from ..tools.image.selector import image_tool_available
+
+        if not image_tool_available(config):
+            builtin = [t for t in builtin if t["name"] != "generate_image"]
         builtin_names = {t["name"] for t in builtin}
         skill_defs = [
             t for t in self.skill_manager.get_tool_definitions() if t["name"] not in builtin_names

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -618,24 +618,23 @@ def build_components(bot, services: BotServices) -> BotComponents:
         get_channel=bot.get_channel,
     )
     # Image-generation backends behind one selector. Native OpenAI rides the
-    # SAME CodexAuthPool the codex client uses (no separate auth); it's only
-    # built when Codex credentials exist. ComfyUI is always available as a
-    # backend object (its own config gates it at call time).
+    # SAME CodexAuthPool the codex client uses (no separate auth). It resolves
+    # that pool via the gateway at CALL time — a live Codex login/reload replaces
+    # the client, so a snapshot would run on stale/absent credentials. Always
+    # built; is_configured() reports false until a pool exists.
     from ..tools.image import (
         ComfyUIImageBackend,
         ImageBackendSelector,
         OpenAIImageBackend,
     )
 
-    _image_auth = getattr(services.codex_client, "auth", None)
-    _openai_image_backend = (
-        OpenAIImageBackend(auth=_image_auth, get_config=lambda: bot.config)
-        if _image_auth is not None
-        else None
+    openai_image_backend = OpenAIImageBackend(
+        get_auth=lambda: getattr(llm_gateway.codex_client, "auth", None),
+        get_config=lambda: bot.config,
     )
     image_selector = ImageBackendSelector(
         get_config=lambda: bot.config,
-        openai_backend=_openai_image_backend,
+        openai_backend=openai_image_backend,
         comfyui_backend=ComfyUIImageBackend(get_config=lambda: bot.config),
     )
 
@@ -939,6 +938,18 @@ async def shutdown_services(bot) -> None:
             await kimi.close()
         except Exception:
             log.exception("Error closing Kimi client")
+
+    # Close the native image backend's own HTTP session (separate transport
+    # from the codex chat client, so it isn't covered by codex.close()).
+    _components = getattr(bot, "components", None)
+    _media = getattr(_components, "media_tools", None)
+    _selector = getattr(_media, "image_selector", None)
+    _image_backend = getattr(_selector, "openai", None)
+    if _image_backend is not None:
+        try:
+            await _image_backend.close()
+        except Exception:
+            log.exception("Error closing image backend")
 
     # Shut down Playwright browser
     browser = getattr(bot, "browser_manager", None)

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -598,6 +598,9 @@ def build_components(bot, services: BotServices) -> BotComponents:
         get_config=lambda: bot.config,
         skill_manager=services.skill_manager,
     )
+    # A live provider switch must rebuild the tool registry so provider-gated
+    # tools (native image gen is Codex-only) reappear/disappear immediately.
+    llm_gateway.on_provider_switch = tool_catalog.invalidate
 
     # Domain handler bundles (P5b) — built BEFORE the dispatcher so they can
     # be its owners (RFC-002 P5).
@@ -614,10 +617,33 @@ def build_components(bot, services: BotServices) -> BotComponents:
         permissions=services.permissions,
         get_channel=bot.get_channel,
     )
+    # Image-generation backends behind one selector. Native OpenAI rides the
+    # SAME CodexAuthPool the codex client uses (no separate auth); it's only
+    # built when Codex credentials exist. ComfyUI is always available as a
+    # backend object (its own config gates it at call time).
+    from ..tools.image import (
+        ComfyUIImageBackend,
+        ImageBackendSelector,
+        OpenAIImageBackend,
+    )
+
+    _image_auth = getattr(services.codex_client, "auth", None)
+    _openai_image_backend = (
+        OpenAIImageBackend(auth=_image_auth, get_config=lambda: bot.config)
+        if _image_auth is not None
+        else None
+    )
+    image_selector = ImageBackendSelector(
+        get_config=lambda: bot.config,
+        openai_backend=_openai_image_backend,
+        comfyui_backend=ComfyUIImageBackend(get_config=lambda: bot.config),
+    )
+
     media_tools = MediaTools(
         get_config=lambda: bot.config,
         browser_manager=services.browser_manager,
         tool_executor=services.tool_executor,
+        image_selector=image_selector,
     )
 
     # One Discord-native dispatch table for both pipelines (RFC-001 P5a);

--- a/src/tools/defs/integrations_email.py
+++ b/src/tools/defs/integrations_email.py
@@ -143,12 +143,13 @@ TOOLS_SECTION: list[dict] = [
             "required": ["action"],
         },
     },
-    # --- Image generation (ComfyUI) ---
+    # --- Image generation (native OpenAI or ComfyUI, per config) ---
     {
         "name": "generate_image",
         "description": (
-            "Generates an image from a text prompt via ComfyUI and posts to Discord. "
-            "Requires ComfyUI enabled in config."
+            "Generates an image from a text prompt and posts it to Discord. "
+            "The backend is chosen by config (native OpenAI on the Codex provider, "
+            "or ComfyUI). Use 'prompt' and optionally 'size'."
         ),
         "input_schema": {
             "type": "object",
@@ -157,24 +158,28 @@ TOOLS_SECTION: list[dict] = [
                     "type": "string",
                     "description": "Text description of the image to generate",
                 },
+                "size": {
+                    "type": "string",
+                    "description": "Image size as WxH (e.g. '1024x1024'). Uses the "
+                    "configured default if omitted.",
+                },
                 "negative": {
                     "type": "string",
-                    "description": "Negative prompt — things to avoid (default: empty)",
+                    "description": "ComfyUI only — negative prompt. Ignored/rejected by the "
+                    "OpenAI backend; in 'auto' its presence selects ComfyUI.",
                 },
                 "width": {
                     "type": "integer",
-                    "description": "Image width in pixels (default 1024)",
+                    "description": "ComfyUI only — width in pixels (use 'size' for OpenAI).",
                 },
                 "height": {
                     "type": "integer",
-                    "description": "Image height in pixels (default 1024)",
+                    "description": "ComfyUI only — height in pixels (use 'size' for OpenAI).",
                 },
                 "model": {
                     "type": "string",
-                    "description": "Checkpoint/model name to use "
-                    "(e.g. 'realisticVisionV60B1_v60B1VAE.safetensors'). "
-                    "If omitted, uses the default. Query available models via run_command: "
-                    "curl -s http://localhost:8188/object_info/CheckpointLoaderSimple",
+                    "description": "ComfyUI only — checkpoint name. In 'auto' its presence "
+                    "selects ComfyUI. The OpenAI image model is set in config, not here.",
                 },
             },
             "required": ["prompt"],

--- a/src/tools/image/__init__.py
+++ b/src/tools/image/__init__.py
@@ -1,0 +1,38 @@
+"""Image-generation backends.
+
+A backend-neutral seam so the image tool can target either native OpenAI
+(over the Codex OAuth backend) or ComfyUI, selected by config + active
+provider. Backends return an :class:`ImageResult` and never touch Discord —
+the native tool layer owns attachment posting, keeping backends reusable from
+the Web/API surface.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    ImageBackend,
+    ImageBackendUnavailableError,
+    ImageGenError,
+    ImageQuotaError,
+    ImageRequestError,
+    ImageResult,
+    ImageTransportError,
+    png_dimensions,
+)
+from .comfyui_backend import ComfyUIImageBackend
+from .openai_backend import OpenAIImageBackend
+from .selector import ImageBackendSelector
+
+__all__ = [
+    "ImageBackend",
+    "ImageBackendSelector",
+    "ImageBackendUnavailableError",
+    "ImageGenError",
+    "ImageQuotaError",
+    "ImageRequestError",
+    "ImageResult",
+    "ImageTransportError",
+    "ComfyUIImageBackend",
+    "OpenAIImageBackend",
+    "png_dimensions",
+]

--- a/src/tools/image/base.py
+++ b/src/tools/image/base.py
@@ -1,0 +1,94 @@
+"""Backend-neutral image-generation contract."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def png_dimensions(data: bytes) -> tuple[int, int] | None:
+    """(width, height) from a PNG's IHDR, or None if not a valid PNG.
+
+    Also serves as the magic-byte check — the decoded bytes must actually be a
+    PNG before we ever attach or report dimensions.
+    """
+    if len(data) < 24 or data[:8] != _PNG_MAGIC or data[12:16] != b"IHDR":
+        return None
+    width = int.from_bytes(data[16:20], "big")
+    height = int.from_bytes(data[20:24], "big")
+    if width <= 0 or height <= 0:
+        return None
+    return width, height
+
+
+@dataclass
+class ImageResult:
+    """A generated image, ready for the tool layer to attach.
+
+    Carries only non-sensitive metadata — never account identifiers, tokens,
+    or raw provider payloads.
+    """
+
+    data: bytes
+    mime: str
+    width: int
+    height: int
+    backend: str  # "openai" | "comfyui"
+    image_model: str
+
+
+class ImageGenError(Exception):
+    """Base image-generation failure.
+
+    ``pre_generation`` is True only when generation is known NOT to have started
+    (no accepted response / no generation event yet), so failing over to another
+    account or falling back to ComfyUI cannot duplicate work or quota. Anything
+    that happens after a 2xx or the first generation event is post-generation
+    and must NOT be retried or fallen back.
+    """
+
+    pre_generation: bool = False
+
+
+class ImageBackendUnavailableError(ImageGenError):
+    """The backend is not configured/usable at all (structural)."""
+
+    pre_generation = True
+
+
+class ImageQuotaError(ImageGenError):
+    """usage_limit_reached / account disabled / pool exhausted — account-scoped,
+    pre-generation, eligible for failover and ComfyUI fallback."""
+
+    pre_generation = True
+
+
+class ImageTransportError(ImageGenError):
+    """5xx / connection / protocol failure. Pre-generation only when it happened
+    before an accepted response; a mid-stream break after 2xx is post-generation
+    (constructed with ``pre_generation=False``)."""
+
+    def __init__(self, message: str, *, pre_generation: bool = True) -> None:
+        super().__init__(message)
+        self.pre_generation = pre_generation
+
+
+class ImageRequestError(ImageGenError):
+    """Content-policy refusal, invalid parameters, or malformed image output.
+    A property of the request/response itself — never turned into a ComfyUI
+    fallback, which would silently bypass the selected service's semantics."""
+
+    pre_generation = False
+
+
+class ImageBackend(ABC):
+    """A single image-generation backend."""
+
+    name: str
+
+    @abstractmethod
+    async def generate(self, *, prompt: str, size: str | None = None, **opts) -> ImageResult:
+        """Generate one image or raise an :class:`ImageGenError` subclass."""
+        raise NotImplementedError

--- a/src/tools/image/comfyui_backend.py
+++ b/src/tools/image/comfyui_backend.py
@@ -1,0 +1,82 @@
+"""ComfyUI image backend — wraps the existing ComfyUIClient behind the seam."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ...odin_log import get_logger
+from ..comfyui import ComfyUIClient
+from .base import (
+    ImageBackend,
+    ImageBackendUnavailableError,
+    ImageResult,
+    ImageTransportError,
+    png_dimensions,
+)
+
+log = get_logger("image.comfyui")
+
+
+def _parse_size(size: str | None, width: int | None, height: int | None) -> tuple[int, int]:
+    """Resolve a WxH pair from an explicit size string or width/height args.
+
+    Explicit width/height (a ComfyUI-only concept) win; otherwise parse the
+    backend-neutral ``size`` string; default 1024x1024. Clamped to a sane range.
+    """
+    w, h = 1024, 1024
+    if size and "x" in size:
+        try:
+            sw, sh = size.lower().split("x", 1)
+            w, h = int(sw), int(sh)
+        except ValueError:
+            pass
+    if width:
+        w = int(width)
+    if height:
+        h = int(height)
+    w = max(64, min(2048, w))
+    h = max(64, min(2048, h))
+    return w, h
+
+
+class ComfyUIImageBackend(ImageBackend):
+    name = "comfyui"
+
+    def __init__(self, *, get_config: Callable) -> None:
+        self.get_config = get_config
+
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        size: str | None = None,
+        negative: str = "",
+        model: str = "",
+        width: int | None = None,
+        height: int | None = None,
+        **_ignored,
+    ) -> ImageResult:
+        config = self.get_config()
+        if not config.comfyui.enabled:
+            raise ImageBackendUnavailableError("ComfyUI is not enabled")
+
+        w, h = _parse_size(size, width, height)
+        client = ComfyUIClient(
+            config.comfyui.url, default_checkpoint=config.comfyui.default_checkpoint
+        )
+        image_bytes = await client.generate(
+            prompt=prompt, negative=negative, width=w, height=h, model=model
+        )
+        if not image_bytes:
+            raise ImageTransportError("ComfyUI generation failed (unavailable or timed out)")
+
+        dims = png_dimensions(image_bytes)
+        aw, ah = dims if dims else (w, h)
+        return ImageResult(
+            data=image_bytes,
+            mime="image/png",
+            width=aw,
+            height=ah,
+            backend="comfyui",
+            image_model=model or config.comfyui.default_checkpoint or "default",
+        )

--- a/src/tools/image/openai_backend.py
+++ b/src/tools/image/openai_backend.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 
 import aiohttp
 
-from ...llm.circuit_breaker import CircuitBreaker
+from ...llm.circuit_breaker import CircuitBreaker, CircuitOpenError
 from ...odin_log import get_logger
 from .base import (
     ImageBackend,
@@ -44,9 +44,11 @@ _INSTRUCTIONS = "You are an image generation assistant. Produce exactly the requ
 class OpenAIImageBackend(ImageBackend):
     name = "openai"
 
-    def __init__(self, *, auth, get_config: Callable) -> None:
-        # `auth` is the shared CodexAuthPool (may be None if Codex isn't set up).
-        self._auth = auth
+    def __init__(self, *, get_auth: Callable, get_config: Callable) -> None:
+        # get_auth resolves the LIVE shared CodexAuthPool at CALL time (may
+        # return None). A live Codex login/reload REPLACES the pool, so we must
+        # never snapshot it here or the backend runs on stale/absent credentials.
+        self._get_auth = get_auth
         self.get_config = get_config
         self.breaker = CircuitBreaker("codex_image")
         self._session: aiohttp.ClientSession | None = None
@@ -82,7 +84,8 @@ class OpenAIImageBackend(ImageBackend):
         }
 
     def is_configured(self) -> bool:
-        return self._auth is not None and self._auth.is_configured()
+        pool = self._get_auth()
+        return pool is not None and pool.is_configured()
 
     async def generate(
         self, *, prompt: str, size: str | None = None, **_ignored
@@ -91,7 +94,8 @@ class OpenAIImageBackend(ImageBackend):
         icfg = cfg.image
         if not icfg.openai.enabled:
             raise ImageBackendUnavailableError("Native OpenAI image backend is disabled")
-        if not self.is_configured():
+        pool = self._get_auth()
+        if pool is None or not pool.is_configured():
             raise ImageBackendUnavailableError("No Codex credentials for native image generation")
 
         size = size or icfg.openai.default_size
@@ -100,7 +104,12 @@ class OpenAIImageBackend(ImageBackend):
                 f"Unsupported size {size!r}. Allowed: {', '.join(icfg.openai.allowed_sizes)}"
             )
 
-        self.breaker.check()
+        # An open image breaker is pre-generation — let auto fall back to ComfyUI.
+        try:
+            self.breaker.check()
+        except CircuitOpenError as e:
+            raise ImageTransportError("image endpoint breaker open", pre_generation=True) from e
+
         body = self._body(icfg, prompt, size)
         session = await self._get_session()
         timeout = aiohttp.ClientTimeout(
@@ -111,10 +120,16 @@ class OpenAIImageBackend(ImageBackend):
 
         # Failover across accounts ONLY on pre-generation failures. The loop is
         # bounded by the account count; once a POST returns 200 we commit.
-        attempts = max(1, self._auth.account_count())
+        attempts = max(1, pool.account_count)
         last_err: ImageQuotaError | ImageTransportError | None = None
         for _attempt in range(attempts):
-            token, account_id, idx = await self._auth.acquire()
+            try:
+                token, account_id, idx = await pool.acquire()
+            except RuntimeError:
+                # Pool exhausted / no healthy account — pre-generation, so auto
+                # can fall back to ComfyUI. Never surface the raw pool error.
+                last_err = ImageQuotaError("no healthy Codex account for image generation")
+                break
             try:
                 async with session.post(
                     CODEX_IMAGE_URL,
@@ -130,20 +145,21 @@ class OpenAIImageBackend(ImageBackend):
                         return result
 
                     if resp.status == 429:
-                        await self._auth.mark_limited(idx)
+                        await pool.mark_limited(idx)
                         last_err = ImageQuotaError("usage limit reached (HTTP 429)")
                         continue
                     if resp.status == 401:
-                        await self._auth.mark_auth_failed(idx)
+                        await pool.mark_auth_failed(idx)
                         last_err = ImageQuotaError("account authentication failed (HTTP 401)")
                         continue
                     if resp.status in (500, 502, 503, 504):
+                        # Endpoint health — this one counts against the breaker.
                         self.breaker.record_failure()
                         last_err = ImageTransportError(f"image endpoint HTTP {resp.status}")
                         continue
-                    # Other 4xx: request-level (bad params / content policy).
-                    # Do NOT fail over or fall back — the request is the problem.
-                    self.breaker.record_failure()
+                    # Other 4xx: request-level (bad params / content policy). Do
+                    # NOT fail over, fall back, OR poison the shared breaker — a
+                    # bad prompt must not disable image generation for everyone.
                     raise ImageRequestError(f"image request rejected (HTTP {resp.status})")
             except (TimeoutError, aiohttp.ClientError) as e:
                 # Pre-response transport failure (connection/handshake) — a
@@ -165,6 +181,10 @@ class OpenAIImageBackend(ImageBackend):
         """
         max_bytes = icfg.openai.max_image_bytes
         max_b64 = max_bytes * 4 // 3 + 8
+        # A single legitimate line is one base64 image plus a little JSON/SSE
+        # framing; anything past that with no newline is an unterminated frame
+        # and must be rejected BEFORE it is fully buffered into memory.
+        max_line = max_b64 + 65536
         final_b64: str | None = None
         buf = b""
         try:
@@ -209,6 +229,10 @@ class OpenAIImageBackend(ImageBackend):
                         raise ImageRequestError("image generation failed upstream")
                     if final_b64 is not None and len(final_b64) > max_b64:
                         raise ImageRequestError("generated image exceeds the configured size cap")
+                # Complete lines are drained above; a leftover past one max line
+                # is an unterminated frame — reject before buffering more.
+                if len(buf) > max_line:
+                    raise ImageRequestError("unterminated oversized SSE frame")
         except (TimeoutError, aiohttp.ClientError) as e:
             # Mid-stream break AFTER a 200 — post-generation, no failover.
             self.breaker.record_failure()

--- a/src/tools/image/openai_backend.py
+++ b/src/tools/image/openai_backend.py
@@ -1,0 +1,237 @@
+"""Native OpenAI image generation over the Codex ChatGPT OAuth backend.
+
+Rides the SAME CodexAuthPool / current account Odin uses for chat (no separate
+auth, subscription-quota-backed — the endpoint is private and quota-bearing,
+NOT the public Images API). Isolated wire implementation with its own HTTP
+transport, SSE parser, and circuit breaker so image failures never poison chat.
+
+Hard rules enforced here:
+- Once a request receives 2xx (an accepted response), the account is PINNED —
+  no rotation, no retry, no ComfyUI fallback. Failover happens only on
+  pre-generation failures (usage-limit / auth / pre-response transport).
+- partial_image frames are discarded; exactly one terminal full image is
+  required. Base64 length, decoded byte size, and PNG validity are all bounded.
+- No token, account id, SSE body, base64 fragment, or raw payload is ever put
+  in a log, exception message, or the returned result.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+
+import aiohttp
+
+from ...llm.circuit_breaker import CircuitBreaker
+from ...odin_log import get_logger
+from .base import (
+    ImageBackend,
+    ImageBackendUnavailableError,
+    ImageQuotaError,
+    ImageRequestError,
+    ImageResult,
+    ImageTransportError,
+    png_dimensions,
+)
+
+log = get_logger("image.openai")
+
+CODEX_IMAGE_URL = "https://chatgpt.com/backend-api/codex/responses"
+_INSTRUCTIONS = "You are an image generation assistant. Produce exactly the requested image."
+
+
+class OpenAIImageBackend(ImageBackend):
+    name = "openai"
+
+    def __init__(self, *, auth, get_config: Callable) -> None:
+        # `auth` is the shared CodexAuthPool (may be None if Codex isn't set up).
+        self._auth = auth
+        self.get_config = get_config
+        self.breaker = CircuitBreaker("codex_image")
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    @staticmethod
+    def _headers(token: str, account_id: str | None) -> dict:
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        return headers
+
+    @staticmethod
+    def _body(icfg, prompt: str, size: str) -> dict:
+        return {
+            "model": icfg.openai.outer_model,
+            "instructions": _INSTRUCTIONS,
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": prompt}]}],
+            "tools": [
+                {"type": "image_generation", "model": icfg.openai.image_model, "size": size}
+            ],
+            "tool_choice": {"type": "image_generation"},
+            "stream": True,
+            "store": False,
+        }
+
+    def is_configured(self) -> bool:
+        return self._auth is not None and self._auth.is_configured()
+
+    async def generate(
+        self, *, prompt: str, size: str | None = None, **_ignored
+    ) -> ImageResult:
+        cfg = self.get_config()
+        icfg = cfg.image
+        if not icfg.openai.enabled:
+            raise ImageBackendUnavailableError("Native OpenAI image backend is disabled")
+        if not self.is_configured():
+            raise ImageBackendUnavailableError("No Codex credentials for native image generation")
+
+        size = size or icfg.openai.default_size
+        if size not in icfg.openai.allowed_sizes:
+            raise ImageRequestError(
+                f"Unsupported size {size!r}. Allowed: {', '.join(icfg.openai.allowed_sizes)}"
+            )
+
+        self.breaker.check()
+        body = self._body(icfg, prompt, size)
+        session = await self._get_session()
+        timeout = aiohttp.ClientTimeout(
+            total=icfg.openai.request_timeout_seconds,
+            sock_connect=icfg.openai.connect_timeout_seconds,
+            sock_read=icfg.openai.stream_stall_timeout_seconds,
+        )
+
+        # Failover across accounts ONLY on pre-generation failures. The loop is
+        # bounded by the account count; once a POST returns 200 we commit.
+        attempts = max(1, self._auth.account_count())
+        last_err: ImageQuotaError | ImageTransportError | None = None
+        for _attempt in range(attempts):
+            token, account_id, idx = await self._auth.acquire()
+            try:
+                async with session.post(
+                    CODEX_IMAGE_URL,
+                    headers=self._headers(token, account_id),
+                    json=body,
+                    timeout=timeout,
+                ) as resp:
+                    if resp.status == 200:
+                        # Accepted — pinned. Stream errors from here on are
+                        # post-generation and propagate WITHOUT failover.
+                        result = await self._read_stream(resp, icfg)
+                        self.breaker.record_success()
+                        return result
+
+                    if resp.status == 429:
+                        await self._auth.mark_limited(idx)
+                        last_err = ImageQuotaError("usage limit reached (HTTP 429)")
+                        continue
+                    if resp.status == 401:
+                        await self._auth.mark_auth_failed(idx)
+                        last_err = ImageQuotaError("account authentication failed (HTTP 401)")
+                        continue
+                    if resp.status in (500, 502, 503, 504):
+                        self.breaker.record_failure()
+                        last_err = ImageTransportError(f"image endpoint HTTP {resp.status}")
+                        continue
+                    # Other 4xx: request-level (bad params / content policy).
+                    # Do NOT fail over or fall back — the request is the problem.
+                    self.breaker.record_failure()
+                    raise ImageRequestError(f"image request rejected (HTTP {resp.status})")
+            except (TimeoutError, aiohttp.ClientError) as e:
+                # Pre-response transport failure (connection/handshake) — a
+                # mid-stream break after 200 is caught inside _read_stream and
+                # re-raised as a non-failover ImageTransportError instead.
+                self.breaker.record_failure()
+                last_err = ImageTransportError(f"image request transport error: {type(e).__name__}")
+                continue
+
+        if last_err is not None:
+            raise last_err
+        raise ImageQuotaError("no healthy Codex account for image generation")
+
+    async def _read_stream(self, resp: aiohttp.ClientResponse, icfg) -> ImageResult:
+        """Parse the SSE stream and return the single terminal image.
+
+        Reads raw chunks and splits lines manually — aiohttp's default readline
+        caps a line at ~512KB and the base64 image lines exceed that.
+        """
+        max_bytes = icfg.openai.max_image_bytes
+        max_b64 = max_bytes * 4 // 3 + 8
+        final_b64: str | None = None
+        buf = b""
+        try:
+            async for chunk in resp.content.iter_chunked(65536):
+                buf += chunk
+                while b"\n" in buf:
+                    raw, buf = buf.split(b"\n", 1)
+                    line = raw.strip()
+                    if not line.startswith(b"data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == b"[DONE]":
+                        buf = b""
+                        break
+                    try:
+                        ev = json.loads(data)
+                    except (ValueError, TypeError):
+                        continue
+                    t = ev.get("type", "")
+                    if t == "response.image_generation_call.partial_image":
+                        continue  # discard partial previews in v1
+                    if t in (
+                        "response.image_generation_call.completed",
+                        "response.image_generation_call.done",
+                    ):
+                        for key in ("b64_json", "result", "image_b64"):
+                            v = ev.get(key)
+                            if isinstance(v, str) and len(v) > 100:
+                                final_b64 = v
+                    if t in ("response.output_item.done", "response.completed"):
+                        item = ev.get("item") or {}
+                        if item.get("type") == "image_generation_call" and isinstance(
+                            item.get("result"), str
+                        ):
+                            final_b64 = item["result"]
+                        for out in (ev.get("response") or {}).get("output", []) or []:
+                            if out.get("type") == "image_generation_call" and isinstance(
+                                out.get("result"), str
+                            ):
+                                final_b64 = out["result"]
+                    if t in ("response.failed", "error", "response.error"):
+                        raise ImageRequestError("image generation failed upstream")
+                    if final_b64 is not None and len(final_b64) > max_b64:
+                        raise ImageRequestError("generated image exceeds the configured size cap")
+        except (TimeoutError, aiohttp.ClientError) as e:
+            # Mid-stream break AFTER a 200 — post-generation, no failover.
+            self.breaker.record_failure()
+            raise ImageTransportError(
+                f"image stream error: {type(e).__name__}", pre_generation=False
+            ) from e
+
+        if not final_b64:
+            raise ImageRequestError("no image returned in the response")
+        try:
+            data = base64.b64decode(final_b64, validate=True)
+        except (ValueError, TypeError) as e:
+            raise ImageRequestError("malformed image data") from e
+        if len(data) > max_bytes:
+            raise ImageRequestError("generated image exceeds the configured size cap")
+        dims = png_dimensions(data)
+        if not dims:
+            raise ImageRequestError("image output is not a valid PNG")
+        return ImageResult(
+            data=data,
+            mime="image/png",
+            width=dims[0],
+            height=dims[1],
+            backend="openai",
+            image_model=icfg.openai.image_model,
+        )

--- a/src/tools/image/openai_backend.py
+++ b/src/tools/image/openai_backend.py
@@ -130,6 +130,7 @@ class OpenAIImageBackend(ImageBackend):
                 # can fall back to ComfyUI. Never surface the raw pool error.
                 last_err = ImageQuotaError("no healthy Codex account for image generation")
                 break
+            committed = False
             try:
                 async with session.post(
                     CODEX_IMAGE_URL,
@@ -138,8 +139,10 @@ class OpenAIImageBackend(ImageBackend):
                     timeout=timeout,
                 ) as resp:
                     if resp.status == 200:
-                        # Accepted — pinned. Stream errors from here on are
-                        # post-generation and propagate WITHOUT failover.
+                        # Accepted — PINNED. Everything from here (stream AND the
+                        # response context manager's own cleanup) is
+                        # post-generation: no failover, no fallback.
+                        committed = True
                         result = await self._read_stream(resp, icfg)
                         self.breaker.record_success()
                         return result
@@ -162,6 +165,15 @@ class OpenAIImageBackend(ImageBackend):
                     # bad prompt must not disable image generation for everyone.
                     raise ImageRequestError(f"image request rejected (HTTP {resp.status})")
             except (TimeoutError, aiohttp.ClientError) as e:
+                if committed:
+                    # A 200 was accepted; this is the response context manager's
+                    # own cleanup failing AFTER the image was produced. Pinned —
+                    # never fail over (that would generate twice). The endpoint
+                    # was healthy, so don't count it against the breaker either.
+                    raise ImageTransportError(
+                        f"image response cleanup error: {type(e).__name__}",
+                        pre_generation=False,
+                    ) from e
                 # Pre-response transport failure (connection/handshake) — a
                 # mid-stream break after 200 is caught inside _read_stream and
                 # re-raised as a non-failover ImageTransportError instead.

--- a/src/tools/image/selector.py
+++ b/src/tools/image/selector.py
@@ -1,0 +1,133 @@
+"""Backend selection + the structural availability check used for tool visibility.
+
+Availability is STRUCTURAL (config + active provider) so the tool definition does
+not appear/disappear on transient health (a cooling-down account, an offline
+ComfyUI, an open breaker). Only a provider/config change flips it — and that
+rebuilds the registry + system prompt.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ...odin_log import get_logger
+from .base import (
+    ImageBackendUnavailableError,
+    ImageGenError,
+    ImageRequestError,
+    ImageResult,
+)
+
+log = get_logger("image.selector")
+
+
+def _native_possible(config) -> bool:
+    """Native OpenAI image gen is available only when Odin is actively on the
+    Codex provider (it rides that live auth) with the kill switch on."""
+    oc = getattr(config, "openai_codex", None)
+    lp = getattr(config, "llm_provider", None)
+    return bool(
+        oc
+        and getattr(oc, "enabled", False)
+        and config.image.openai.enabled
+        and lp
+        and getattr(lp, "active_provider", None) == "codex"
+    )
+
+
+def _comfy_possible(config) -> bool:
+    comfy = getattr(config, "comfyui", None)
+    return bool(comfy and getattr(comfy, "enabled", False))
+
+
+def image_tool_available(config) -> bool:
+    """Whether the image tool should appear in the registry for this config.
+
+    - ``openai``: only when native is available (Codex provider + creds).
+    - ``comfyui``: only when ComfyUI is configured.
+    - ``auto``: whenever EITHER is available — so Kimi with no ComfyUI hides it.
+    """
+    backend = config.image.backend
+    if backend == "openai":
+        return _native_possible(config)
+    if backend == "comfyui":
+        return _comfy_possible(config)
+    return _native_possible(config) or _comfy_possible(config)
+
+
+class ImageBackendSelector:
+    def __init__(self, *, get_config: Callable, openai_backend, comfyui_backend) -> None:
+        self.get_config = get_config
+        self.openai = openai_backend  # OpenAIImageBackend | None
+        self.comfyui = comfyui_backend  # ComfyUIImageBackend
+
+    def tool_available(self, config=None) -> bool:
+        return image_tool_available(config or self.get_config())
+
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        size: str | None = None,
+        negative: str = "",
+        model: str = "",
+        width: int | None = None,
+        height: int | None = None,
+    ) -> ImageResult:
+        config = self.get_config()
+        backend = config.image.backend
+        native = self.openai is not None and _native_possible(config)
+        comfy = _comfy_possible(config)
+        # ComfyUI-only concepts. Their presence routes to ComfyUI in auto and is
+        # rejected (never silently ignored) under the OpenAI backend.
+        wants_comfy_features = (
+            bool(negative) or bool(model) or width is not None or height is not None
+        )
+
+        if backend == "comfyui":
+            if not comfy:
+                raise ImageBackendUnavailableError("ComfyUI is not configured")
+            return await self.comfyui.generate(
+                prompt=prompt, size=size, negative=negative, model=model, width=width, height=height
+            )
+
+        if backend == "openai":
+            if wants_comfy_features:
+                raise ImageRequestError(
+                    "negative/model/width/height are ComfyUI-only and not supported "
+                    "by the OpenAI backend"
+                )
+            if not native:
+                raise ImageBackendUnavailableError(
+                    "Native OpenAI image generation requires the Codex provider and credentials"
+                )
+            return await self.openai.generate(prompt=prompt, size=size)
+
+        # auto — follow the active provider, with ComfyUI as the pre-generation fallback
+        if wants_comfy_features:
+            if comfy:
+                return await self.comfyui.generate(
+                    prompt=prompt,
+                    size=size,
+                    negative=negative,
+                    model=model,
+                    width=width,
+                    height=height,
+                )
+            raise ImageRequestError(
+                "negative/model/width/height require ComfyUI, which is not configured"
+            )
+        if native:
+            try:
+                return await self.openai.generate(prompt=prompt, size=size)
+            except ImageGenError as e:
+                if e.pre_generation and comfy:
+                    log.info(
+                        "Native image gen unavailable (%s); falling back to ComfyUI",
+                        type(e).__name__,
+                    )
+                    return await self.comfyui.generate(prompt=prompt, size=size)
+                raise
+        if comfy:
+            return await self.comfyui.generate(prompt=prompt, size=size)
+        raise ImageBackendUnavailableError("No image backend is available")

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -121,7 +121,7 @@ EXPECTED_TOOL_HASHES = {
     "terraform_ops": "054cd8877208bc7d",
     "http_probe": "dfc3b04b36c5e7f9",
     "issue_tracker": "4f0a793414052b40",
-    "generate_image": "3df436d69f3b9169",
+    "generate_image": "ee28d2ae514c51e0",
     "validate_action": "199baeb4723517d7",
     "email_send": "1282279440e34e6f",
     "email_search": "3a7584b725d1c134",
@@ -175,11 +175,12 @@ class TestBackendGatedVisibility:
 
     Gated groups: claude_code (needs tools.claude_code_host), the four
     email tools (need email.enabled), issue_tracker (needs
-    issue_tracker.enabled).
+    issue_tracker.enabled), generate_image (needs a native-OpenAI or ComfyUI
+    backend — hidden when neither is available).
     """
 
     GATED = {"claude_code", "email_send", "email_search", "email_read",
-             "email_list_recent", "issue_tracker"}
+             "email_list_recent", "issue_tracker", "generate_image"}
 
     def _catalog_names(self, **config_kwargs) -> set[str]:
         from src.config.schema import Config

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -239,6 +239,25 @@ class TestProcessRegistryShutdown:
             assert info._reader_task.done() or info._reader_task.cancelled()
 
     @pytest.mark.asyncio
+    async def test_shutdown_services_closes_image_backend(self):
+        # shutdown_services must close the native image backend's own HTTP
+        # session (separate transport from the codex chat client) and tolerate
+        # its errors. Only `components` is set, so every other getattr-guarded
+        # block short-circuits to None.
+        from types import SimpleNamespace
+
+        from src.discord.wiring import shutdown_services
+
+        backend = SimpleNamespace(close=AsyncMock(side_effect=RuntimeError("boom")))
+        bot = SimpleNamespace(
+            components=SimpleNamespace(
+                media_tools=SimpleNamespace(image_selector=SimpleNamespace(openai=backend))
+            )
+        )
+        await shutdown_services(bot)  # must not raise despite close() erroring
+        backend.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_shutdown_skips_already_finished(self):
         registry = ProcessRegistry()
         await registry.start("localhost", "echo done")

--- a/tests/test_image_backends.py
+++ b/tests/test_image_backends.py
@@ -107,21 +107,28 @@ class _FakeSession:
             return _RaiseCtx(r)
         return r
 
+    async def close(self):
+        self.closed = True
+
 
 class _FakePool:
-    def __init__(self, count: int = 3) -> None:
+    def __init__(self, count: int = 3, acquire_error: Exception | None = None) -> None:
         self._count = count
         self._idx = 0
+        self._acquire_error = acquire_error
         self.limited: list[int] = []
         self.auth_failed: list[int] = []
 
     def is_configured(self):
         return self._count > 0
 
-    def account_count(self):
+    @property
+    def account_count(self):  # mirrors the REAL CodexAuthPool: a property, not a method
         return self._count
 
     async def acquire(self):
+        if self._acquire_error is not None:
+            raise self._acquire_error
         i = self._idx % self._count
         self._idx += 1
         return ("tok", "acct", i)
@@ -139,7 +146,7 @@ def _backend(pool, responses, **cfg_over):
     cfg.openai_codex.enabled = True
     for k, v in cfg_over.items():
         setattr(cfg.image.openai, k, v)
-    b = OpenAIImageBackend(auth=pool, get_config=lambda: cfg)
+    b = OpenAIImageBackend(get_auth=lambda: pool, get_config=lambda: cfg)
     b._session = _FakeSession(responses)
     return b, cfg
 
@@ -301,6 +308,90 @@ async def test_unconfigured_pool_unavailable():
     b, _ = _backend(_FakePool(count=0), [])
     with pytest.raises(ImageBackendUnavailableError):
         await b.generate(prompt="p")
+
+
+async def test_no_pool_resolved_is_unavailable():
+    # get_auth resolves live and may return None (Codex not logged in yet).
+    cfg = Config(discord={"token": "x"})
+    cfg.openai_codex.enabled = True
+    b = OpenAIImageBackend(get_auth=lambda: None, get_config=lambda: cfg)
+    with pytest.raises(ImageBackendUnavailableError):
+        await b.generate(prompt="p")
+
+
+async def test_auth_resolved_live_not_snapshotted():
+    # A pool that appears AFTER construction must be used (live login/reload).
+    holder = {"pool": None}
+    cfg = Config(discord={"token": "x"})
+    cfg.openai_codex.enabled = True
+    b = OpenAIImageBackend(get_auth=lambda: holder["pool"], get_config=lambda: cfg)
+    assert b.is_configured() is False
+    holder["pool"] = _FakePool()
+    b._session = _FakeSession([_FakeResp(200, (_sse(_final_image_event()),))])
+    assert b.is_configured() is True
+    res = await b.generate(prompt="p")
+    assert res.backend == "openai"
+
+
+async def test_pool_exhaustion_is_quota_error():
+    # acquire() raising RuntimeError must become a pre-generation ImageQuotaError
+    # (so `auto` can fall back), not a raw RuntimeError that bypasses fallback.
+    pool = _FakePool(acquire_error=RuntimeError("No Codex credentials configured."))
+    b, _ = _backend(pool, [])
+    with pytest.raises(ImageQuotaError) as ei:
+        await b.generate(prompt="p")
+    assert ei.value.pre_generation is True
+    assert b._session.posts == 0
+
+
+async def test_open_breaker_is_pre_generation():
+    from src.llm.circuit_breaker import CircuitOpenError
+
+    pool = _FakePool()
+    b, _ = _backend(pool, [])
+    b.breaker.check = lambda: (_ for _ in ()).throw(CircuitOpenError("codex_image", 5.0))
+    with pytest.raises(ImageTransportError) as ei:
+        await b.generate(prompt="p")
+    assert ei.value.pre_generation is True  # auto can fall back
+    assert b._session.posts == 0
+
+
+async def test_4xx_does_not_poison_the_breaker():
+    from unittest.mock import MagicMock
+
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(400, body=b"bad prompt")])
+    b.breaker.record_failure = MagicMock()
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+    b.breaker.record_failure.assert_not_called()  # a bad prompt must not disable everyone
+
+
+async def test_5xx_does_count_against_the_breaker():
+    from unittest.mock import MagicMock
+
+    pool = _FakePool(count=1)
+    b, _ = _backend(pool, [_FakeResp(503)])
+    b.breaker.record_failure = MagicMock()
+    with pytest.raises(ImageTransportError):
+        await b.generate(prompt="p")
+    b.breaker.record_failure.assert_called()
+
+
+async def test_unterminated_oversized_frame_rejected():
+    # A giant frame with no newline must be rejected before it is fully buffered.
+    pool = _FakePool()
+    huge = b"data: " + b"A" * 200_000  # no newline
+    b, _ = _backend(pool, [_FakeResp(200, (huge,))], max_image_bytes=1024)
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+
+
+async def test_close_closes_session():
+    pool = _FakePool()
+    b, _ = _backend(pool, [])
+    await b.close()
+    assert b._session.closed
 
 
 # ── ComfyUIImageBackend ───────────────────────────────────────────────

--- a/tests/test_image_backends.py
+++ b/tests/test_image_backends.py
@@ -259,6 +259,28 @@ async def test_no_failover_after_200_then_transport_break():
     assert b._session.posts == 1
 
 
+async def test_no_failover_when_response_cleanup_fails_after_success():
+    # A successful 200 stream whose response __aexit__ then raises must NOT retry
+    # another account — that double-generates after the account is pinned.
+    pool = _FakePool(count=3)
+
+    class _AexitFailResp(_FakeResp):
+        async def __aexit__(self, *a):
+            raise aiohttp.ClientError("cleanup boom")
+
+    b, _ = _backend(
+        pool,
+        [
+            _AexitFailResp(200, (_sse(_final_image_event()),)),
+            _FakeResp(200, (_sse(_final_image_event()),)),  # must NOT be reached
+        ],
+    )
+    with pytest.raises(ImageTransportError) as ei:
+        await b.generate(prompt="p")
+    assert ei.value.pre_generation is False
+    assert b._session.posts == 1  # exactly one POST — no double generation
+
+
 async def test_oversized_decoded_image_rejected():
     big = base64.b64encode(PNG_1x1 + b"\x00" * 5000).decode()
     pool = _FakePool()

--- a/tests/test_image_backends.py
+++ b/tests/test_image_backends.py
@@ -1,0 +1,478 @@
+"""Image-generation backend tests.
+
+Covers the native OpenAI wire impl's failure classification and the hard
+"no retry/fallback after generation begins" rule, the SSE parsing (including
+the >512KB base64 line that broke the first probe), the backend-neutral
+selector routing, and the structural visibility matrix that gates the tool.
+
+No network: the pool and HTTP session are faked; the only real crypto is a
+1x1 PNG used to exercise the magic-byte + dimension checks.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import aiohttp
+import pytest
+
+from src.config.schema import Config
+from src.tools.image.base import (
+    ImageBackendUnavailableError,
+    ImageQuotaError,
+    ImageRequestError,
+    ImageResult,
+    ImageTransportError,
+    png_dimensions,
+)
+from src.tools.image.openai_backend import OpenAIImageBackend
+from src.tools.image.selector import ImageBackendSelector, image_tool_available
+
+PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+PNG_1x1_B64 = base64.b64encode(PNG_1x1).decode()
+
+
+# ── png_dimensions ────────────────────────────────────────────────────
+
+
+def test_png_dimensions_valid():
+    assert png_dimensions(PNG_1x1) == (1, 1)
+
+
+def test_png_dimensions_rejects_non_png():
+    assert png_dimensions(b"\xff\xd8\xff\xe0jpegjunk" + b"\x00" * 40) is None
+    assert png_dimensions(b"too short") is None
+
+
+# ── fakes ─────────────────────────────────────────────────────────────
+
+
+def _sse(*events: dict) -> bytes:
+    body = b"".join(b"data: " + json.dumps(e).encode() + b"\n" for e in events)
+    return body + b"data: [DONE]\n"
+
+
+def _final_image_event(b64: str = PNG_1x1_B64) -> dict:
+    return {
+        "type": "response.output_item.done",
+        "item": {"type": "image_generation_call", "result": b64},
+    }
+
+
+class _FakeResp:
+    def __init__(self, status: int, chunks: tuple[bytes, ...] = (), body: bytes = b"") -> None:
+        self.status = status
+        self._chunks = chunks
+        self._body = body
+        self.content = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def iter_chunked(self, _n):
+        for c in self._chunks:
+            yield c
+
+    async def read(self):
+        return self._body
+
+
+class _RaiseCtx:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self):
+        raise self._exc
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, responses: list) -> None:
+        self._responses = list(responses)
+        self.posts = 0
+        self.closed = False
+
+    def post(self, _url, **_kw):
+        self.posts += 1
+        r = self._responses.pop(0)
+        if isinstance(r, Exception):
+            return _RaiseCtx(r)
+        return r
+
+
+class _FakePool:
+    def __init__(self, count: int = 3) -> None:
+        self._count = count
+        self._idx = 0
+        self.limited: list[int] = []
+        self.auth_failed: list[int] = []
+
+    def is_configured(self):
+        return self._count > 0
+
+    def account_count(self):
+        return self._count
+
+    async def acquire(self):
+        i = self._idx % self._count
+        self._idx += 1
+        return ("tok", "acct", i)
+
+    async def mark_limited(self, i):
+        self.limited.append(i)
+
+    async def mark_auth_failed(self, i):
+        self.auth_failed.append(i)
+        return True
+
+
+def _backend(pool, responses, **cfg_over):
+    cfg = Config(discord={"token": "x"})
+    cfg.openai_codex.enabled = True
+    for k, v in cfg_over.items():
+        setattr(cfg.image.openai, k, v)
+    b = OpenAIImageBackend(auth=pool, get_config=lambda: cfg)
+    b._session = _FakeSession(responses)
+    return b, cfg
+
+
+# ── OpenAIImageBackend: happy path + SSE ──────────────────────────────
+
+
+async def test_openai_backend_returns_image():
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event()),))])
+    res = await b.generate(prompt="a red circle")
+    assert isinstance(res, ImageResult)
+    assert res.backend == "openai" and res.mime == "image/png"
+    assert (res.width, res.height) == (1, 1)
+    assert b._session.posts == 1  # accepted first try, no rotation
+
+
+async def test_openai_backend_discards_partial_images():
+    pool = _FakePool()
+    partial = {
+        "type": "response.image_generation_call.partial_image",
+        "partial_image_b64": "x" * 200,
+    }
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(partial, _final_image_event()),))])
+    res = await b.generate(prompt="p")
+    assert res.width == 1  # returned the FINAL image, not the partial
+
+
+async def test_openai_backend_huge_base64_line_is_parsed():
+    # The >512KB base64 line that broke the first probe (aiohttp readline cap).
+    big = base64.b64encode(PNG_1x1 + b"\x00" * 600_000).decode()
+    pool = _FakePool()
+    b, cfg = _backend(
+        pool, [_FakeResp(200, (_sse(_final_image_event(big)),))], max_image_bytes=2_000_000
+    )
+    res = await b.generate(prompt="p")
+    assert res.backend == "openai"  # decoded despite the giant single line
+
+
+# ── OpenAIImageBackend: failure classification ────────────────────────
+
+
+async def test_429_marks_limited_and_fails_over_then_quota_error():
+    pool = _FakePool(count=3)
+    b, _ = _backend(pool, [_FakeResp(429, body=b"usage_limit_reached")] * 3)
+    with pytest.raises(ImageQuotaError):
+        await b.generate(prompt="p")
+    assert pool.limited == [0, 1, 2]  # every account tried and benched
+    assert b._session.posts == 3
+
+
+async def test_429_then_success_on_next_account():
+    pool = _FakePool(count=3)
+    b, _ = _backend(
+        pool, [_FakeResp(429), _FakeResp(200, (_sse(_final_image_event()),))]
+    )
+    res = await b.generate(prompt="p")
+    assert res.width == 1
+    assert pool.limited == [0] and b._session.posts == 2
+
+
+async def test_401_marks_auth_failed_and_fails_over():
+    pool = _FakePool(count=2)
+    b, _ = _backend(pool, [_FakeResp(401), _FakeResp(200, (_sse(_final_image_event()),))])
+    res = await b.generate(prompt="p")
+    assert res.width == 1 and pool.auth_failed == [0]
+
+
+async def test_5xx_is_transport_error_after_exhaustion():
+    pool = _FakePool(count=2)
+    b, _ = _backend(pool, [_FakeResp(503), _FakeResp(502)])
+    with pytest.raises(ImageTransportError):
+        await b.generate(prompt="p")
+    assert b._session.posts == 2
+
+
+async def test_4xx_is_request_error_with_no_failover():
+    pool = _FakePool(count=3)
+    b, _ = _backend(pool, [_FakeResp(400, body=b"bad params")])
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+    assert b._session.posts == 1  # request-level: did NOT rotate
+    assert pool.limited == [] and pool.auth_failed == []
+
+
+async def test_no_failover_after_200_then_upstream_failure():
+    # response.failed AFTER a 200 must NOT retry/rotate — the account is pinned.
+    pool = _FakePool(count=3)
+    failed = {"type": "response.failed", "error": {"message": "policy"}}
+    b, _ = _backend(
+        pool, [_FakeResp(200, (_sse(failed),)), _FakeResp(200, (_sse(_final_image_event()),))]
+    )
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+    assert b._session.posts == 1  # never tried the second (would double-generate)
+
+
+async def test_no_failover_after_200_then_transport_break():
+    pool = _FakePool(count=3)
+
+    class _BreakingResp(_FakeResp):
+        async def iter_chunked(self, _n):
+            raise aiohttp.ClientError("mid-stream reset")
+            yield b""  # pragma: no cover
+
+    b, _ = _backend(pool, [_BreakingResp(200)])
+    with pytest.raises(ImageTransportError) as ei:
+        await b.generate(prompt="p")
+    assert ei.value.pre_generation is False  # post-generation: no fallback
+    assert b._session.posts == 1
+
+
+async def test_oversized_decoded_image_rejected():
+    big = base64.b64encode(PNG_1x1 + b"\x00" * 5000).decode()
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event(big)),))], max_image_bytes=100)
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+
+
+async def test_malformed_base64_rejected():
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event("!!!not base64!!!")),))])
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+
+
+async def test_non_png_output_rejected():
+    jpeg_b64 = base64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 40).decode()
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event(jpeg_b64)),))])
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+
+
+async def test_no_image_in_stream_rejected():
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse({"type": "response.completed"}),))])
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p")
+
+
+async def test_disallowed_size_rejected_without_request():
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event()),))])
+    with pytest.raises(ImageRequestError):
+        await b.generate(prompt="p", size="4096x4096")
+    assert b._session.posts == 0  # rejected before any HTTP call
+
+
+async def test_kill_switch_unavailable():
+    pool = _FakePool()
+    b, _ = _backend(pool, [], enabled=False)
+    with pytest.raises(ImageBackendUnavailableError):
+        await b.generate(prompt="p")
+
+
+async def test_unconfigured_pool_unavailable():
+    b, _ = _backend(_FakePool(count=0), [])
+    with pytest.raises(ImageBackendUnavailableError):
+        await b.generate(prompt="p")
+
+
+# ── ComfyUIImageBackend ───────────────────────────────────────────────
+
+
+class _FakeComfyClient:
+    def __init__(self, result):
+        self._result = result
+        self.calls: list[dict] = []
+
+    async def generate(self, **kw):
+        self.calls.append(kw)
+        return self._result
+
+
+def _comfy_cfg(enabled=True):
+    c = Config(discord={"token": "x"})
+    c.comfyui.enabled = enabled
+    c.comfyui.url = "http://comfy"
+    c.comfyui.default_checkpoint = "cp.safetensors"
+    return c
+
+
+async def test_comfyui_backend_disabled():
+    from src.tools.image.comfyui_backend import ComfyUIImageBackend
+
+    b = ComfyUIImageBackend(get_config=lambda: _comfy_cfg(enabled=False))
+    with pytest.raises(ImageBackendUnavailableError):
+        await b.generate(prompt="p")
+
+
+async def test_comfyui_backend_success(monkeypatch):
+    from src.tools.image import comfyui_backend as mod
+
+    fake = _FakeComfyClient(PNG_1x1)
+    monkeypatch.setattr(mod, "ComfyUIClient", lambda url, default_checkpoint="": fake)
+    b = mod.ComfyUIImageBackend(get_config=lambda: _comfy_cfg())
+    res = await b.generate(prompt="p", size="512x768", negative="ugly", model="m")
+    assert res.backend == "comfyui" and (res.width, res.height) == (1, 1)
+    assert fake.calls[0]["width"] == 512 and fake.calls[0]["height"] == 768
+    assert fake.calls[0]["negative"] == "ugly" and fake.calls[0]["model"] == "m"
+
+
+async def test_comfyui_backend_failure_is_transport_error(monkeypatch):
+    from src.tools.image import comfyui_backend as mod
+
+    monkeypatch.setattr(
+        mod, "ComfyUIClient", lambda url, default_checkpoint="": _FakeComfyClient(None)
+    )
+    b = mod.ComfyUIImageBackend(get_config=lambda: _comfy_cfg())
+    with pytest.raises(ImageTransportError):
+        await b.generate(prompt="p")
+
+
+def test_parse_size_variants():
+    from src.tools.image.comfyui_backend import _parse_size
+
+    assert _parse_size("512x768", None, None) == (512, 768)
+    assert _parse_size(None, None, None) == (1024, 1024)
+    assert _parse_size("garbage", None, None) == (1024, 1024)
+    assert _parse_size("100x100", 200, 300) == (200, 300)  # explicit w/h win
+    assert _parse_size(None, 99999, 10) == (2048, 64)  # clamped both ends
+
+
+# ── visibility matrix (Aaron's rules) ─────────────────────────────────
+
+
+def _cfg(*, backend="auto", provider="codex", codex=False, comfy=False):
+    c = Config(discord={"token": "x"})
+    c.image.backend = backend
+    c.llm_provider.active_provider = provider
+    c.openai_codex.enabled = codex
+    c.comfyui.enabled = comfy
+    return c
+
+
+@pytest.mark.parametrize(
+    "kw,expected",
+    [
+        # auto: native on codex, comfy otherwise, hidden when neither
+        (dict(backend="auto", provider="codex", codex=True), True),
+        (dict(backend="auto", provider="kimi", codex=True, comfy=True), True),
+        (dict(backend="auto", provider="kimi", codex=True, comfy=False), False),  # Aaron's key case
+        (dict(backend="auto", provider="codex", codex=False, comfy=False), False),
+        # openai mode: only when native available (codex provider + enabled)
+        (dict(backend="openai", provider="codex", codex=True), True),
+        (dict(backend="openai", provider="kimi", codex=True, comfy=True), False),
+        # comfyui mode: only when comfy configured
+        (dict(backend="comfyui", provider="kimi", comfy=True), True),
+        (dict(backend="comfyui", provider="codex", codex=True, comfy=False), False),
+    ],
+)
+def test_visibility_matrix(kw, expected):
+    assert image_tool_available(_cfg(**kw)) is expected
+
+
+# ── selector routing ──────────────────────────────────────────────────
+
+
+class _RecordingBackend:
+    def __init__(self, name, *, result=None, error=None):
+        self.name = name
+        self._result = result or ImageResult(PNG_1x1, "image/png", 1, 1, name, "m")
+        self._error = error
+        self.calls: list[dict] = []
+
+    async def generate(self, **kw):
+        self.calls.append(kw)
+        if self._error:
+            raise self._error
+        return self._result
+
+
+def _selector(cfg, *, native=None, comfy=None):
+    return ImageBackendSelector(
+        get_config=lambda: cfg, openai_backend=native, comfyui_backend=comfy
+    )
+
+
+async def test_selector_comfyui_mode_routes_to_comfy():
+    cfg = _cfg(backend="comfyui", provider="codex", codex=True, comfy=True)
+    comfy = _RecordingBackend("comfyui")
+    native = _RecordingBackend("openai")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p")
+    assert res.backend == "comfyui" and comfy.calls and not native.calls
+
+
+async def test_selector_openai_mode_rejects_comfy_features():
+    cfg = _cfg(backend="openai", provider="codex", codex=True)
+    native = _RecordingBackend("openai")
+    with pytest.raises(ImageRequestError):
+        await _selector(cfg, native=native, comfy=_RecordingBackend("comfyui")).generate(
+            prompt="p", negative="blurry"
+        )
+    assert not native.calls
+
+
+async def test_selector_auto_prefers_native_then_falls_back_on_pre_generation():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai", error=ImageQuotaError("limit"))  # pre_generation
+    comfy = _RecordingBackend("comfyui")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p")
+    assert res.backend == "comfyui"  # fell back
+    assert native.calls and comfy.calls
+
+
+async def test_selector_auto_does_not_fall_back_after_generation():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai", error=ImageRequestError("policy"))  # post-generation
+    comfy = _RecordingBackend("comfyui")
+    with pytest.raises(ImageRequestError):
+        await _selector(cfg, native=native, comfy=comfy).generate(prompt="p")
+    assert native.calls and not comfy.calls  # no fallback
+
+
+async def test_selector_auto_comfy_feature_routes_to_comfy():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", negative="blurry")
+    assert comfy.calls and not native.calls  # comfy-specific field selects comfy
+
+
+async def test_selector_auto_kimi_uses_comfy():
+    cfg = _cfg(backend="auto", provider="kimi", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p")
+    assert res.backend == "comfyui" and not native.calls
+
+
+async def test_selector_no_backend_available_raises():
+    cfg = _cfg(backend="auto", provider="kimi", comfy=False)
+    with pytest.raises(ImageBackendUnavailableError):
+        await _selector(cfg, native=None, comfy=_RecordingBackend("comfyui")).generate(prompt="p")

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -71,6 +71,16 @@ class TestActiveClientAndCallbacks:
         reflection_fn = gw.reflector.set_text_fn.call_args.args[0]
         assert await reflection_fn([], "sys") == "summary"
 
+    async def test_switch_provider_fires_on_provider_switch(self):
+        # The hook wiring points at the tool catalog's invalidate() so a live
+        # switch rebuilds the registry (native image gen is Codex-only).
+        gw = _gw(_cfg("kimi"), codex=object())
+        fired: list[bool] = []
+        gw.on_provider_switch = lambda: fired.append(True)
+        result = await gw.switch_provider("codex")
+        assert result["active_provider"] == "codex"
+        assert fired == [True]
+
     async def test_callbacks_raise_without_client(self):
         gw = _gw(codex=None)  # no active client
         gw.wire_callbacks()

--- a/tests/test_native_media.py
+++ b/tests/test_native_media.py
@@ -37,11 +37,12 @@ def _executor(resolve=("1.2.3.4", "root", "linux"), exec_ret=(0, "")):
     return ex
 
 
-def _tools(config=None, browser_manager=None, tool_executor=None):
+def _tools(config=None, browser_manager=None, tool_executor=None, image_selector=None):
     return MediaTools(
         get_config=lambda: config or _config(),
         browser_manager=browser_manager,
         tool_executor=tool_executor or _executor(),
+        image_selector=image_selector,
     )
 
 
@@ -268,30 +269,53 @@ class TestAnalyzeImage:
 
 
 class TestGenerateImage:
-    async def test_disabled_and_no_prompt(self):
-        disabled = _tools(config=_config(comfy_enabled=False))
-        assert "disabled" in await disabled._handle_generate_image(_message(), {"prompt": "x"})
-        assert "required" in await _tools()._handle_generate_image(_message(), {})
+    """The handler dispatches to the image selector and owns Discord posting;
+    backend selection/wire behavior is covered in test_image_backends.py."""
 
-    async def test_success(self):
-        client = MagicMock()
-        client.generate = AsyncMock(return_value=PNG)
+    @staticmethod
+    def _selector(result=None, error=None):
+        sel = MagicMock()
+        sel.generate = AsyncMock(return_value=result, side_effect=error)
+        return sel
+
+    @staticmethod
+    def _result(backend="openai"):
+        from src.tools.image import ImageResult
+
+        return ImageResult(PNG, "image/png", 1024, 1024, backend, "gpt-image-2")
+
+    async def test_no_selector_and_no_prompt(self):
+        # No backend wired at all -> not available.
+        no_sel = _tools()
+        assert "not available" in await no_sel._handle_generate_image(_message(), {"prompt": "x"})
+        # Selector present but missing prompt -> required.
+        t = _tools(image_selector=self._selector(result=self._result()))
+        assert "required" in await t._handle_generate_image(_message(), {})
+
+    async def test_success_posts_attachment(self):
+        sel = self._selector(result=self._result(backend="openai"))
         msg = _message()
-        with patch("src.tools.comfyui.ComfyUIClient", return_value=client):
-            out = await _tools()._handle_generate_image(
-                msg, {"prompt": "a cat", "width": 99999, "height": 10})
-            assert "Image generated and posted" in out
-            msg.channel.send.assert_awaited_once()
+        out = await _tools(image_selector=sel)._handle_generate_image(msg, {"prompt": "a cat"})
+        assert "Image generated via openai" in out
+        msg.channel.send.assert_awaited_once()
 
-    async def test_generation_failed_and_http_error(self):
-        client = MagicMock()
-        client.generate = AsyncMock(return_value=None)
-        with patch("src.tools.comfyui.ComfyUIClient", return_value=client):
-            assert "generation failed" in await _tools()._handle_generate_image(
-                _message(), {"prompt": "x"})
-        client.generate = AsyncMock(return_value=PNG)
+    async def test_backend_failure_and_http_error(self):
+        from src.tools.image import ImageGenError
+
+        sel = self._selector(error=ImageGenError("no backend"))
+        assert "failed" in await _tools(image_selector=sel)._handle_generate_image(
+            _message(), {"prompt": "x"}
+        )
+        sel = self._selector(result=self._result(backend="comfyui"))
         msg = _message()
         msg.channel.send = AsyncMock(side_effect=_http_exc())
-        with patch("src.tools.comfyui.ComfyUIClient", return_value=client):
-            assert "Failed to upload generated" in await _tools()._handle_generate_image(
-                msg, {"prompt": "x"})
+        out = await _tools(image_selector=sel)._handle_generate_image(msg, {"prompt": "x"})
+        assert "Failed to upload generated" in out
+
+    async def test_unexpected_error_is_contained(self):
+        # A non-ImageGenError must not leak a payload — generic catch-all.
+        sel = self._selector(error=RuntimeError("raw provider blob"))
+        out = await _tools(image_selector=sel)._handle_generate_image(
+            _message(), {"prompt": "x"}
+        )
+        assert "unexpectedly" in out and "raw provider blob" not in out


### PR DESCRIPTION
## Summary

Adds native OpenAI image generation as a toggleable alternative to the ComfyUI image tool, behind a backend-neutral `ImageBackend` seam. The old `generate_image` ComfyUI tool becomes one backend rather than a permanent special case.

**Feasibility proven live** before building: the `image_generation` Responses tool works over our existing Codex ChatGPT OAuth backend (`chatgpt.com/backend-api/codex/responses`) using the current pool account — HTTP 200, full SSE flow, a real PNG returned. Subscription-quota-backed (no per-token billing); image gen draws on the same account usage limit as chat.

## Design

- **`src/tools/image/`** — `ImageBackend` ABC + `ImageResult` + typed error taxonomy (`pre_generation` flag = safe-to-fail-over/fall-back); `OpenAIImageBackend` (native wire impl), `ComfyUIImageBackend` (wraps the existing client), `ImageBackendSelector`.
- **Native backend** rides the **same `CodexAuthPool`** the chat client uses (no separate auth) but has its own transport, SSE parser, and circuit breaker so image failures never poison chat. Failover only on pre-generation failures; **once a POST returns 200 the account is pinned — no retry/rotation/fallback** (never double-spends quota). partial_image discarded; one terminal PNG required; base64 length / decoded size / PNG magic all bounded; no token/account/payload in logs, errors, or results.
- **Modes** (`image.backend`): `auto` (default) follows the active provider — codex → native (ComfyUI as pre-generation fallback), otherwise ComfyUI; `openai` / `comfyui` force one. `outer_model` pinned in config (not the chat model), sizes allowlisted to probed values, kill switch.
- **Visibility** is structural: the tool appears iff a native (Codex provider + creds) or ComfyUI backend is configured — **Kimi with no ComfyUI hides it**. A live provider switch rebuilds the registry.

## Two deliberate deviations from the design review — Aaron's explicit calls

1. **Availability IS tied to the active chat provider** (Odin's R2 argued to decouple). Rationale: native image rides *whatever Codex auth Odin is currently using*, so on Kimi there's no active Codex auth → ComfyUI only.
2. **`auto` is the flat default with no migration guard** (Odin flagged a silent behavior change for existing ComfyUI installs). Intended: existing installs switch to native-first on upgrade.

## Gates

7,406 passed / 4 skip / 0 failed · ruff 0 · mypy 0 (227 files) · lint/type/coverage gates all clean. New fixture tests cover failure classification, the no-retry-after-generation boundary, the >512KB SSE line, the visibility matrix, and selector routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)