### PR TITLE
fix(image): native is square-only; route by capability; hide backend name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -253,19 +253,20 @@ comfyui:
 
 # Image generation backend selection.
 #   auto    (default): follow the active chat provider — on 'codex' use native
-#            OpenAI (ComfyUI is the pre-generation fallback); on any other
-#            provider use ComfyUI only. If neither is available the tool hides.
-#   openai : native OpenAI only (rides the current Codex auth; Codex-provider only).
+#            OpenAI for square/unspecified requests (ComfyUI is the pre-generation
+#            fallback); a non-square size, a negative prompt, or a checkpoint
+#            routes to ComfyUI; on any other provider use ComfyUI only. If
+#            neither is available the tool hides.
+#   openai : native OpenAI only (rides the current Codex auth; Codex-provider
+#            only; square output only — non-square requests are rejected).
 #   comfyui: ComfyUI only.
+# Native OpenAI ignores the requested size and returns a backend-selected square.
 image:
   backend: auto
   openai:
     enabled: true          # kill switch for the native wire implementation
     outer_model: gpt-5.5   # Responses model hosting the image tool (pinned, not the chat model)
     image_model: gpt-image-2
-    # Only sizes probed against this private endpoint — widen after verifying each.
-    allowed_sizes: ["1024x1024"]
-    default_size: "1024x1024"
 
 # Web UI and API — all web configuration lives here (not in .env)
 web:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,8 +154,6 @@ image:
     enabled: true          # kill switch for the native wire implementation
     outer_model: gpt-5.5   # Responses model hosting the image tool (pinned)
     image_model: gpt-image-2
-    allowed_sizes: ["1024x1024"]
-    default_size: "1024x1024"
 ```
 
 The `generate_image` tool can target two backends:
@@ -163,24 +161,28 @@ The `generate_image` tool can target two backends:
 - **Native OpenAI** — generates via the `image_generation` tool on the Codex
   ChatGPT OAuth backend, riding the **same account Odin uses for chat** (no
   separate auth; subscription-quota-backed, so it draws on that account's usage
-  limit). Available only while the active provider is `codex`.
+  limit). Available only while the active provider is `codex`. This route
+  **ignores the requested size and always returns a backend-selected square
+  image** — it cannot produce aspect ratios.
 - **ComfyUI** — the local Stable-Diffusion backend (`comfyui.enabled`), which
-  also supports `negative`, `width`/`height`, and checkpoint `model`.
+  honors exact `size` dimensions and also supports `negative` and a checkpoint
+  `model`.
 
 `backend` selects between them:
 
-- `auto` (default) follows the active chat provider: on `codex`, native OpenAI
-  is used with ComfyUI as a pre-generation fallback; on any other provider,
-  ComfyUI only. A `negative`/`width`/`height`/`model` argument routes the
-  request to ComfyUI. If neither backend is available (e.g. Kimi with no
-  ComfyUI) the tool is hidden from the registry.
-- `openai` forces native OpenAI (ComfyUI-only arguments are rejected).
+- `auto` (default) follows the active chat provider. On `codex`: a square (or
+  omitted) `size` uses native OpenAI, with ComfyUI as a pre-generation fallback;
+  a **non-square** `size`, a `negative` prompt, or a checkpoint `model` routes to
+  ComfyUI (native can't satisfy those). On any other provider: ComfyUI only. If
+  neither backend is available (e.g. Kimi with no ComfyUI) the tool is hidden
+  from the registry.
+- `openai` forces native OpenAI; a non-square size or a ComfyUI-only argument is
+  rejected.
 - `comfyui` forces ComfyUI.
 
-`outer_model` is pinned here rather than following your chat model, so changing
-the chat model (Sol/Terra/…) never alters image generation. Only sizes listed in
-`allowed_sizes` are accepted — widen it only after verifying a size works against
-this private endpoint.
+`size` is `WxH` (e.g. `1024x1024`, `1536x1024`). `outer_model` is pinned here
+rather than following your chat model, so changing the chat model (Sol/Terra/…)
+never alters image generation.
 
 ## Web Management UI
 

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -609,10 +609,9 @@ class ImageOpenAIConfig(BaseModel):
     enabled: bool = True  # kill switch for the native wire implementation
     outer_model: str = "gpt-5.5"  # Responses model that hosts the image tool
     image_model: str = "gpt-image-2"  # the image_generation tool's model
-    # Only sizes actually probed against THIS private endpoint are allowed;
-    # widen after verifying each value (the Codex endpoint != public Images API).
-    allowed_sizes: list[str] = Field(default_factory=lambda: ["1024x1024"])
-    default_size: str = "1024x1024"
+    # NOTE: this route IGNORES the requested size and always returns a
+    # backend-selected SQUARE image, so there is no size allowlist — the
+    # selector sends non-square requests to ComfyUI instead.
     # Image-specific deadline (separate from chat). Progress events keep the
     # read timer alive but must not defeat the total.
     request_timeout_seconds: int = 180

--- a/src/discord/native_tools/media.py
+++ b/src/discord/native_tools/media.py
@@ -294,9 +294,18 @@ class MediaTools:
         try:
             file = discord.File(io.BytesIO(result.data), filename="generated.png")
             await message.channel.send(file=file)
+            # The selected backend is recorded internally (here + selector logs)
+            # but never surfaced in the user-facing result.
+            log.info(
+                "image generated: backend=%s model=%s decoded=%dx%d",
+                result.backend,
+                result.image_model,
+                result.width,
+                result.height,
+            )
             return (
-                f"Image generated via {result.backend} ({result.image_model}, "
-                f"{result.width}x{result.height}, {len(result.data) / 1024:.1f} KB) and posted."
+                f"Image generated ({result.width}x{result.height}, "
+                f"{len(result.data) / 1024:.1f} KB) and posted."
             )
         except discord.HTTPException as e:
             return f"Failed to upload generated image to Discord: {e}"

--- a/src/tools/defs/integrations_email.py
+++ b/src/tools/defs/integrations_email.py
@@ -147,9 +147,9 @@ TOOLS_SECTION: list[dict] = [
     {
         "name": "generate_image",
         "description": (
-            "Generates an image from a text prompt and posts it to Discord. "
-            "The backend is chosen by config (native OpenAI on the Codex provider, "
-            "or ComfyUI). Use 'prompt' and optionally 'size'."
+            "Generates an image from a text prompt and posts it to Discord. The "
+            "backend is chosen by config. Provide 'prompt'; add 'size' only when a "
+            "specific size/aspect ratio is wanted."
         ),
         "input_schema": {
             "type": "object",
@@ -160,26 +160,20 @@ TOOLS_SECTION: list[dict] = [
                 },
                 "size": {
                     "type": "string",
-                    "description": "Image size as WxH (e.g. '1024x1024'). Uses the "
-                    "configured default if omitted.",
+                    "description": "Optional size as WxH (e.g. '1024x1024' or '1536x1024'). "
+                    "A non-square size is served by ComfyUI (native OpenAI only produces "
+                    "square images). Omit for the default; do not pass unless the user "
+                    "asked for a specific size.",
                 },
                 "negative": {
                     "type": "string",
-                    "description": "ComfyUI only — negative prompt. Ignored/rejected by the "
-                    "OpenAI backend; in 'auto' its presence selects ComfyUI.",
-                },
-                "width": {
-                    "type": "integer",
-                    "description": "ComfyUI only — width in pixels (use 'size' for OpenAI).",
-                },
-                "height": {
-                    "type": "integer",
-                    "description": "ComfyUI only — height in pixels (use 'size' for OpenAI).",
+                    "description": "ComfyUI only — negative prompt. Selects ComfyUI; rejected "
+                    "by the OpenAI backend. Omit unless the user specifically wants one.",
                 },
                 "model": {
                     "type": "string",
-                    "description": "ComfyUI only — checkpoint name. In 'auto' its presence "
-                    "selects ComfyUI. The OpenAI image model is set in config, not here.",
+                    "description": "ComfyUI only — checkpoint name. Selects ComfyUI. The OpenAI "
+                    "image model is set in config, not here. Omit unless a checkpoint is named.",
                 },
             },
             "required": ["prompt"],

--- a/src/tools/image/__init__.py
+++ b/src/tools/image/__init__.py
@@ -17,6 +17,8 @@ from .base import (
     ImageRequestError,
     ImageResult,
     ImageTransportError,
+    is_square_size,
+    parse_size,
     png_dimensions,
 )
 from .comfyui_backend import ComfyUIImageBackend
@@ -34,5 +36,7 @@ __all__ = [
     "ImageTransportError",
     "ComfyUIImageBackend",
     "OpenAIImageBackend",
+    "is_square_size",
+    "parse_size",
     "png_dimensions",
 ]

--- a/src/tools/image/base.py
+++ b/src/tools/image/base.py
@@ -23,12 +23,19 @@ def png_dimensions(data: bytes) -> tuple[int, int] | None:
     return width, height
 
 
+# One canonical dimension contract for BOTH backends — the range ComfyUI can
+# actually honor. Requests outside it are rejected (never silently clamped,
+# which would change the caller's aspect ratio).
+MIN_DIM = 64
+MAX_DIM = 2048
+
+
 def parse_size(size: str | None) -> tuple[int, int] | None:
     """Parse a ``WxH`` size string to ``(width, height)``.
 
     Returns None for an omitted/empty size. Raises ValueError for a malformed,
-    one-sided, zero/negative, or out-of-bounds value so callers reject before
-    routing rather than guess.
+    one-sided, non-integer, or out-of-range value so callers reject before
+    routing rather than guess or clamp.
     """
     if not size:
         return None
@@ -39,10 +46,10 @@ def parse_size(size: str | None) -> tuple[int, int] | None:
         width, height = int(parts[0]), int(parts[1])
     except ValueError:
         raise ValueError(f"malformed size {size!r} (expected integer WxH)") from None
-    if width <= 0 or height <= 0:
-        raise ValueError(f"size {size!r} must be positive")
-    if width > 4096 or height > 4096:
-        raise ValueError(f"size {size!r} exceeds the 4096px limit")
+    if not (MIN_DIM <= width <= MAX_DIM) or not (MIN_DIM <= height <= MAX_DIM):
+        raise ValueError(
+            f"size {size!r} out of range — each dimension must be {MIN_DIM}..{MAX_DIM}"
+        )
     return (width, height)
 
 

--- a/src/tools/image/base.py
+++ b/src/tools/image/base.py
@@ -23,6 +23,39 @@ def png_dimensions(data: bytes) -> tuple[int, int] | None:
     return width, height
 
 
+def parse_size(size: str | None) -> tuple[int, int] | None:
+    """Parse a ``WxH`` size string to ``(width, height)``.
+
+    Returns None for an omitted/empty size. Raises ValueError for a malformed,
+    one-sided, zero/negative, or out-of-bounds value so callers reject before
+    routing rather than guess.
+    """
+    if not size:
+        return None
+    parts = str(size).strip().lower().split("x")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"malformed size {size!r} (expected WxH)")
+    try:
+        width, height = int(parts[0]), int(parts[1])
+    except ValueError:
+        raise ValueError(f"malformed size {size!r} (expected integer WxH)") from None
+    if width <= 0 or height <= 0:
+        raise ValueError(f"size {size!r} must be positive")
+    if width > 4096 or height > 4096:
+        raise ValueError(f"size {size!r} exceeds the 4096px limit")
+    return (width, height)
+
+
+def is_square_size(size: str | None) -> bool:
+    """True when no size is given (unconstrained) or the requested size is square.
+
+    Native OpenAI produces a backend-selected SQUARE image and ignores the
+    requested size, so only square/unspecified requests can be honored there.
+    """
+    dims = parse_size(size)
+    return dims is None or dims[0] == dims[1]
+
+
 @dataclass
 class ImageResult:
     """A generated image, ready for the tool layer to attach.

--- a/src/tools/image/comfyui_backend.py
+++ b/src/tools/image/comfyui_backend.py
@@ -9,34 +9,27 @@ from ..comfyui import ComfyUIClient
 from .base import (
     ImageBackend,
     ImageBackendUnavailableError,
+    ImageRequestError,
     ImageResult,
     ImageTransportError,
+    parse_size,
     png_dimensions,
 )
 
 log = get_logger("image.comfyui")
 
 
-def _parse_size(size: str | None, width: int | None, height: int | None) -> tuple[int, int]:
-    """Resolve a WxH pair from an explicit size string or width/height args.
+def _resolve_size(size: str | None, width: int | None, height: int | None) -> tuple[int, int]:
+    """Resolve a WxH pair, defaulting to 1024x1024.
 
-    Explicit width/height (a ComfyUI-only concept) win; otherwise parse the
-    backend-neutral ``size`` string; default 1024x1024. Clamped to a sane range.
+    Uses the ONE canonical contract (``parse_size``) shared with the selector —
+    out-of-range values are rejected, never clamped, so an accepted request's
+    aspect ratio is never silently altered. Raises ValueError on invalid input.
     """
-    w, h = 1024, 1024
-    if size and "x" in size:
-        try:
-            sw, sh = size.lower().split("x", 1)
-            w, h = int(sw), int(sh)
-        except ValueError:
-            pass
-    if width:
-        w = int(width)
-    if height:
-        h = int(height)
-    w = max(64, min(2048, w))
-    h = max(64, min(2048, h))
-    return w, h
+    dims = parse_size(size)
+    if dims is None and width is not None and height is not None:
+        dims = parse_size(f"{width}x{height}")
+    return dims if dims is not None else (1024, 1024)
 
 
 class ComfyUIImageBackend(ImageBackend):
@@ -60,7 +53,10 @@ class ComfyUIImageBackend(ImageBackend):
         if not config.comfyui.enabled:
             raise ImageBackendUnavailableError("ComfyUI is not enabled")
 
-        w, h = _parse_size(size, width, height)
+        try:
+            w, h = _resolve_size(size, width, height)
+        except ValueError as e:
+            raise ImageRequestError(str(e)) from e
         client = ComfyUIClient(
             config.comfyui.url, default_checkpoint=config.comfyui.default_checkpoint
         )
@@ -70,13 +66,18 @@ class ComfyUIImageBackend(ImageBackend):
         if not image_bytes:
             raise ImageTransportError("ComfyUI generation failed (unavailable or timed out)")
 
+        # Report DECODED dimensions — never substitute the request. Invalid /
+        # non-PNG output is rejected, not posted with a fabricated size.
         dims = png_dimensions(image_bytes)
-        aw, ah = dims if dims else (w, h)
+        if dims is None:
+            raise ImageTransportError(
+                "ComfyUI returned invalid (non-PNG) image data", pre_generation=False
+            )
         return ImageResult(
             data=image_bytes,
             mime="image/png",
-            width=aw,
-            height=ah,
+            width=dims[0],
+            height=dims[1],
             backend="comfyui",
             image_model=model or config.comfyui.default_checkpoint or "default",
         )

--- a/src/tools/image/openai_backend.py
+++ b/src/tools/image/openai_backend.py
@@ -32,6 +32,7 @@ from .base import (
     ImageRequestError,
     ImageResult,
     ImageTransportError,
+    is_square_size,
     png_dimensions,
 )
 
@@ -70,14 +71,15 @@ class OpenAIImageBackend(ImageBackend):
         return headers
 
     @staticmethod
-    def _body(icfg, prompt: str, size: str) -> dict:
+    def _body(icfg, prompt: str) -> dict:
+        # `size` is deliberately omitted: this route ignores it and always
+        # returns a backend-selected square, so sending it would imply a
+        # contract that does not exist.
         return {
             "model": icfg.openai.outer_model,
             "instructions": _INSTRUCTIONS,
             "input": [{"role": "user", "content": [{"type": "input_text", "text": prompt}]}],
-            "tools": [
-                {"type": "image_generation", "model": icfg.openai.image_model, "size": size}
-            ],
+            "tools": [{"type": "image_generation", "model": icfg.openai.image_model}],
             "tool_choice": {"type": "image_generation"},
             "stream": True,
             "store": False,
@@ -98,10 +100,13 @@ class OpenAIImageBackend(ImageBackend):
         if pool is None or not pool.is_configured():
             raise ImageBackendUnavailableError("No Codex credentials for native image generation")
 
-        size = size or icfg.openai.default_size
-        if size not in icfg.openai.allowed_sizes:
+        # Defense in depth: the selector routes non-square requests to ComfyUI,
+        # but native only ever produces a square image, so refuse a non-square
+        # size here too rather than silently returning the wrong shape.
+        if not is_square_size(size):
             raise ImageRequestError(
-                f"Unsupported size {size!r}. Allowed: {', '.join(icfg.openai.allowed_sizes)}"
+                "the OpenAI backend only produces square images "
+                f"(requested {size})"
             )
 
         # An open image breaker is pre-generation — let auto fall back to ComfyUI.
@@ -110,7 +115,7 @@ class OpenAIImageBackend(ImageBackend):
         except CircuitOpenError as e:
             raise ImageTransportError("image endpoint breaker open", pre_generation=True) from e
 
-        body = self._body(icfg, prompt, size)
+        body = self._body(icfg, prompt)
         session = await self._get_session()
         timeout = aiohttp.ClientTimeout(
             total=icfg.openai.request_timeout_seconds,

--- a/src/tools/image/selector.py
+++ b/src/tools/image/selector.py
@@ -16,6 +16,8 @@ from .base import (
     ImageGenError,
     ImageRequestError,
     ImageResult,
+    is_square_size,
+    parse_size,
 )
 
 log = get_logger("image.selector")
@@ -64,6 +66,31 @@ class ImageBackendSelector:
     def tool_available(self, config=None) -> bool:
         return image_tool_available(config or self.get_config())
 
+    @staticmethod
+    def _resolve_size(size: str | None, width: int | None, height: int | None) -> str | None:
+        """Canonical requested size (``WxH``) or None.
+
+        Explicit ``size`` wins; otherwise legacy ``width``/``height`` (both
+        required) are normalized. Malformed/one-sided/out-of-bounds inputs are
+        rejected here so routing never guesses.
+        """
+        if size:
+            try:
+                parse_size(size)
+            except ValueError as e:
+                raise ImageRequestError(str(e)) from e
+            return str(size).strip().lower()
+        if width is not None and height is not None:
+            combined = f"{int(width)}x{int(height)}"
+            try:
+                parse_size(combined)
+            except ValueError as e:
+                raise ImageRequestError(str(e)) from e
+            return combined
+        if width is not None or height is not None:
+            raise ImageRequestError("both width and height are required (or use size WxH)")
+        return None
+
     async def generate(
         self,
         *,
@@ -78,56 +105,64 @@ class ImageBackendSelector:
         backend = config.image.backend
         native = self.openai is not None and _native_possible(config)
         comfy = _comfy_possible(config)
-        # ComfyUI-only concepts. Their presence routes to ComfyUI in auto and is
-        # rejected (never silently ignored) under the OpenAI backend.
-        wants_comfy_features = (
-            bool(negative) or bool(model) or width is not None or height is not None
-        )
+
+        req_size = self._resolve_size(size, width, height)
+        # Only `negative` and a checkpoint `model` are genuinely ComfyUI-only;
+        # width/height are just geometry and fold into `req_size`.
+        comfy_only = bool(negative) or bool(model)
+        # Native produces a backend-selected SQUARE image and cannot honor an
+        # aspect ratio, so a non-square request is a ComfyUI-capability request.
+        non_square = not is_square_size(req_size)
+
+        async def _comfy(reason: str = "") -> ImageResult:
+            if reason:
+                log.info("image gen -> ComfyUI (%s)", reason)
+            return await self.comfyui.generate(
+                prompt=prompt, size=req_size, negative=negative, model=model
+            )
 
         if backend == "comfyui":
             if not comfy:
                 raise ImageBackendUnavailableError("ComfyUI is not configured")
-            return await self.comfyui.generate(
-                prompt=prompt, size=size, negative=negative, model=model, width=width, height=height
-            )
+            return await _comfy()
 
         if backend == "openai":
-            if wants_comfy_features:
+            if comfy_only:
                 raise ImageRequestError(
-                    "negative/model/width/height are ComfyUI-only and not supported "
-                    "by the OpenAI backend"
+                    "negative/model are ComfyUI-only and not supported by the OpenAI backend"
+                )
+            if non_square:
+                raise ImageRequestError(
+                    "OpenAI image generation only supports square output on this "
+                    f"authentication route; requested {req_size}"
                 )
             if not native:
                 raise ImageBackendUnavailableError(
                     "Native OpenAI image generation requires the Codex provider and credentials"
                 )
-            return await self.openai.generate(prompt=prompt, size=size)
+            return await self.openai.generate(prompt=prompt, size=req_size)
 
-        # auto — follow the active provider, with ComfyUI as the pre-generation fallback
-        if wants_comfy_features:
+        # auto — capability routing
+        if comfy_only:
             if comfy:
-                return await self.comfyui.generate(
-                    prompt=prompt,
-                    size=size,
-                    negative=negative,
-                    model=model,
-                    width=width,
-                    height=height,
-                )
-            raise ImageRequestError(
-                "negative/model/width/height require ComfyUI, which is not configured"
+                return await _comfy("negative/checkpoint requested")
+            raise ImageRequestError("negative/model require ComfyUI, which is not configured")
+        if non_square:
+            # ComfyUI is the ONLY backend that can produce this shape — never
+            # fall back to native, which would knowingly return a square.
+            if comfy:
+                return await _comfy(f"non-square {req_size}")
+            raise ImageBackendUnavailableError(
+                f"the requested aspect ratio {req_size} needs ComfyUI, which is unavailable; "
+                "the OpenAI backend only produces square images"
             )
         if native:
             try:
-                return await self.openai.generate(prompt=prompt, size=size)
+                return await self.openai.generate(prompt=prompt, size=req_size)
             except ImageGenError as e:
                 if e.pre_generation and comfy:
-                    log.info(
-                        "Native image gen unavailable (%s); falling back to ComfyUI",
-                        type(e).__name__,
-                    )
-                    return await self.comfyui.generate(prompt=prompt, size=size)
+                    return await _comfy(f"native unavailable: {type(e).__name__}")
                 raise
         if comfy:
-            return await self.comfyui.generate(prompt=prompt, size=size)
+            return await _comfy()
         raise ImageBackendUnavailableError("No image backend is available")

--- a/src/tools/image/selector.py
+++ b/src/tools/image/selector.py
@@ -76,17 +76,18 @@ class ImageBackendSelector:
         """
         if size:
             try:
-                parse_size(size)
+                dims = parse_size(size)
             except ValueError as e:
                 raise ImageRequestError(str(e)) from e
-            return str(size).strip().lower()
+            return f"{dims[0]}x{dims[1]}"  # type: ignore[index]
         if width is not None and height is not None:
-            combined = f"{int(width)}x{int(height)}"
+            # Let parse_size do all validation — never int() raw input (a
+            # non-integer would leak a ValueError; a float would truncate).
             try:
-                parse_size(combined)
+                dims = parse_size(f"{width}x{height}")
             except ValueError as e:
                 raise ImageRequestError(str(e)) from e
-            return combined
+            return f"{dims[0]}x{dims[1]}"  # type: ignore[index]
         if width is not None or height is not None:
             raise ImageRequestError("both width and height are required (or use size WxH)")
         return None

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -121,7 +121,7 @@ EXPECTED_TOOL_HASHES = {
     "terraform_ops": "054cd8877208bc7d",
     "http_probe": "dfc3b04b36c5e7f9",
     "issue_tracker": "4f0a793414052b40",
-    "generate_image": "ee28d2ae514c51e0",
+    "generate_image": "ef74ebec4eafcaf1",
     "validate_action": "199baeb4723517d7",
     "email_send": "1282279440e34e6f",
     "email_search": "3a7584b725d1c134",

--- a/tests/test_image_backends.py
+++ b/tests/test_image_backends.py
@@ -480,14 +480,35 @@ async def test_comfyui_backend_failure_is_transport_error(monkeypatch):
         await b.generate(prompt="p")
 
 
-def test_parse_size_variants():
-    from src.tools.image.comfyui_backend import _parse_size
+async def test_comfyui_backend_rejects_non_png_output(monkeypatch):
+    # A non-PNG payload must be rejected, not posted with a fabricated size.
+    from src.tools.image import comfyui_backend as mod
 
-    assert _parse_size("512x768", None, None) == (512, 768)
-    assert _parse_size(None, None, None) == (1024, 1024)
-    assert _parse_size("garbage", None, None) == (1024, 1024)
-    assert _parse_size("100x100", 200, 300) == (200, 300)  # explicit w/h win
-    assert _parse_size(None, 99999, 10) == (2048, 64)  # clamped both ends
+    junk = b"\xff\xd8\xff\xe0 not a png " + b"\x00" * 40
+    monkeypatch.setattr(
+        mod, "ComfyUIClient", lambda url, default_checkpoint="": _FakeComfyClient(junk)
+    )
+    b = mod.ComfyUIImageBackend(get_config=lambda: _comfy_cfg())
+    with pytest.raises(ImageTransportError):
+        await b.generate(prompt="p", size="512x512")
+
+
+def test_comfy_resolve_size():
+    from src.tools.image.comfyui_backend import _resolve_size
+
+    assert _resolve_size("512x768", None, None) == (512, 768)
+    assert _resolve_size(None, None, None) == (1024, 1024)  # default
+    assert _resolve_size(None, 200, 300) == (200, 300)  # width/height when no size
+    # Out-of-range is REJECTED, never clamped (would change the aspect ratio).
+    bad_inputs = [
+        ("garbage", None, None),
+        (None, 99999, 10),
+        ("4096x1024", None, None),
+        (None, 1, 2),
+    ]
+    for bad in bad_inputs:
+        with pytest.raises(ValueError):
+            _resolve_size(*bad)
 
 
 # ── visibility matrix (Aaron's rules) ─────────────────────────────────
@@ -613,10 +634,14 @@ def test_parse_size_and_is_square():
     assert parse_size("") is None
     assert parse_size("1024x1024") == (1024, 1024)
     assert parse_size("1536X1024") == (1536, 1024)  # case-insensitive
+    assert parse_size("64x64") == (64, 64)  # lower bound ok
+    assert parse_size("2048x2048") == (2048, 2048)  # upper bound ok
     assert is_square_size(None) is True
     assert is_square_size("1024x1024") is True
     assert is_square_size("1536x1024") is False
-    for bad in ["1024", "1024x", "x1024", "0x0", "-1x-1", "axb", "5000x5000"]:
+    # malformed, non-integer, or out of the canonical 64..2048 range
+    for bad in ["1024", "1024x", "x1024", "0x0", "-1x-1", "axb", "1024.5x1024",
+                "32x32", "2049x2048", "5000x5000", "64x4096"]:
         with pytest.raises(ValueError):
             parse_size(bad)
 
@@ -684,3 +709,21 @@ async def test_selector_explicit_size_wins_over_width_height():
         prompt="p", size="1024x1024", width=1536, height=1024
     )
     assert native.calls and native.calls[0]["size"] == "1024x1024" and not comfy.calls
+
+
+async def test_selector_rejects_out_of_range_size():
+    # 4096x1024 exceeds the 2048 cap ComfyUI honors — reject, never clamp
+    # (clamping would change the caller's requested aspect ratio).
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    with pytest.raises(ImageRequestError):
+        await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", size="4096x1024")
+    assert not native.calls and not comfy.calls
+
+
+async def test_selector_bad_dimension_does_not_leak_valueerror():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    sel = _selector(cfg, native=_RecordingBackend("openai"), comfy=_RecordingBackend("comfyui"))
+    with pytest.raises(ImageRequestError):  # a clean ImageRequestError, NOT a raw ValueError
+        await sel.generate(prompt="p", width="bad", height=1024)

--- a/tests/test_image_backends.py
+++ b/tests/test_image_backends.py
@@ -311,12 +311,24 @@ async def test_no_image_in_stream_rejected():
         await b.generate(prompt="p")
 
 
-async def test_disallowed_size_rejected_without_request():
+async def test_native_rejects_non_square_without_request():
+    # Native only produces squares; a non-square size is refused before any HTTP
+    # call (defense in depth — the selector also routes non-square to ComfyUI).
     pool = _FakePool()
     b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event()),))])
     with pytest.raises(ImageRequestError):
-        await b.generate(prompt="p", size="4096x4096")
-    assert b._session.posts == 0  # rejected before any HTTP call
+        await b.generate(prompt="p", size="1536x1024")
+    assert b._session.posts == 0
+
+
+async def test_native_accepts_square_and_omits_size_in_payload():
+    pool = _FakePool()
+    b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event()),))])
+    res = await b.generate(prompt="p", size="1024x1024")
+    assert res.backend == "openai"
+    # `size` must NOT be sent — the endpoint ignores it.
+    sent = b._body(b.get_config().image, "p")
+    assert "size" not in sent["tools"][0]
 
 
 async def test_kill_switch_unavailable():
@@ -589,3 +601,86 @@ async def test_selector_no_backend_available_raises():
     cfg = _cfg(backend="auto", provider="kimi", comfy=False)
     with pytest.raises(ImageBackendUnavailableError):
         await _selector(cfg, native=None, comfy=_RecordingBackend("comfyui")).generate(prompt="p")
+
+
+# ── size handling + square-only routing (Odin round-2) ────────────────
+
+
+def test_parse_size_and_is_square():
+    from src.tools.image.base import is_square_size, parse_size
+
+    assert parse_size(None) is None
+    assert parse_size("") is None
+    assert parse_size("1024x1024") == (1024, 1024)
+    assert parse_size("1536X1024") == (1536, 1024)  # case-insensitive
+    assert is_square_size(None) is True
+    assert is_square_size("1024x1024") is True
+    assert is_square_size("1536x1024") is False
+    for bad in ["1024", "1024x", "x1024", "0x0", "-1x-1", "axb", "5000x5000"]:
+        with pytest.raises(ValueError):
+            parse_size(bad)
+
+
+async def test_selector_width_height_fold_to_size_and_use_native():
+    # The original bug: width/height (auto-filled from the schema) forced
+    # ComfyUI. They now fold into a square size and go native.
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", width=1024, height=1024)
+    assert native.calls and not comfy.calls
+    assert native.calls[0]["size"] == "1024x1024"
+
+
+async def test_selector_auto_non_square_routes_to_comfy():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", size="1536x1024")
+    assert res.backend == "comfyui" and not native.calls  # native never tried
+
+
+async def test_selector_auto_non_square_no_comfy_does_not_fall_back_to_native():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=False)
+    native = _RecordingBackend("openai")
+    with pytest.raises(ImageBackendUnavailableError):
+        await _selector(cfg, native=native, comfy=_RecordingBackend("comfyui")).generate(
+            prompt="p", size="1536x1024"
+        )
+    assert not native.calls  # a non-square request must never fall back to native
+
+
+async def test_selector_openai_mode_rejects_non_square():
+    cfg = _cfg(backend="openai", provider="codex", codex=True)
+    native = _RecordingBackend("openai")
+    with pytest.raises(ImageRequestError):
+        await _selector(cfg, native=native, comfy=_RecordingBackend("comfyui")).generate(
+            prompt="p", size="1536x1024"
+        )
+    assert not native.calls  # rejected before any native call
+
+
+async def test_selector_auto_square_size_uses_native():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", size="512x512")
+    assert res.backend == "openai" and native.calls and not comfy.calls
+
+
+async def test_selector_rejects_one_sided_dimension():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    sel = _selector(cfg, native=_RecordingBackend("openai"), comfy=_RecordingBackend("comfyui"))
+    with pytest.raises(ImageRequestError):
+        await sel.generate(prompt="p", width=1024)  # height missing
+
+
+async def test_selector_explicit_size_wins_over_width_height():
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    # explicit square size beats a non-square width/height -> native
+    await _selector(cfg, native=native, comfy=comfy).generate(
+        prompt="p", size="1024x1024", width=1536, height=1024
+    )
+    assert native.calls and native.calls[0]["size"] == "1024x1024" and not comfy.calls

--- a/tests/test_native_media.py
+++ b/tests/test_native_media.py
@@ -296,7 +296,8 @@ class TestGenerateImage:
         sel = self._selector(result=self._result(backend="openai"))
         msg = _message()
         out = await _tools(image_selector=sel)._handle_generate_image(msg, {"prompt": "a cat"})
-        assert "Image generated via openai" in out
+        assert "Image generated (1024x1024" in out
+        assert "openai" not in out.lower()  # backend name is NOT surfaced
         msg.channel.send.assert_awaited_once()
 
     async def test_backend_failure_and_http_error(self):


### PR DESCRIPTION
## Problem

In Aaron's live test, "generate an image of a cat" went to ComfyUI, not native OpenAI. Root cause: the LLM auto-filled `width`/`height` from the tool schema, and the selector treated **any** width/height as a ComfyUI-only feature — short-circuiting to ComfyUI before native was tried. That over-implemented the design (only `negative`/checkpoint were meant to force ComfyUI).

Probing the endpoint also revealed it **ignores the requested size**: `1024x1024`, `1536x1024`, and `1024x1536` all returned the same ~`1254x1254` square. Native is a square-only, backend-selected-resolution generator.

## Fix (Odin-reviewed design)

- Only `negative` or a checkpoint `model` force ComfyUI. `width`/`height` fold into a canonical `size` (explicit `size` wins; one-sided/malformed rejected before routing).
- **Capability routing**: a non-square size is a ComfyUI request. In `auto` it goes straight to ComfyUI and **never falls back to native** (which would return the wrong shape); with no ComfyUI it errors honestly. In `openai`, a non-square size or a ComfyUI-only field is **rejected before acquiring auth**.
- The native payload no longer sends the ignored `size`; the backend also refuses non-square as defense in depth.
- Drop `allowed_sizes`/`default_size` (meaningless — the endpoint ignores size).
- Remove `width`/`height` from the LLM-visible tool schema (still accepted internally for replay/scheduled calls); document `size` semantics.
- The result message **drops the backend name** and reports **decoded** dimensions (`"Image generated (1254x1254, N KB) and posted"`); backend/fallback recorded in logs only.

## Routing table

| Mode | Request | Route |
|---|---|---|
| `auto` | `negative` or checkpoint `model` | ComfyUI |
| `auto` | explicit non-square size | ComfyUI directly (no native fallback) |
| `auto` | no size or square size | native first; pre-generation fallback to ComfyUI |
| `openai` | non-square size or ComfyUI-only field | reject before auth |
| `openai` | no size or square size | native |
| `comfyui` | any valid request | ComfyUI |

## Gates

7,425 passed / 4 skip / 0 failed · ruff 0 · mypy 0 (227 files) · lint/type/coverage clean. Tests pin: width/height fold to native, auto non-square → ComfyUI (zero native calls), no native fallback when ComfyUI can't do non-square, explicit-openai non-square rejection, square native routing, one-sided rejection, decoded dims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)