### PR TITLE
fix(image): route on size-presence; make the chosen backend queryable via audit

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -253,14 +253,14 @@ comfyui:
 
 # Image generation backend selection.
 #   auto    (default): follow the active chat provider — on 'codex' use native
-#            OpenAI for square/unspecified requests (ComfyUI is the pre-generation
-#            fallback); a non-square size, a negative prompt, or a checkpoint
-#            routes to ComfyUI; on any other provider use ComfyUI only. If
-#            neither is available the tool hides.
+#            OpenAI when NO size is requested (ComfyUI is the pre-generation
+#            fallback); ANY explicit size, a negative prompt, or a checkpoint
+#            routes to ComfyUI (only it honors those); on any other provider use
+#            ComfyUI only. If neither is available the tool hides.
 #   openai : native OpenAI only (rides the current Codex auth; Codex-provider
-#            only; square output only — non-square requests are rejected).
+#            only; an explicit size or ComfyUI-only field is rejected).
 #   comfyui: ComfyUI only.
-# Native OpenAI ignores the requested size and returns a backend-selected square.
+# Native OpenAI ignores the requested size and returns backend-selected dimensions.
 image:
   backend: auto
   openai:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,27 +162,29 @@ The `generate_image` tool can target two backends:
   ChatGPT OAuth backend, riding the **same account Odin uses for chat** (no
   separate auth; subscription-quota-backed, so it draws on that account's usage
   limit). Available only while the active provider is `codex`. This route
-  **ignores the requested size and always returns a backend-selected square
-  image** — it cannot produce aspect ratios.
+  **ignores the requested size and returns backend-selected dimensions** (it may
+  pick any aspect ratio based on the content), so it can't honor a specific size.
 - **ComfyUI** — the local Stable-Diffusion backend (`comfyui.enabled`), which
   honors exact `size` dimensions and also supports `negative` and a checkpoint
   `model`.
 
 `backend` selects between them:
 
-- `auto` (default) follows the active chat provider. On `codex`: a square (or
-  omitted) `size` uses native OpenAI, with ComfyUI as a pre-generation fallback;
-  a **non-square** `size`, a `negative` prompt, or a checkpoint `model` routes to
-  ComfyUI (native can't satisfy those). On any other provider: ComfyUI only. If
-  neither backend is available (e.g. Kimi with no ComfyUI) the tool is hidden
-  from the registry.
-- `openai` forces native OpenAI; a non-square size or a ComfyUI-only argument is
+- `auto` (default) follows the active chat provider. On `codex`: a request with
+  **no size** (and no ComfyUI-only field) uses native OpenAI, with ComfyUI as a
+  pre-generation fallback; **any explicit `size`**, a `negative` prompt, or a
+  checkpoint `model` routes to ComfyUI (only it honors those). On any other
+  provider: ComfyUI only. If neither backend is available (e.g. Kimi with no
+  ComfyUI) the tool is hidden from the registry.
+- `openai` forces native OpenAI; an explicit size or a ComfyUI-only argument is
   rejected.
 - `comfyui` forces ComfyUI.
 
 `size` is `WxH` (e.g. `1024x1024`, `1536x1024`). `outer_model` is pinned here
 rather than following your chat model, so changing the chat model (Sol/Terra/…)
-never alters image generation.
+never alters image generation. The backend that actually ran (and any fallback)
+is recorded in the audit log — queryable via `search_audit`, not shown in the
+tool's reply.
 
 ## Web Management UI
 

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -192,6 +192,7 @@ class AuditLogger:
         diff: str | None = None,
         risk_level: str | None = None,
         risk_reason: str | None = None,
+        audit_metadata: dict | None = None,
     ) -> None:
         entry = {
             "timestamp": datetime.now(UTC).isoformat(),
@@ -220,6 +221,10 @@ class AuditLogger:
             entry["risk_level"] = risk_level
         if risk_reason:
             entry["risk_reason"] = risk_reason
+        if audit_metadata:
+            # Bounded structured metadata (e.g. image backend/route/dims) — the
+            # caller guarantees no prompts, IDs, or payloads.
+            entry["audit_metadata"] = audit_metadata
         await self._persist(entry)
 
     async def log_event(

--- a/src/discord/native_tools/knowledge.py
+++ b/src/discord/native_tools/knowledge.py
@@ -184,5 +184,11 @@ class KnowledgeTools:
             summary = entry.get("result_summary", "")[:200]
             err = entry.get("error")
             status = f"ERROR: {err}" if err else summary
-            lines.append(f"[{ts}] **{tool}** by {user} ({approved}, {elapsed}ms)\n  {status}")
+            line = f"[{ts}] **{tool}** by {user} ({approved}, {elapsed}ms)\n  {status}"
+            meta = entry.get("audit_metadata")
+            if isinstance(meta, dict) and meta:
+                # Structured record (e.g. which image backend actually ran).
+                rendered = " ".join(f"{k}={v}" for k, v in meta.items())
+                line += f"\n  [{rendered}]"
+            lines.append(line)
         return f"**Audit log ({len(results)} entries):**\n" + "\n".join(lines)

--- a/src/discord/native_tools/media.py
+++ b/src/discord/native_tools/media.py
@@ -262,10 +262,16 @@ class MediaTools:
             "__prompt__": prompt,
         }
 
-    async def _handle_generate_image(self, message, inp: dict) -> str:
+    async def _handle_generate_image(self, message, inp: dict):
         """Generate an image via the selected backend and post as a Discord
-        attachment. The backend returns bytes; this tool layer owns Discord."""
+        attachment. The backend returns bytes; this tool layer owns Discord.
+
+        Returns a ToolResult whose ``output`` is a generic user-facing string
+        (never names the backend) plus ``audit_metadata`` — a bounded structured
+        record so ``search_audit`` can answer "which backend?" when asked.
+        """
         from ...tools.image import ImageGenError
+        from ...tools.result_validator import ToolResult
 
         if self.image_selector is None:
             return "Image generation is not available."
@@ -291,21 +297,37 @@ class MediaTools:
             log.warning("image generation raised unexpectedly", exc_info=True)
             return "Image generation failed unexpectedly."
 
+        # Non-sensitive structured record — enums + decoded dims only.
+        meta: dict = {
+            "backend": result.backend,
+            "route": result.route,
+            "fallback_reason": result.fallback_reason,
+            "decoded_width": result.width,
+            "decoded_height": result.height,
+        }
         try:
             file = discord.File(io.BytesIO(result.data), filename="generated.png")
             await message.channel.send(file=file)
-            # The selected backend is recorded internally (here + selector logs)
-            # but never surfaced in the user-facing result.
-            log.info(
-                "image generated: backend=%s model=%s decoded=%dx%d",
-                result.backend,
-                result.image_model,
-                result.width,
-                result.height,
+        except discord.HTTPException as e:
+            # Generation succeeded even though delivery failed — record both.
+            meta["delivery_status"] = "upload_failed"
+            log.info("image generated (backend=%s) but upload failed: %s", result.backend, e)
+            return ToolResult(
+                output=f"Failed to upload generated image to Discord: {e}",
+                tool_name="generate_image",
+                audit_metadata=meta,
             )
-            return (
+
+        meta["delivery_status"] = "posted"
+        log.info(
+            "image generated: backend=%s model=%s decoded=%dx%d route=%s",
+            result.backend, result.image_model, result.width, result.height, result.route,
+        )
+        return ToolResult(
+            output=(
                 f"Image generated ({result.width}x{result.height}, "
                 f"{len(result.data) / 1024:.1f} KB) and posted."
-            )
-        except discord.HTTPException as e:
-            return f"Failed to upload generated image to Discord: {e}"
+            ),
+            tool_name="generate_image",
+            audit_metadata=meta,
+        )

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -112,6 +112,15 @@ class _LoopAuthorProxy:
         return self._name
 
 
+def _unwrap_native_result(result):
+    """A native handler may return a ToolResult (carrying non-model-facing
+    audit_metadata) or a plain string/dict. Return ``(tool_result_or_None,
+    output)`` so the caller audits the metadata and sends the string."""
+    if isinstance(result, ToolResult):
+        return result, str(result)
+    return None, result
+
+
 @dataclass(frozen=True)
 class LoopPolicy:
     """The chat-vs-autonomous behavioral dimensions (RFC-001 §4.3) as data.
@@ -905,6 +914,10 @@ class ToolLoopRunner:
                         channel=st.message.channel,
                         user_id=st.user_id,
                     )
+                # A native handler may return a ToolResult (e.g. generate_image
+                # carries non-model-facing audit_metadata) — unwrap it so the
+                # audit record picks up the metadata like the executor path.
+                tool_result, result = _unwrap_native_result(result)
             else:
                 tool_result = await self._tool_executor.execute(
                     tool_name,
@@ -1003,6 +1016,7 @@ class ToolLoopRunner:
                 error=error,
                 risk_level=tool_result.risk_level if tool_result else None,
                 risk_reason=tool_result.risk_reason if tool_result else None,
+                audit_metadata=tool_result.audit_metadata if tool_result else None,
             )
             await self._audit.log_event(
                 event_type="tool_end",
@@ -1469,7 +1483,9 @@ class ToolLoopRunner:
 
         # Make structured failure visible (see ensure_failure_visible)
         # and propagate it into the audit error field.
+        _audit_meta = None
         if isinstance(raw, ToolResult):
+            _audit_meta = raw.audit_metadata
             if not raw.ok and not error:
                 error = raw.error or "tool reported failure"
             raw = ensure_failure_visible(str(raw), raw.ok)
@@ -1488,6 +1504,7 @@ class ToolLoopRunner:
                 result_summary=result,
                 execution_time_ms=elapsed_ms,
                 error=error,
+                audit_metadata=_audit_meta,
             )
         except OSError as audit_err:
             log.warning("Audit write failed (I/O): %s", audit_err)

--- a/src/tools/defs/integrations_email.py
+++ b/src/tools/defs/integrations_email.py
@@ -160,10 +160,10 @@ TOOLS_SECTION: list[dict] = [
                 },
                 "size": {
                     "type": "string",
-                    "description": "Optional size as WxH (e.g. '1024x1024' or '1536x1024'). "
-                    "A non-square size is served by ComfyUI (native OpenAI only produces "
-                    "square images). Omit for the default; do not pass unless the user "
-                    "asked for a specific size.",
+                    "description": "Optional size as WxH (e.g. '1024x1024', '1536x1024'). Any "
+                    "specified size selects ComfyUI; OMIT it to let the native backend choose "
+                    "its own dimensions and aspect ratio. Only pass it if the user asked for a "
+                    "specific size.",
                 },
                 "negative": {
                     "type": "string",

--- a/src/tools/image/__init__.py
+++ b/src/tools/image/__init__.py
@@ -17,7 +17,6 @@ from .base import (
     ImageRequestError,
     ImageResult,
     ImageTransportError,
-    is_square_size,
     parse_size,
     png_dimensions,
 )
@@ -36,7 +35,6 @@ __all__ = [
     "ImageTransportError",
     "ComfyUIImageBackend",
     "OpenAIImageBackend",
-    "is_square_size",
     "parse_size",
     "png_dimensions",
 ]

--- a/src/tools/image/base.py
+++ b/src/tools/image/base.py
@@ -53,22 +53,13 @@ def parse_size(size: str | None) -> tuple[int, int] | None:
     return (width, height)
 
 
-def is_square_size(size: str | None) -> bool:
-    """True when no size is given (unconstrained) or the requested size is square.
-
-    Native OpenAI produces a backend-selected SQUARE image and ignores the
-    requested size, so only square/unspecified requests can be honored there.
-    """
-    dims = parse_size(size)
-    return dims is None or dims[0] == dims[1]
-
-
 @dataclass
 class ImageResult:
     """A generated image, ready for the tool layer to attach.
 
     Carries only non-sensitive metadata — never account identifiers, tokens,
-    or raw provider payloads.
+    or raw provider payloads. ``route``/``fallback_reason`` are stamped by the
+    selector for the audit record.
     """
 
     data: bytes
@@ -77,6 +68,8 @@ class ImageResult:
     height: int
     backend: str  # "openai" | "comfyui"
     image_model: str
+    route: str = ""  # stable enum, e.g. auto_native / auto_comfy_size (selector-set)
+    fallback_reason: str | None = None  # stable enum when native fell back
 
 
 class ImageGenError(Exception):
@@ -87,9 +80,19 @@ class ImageGenError(Exception):
     account or falling back to ComfyUI cannot duplicate work or quota. Anything
     that happens after a 2xx or the first generation event is post-generation
     and must NOT be retried or fallen back.
+
+    ``reason`` is a stable enum (quota / account_unavailable / pool_exhausted /
+    pre_response_transport) recorded as the audit fallback_reason — never raw
+    exception text.
     """
 
     pre_generation: bool = False
+    reason: str | None = None
+
+    def __init__(self, message: str = "", *, reason: str | None = None) -> None:
+        super().__init__(message)
+        if reason is not None:
+            self.reason = reason
 
 
 class ImageBackendUnavailableError(ImageGenError):
@@ -110,8 +113,10 @@ class ImageTransportError(ImageGenError):
     before an accepted response; a mid-stream break after 2xx is post-generation
     (constructed with ``pre_generation=False``)."""
 
-    def __init__(self, message: str, *, pre_generation: bool = True) -> None:
-        super().__init__(message)
+    def __init__(
+        self, message: str, *, pre_generation: bool = True, reason: str | None = None
+    ) -> None:
+        super().__init__(message, reason=reason)
         self.pre_generation = pre_generation
 
 

--- a/src/tools/image/openai_backend.py
+++ b/src/tools/image/openai_backend.py
@@ -32,7 +32,6 @@ from .base import (
     ImageRequestError,
     ImageResult,
     ImageTransportError,
-    is_square_size,
     png_dimensions,
 )
 
@@ -100,20 +99,24 @@ class OpenAIImageBackend(ImageBackend):
         if pool is None or not pool.is_configured():
             raise ImageBackendUnavailableError("No Codex credentials for native image generation")
 
-        # Defense in depth: the selector routes non-square requests to ComfyUI,
-        # but native only ever produces a square image, so refuse a non-square
-        # size here too rather than silently returning the wrong shape.
-        if not is_square_size(size):
+        # Defense in depth: native ignores the requested size and picks its own
+        # dimensions, so it can't honor ANY specific size. The selector routes
+        # every sized request to ComfyUI; refuse one here too rather than
+        # pretending we honored it.
+        if size is not None:
             raise ImageRequestError(
-                "the OpenAI backend only produces square images "
-                f"(requested {size})"
+                "the OpenAI backend chooses its own dimensions and cannot honor a "
+                f"requested size ({size})"
             )
 
         # An open image breaker is pre-generation — let auto fall back to ComfyUI.
         try:
             self.breaker.check()
         except CircuitOpenError as e:
-            raise ImageTransportError("image endpoint breaker open", pre_generation=True) from e
+            raise ImageTransportError(
+                "image endpoint breaker open", pre_generation=True,
+                reason="pre_response_transport",
+            ) from e
 
         body = self._body(icfg, prompt)
         session = await self._get_session()
@@ -133,7 +136,9 @@ class OpenAIImageBackend(ImageBackend):
             except RuntimeError:
                 # Pool exhausted / no healthy account — pre-generation, so auto
                 # can fall back to ComfyUI. Never surface the raw pool error.
-                last_err = ImageQuotaError("no healthy Codex account for image generation")
+                last_err = ImageQuotaError(
+                    "no healthy Codex account for image generation", reason="pool_exhausted"
+                )
                 break
             committed = False
             try:
@@ -154,16 +159,23 @@ class OpenAIImageBackend(ImageBackend):
 
                     if resp.status == 429:
                         await pool.mark_limited(idx)
-                        last_err = ImageQuotaError("usage limit reached (HTTP 429)")
+                        last_err = ImageQuotaError(
+                            "usage limit reached (HTTP 429)", reason="quota"
+                        )
                         continue
                     if resp.status == 401:
                         await pool.mark_auth_failed(idx)
-                        last_err = ImageQuotaError("account authentication failed (HTTP 401)")
+                        last_err = ImageQuotaError(
+                            "account authentication failed (HTTP 401)",
+                            reason="account_unavailable",
+                        )
                         continue
                     if resp.status in (500, 502, 503, 504):
                         # Endpoint health — this one counts against the breaker.
                         self.breaker.record_failure()
-                        last_err = ImageTransportError(f"image endpoint HTTP {resp.status}")
+                        last_err = ImageTransportError(
+                            f"image endpoint HTTP {resp.status}", reason="pre_response_transport"
+                        )
                         continue
                     # Other 4xx: request-level (bad params / content policy). Do
                     # NOT fail over, fall back, OR poison the shared breaker — a
@@ -183,12 +195,17 @@ class OpenAIImageBackend(ImageBackend):
                 # mid-stream break after 200 is caught inside _read_stream and
                 # re-raised as a non-failover ImageTransportError instead.
                 self.breaker.record_failure()
-                last_err = ImageTransportError(f"image request transport error: {type(e).__name__}")
+                last_err = ImageTransportError(
+                    f"image request transport error: {type(e).__name__}",
+                    reason="pre_response_transport",
+                )
                 continue
 
         if last_err is not None:
             raise last_err
-        raise ImageQuotaError("no healthy Codex account for image generation")
+        raise ImageQuotaError(
+            "no healthy Codex account for image generation", reason="pool_exhausted"
+        )
 
     async def _read_stream(self, resp: aiohttp.ClientResponse, icfg) -> ImageResult:
         """Parse the SSE stream and return the single terminal image.

--- a/src/tools/image/selector.py
+++ b/src/tools/image/selector.py
@@ -16,7 +16,6 @@ from .base import (
     ImageGenError,
     ImageRequestError,
     ImageResult,
-    is_square_size,
     parse_size,
 )
 
@@ -108,62 +107,70 @@ class ImageBackendSelector:
         comfy = _comfy_possible(config)
 
         req_size = self._resolve_size(size, width, height)
-        # Only `negative` and a checkpoint `model` are genuinely ComfyUI-only;
-        # width/height are just geometry and fold into `req_size`.
+        # Only `negative` and a checkpoint `model` are genuinely ComfyUI-only.
         comfy_only = bool(negative) or bool(model)
-        # Native produces a backend-selected SQUARE image and cannot honor an
-        # aspect ratio, so a non-square request is a ComfyUI-capability request.
-        non_square = not is_square_size(req_size)
+        # Native ignores the requested size and picks its own dimensions, so ANY
+        # explicit size is a request only ComfyUI can honor.
+        has_size = req_size is not None
 
-        async def _comfy(reason: str = "") -> ImageResult:
-            if reason:
-                log.info("image gen -> ComfyUI (%s)", reason)
-            return await self.comfyui.generate(
+        async def _comfy(route: str, fallback_reason: str | None = None) -> ImageResult:
+            if fallback_reason:
+                log.info("image gen -> ComfyUI (%s: %s)", route, fallback_reason)
+            res = await self.comfyui.generate(
                 prompt=prompt, size=req_size, negative=negative, model=model
             )
+            res.route = route
+            res.fallback_reason = fallback_reason
+            return res
+
+        async def _native(route: str) -> ImageResult:
+            res = await self.openai.generate(prompt=prompt)
+            res.route = route
+            return res
 
         if backend == "comfyui":
             if not comfy:
                 raise ImageBackendUnavailableError("ComfyUI is not configured")
-            return await _comfy()
+            return await _comfy("forced_comfyui")
 
         if backend == "openai":
             if comfy_only:
                 raise ImageRequestError(
                     "negative/model are ComfyUI-only and not supported by the OpenAI backend"
                 )
-            if non_square:
+            if has_size:
                 raise ImageRequestError(
-                    "OpenAI image generation only supports square output on this "
-                    f"authentication route; requested {req_size}"
+                    "the OpenAI backend chooses its own dimensions and cannot honor a "
+                    f"requested size ({req_size}); omit size or use ComfyUI"
                 )
             if not native:
                 raise ImageBackendUnavailableError(
                     "Native OpenAI image generation requires the Codex provider and credentials"
                 )
-            return await self.openai.generate(prompt=prompt, size=req_size)
+            return await _native("forced_openai")
 
-        # auto — capability routing
+        # auto — the gate is whether an exact size (or ComfyUI-only field) was asked for
         if comfy_only:
             if comfy:
-                return await _comfy("negative/checkpoint requested")
+                return await _comfy("auto_comfy_features")
             raise ImageRequestError("negative/model require ComfyUI, which is not configured")
-        if non_square:
-            # ComfyUI is the ONLY backend that can produce this shape — never
-            # fall back to native, which would knowingly return a square.
+        if has_size:
+            # Only ComfyUI honors an exact size — NEVER fall back to native, which
+            # would ignore it and return arbitrary dimensions.
             if comfy:
-                return await _comfy(f"non-square {req_size}")
+                return await _comfy("auto_comfy_size")
             raise ImageBackendUnavailableError(
-                f"the requested aspect ratio {req_size} needs ComfyUI, which is unavailable; "
-                "the OpenAI backend only produces square images"
+                f"the requested size {req_size} needs ComfyUI, which is unavailable; "
+                "the OpenAI backend cannot honor a specific size"
             )
         if native:
             try:
-                return await self.openai.generate(prompt=prompt, size=req_size)
+                return await _native("auto_native")
             except ImageGenError as e:
                 if e.pre_generation and comfy:
-                    return await _comfy(f"native unavailable: {type(e).__name__}")
+                    return await _comfy("auto_comfy_fallback", e.reason or "unavailable")
                 raise
         if comfy:
-            return await _comfy()
+            # native not available on this provider — ComfyUI is the only backend
+            return await _comfy("auto_comfy_fallback")
         raise ImageBackendUnavailableError("No image backend is available")

--- a/src/tools/result_validator.py
+++ b/src/tools/result_validator.py
@@ -97,6 +97,9 @@ class ToolResult:
     risk_reason: str = ""
     requires_validation: bool = False
     validation_reason: str = ""
+    # Non-model-facing structured record for the audit log (never in output).
+    # Bounded, non-sensitive enums/metadata only — no prompts, IDs, or payloads.
+    audit_metadata: dict | None = None
 
     def __str__(self) -> str:
         return self.output

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -121,7 +121,7 @@ EXPECTED_TOOL_HASHES = {
     "terraform_ops": "054cd8877208bc7d",
     "http_probe": "dfc3b04b36c5e7f9",
     "issue_tracker": "4f0a793414052b40",
-    "generate_image": "ef74ebec4eafcaf1",
+    "generate_image": "ad893100a9b9c478",
     "validate_action": "199baeb4723517d7",
     "email_send": "1282279440e34e6f",
     "email_search": "3a7584b725d1c134",

--- a/tests/test_audit_logger_search.py
+++ b/tests/test_audit_logger_search.py
@@ -123,3 +123,27 @@ class TestChainAndRotation:
         await _exec(logger, result_summary="x" * 200)  # one entry already > cap
         await _exec(logger, result_summary="y" * 200)  # triggers rotation
         assert (tmp_path / "rot.jsonl.1").exists()
+
+
+class TestAuditMetadata:
+    """Structured audit_metadata (e.g. image backend/route) is persisted and
+    searchable, so a later lookup can answer 'which backend?' truthfully."""
+
+    async def test_metadata_persisted_and_searchable(self, logger):
+        meta = {
+            "backend": "openai",
+            "route": "auto_native",
+            "fallback_reason": None,
+            "decoded_width": 1536,
+            "decoded_height": 1024,
+            "delivery_status": "posted",
+        }
+        await _exec(logger, tool_name="generate_image", audit_metadata=meta)
+        results = await logger.search(tool_name="generate_image")
+        assert len(results) == 1
+        assert results[0]["audit_metadata"] == meta
+
+    async def test_no_metadata_key_when_absent(self, logger):
+        await _exec(logger, tool_name="run_command")
+        results = await logger.search(tool_name="run_command")
+        assert "audit_metadata" not in results[0]

--- a/tests/test_image_backends.py
+++ b/tests/test_image_backends.py
@@ -311,20 +311,21 @@ async def test_no_image_in_stream_rejected():
         await b.generate(prompt="p")
 
 
-async def test_native_rejects_non_square_without_request():
-    # Native only produces squares; a non-square size is refused before any HTTP
-    # call (defense in depth — the selector also routes non-square to ComfyUI).
+@pytest.mark.parametrize("size", ["1024x1024", "1536x1024"])
+async def test_native_rejects_any_explicit_size(size):
+    # Native ignores/refuses ANY size (square or not) — it can't honor a specific
+    # size (defense in depth; the selector routes every sized request to ComfyUI).
     pool = _FakePool()
     b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event()),))])
     with pytest.raises(ImageRequestError):
-        await b.generate(prompt="p", size="1536x1024")
+        await b.generate(prompt="p", size=size)
     assert b._session.posts == 0
 
 
-async def test_native_accepts_square_and_omits_size_in_payload():
+async def test_native_no_size_omits_it_from_payload():
     pool = _FakePool()
     b, _ = _backend(pool, [_FakeResp(200, (_sse(_final_image_event()),))])
-    res = await b.generate(prompt="p", size="1024x1024")
+    res = await b.generate(prompt="p")  # no size
     assert res.backend == "openai"
     # `size` must NOT be sent — the endpoint ignores it.
     sent = b._body(b.get_config().image, "p")
@@ -557,7 +558,11 @@ class _RecordingBackend:
         self.calls.append(kw)
         if self._error:
             raise self._error
-        return self._result
+        import dataclasses
+
+        # Fresh instance per call — the selector stamps route/fallback_reason on
+        # the returned result, so concurrent calls must not share one object.
+        return dataclasses.replace(self._result)
 
 
 def _selector(cfg, *, native=None, comfy=None):
@@ -627,8 +632,8 @@ async def test_selector_no_backend_available_raises():
 # ── size handling + square-only routing (Odin round-2) ────────────────
 
 
-def test_parse_size_and_is_square():
-    from src.tools.image.base import is_square_size, parse_size
+def test_parse_size():
+    from src.tools.image.base import parse_size
 
     assert parse_size(None) is None
     assert parse_size("") is None
@@ -636,9 +641,6 @@ def test_parse_size_and_is_square():
     assert parse_size("1536X1024") == (1536, 1024)  # case-insensitive
     assert parse_size("64x64") == (64, 64)  # lower bound ok
     assert parse_size("2048x2048") == (2048, 2048)  # upper bound ok
-    assert is_square_size(None) is True
-    assert is_square_size("1024x1024") is True
-    assert is_square_size("1536x1024") is False
     # malformed, non-integer, or out of the canonical 64..2048 range
     for bad in ["1024", "1024x", "x1024", "0x0", "-1x-1", "axb", "1024.5x1024",
                 "32x32", "2049x2048", "5000x5000", "64x4096"]:
@@ -646,51 +648,67 @@ def test_parse_size_and_is_square():
             parse_size(bad)
 
 
-async def test_selector_width_height_fold_to_size_and_use_native():
-    # The original bug: width/height (auto-filled from the schema) forced
-    # ComfyUI. They now fold into a square size and go native.
+async def test_selector_no_size_uses_native():
+    # A plain request (no size, no ComfyUI-only fields) goes native — the cat
+    # case. width/height are out of the schema, so the LLM sends no size.
     cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
     native = _RecordingBackend("openai")
     comfy = _RecordingBackend("comfyui")
-    await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", width=1024, height=1024)
-    assert native.calls and not comfy.calls
-    assert native.calls[0]["size"] == "1024x1024"
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p")
+    assert res.backend == "openai" and native.calls and not comfy.calls
+    assert res.route == "auto_native"
 
 
-async def test_selector_auto_non_square_routes_to_comfy():
+async def test_selector_legacy_width_height_fold_to_size_route_comfy():
+    # Legacy width/height fold into an explicit size -> ComfyUI (native can't
+    # honor exact dims); native is never tried.
     cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
     native = _RecordingBackend("openai")
     comfy = _RecordingBackend("comfyui")
-    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", size="1536x1024")
-    assert res.backend == "comfyui" and not native.calls  # native never tried
+    res = await _selector(cfg, native=native, comfy=comfy).generate(
+        prompt="p", width=1024, height=1024
+    )
+    assert res.backend == "comfyui" and not native.calls
+    assert comfy.calls[0]["size"] == "1024x1024" and res.route == "auto_comfy_size"
 
 
-async def test_selector_auto_non_square_no_comfy_does_not_fall_back_to_native():
+@pytest.mark.parametrize("size", ["1024x1024", "1536x1024"])
+async def test_selector_auto_any_size_routes_to_comfy(size):
+    # ANY explicit size (square OR not) -> ComfyUI; native never tried.
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai")
+    comfy = _RecordingBackend("comfyui")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", size=size)
+    assert res.backend == "comfyui" and not native.calls and res.route == "auto_comfy_size"
+
+
+async def test_selector_auto_sized_no_comfy_does_not_fall_back_to_native():
     cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=False)
     native = _RecordingBackend("openai")
     with pytest.raises(ImageBackendUnavailableError):
         await _selector(cfg, native=native, comfy=_RecordingBackend("comfyui")).generate(
-            prompt="p", size="1536x1024"
+            prompt="p", size="1024x1024"
         )
-    assert not native.calls  # a non-square request must never fall back to native
+    assert not native.calls  # a sized request must never fall back to native
 
 
-async def test_selector_openai_mode_rejects_non_square():
+@pytest.mark.parametrize("size", ["1024x1024", "1536x1024"])
+async def test_selector_openai_mode_rejects_any_size(size):
     cfg = _cfg(backend="openai", provider="codex", codex=True)
     native = _RecordingBackend("openai")
     with pytest.raises(ImageRequestError):
         await _selector(cfg, native=native, comfy=_RecordingBackend("comfyui")).generate(
-            prompt="p", size="1536x1024"
+            prompt="p", size=size
         )
     assert not native.calls  # rejected before any native call
 
 
-async def test_selector_auto_square_size_uses_native():
-    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+async def test_selector_openai_mode_no_size_uses_native():
+    cfg = _cfg(backend="openai", provider="codex", codex=True)
     native = _RecordingBackend("openai")
-    comfy = _RecordingBackend("comfyui")
-    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p", size="512x512")
-    assert res.backend == "openai" and native.calls and not comfy.calls
+    sel = _selector(cfg, native=native, comfy=_RecordingBackend("comfyui"))
+    res = await sel.generate(prompt="p")
+    assert res.backend == "openai" and res.route == "forced_openai"
 
 
 async def test_selector_rejects_one_sided_dimension():
@@ -704,11 +722,22 @@ async def test_selector_explicit_size_wins_over_width_height():
     cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
     native = _RecordingBackend("openai")
     comfy = _RecordingBackend("comfyui")
-    # explicit square size beats a non-square width/height -> native
-    await _selector(cfg, native=native, comfy=comfy).generate(
+    # explicit size beats width/height; any size -> ComfyUI
+    res = await _selector(cfg, native=native, comfy=comfy).generate(
         prompt="p", size="1024x1024", width=1536, height=1024
     )
-    assert native.calls and native.calls[0]["size"] == "1024x1024" and not comfy.calls
+    assert res.backend == "comfyui" and comfy.calls[0]["size"] == "1024x1024" and not native.calls
+
+
+async def test_selector_stamps_fallback_route_and_reason():
+    from src.tools.image.base import ImageQuotaError
+
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    native = _RecordingBackend("openai", error=ImageQuotaError("limit", reason="quota"))
+    comfy = _RecordingBackend("comfyui")
+    res = await _selector(cfg, native=native, comfy=comfy).generate(prompt="p")
+    assert res.backend == "comfyui" and res.route == "auto_comfy_fallback"
+    assert res.fallback_reason == "quota"
 
 
 async def test_selector_rejects_out_of_range_size():
@@ -727,3 +756,18 @@ async def test_selector_bad_dimension_does_not_leak_valueerror():
     sel = _selector(cfg, native=_RecordingBackend("openai"), comfy=_RecordingBackend("comfyui"))
     with pytest.raises(ImageRequestError):  # a clean ImageRequestError, NOT a raw ValueError
         await sel.generate(prompt="p", width="bad", height=1024)
+
+
+async def test_concurrent_generations_keep_separate_metadata():
+    # Metadata rides on each call's returned result (task-local) — two concurrent
+    # generations down different routes must not swap backend/route.
+    import asyncio
+
+    cfg = _cfg(backend="auto", provider="codex", codex=True, comfy=True)
+    sel = _selector(cfg, native=_RecordingBackend("openai"), comfy=_RecordingBackend("comfyui"))
+    r_native, r_comfy = await asyncio.gather(
+        sel.generate(prompt="a"),  # no size -> native
+        sel.generate(prompt="b", size="1024x1024"),  # sized -> comfy
+    )
+    assert (r_native.backend, r_native.route) == ("openai", "auto_native")
+    assert (r_comfy.backend, r_comfy.route) == ("comfyui", "auto_comfy_size")

--- a/tests/test_native_knowledge.py
+++ b/tests/test_native_knowledge.py
@@ -151,3 +151,16 @@ class TestSearchAudit:
         out = await _tools(audit=a)._handle_search_audit(
             {"has_error": 1, "min_duration_ms": "5", "limit": 5})
         assert "2 entries" in out and "run_command" in out and "ERROR: boom" in out
+
+    async def test_renders_audit_metadata(self):
+        # A later "which backend?" lookup surfaces the structured record.
+        a = MagicMock()
+        a.search = AsyncMock(return_value=[
+            {"timestamp": "2026-07-07T12:00:00Z", "tool_name": "generate_image",
+             "user_name": "aaron", "approved": True, "execution_time_ms": 63000,
+             "result_summary": "Image generated (1536x1024, 800 KB) and posted.",
+             "audit_metadata": {"backend": "openai", "route": "auto_native",
+                                "decoded_width": 1536, "decoded_height": 1024}},
+        ])
+        out = await _tools(audit=a)._handle_search_audit({"tool_name": "generate_image"})
+        assert "backend=openai" in out and "route=auto_native" in out

--- a/tests/test_native_media.py
+++ b/tests/test_native_media.py
@@ -296,9 +296,13 @@ class TestGenerateImage:
         sel = self._selector(result=self._result(backend="openai"))
         msg = _message()
         out = await _tools(image_selector=sel)._handle_generate_image(msg, {"prompt": "a cat"})
-        assert "Image generated (1024x1024" in out
-        assert "openai" not in out.lower()  # backend name is NOT surfaced
+        # Generic user-facing string — the backend name is NOT surfaced there...
+        assert "Image generated (1024x1024" in str(out)
+        assert "openai" not in str(out).lower()
         msg.channel.send.assert_awaited_once()
+        # ...but IS recorded in the (non-model-facing) audit metadata.
+        assert out.audit_metadata["backend"] == "openai"
+        assert out.audit_metadata["delivery_status"] == "posted"
 
     async def test_backend_failure_and_http_error(self):
         from src.tools.image import ImageGenError
@@ -307,11 +311,15 @@ class TestGenerateImage:
         assert "failed" in await _tools(image_selector=sel)._handle_generate_image(
             _message(), {"prompt": "x"}
         )
+        # Upload failure: generation ran, so the metadata still records the
+        # backend with delivery_status=upload_failed.
         sel = self._selector(result=self._result(backend="comfyui"))
         msg = _message()
         msg.channel.send = AsyncMock(side_effect=_http_exc())
         out = await _tools(image_selector=sel)._handle_generate_image(msg, {"prompt": "x"})
-        assert "Failed to upload generated" in out
+        assert "Failed to upload generated" in str(out)
+        assert out.audit_metadata["backend"] == "comfyui"
+        assert out.audit_metadata["delivery_status"] == "upload_failed"
 
     async def test_unexpected_error_is_contained(self):
         # A non-ImageGenError must not leak a payload — generic catch-all.
@@ -320,3 +328,17 @@ class TestGenerateImage:
             _message(), {"prompt": "x"}
         )
         assert "unexpectedly" in out and "raw provider blob" not in out
+
+
+def test_unwrap_native_result():
+    # generate_image returns a ToolResult (audit_metadata); other native tools
+    # return a plain string/dict. The tool_loop unwrapper handles both.
+    from src.discord.tool_loop import _unwrap_native_result
+    from src.tools.result_validator import ToolResult
+
+    tr = ToolResult(output="hi", audit_metadata={"backend": "openai"})
+    tool_result, out = _unwrap_native_result(tr)
+    assert tool_result is tr and out == "hi"
+    assert _unwrap_native_result("plain") == (None, "plain")
+    block = {"__image_block__": 1}
+    assert _unwrap_native_result(block) == (None, block)


### PR DESCRIPTION
Two refinements from Aaron's live test of the image feature (the cat routed to native correctly, but the test exposed two issues).

## 1. Route on whether an exact size was requested

The probe showed native **ignores** the requested size and picks its own dimensions (the cat came back 1536×1024) — so "square-only" was wrong. The real gate is *was an exact size asked for?*

| Mode | Request | Route |
|---|---|---|
| `auto` | `negative` or checkpoint `model` | ComfyUI |
| `auto` | **any** explicit `size` (square or not) | ComfyUI |
| `auto` | no size, no ComfyUI-only field | native first; pre-generation fallback to ComfyUI |
| `openai` | any explicit size or ComfyUI-only field | reject before auth |
| `openai` | no size | native (backend chooses dimensions) |
| `comfyui` | valid | ComfyUI |

A sized `auto` request with no ComfyUI fails honestly — never native. Native rejects any non-`None` size as defense in depth. `is_square_size` deleted; `width`/`height` fold into the canonical size.

## 2. Backend queryable-if-asked (structured audit metadata)

The generic result meant Odin couldn't tell which backend ran and **guessed wrong** ("ComfyUI" when it was native). The immediate result stays generic; the backend is now recorded in **structured, non-model-facing audit metadata** (Odin's call — audit is persistent, signed, and searchable, unlike logs/trajectory).

`generate_image` returns a `ToolResult` whose `output` is the generic string plus `audit_metadata` = `{backend, route, fallback_reason, decoded_width/height, delivery_status}` (stable enums; no prompts/IDs/payloads). `tool_loop` threads it to `AuditLogger.log_execution`; `search_audit` renders it. So a later `search_audit(generate_image)` answers "which backend?" truthfully — without announcing it unprompted. Upload failure still records the backend with `delivery_status=upload_failed`.

## Gates

7,438 passed / 4 skip / 0 failed · ruff 0 · mypy 0 (227 files) · lint/type/coverage clean. Tests cover the full routing matrix, route/fallback-reason stamping, the audit-metadata round-trip (stored + searchable + rendered), concurrent isolation, upload-failure metadata, and the ToolResult unwrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)