### PR TITLE
fix: typing-indicator failures no longer abort turns or dump HTML into chat

### DIFF
--- a/src/discord/intake_pipeline.py
+++ b/src/discord/intake_pipeline.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import io
 import re
+import unicodedata
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -89,7 +90,11 @@ def _user_facing_error(exc: BaseException, limit: int = 200) -> str:
             text = ""
         lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
         detail = lines[0] if lines else ""
-        detail = "".join(ch for ch in detail if ch == "\t" or ch >= " ")
+        # Category-aware strip: C* covers C0, DEL, C1, and format chars —
+        # a plain `ch >= " "` check lets U+007F/U+0080–U+009F through.
+        detail = "".join(
+            ch for ch in detail if ch == "\t" or not unicodedata.category(ch).startswith("C")
+        )
         if any(m in detail.lower() for m in _HTML_MARKERS):
             detail = ""
         # Zero-width space after "@" — error text must not ping the server.
@@ -699,15 +704,18 @@ class MessagePipeline:
                         response = _skill_response
                         already_sent = False
         except (TimeoutError, discord.HTTPException, discord.Forbidden) as e:
+            # Same raw-interpolation disease as the tool-loop catch: str() on
+            # a discord.HTTPException carries the raw HTTP body (HTML pages).
+            _err = _user_facing_error(e)
             await self._delivery.set_status(None, task_end=True)
-            log.error("Discord/network error processing message: %s", e, exc_info=True)
+            log.error("Discord/network error processing message: %s", _err, exc_info=True)
             leaked = self._channel_state.pending_files.pop(channel_id, None)
             if leaked:
                 log.warning(
                     "Cleaned %d leaked pending file(s) for channel %s", len(leaked), channel_id
                 )
             await self._delivery.send_with_retry(
-                message, scrub_response_secrets(f"Something went wrong: {e}")
+                message, scrub_response_secrets(f"Something went wrong: {_err}")
             )
             self._sessions.remove_last_message(channel_id, "user")
             return
@@ -721,15 +729,16 @@ class MessagePipeline:
             self._sessions.remove_last_message(channel_id, "user")
             raise
         except Exception as e:
+            _err = _user_facing_error(e)
             await self._delivery.set_status(None, task_end=True)
-            log.error("Unexpected error processing message: %s", e, exc_info=True)
+            log.error("Unexpected error processing message: %s", _err, exc_info=True)
             leaked = self._channel_state.pending_files.pop(channel_id, None)
             if leaked:
                 log.warning(
                     "Cleaned %d leaked pending file(s) for channel %s", len(leaked), channel_id
                 )
             await self._delivery.send_with_retry(
-                message, scrub_response_secrets(f"Something went wrong: {e}")
+                message, scrub_response_secrets(f"Something went wrong: {_err}")
             )
             self._sessions.remove_last_message(channel_id, "user")
             return

--- a/src/discord/intake_pipeline.py
+++ b/src/discord/intake_pipeline.py
@@ -64,6 +64,42 @@ def check_for_secrets(content: str) -> bool:
     return any(p.search(content) for p in SECRET_SCRUB_PATTERNS)
 
 
+_HTML_MARKERS = ("<html", "<!doctype")
+
+
+def _user_facing_error(exc: BaseException, limit: int = 200) -> str:
+    """Bounded, HTML-free, mention-safe one-line exception summary for chat.
+
+    Presentation policy for the user-facing error boundary in ``_run_inner``
+    — total and non-throwing (any internal failure falls back to the
+    exception type name). Never renders ``discord.HTTPException`` bodies:
+    ``str(exc)``/``.text`` carry the raw HTTP response, and Discord 500s are
+    whole Cloudflare HTML pages (the 2026-07-16 incident dumped them into
+    chat verbatim). Full diagnostics stay in the journal via ``exc_info``.
+    """
+    name = type(exc).__name__
+    try:
+        if isinstance(exc, discord.HTTPException):
+            reason = str(getattr(getattr(exc, "response", None), "reason", "") or "").strip()
+            status = getattr(exc, "status", "?")
+            return f"Discord API error: HTTP {status} {reason}".strip()[:limit]
+        try:
+            text = str(exc)
+        except Exception:
+            text = ""
+        lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
+        detail = lines[0] if lines else ""
+        detail = "".join(ch for ch in detail if ch == "\t" or ch >= " ")
+        if any(m in detail.lower() for m in _HTML_MARKERS):
+            detail = ""
+        # Zero-width space after "@" — error text must not ping the server.
+        detail = detail.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
+        out = f"{name}: {detail}" if detail else name
+        return out[:limit]
+    except Exception:
+        return name
+
+
 @dataclass(frozen=True)
 class MessageIntakeDeps:
     """The true dependency surface of the intake gating chain."""
@@ -615,12 +651,17 @@ class MessagePipeline:
                         trace=_trace,
                     )
                 except TimeoutError as codex_err:
-                    log.warning("Codex tool loop timed out: %s", codex_err)
-                    response = f"Tool execution timed out: {codex_err}"
+                    _err = _user_facing_error(codex_err)
+                    log.warning("Codex tool loop timed out: %s", _err)
+                    response = f"Tool execution timed out: {_err}"
                     is_error = True
                 except Exception as codex_err:
-                    log.error("Codex tool loop unexpected error: %s", codex_err, exc_info=True)
-                    response = f"Tool execution failed: {codex_err}"
+                    # exc_info carries the full traceback; the message arg is
+                    # bounded so upstream HTML bodies aren't duplicated into
+                    # the journal — and never reach chat.
+                    _err = _user_facing_error(codex_err)
+                    log.error("Codex tool loop unexpected error: %s", _err, exc_info=True)
+                    response = f"Tool execution failed: {_err}"
                     is_error = True
                     handoff = False
                 # Skill requested Codex handoff — route skill result to Codex for response

--- a/src/discord/intake_pipeline.py
+++ b/src/discord/intake_pipeline.py
@@ -68,37 +68,53 @@ def check_for_secrets(content: str) -> bool:
 _HTML_MARKERS = ("<html", "<!doctype")
 
 
+def _clean_detail(detail: str) -> str:
+    """Shared normalization for ANY exception-derived text fragment.
+
+    Every fragment that can carry upstream-controlled bytes -- str(exc)
+    first lines and HTTP response.reason phrases alike -- must pass through
+    here before reaching chat: category-C strip (C0, DEL, C1, format chars;
+    tab deliberately retained -- a plain ch >= " " check lets U+007F and
+    U+0080..U+009F through), HTML-page fragments dropped, and mass mentions
+    neutralized with a zero-width space so error text can never ping the
+    server.
+    """
+    detail = "".join(
+        ch for ch in detail if ch == "\t" or not unicodedata.category(ch).startswith("C")
+    )
+    if any(m in detail.lower() for m in _HTML_MARKERS):
+        return ""
+    detail = detail.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
+    return detail.strip()
+
+
 def _user_facing_error(exc: BaseException, limit: int = 200) -> str:
     """Bounded, HTML-free, mention-safe one-line exception summary for chat.
 
-    Presentation policy for the user-facing error boundary in ``_run_inner``
-    — total and non-throwing (any internal failure falls back to the
-    exception type name). Never renders ``discord.HTTPException`` bodies:
-    ``str(exc)``/``.text`` carry the raw HTTP response, and Discord 500s are
-    whole Cloudflare HTML pages (the 2026-07-16 incident dumped them into
-    chat verbatim). Full diagnostics stay in the journal via ``exc_info``.
+    Presentation policy for the user-facing error boundary in _run_inner --
+    total and non-throwing (any internal failure falls back to the exception
+    type name). Never renders discord.HTTPException bodies: str(exc)/.text
+    carry the raw HTTP response, and Discord 500s are whole Cloudflare HTML
+    pages (the 2026-07-16 incident dumped them into chat verbatim).
+    Structured fields go through the SAME _clean_detail normalization -- the
+    reason phrase is upstream-controlled text too -- and a non-int status
+    renders as "?". Full diagnostics stay in the journal via exc_info.
     """
     name = type(exc).__name__
     try:
         if isinstance(exc, discord.HTTPException):
-            reason = str(getattr(getattr(exc, "response", None), "reason", "") or "").strip()
-            status = getattr(exc, "status", "?")
-            return f"Discord API error: HTTP {status} {reason}".strip()[:limit]
+            status = getattr(exc, "status", None)
+            status_s = str(status) if isinstance(status, int) else "?"
+            reason = _clean_detail(
+                str(getattr(getattr(exc, "response", None), "reason", "") or "")
+            )
+            return f"Discord API error: HTTP {status_s} {reason}".strip()[:limit]
         try:
             text = str(exc)
         except Exception:
             text = ""
         lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
-        detail = lines[0] if lines else ""
-        # Category-aware strip: C* covers C0, DEL, C1, and format chars —
-        # a plain `ch >= " "` check lets U+007F/U+0080–U+009F through.
-        detail = "".join(
-            ch for ch in detail if ch == "\t" or not unicodedata.category(ch).startswith("C")
-        )
-        if any(m in detail.lower() for m in _HTML_MARKERS):
-            detail = ""
-        # Zero-width space after "@" — error text must not ping the server.
-        detail = detail.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
+        detail = _clean_detail(lines[0] if lines else "")
         out = f"{name}: {detail}" if detail else name
         return out[:limit]
     except Exception:

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import unicodedata
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -108,6 +109,13 @@ def _error_summary(exc: BaseException, limit: int = 200) -> str:
                 text = ""
             lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
             detail = lines[0] if lines else ""
+            # Category-aware strip (C0, DEL, C1, format chars) — journal and
+            # trajectory text must not carry control/CSI sequences either.
+            detail = "".join(
+                ch
+                for ch in detail
+                if ch == "\t" or not unicodedata.category(ch).startswith("C")
+            )
             if "<html" in detail.lower() or "<!doctype" in detail.lower():
                 detail = ""
         out = f"{name}: {detail}" if detail else name

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -88,36 +88,43 @@ log = get_logger("discord")
 _LONG_TIMEOUT_TOOL_SET = frozenset({"claude_code"})
 
 
+def _clean_fragment(s: str) -> str:
+    """Normalize an exception-derived fragment for logs/trajectory storage:
+    category-C strip (C0, DEL, C1, format chars; tab retained) and HTML-page
+    fragments dropped. The reason phrase of an HTTP error is upstream-
+    controlled text, so it goes through here exactly like str(exc) does.
+    """
+    s = "".join(ch for ch in s if ch == "\t" or not unicodedata.category(ch).startswith("C"))
+    if "<html" in s.lower() or "<!doctype" in s.lower():
+        return ""
+    return s.strip()
+
+
 def _error_summary(exc: BaseException, limit: int = 200) -> str:
     """Bounded one-line exception summary for logs and trajectory storage.
 
     Total and non-throwing. Never includes response bodies: upstream HTTP
-    errors (Discord 500s carry whole Cloudflare HTML pages in ``str(exc)``)
-    are reduced to type + status/reason; the journal traceback remains the
-    source of full diagnostics.
+    errors (Discord 500s carry whole Cloudflare HTML pages in str(exc))
+    are reduced to type + status/reason -- both cleaned -- and a non-int
+    status renders as "?". The journal traceback remains the source of
+    full diagnostics.
     """
     name = type(exc).__name__
     try:
         status = getattr(exc, "status", None)
         if status is not None:
-            reason = str(getattr(getattr(exc, "response", None), "reason", "") or "").strip()
-            detail = f"HTTP {status} {reason}".strip()
+            status_s = str(status) if isinstance(status, int) else "?"
+            reason = _clean_fragment(
+                str(getattr(getattr(exc, "response", None), "reason", "") or "")
+            )
+            detail = f"HTTP {status_s} {reason}".strip()
         else:
             try:
                 text = str(exc)
             except Exception:
                 text = ""
-            lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
-            detail = lines[0] if lines else ""
-            # Category-aware strip (C0, DEL, C1, format chars) — journal and
-            # trajectory text must not carry control/CSI sequences either.
-            detail = "".join(
-                ch
-                for ch in detail
-                if ch == "\t" or not unicodedata.category(ch).startswith("C")
-            )
-            if "<html" in detail.lower() or "<!doctype" in detail.lower():
-                detail = ""
+            first = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
+            detail = _clean_fragment(first[0] if first else "")
         out = f"{name}: {detail}" if detail else name
         return out[:limit]
     except Exception:

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
@@ -84,6 +85,68 @@ from .tool_loop_helpers import (
 log = get_logger("discord")
 
 _LONG_TIMEOUT_TOOL_SET = frozenset({"claude_code"})
+
+
+def _error_summary(exc: BaseException, limit: int = 200) -> str:
+    """Bounded one-line exception summary for logs and trajectory storage.
+
+    Total and non-throwing. Never includes response bodies: upstream HTTP
+    errors (Discord 500s carry whole Cloudflare HTML pages in ``str(exc)``)
+    are reduced to type + status/reason; the journal traceback remains the
+    source of full diagnostics.
+    """
+    name = type(exc).__name__
+    try:
+        status = getattr(exc, "status", None)
+        if status is not None:
+            reason = str(getattr(getattr(exc, "response", None), "reason", "") or "").strip()
+            detail = f"HTTP {status} {reason}".strip()
+        else:
+            try:
+                text = str(exc)
+            except Exception:
+                text = ""
+            lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
+            detail = lines[0] if lines else ""
+            if "<html" in detail.lower() or "<!doctype" in detail.lower():
+                detail = ""
+        out = f"{name}: {detail}" if detail else name
+        return out[:limit]
+    except Exception:
+        return name
+
+
+@asynccontextmanager
+async def _best_effort_typing(channel):
+    """Discord typing indicator that can never fail the wrapped work.
+
+    The indicator is attempted on every call — no failure memory, so a
+    Discord API outage degrades cosmetics, not behavior — and any ordinary
+    ``Exception`` from typing setup or cleanup is logged bounded and
+    swallowed. Cancellation and exceptions raised by the wrapped body
+    always propagate; a cleanup failure never replaces a body exception.
+    """
+    cm = None
+    try:
+        cm = channel.typing()
+        await cm.__aenter__()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        log.warning("Typing indicator failed (non-fatal): %s", _error_summary(exc))
+        cm = None
+    try:
+        yield
+    finally:
+        if cm is not None:
+            try:
+                await cm.__aexit__(None, None, None)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                log.warning(
+                    "Typing indicator cleanup failed (non-fatal): %s", _error_summary(exc)
+                )
 
 
 class _LoopMessageProxy:
@@ -319,6 +382,34 @@ class ToolLoopRunner:
             message, history, system_prompt_override, trace, policy
         )
 
+        try:
+            return await self._run_chat_iterations(st)
+        except asyncio.CancelledError:
+            # Cancellation is not an error turn: release channel ownership
+            # and let it propagate untouched (no error trajectory).
+            self._clear_active(st)
+            raise
+        except Exception as exc:
+            # An escaping exception used to skip BOTH the trajectory record
+            # and active-request cleanup (found 2026-07-16: Discord's typing
+            # endpoint 500s left six dead turns with no trajectory at all).
+            # Record bounded, clean up, re-raise — the user-facing message
+            # is intake_pipeline's job, not ours.
+            try:
+                await self._turn_recorder._save_turn_trajectory(
+                    st._trajectory, error=_error_summary(exc), trace=st.trace
+                )
+            except Exception:
+                log.exception("Trajectory record failed while handling tool-loop escape")
+            finally:
+                self._clear_active(st)
+            raise
+
+    async def _run_chat_iterations(
+        self, st: _ChatTurn
+    ) -> tuple[str, bool, bool, list[str], bool]:
+        """The chat iteration loop — every phase-method exit returns through
+        here; unexpected escapes are handled by run()'s guard above."""
         for iteration in range(st.chat_cap):
             st.iteration = iteration
             if st._cancel.is_set():
@@ -577,77 +668,63 @@ class ToolLoopRunner:
 
         Returns ("ok", llm_resp) or ("done", <run() return tuple>).
         """
-        # Show typing indicator while waiting for LLM response.
-        # Typing is best-effort — isolate typing setup failures from
-        # LLM call failures so we don't misclassify provider errors.
-        typing_cm = None
-        try:
-            typing_cm = st.message.channel.typing()
-            await typing_cm.__aenter__()
-        except (discord.HTTPException, ConnectionError, OSError) as typing_err:
-            log.warning("Typing indicator failed (non-fatal): %s", typing_err)
-            typing_cm = None
-
         _channel_id = str(st.message.channel.id)
-        try:
-            llm_resp = await self._llm_gateway.call_with_tools(
-                messages=st.messages,
-                system=st.system_prompt,
-                tools=st.tools or [],
-                user_message=getattr(st.message, "content", "") or "",
-                user_id=st.user_id,
-                channel_id=_channel_id,
-                tools_used=st.tools_used_in_loop,
-            )
-        except CircuitOpenError as coe:
-            wait_secs = min(coe.retry_after, 90.0)
-            log.info(
-                "Circuit breaker open for %s, waiting %.0fs for recovery",
-                coe.provider,
-                wait_secs,
-            )
-            await asyncio.sleep(wait_secs)
+        # Typing is best-effort (shared helper): a typing failure — setup or
+        # cleanup — must never fail the call or misclassify provider errors.
+        async with _best_effort_typing(st.message.channel):
             try:
                 llm_resp = await self._llm_gateway.call_with_tools(
                     messages=st.messages,
                     system=st.system_prompt,
                     tools=st.tools or [],
+                    user_message=getattr(st.message, "content", "") or "",
                     user_id=st.user_id,
                     channel_id=_channel_id,
                     tools_used=st.tools_used_in_loop,
                 )
-            except Exception as retry_err:
+            except CircuitOpenError as coe:
+                wait_secs = min(coe.retry_after, 90.0)
+                log.info(
+                    "Circuit breaker open for %s, waiting %.0fs for recovery",
+                    coe.provider,
+                    wait_secs,
+                )
+                await asyncio.sleep(wait_secs)
+                try:
+                    llm_resp = await self._llm_gateway.call_with_tools(
+                        messages=st.messages,
+                        system=st.system_prompt,
+                        tools=st.tools or [],
+                        user_id=st.user_id,
+                        channel_id=_channel_id,
+                        tools_used=st.tools_used_in_loop,
+                    )
+                except Exception as retry_err:
+                    await self._turn_recorder._save_turn_trajectory(
+                        st._trajectory, error=str(retry_err), trace=st.trace
+                    )
+                    self._clear_active(st)
+                    return (
+                        "done",
+                        (
+                            f"LLM API error (circuit breaker recovery failed): {retry_err}",
+                            False,
+                            True,
+                            st.tools_used_in_loop,
+                            False,
+                        ),
+                    )
+            except Exception as api_err:
+                err_msg = str(api_err) or f"{type(api_err).__name__} (no message)"
+                log.error("LLM API call failed: %s", err_msg, exc_info=True)
                 await self._turn_recorder._save_turn_trajectory(
-                    st._trajectory, error=str(retry_err), trace=st.trace
+                    st._trajectory, error=err_msg, trace=st.trace
                 )
                 self._clear_active(st)
                 return (
                     "done",
-                    (
-                        f"LLM API error (circuit breaker recovery failed): {retry_err}",
-                        False,
-                        True,
-                        st.tools_used_in_loop,
-                        False,
-                    ),
+                    (f"LLM API error: {err_msg}", False, True, st.tools_used_in_loop, False),
                 )
-        except Exception as api_err:
-            err_msg = str(api_err) or f"{type(api_err).__name__} (no message)"
-            log.error("LLM API call failed: %s", err_msg, exc_info=True)
-            await self._turn_recorder._save_turn_trajectory(
-                st._trajectory, error=err_msg, trace=st.trace
-            )
-            self._clear_active(st)
-            return (
-                "done",
-                (f"LLM API error: {err_msg}", False, True, st.tools_used_in_loop, False),
-            )
-        finally:
-            if typing_cm is not None:
-                try:
-                    await typing_cm.__aexit__(None, None, None)
-                except Exception:
-                    pass
 
         return ("ok", llm_resp)
 
@@ -1075,7 +1152,10 @@ class ToolLoopRunner:
         result block to the message list (gather preserves call order)."""
         tool_timeout = self._get_config().tools.tool_timeout_seconds
 
-        async with st.message.channel.typing():
+        # Best-effort typing: the 2026-07-16 Discord incident (typing
+        # endpoint returning HTML 500s) aborted whole turns at exactly this
+        # line and dumped raw DiscordServerError HTML into chat.
+        async with _best_effort_typing(st.message.channel):
             tool_results = await asyncio.gather(
                 *[self._run_one_tool_with_timeout(st, b, tool_timeout) for b in tool_calls],
             )

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -1,0 +1,403 @@
+"""Pins for the 2026-07-16 Discord typing-endpoint incident fixes.
+
+Discord's REST API incident that night returned Cloudflare HTML 500 pages
+from ``POST /channels/{id}/typing``; the raw ``discord.DiscordServerError``
+escaped the tool loop and its full HTML body was posted into chat. Three
+surfaces were hardened, each pinned here:
+
+- ``_best_effort_typing`` (tool_loop): the indicator is attempted on every
+  call (no failure memory), can never fail the wrapped work, and never
+  suppresses body exceptions or cancellation.
+- ``run()``'s escape guard (tool_loop): an exception escaping the chat
+  iteration loop records a bounded-error trajectory, clears the
+  active-request entry, and re-raises; cancellation cleans up without an
+  error trajectory; a recorder failure masks nothing.
+- ``_user_facing_error`` (intake_pipeline): user-facing error text is
+  bounded, HTML-free, control-character-free, and mention-safe.
+"""
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import discord
+from src.discord.intake_pipeline import _user_facing_error
+from src.discord.tool_loop import (
+    ToolLoopDeps,
+    ToolLoopRunner,
+    _best_effort_typing,
+    _error_summary,
+)
+
+CF_HTML = (
+    "<html>\n  <head>\n    <title>Internal Server Error</title>\n  </head>\n"
+    "  <body>\n    <h1><p>Internal Server Error</p></h1>\n"
+    "  <script>(function(){/* cloudflare challenge boilerplate */})();"
+    "</script></body>\n</html>"
+)
+
+
+def _http_500(text: str = CF_HTML) -> discord.HTTPException:
+    """A DiscordServerError-shaped exception with the incident's HTML body."""
+    resp = SimpleNamespace(status=500, reason="Internal Server Error")
+    return discord.HTTPException(resp, text)
+
+
+class _FakeTypingCM:
+    def __init__(self, channel, enter_exc, exit_exc):
+        self._channel = channel
+        self._enter_exc = enter_exc
+        self._exit_exc = exit_exc
+
+    async def __aenter__(self):
+        self._channel.enters += 1
+        if self._enter_exc is not None:
+            raise self._enter_exc
+        self._channel.entered += 1
+        return self
+
+    async def __aexit__(self, *exc_info):
+        self._channel.exits += 1
+        if self._exit_exc is not None:
+            raise self._exit_exc
+        return False
+
+
+class FakeChannel:
+    """Instrumented ``channel.typing()`` with scriptable failures."""
+
+    def __init__(self, enter_exc=None, exit_exc=None, ctor_exc=None):
+        self.id = "c1"
+        self.typing_calls = 0
+        self.enters = 0
+        self.entered = 0
+        self.exits = 0
+        self._enter_exc = enter_exc
+        self._exit_exc = exit_exc
+        self._ctor_exc = ctor_exc
+
+    def typing(self):
+        self.typing_calls += 1
+        if self._ctor_exc is not None:
+            raise self._ctor_exc
+        return _FakeTypingCM(self, self._enter_exc, self._exit_exc)
+
+
+class _BrokenStrError(Exception):
+    def __str__(self):
+        raise ValueError("no string for you")
+
+
+# ---------------------------------------------------------------------------
+# _best_effort_typing
+# ---------------------------------------------------------------------------
+
+
+class TestBestEffortTyping:
+    async def test_enter_failure_does_not_stop_work(self):
+        ch = FakeChannel(enter_exc=_http_500())
+        ran = False
+        async with _best_effort_typing(ch):
+            ran = True
+        assert ran
+
+    async def test_typing_constructor_failure_does_not_stop_work(self):
+        ch = FakeChannel(ctor_exc=RuntimeError("constructor boom"))
+        ran = False
+        async with _best_effort_typing(ch):
+            ran = True
+        assert ran
+
+    async def test_exit_failure_swallowed_after_successful_body(self):
+        ch = FakeChannel(exit_exc=RuntimeError("cleanup boom"))
+        ran = False
+        async with _best_effort_typing(ch):
+            ran = True
+        assert ran
+        assert ch.exits == 1
+
+    async def test_body_exception_propagates(self):
+        ch = FakeChannel()
+        with pytest.raises(ValueError, match="body boom"):
+            async with _best_effort_typing(ch):
+                raise ValueError("body boom")
+
+    async def test_body_exception_wins_over_exit_failure(self):
+        ch = FakeChannel(exit_exc=RuntimeError("cleanup boom"))
+        with pytest.raises(ValueError, match="body boom"):
+            async with _best_effort_typing(ch):
+                raise ValueError("body boom")
+        assert ch.exits == 1
+
+    async def test_cancellation_propagates_from_body(self):
+        ch = FakeChannel()
+        with pytest.raises(asyncio.CancelledError):
+            async with _best_effort_typing(ch):
+                raise asyncio.CancelledError()
+
+    async def test_cancellation_on_enter_propagates_and_skips_body(self):
+        ch = FakeChannel(enter_exc=asyncio.CancelledError())
+        ran = False
+        with pytest.raises(asyncio.CancelledError):
+            async with _best_effort_typing(ch):
+                ran = True
+        assert not ran
+
+    async def test_exit_not_called_when_enter_failed(self):
+        ch = FakeChannel(enter_exc=_http_500())
+        async with _best_effort_typing(ch):
+            pass
+        assert ch.exits == 0
+
+    async def test_attempted_on_every_call_after_failure(self):
+        # Aaron's constraint: no failure memory / cooldown — every turn
+        # attempts the indicator again.
+        ch = FakeChannel(enter_exc=_http_500())
+        async with _best_effort_typing(ch):
+            pass
+        async with _best_effort_typing(ch):
+            pass
+        assert ch.typing_calls == 2
+        assert ch.enters == 2
+
+    async def test_failure_log_is_bounded_and_html_free(self, caplog):
+        ch = FakeChannel(enter_exc=_http_500())
+        with caplog.at_level(logging.WARNING):
+            async with _best_effort_typing(ch):
+                pass
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("Typing indicator failed" in m for m in msgs)
+        assert all("<html" not in m for m in msgs)
+        assert any("HTTP 500" in m for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# _error_summary (log/trajectory bounding)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorSummary:
+    def test_status_bearing_exception_uses_structured_fields(self):
+        out = _error_summary(_http_500())
+        assert "HTTP 500" in out
+        assert "Internal Server Error" in out
+        assert "<html" not in out
+
+    def test_html_body_in_generic_exception_reduced_to_type_name(self):
+        assert _error_summary(RuntimeError(CF_HTML)) == "RuntimeError"
+
+    def test_empty_message_falls_back_to_type_name(self):
+        assert _error_summary(TimeoutError()) == "TimeoutError"
+
+    def test_broken_str_falls_back_to_type_name(self):
+        assert _error_summary(_BrokenStrError()) == "_BrokenStrError"
+
+    def test_output_is_bounded(self):
+        assert len(_error_summary(RuntimeError("x" * 5000))) <= 200
+
+
+# ---------------------------------------------------------------------------
+# _user_facing_error (chat presentation)
+# ---------------------------------------------------------------------------
+
+
+class TestUserFacingError:
+    def test_discord_http_exception_never_renders_body(self):
+        out = _user_facing_error(_http_500())
+        assert out == "Discord API error: HTTP 500 Internal Server Error"
+
+    def test_generic_html_reduced_to_type_name(self):
+        assert _user_facing_error(RuntimeError(CF_HTML)) == "RuntimeError"
+
+    def test_html_marker_mid_line_reduced_to_type_name(self):
+        assert _user_facing_error(RuntimeError("500 error: <html><body>")) == "RuntimeError"
+
+    def test_multiline_keeps_first_line_only(self):
+        out = _user_facing_error(RuntimeError("first line\nsecond line"))
+        assert out == "RuntimeError: first line"
+
+    def test_empty_timeout_renders_type_name(self):
+        assert _user_facing_error(TimeoutError()) == "TimeoutError"
+
+    def test_broken_str_falls_back_to_type_name(self):
+        assert _user_facing_error(_BrokenStrError()) == "_BrokenStrError"
+
+    def test_mass_mentions_neutralized(self):
+        out = _user_facing_error(RuntimeError("notify @everyone and @here now"))
+        assert "@everyone" not in out
+        assert "@here" not in out
+        assert "everyone" in out
+
+    def test_control_characters_stripped(self):
+        out = _user_facing_error(RuntimeError("bad\x07\x1bthing"))
+        assert "\x07" not in out
+        assert "\x1b" not in out
+        assert "badthing" in out
+
+    def test_entire_output_is_bounded(self):
+        assert len(_user_facing_error(RuntimeError("y" * 5000))) <= 200
+
+
+# ---------------------------------------------------------------------------
+# run() escape guard
+# ---------------------------------------------------------------------------
+
+
+def _make_runner(recorder_save=None):
+    saved = []
+    cleared = []
+
+    async def _default_save(trajectory, **kwargs):
+        saved.append((trajectory, kwargs))
+
+    deps = ToolLoopDeps(
+        get_config=lambda: None,
+        get_default_system_prompt=lambda: "sys",
+        get_context_compressor=lambda: None,
+        llm_gateway=SimpleNamespace(),
+        prompt_builder=SimpleNamespace(),
+        tool_catalog=SimpleNamespace(),
+        channel_state=SimpleNamespace(
+            clear_active_request=lambda ch, req: cleared.append((ch, req))
+        ),
+        delivery=SimpleNamespace(),
+        turn_recorder=SimpleNamespace(_save_turn_trajectory=recorder_save or _default_save),
+        completion_classifier=SimpleNamespace(),
+        native_tools=SimpleNamespace(),
+        tool_executor=SimpleNamespace(),
+        permissions=SimpleNamespace(),
+        skill_manager=SimpleNamespace(),
+        audit=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+        stuck_loop_tracker_cls=object,
+    )
+    return ToolLoopRunner(deps), saved, cleared
+
+
+def _stub_state(channel=None):
+    return SimpleNamespace(
+        chat_cap=3,
+        iteration=0,
+        _cancel=asyncio.Event(),
+        _trajectory=SimpleNamespace(),
+        trace=None,
+        _ch_id="c1",
+        _req_id="r1",
+        message=SimpleNamespace(channel=channel or FakeChannel(), content="hi"),
+        messages=[],
+        tools_used_in_loop=[],
+        system_prompt="sys",
+        tools=[],
+        user_id="u1",
+    )
+
+
+def _wire(runner, st, call_llm):
+    async def _prep(*args, **kwargs):
+        return st
+
+    runner._prepare_chat_turn = _prep
+    runner._maybe_compress = lambda st: None
+    runner._call_llm = call_llm
+
+
+class TestRunEscapeGuard:
+    async def test_escape_records_bounded_error_clears_and_reraises(self):
+        runner, saved, cleared = _make_runner()
+        st = _stub_state()
+
+        async def _boom(_st):
+            raise RuntimeError(CF_HTML)
+
+        _wire(runner, st, _boom)
+        with pytest.raises(RuntimeError):
+            await runner.run(SimpleNamespace(), [])
+        assert cleared == [("c1", "r1")]
+        assert len(saved) == 1
+        err = saved[0][1]["error"]
+        assert "RuntimeError" in err
+        assert "<html" not in err
+        assert len(err) <= 200
+
+    async def test_cancellation_cleans_up_without_error_trajectory(self):
+        runner, saved, cleared = _make_runner()
+        st = _stub_state()
+
+        async def _cancel(_st):
+            raise asyncio.CancelledError()
+
+        _wire(runner, st, _cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await runner.run(SimpleNamespace(), [])
+        assert cleared == [("c1", "r1")]
+        assert saved == []
+
+    async def test_recorder_failure_masks_nothing_and_still_clears(self):
+        async def _bad_save(trajectory, **kwargs):
+            raise OSError("disk full")
+
+        runner, _saved, cleared = _make_runner(recorder_save=_bad_save)
+        st = _stub_state()
+
+        async def _boom(_st):
+            raise RuntimeError("original failure")
+
+        _wire(runner, st, _boom)
+        with pytest.raises(RuntimeError, match="original failure"):
+            await runner.run(SimpleNamespace(), [])
+        assert cleared == [("c1", "r1")]
+
+    async def test_success_path_gets_no_extra_clear_from_guard(self):
+        # Ordinary "done" exits own their cleanup inside the phase methods;
+        # the guard must not double-clear on success.
+        runner, saved, cleared = _make_runner()
+        st = _stub_state()
+        done = ("all good", False, False, [], False)
+
+        async def _done(_st):
+            return ("done", done)
+
+        _wire(runner, st, _done)
+        result = await runner.run(SimpleNamespace(), [])
+        assert result == done
+        assert cleared == []
+        assert saved == []
+
+
+# ---------------------------------------------------------------------------
+# Both call sites survive a dead typing endpoint (the incident regression)
+# ---------------------------------------------------------------------------
+
+
+class TestCallSitesSurviveTypingFailure:
+    async def test_execute_tool_calls_with_dead_typing_endpoint(self):
+        runner, _saved, _cleared = _make_runner()
+        ch = FakeChannel(enter_exc=_http_500())
+        st = _stub_state(channel=ch)
+        runner._get_config = lambda: SimpleNamespace(tools=SimpleNamespace(tool_timeout_seconds=5))
+
+        async def _one(_st, block, _timeout):
+            return {"type": "tool_result", "tool_use_id": block.id, "content": "ok"}
+
+        runner._run_one_tool_with_timeout = _one
+        block = SimpleNamespace(id="t1", name="run_command", input={})
+        results = await runner._execute_tool_calls(st, [block])
+        assert results == [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+        assert st.messages[-1] == {"role": "user", "content": results}
+        assert ch.typing_calls == 1
+
+    async def test_call_llm_with_dead_typing_endpoint(self):
+        runner, _saved, _cleared = _make_runner()
+        ch = FakeChannel(enter_exc=_http_500())
+        st = _stub_state(channel=ch)
+        resp = SimpleNamespace(text="hello", tool_calls=[])
+
+        async def _cwt(**kwargs):
+            return resp
+
+        runner._llm_gateway = SimpleNamespace(call_with_tools=_cwt)
+        kind, val = await runner._call_llm(st)
+        assert (kind, val) == ("ok", resp)
+        assert ch.typing_calls == 1

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -23,7 +23,11 @@ from types import SimpleNamespace
 import pytest
 
 import discord
-from src.discord.intake_pipeline import _user_facing_error
+from src.discord.intake_pipeline import (
+    MessagePipeline,
+    MessagePipelineDeps,
+    _user_facing_error,
+)
 from src.discord.tool_loop import (
     ToolLoopDeps,
     ToolLoopRunner,
@@ -401,3 +405,165 @@ class TestCallSitesSurviveTypingFailure:
         kind, val = await runner._call_llm(st)
         assert (kind, val) == ("ok", resp)
         assert ch.typing_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Review round 1 additions (PR #233): Unicode-category stripping, formatter
+# fail-safes, and pipeline-level coverage of the _run_inner error paths.
+# ---------------------------------------------------------------------------
+
+class _RaisingInstanceCheckMeta(type):
+    def __instancecheck__(cls, instance):
+        raise RuntimeError("isinstance exploded")
+
+
+class _InstanceCheckBombError(Exception, metaclass=_RaisingInstanceCheckMeta):
+    pass
+
+
+class _EvilStatusError(Exception):
+    @property
+    def status(self):
+        raise RuntimeError("status exploded")
+
+
+class TestUnicodeControlStripping:
+    def test_user_facing_error_strips_del_and_c1(self):
+        out = _user_facing_error(RuntimeError("bad\x7fmid\x9bthing"))
+        assert "\x7f" not in out
+        assert "\x9b" not in out
+        assert "badmidthing" in out
+
+    def test_user_facing_error_retains_tab(self):
+        assert "a\tb" in _user_facing_error(RuntimeError("a\tb"))
+
+    def test_user_facing_error_strips_format_chars(self):
+        out = _user_facing_error(RuntimeError("zero\u200bwidth"))
+        assert "\u200b" not in out
+        assert "zerowidth" in out
+
+    def test_error_summary_strips_del_and_c1(self):
+        out = _error_summary(RuntimeError("bad\x7fmid\x9bthing"))
+        assert "\x7f" not in out
+        assert "\x9b" not in out
+        assert "badmidthing" in out
+
+
+class TestFormatterFailSafes:
+    def test_user_facing_error_internal_failure_falls_back_to_type_name(self, monkeypatch):
+        import src.discord.intake_pipeline as ip
+
+        monkeypatch.setattr(ip.discord, "HTTPException", _InstanceCheckBombError)
+        assert _user_facing_error(RuntimeError("boom")) == "RuntimeError"
+
+    def test_error_summary_internal_failure_falls_back_to_type_name(self):
+        assert _error_summary(_EvilStatusError()) == "_EvilStatusError"
+
+
+class _FakeSessions:
+    def __init__(self):
+        self.added = []
+        self.removed = []
+        self.task_history_exc = None
+
+    def add_message(self, channel_id, role, content, user_id=None):
+        self.added.append((channel_id, role, content))
+
+    async def get_task_history(self, channel_id, max_messages=160, current_query=None, trace=None):
+        if self.task_history_exc is not None:
+            raise self.task_history_exc
+        return [{"role": "user", "content": "hi"}]
+
+    def remove_last_message(self, channel_id, role):
+        self.removed.append((channel_id, role))
+
+    def prune(self):
+        pass
+
+    def save(self):
+        pass
+
+
+class _FakeDelivery:
+    def __init__(self):
+        self.chunked = []
+        self.retried = []
+
+    async def set_status(self, *args, **kwargs):
+        pass
+
+    async def send_chunked(self, message, response):
+        self.chunked.append(response)
+
+    async def send_with_retry(self, message, text):
+        self.retried.append(text)
+
+
+def _make_pipeline(tool_loop_exc=None, sessions=None):
+    sessions = sessions or _FakeSessions()
+    delivery = _FakeDelivery()
+
+    async def _run(message, history, system_prompt_override=None, trace=None):
+        if tool_loop_exc is not None:
+            raise tool_loop_exc
+        return ("ok-response", False, False, [], False)
+
+    deps = MessagePipelineDeps(
+        channel_state=SimpleNamespace(pending_files={}, last_op_details={}),
+        sessions=sessions,
+        permissions=SimpleNamespace(is_guest=lambda uid: False),
+        llm_gateway=SimpleNamespace(active_client=object()),
+        prompt_builder=SimpleNamespace(build_full_prompt=lambda **kwargs: "sys"),
+        turn_recorder=SimpleNamespace(_new_context_trace=lambda: None),
+        tool_loop=SimpleNamespace(run=_run),
+        delivery=delivery,
+        housekeeping=SimpleNamespace(maybe_cleanup=lambda: None),
+    )
+    return MessagePipeline(deps), sessions, delivery
+
+
+def _msg():
+    return SimpleNamespace(
+        author=SimpleNamespace(id=42, display_name="Tester", name="tester"),
+        channel=SimpleNamespace(id="c1"),
+    )
+
+
+class TestRunInnerErrorPresentation:
+    """The incident path end-to-end: what actually reaches chat on failure."""
+
+    async def test_tool_loop_discord_500_sends_sanitized_error(self):
+        pipeline, sessions, delivery = _make_pipeline(tool_loop_exc=_http_500())
+        await pipeline._run_inner(_msg(), "do the thing", "c1")
+        assert delivery.chunked == [
+            "Tool execution failed: Discord API error: HTTP 500 Internal Server Error"
+        ]
+        assert all("<html" not in t for t in delivery.chunked)
+        assert (
+            "c1",
+            "assistant",
+            "[Previous request encountered an error before tool execution.]",
+        ) in sessions.added
+
+    async def test_tool_loop_timeout_sends_sanitized_error(self):
+        pipeline, _sessions, delivery = _make_pipeline(tool_loop_exc=TimeoutError())
+        await pipeline._run_inner(_msg(), "do the thing", "c1")
+        assert delivery.chunked == ["Tool execution timed out: TimeoutError"]
+
+    async def test_outer_discord_error_path_sends_sanitized_error(self):
+        sessions = _FakeSessions()
+        sessions.task_history_exc = _http_500()
+        pipeline, _sessions, delivery = _make_pipeline(sessions=sessions)
+        await pipeline._run_inner(_msg(), "do the thing", "c1")
+        assert delivery.retried == [
+            "Something went wrong: Discord API error: HTTP 500 Internal Server Error"
+        ]
+        assert sessions.removed == [("c1", "user")]
+
+    async def test_outer_generic_error_path_sends_sanitized_error(self):
+        sessions = _FakeSessions()
+        sessions.task_history_exc = RuntimeError(CF_HTML)
+        pipeline, _sessions, delivery = _make_pipeline(sessions=sessions)
+        await pipeline._run_inner(_msg(), "do the thing", "c1")
+        assert delivery.retried == ["Something went wrong: RuntimeError"]
+        assert all("<html" not in t for t in delivery.retried)

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -567,3 +567,59 @@ class TestRunInnerErrorPresentation:
         await pipeline._run_inner(_msg(), "do the thing", "c1")
         assert delivery.retried == ["Something went wrong: RuntimeError"]
         assert all("<html" not in t for t in delivery.retried)
+
+
+# ---------------------------------------------------------------------------
+# Review round 2 (PR #233): the status/HTTPException branches must clean the
+# upstream-controlled reason phrase exactly like generic detail.
+# ---------------------------------------------------------------------------
+
+
+def _http_exc_with_reason(reason, status=500):
+    resp = SimpleNamespace(status=status, reason=reason)
+    return discord.HTTPException(resp, "body")
+
+
+class TestStructuredReasonSanitization:
+    def test_user_facing_error_strips_controls_in_reason(self):
+        out = _user_facing_error(_http_exc_with_reason("Bad\x9b\x7fReason\x00"))
+        assert "\x9b" not in out
+        assert "\x7f" not in out
+        assert "\x00" not in out
+        assert "BadReason" in out
+
+    def test_user_facing_error_neutralizes_mentions_in_reason(self):
+        out = _user_facing_error(_http_exc_with_reason("notify @everyone and @here"))
+        assert "@everyone" not in out
+        assert "@here" not in out
+        assert "everyone" in out
+
+    def test_user_facing_error_strips_format_chars_in_reason(self):
+        out = _user_facing_error(_http_exc_with_reason("zero\u200bwidth"))
+        assert "\u200b" not in out
+        assert "zerowidth" in out
+
+    def test_user_facing_error_html_reason_dropped_status_kept(self):
+        out = _user_facing_error(_http_exc_with_reason("<html>oops</html>"))
+        assert out == "Discord API error: HTTP 500"
+
+    def test_user_facing_error_non_int_status_renders_safely(self):
+        out = _user_facing_error(
+            _http_exc_with_reason("Internal Server Error", status="@everyone 500")
+        )
+        assert "@everyone" not in out
+        assert "HTTP ?" in out
+
+    def test_error_summary_strips_controls_in_reason(self):
+        out = _error_summary(_http_exc_with_reason("Bad\x9bReason\x7f"))
+        assert "\x9b" not in out
+        assert "\x7f" not in out
+        assert "BadReason" in out
+
+    def test_error_summary_html_reason_dropped_status_kept(self):
+        out = _error_summary(_http_exc_with_reason("<html>oops"))
+        assert out == "HTTPException: HTTP 500"
+
+    def test_error_summary_non_int_status_renders_safely(self):
+        out = _error_summary(_http_exc_with_reason("ok", status="evil"))
+        assert out == "HTTPException: HTTP ? ok"


### PR DESCRIPTION
## Summary

During Discord's 2026-07-16 API incident ("API Errors", major impact, started 00:49 UTC), `POST /channels/{id}/typing` returned Cloudflare-fronted HTML 500 pages. Six consecutive tool-using turns died with the identical traceback: `discord.errors.DiscordServerError` raised from the `async with st.message.channel.typing():` wrapper in `_execute_tool_calls`, escaping `run()` into `intake_pipeline`'s catch-all, which posted `Tool execution failed: {exc}` — and `str(DiscordServerError)` embeds the entire HTML error page, so raw HTML (Cloudflare challenge script included) was dumped into chat, repeatedly. One of the dead turns had done 14 minutes of real work that was lost to a cosmetic typing call. The dead turns also left **no trajectory records** and leaked their active-request entries.

Three hardenings, each pinned by tests:

### 1. Best-effort typing indicator, shared by both call sites (`tool_loop.py`)

`_call_llm` already treated typing as best-effort (a prior fix); `_execute_tool_calls` never got the same treatment. Both sites now use one shared `_best_effort_typing()` context manager so they cannot diverge again:

- **Attempted on every call** — no failure memory, no cooldown. An outage degrades cosmetics, never behavior.
- Any ordinary `Exception` from typing setup or cleanup is logged (bounded — type + status/reason, never the response body) and swallowed.
- Body exceptions and cancellation always propagate; a cleanup failure never replaces a body exception; `__aexit__` is not called when `__aenter__` failed.

### 2. Escape-path hygiene in `run()` (`tool_loop.py`)

An exception escaping the chat iteration loop previously skipped both the trajectory record and `_clear_active`. The iteration loop moved verbatim into `_run_chat_iterations()` (phase-method style); `run()` now guards it:

- ordinary `Exception` → best-effort trajectory record with a **bounded** error summary (`_error_summary()` — the HTML must not migrate into trajectory storage either), `_clear_active` in a `finally` (a recorder failure can't skip it), then a bare re-raise (traceback preserved; `intake_pipeline` stays the single user-facing formatter).
- `CancelledError` → cleanup without an error trajectory, propagates untouched.
- Success paths are unchanged (no double-clear; `clear_active_request` is ownership-guarded regardless).

### 3. User-facing error sanitization (`intake_pipeline.py`)

`_user_facing_error()` — total and non-throwing presentation policy at the catch-all boundary, applied to **both** the `TimeoutError` and generic branches:

- `discord.HTTPException` renders structured fields only (`status` + `response.reason`); never `.text`/`str(exc)`, which carry the raw HTTP body.
- Generic branch: type name + first line, control characters stripped, `<html`/`<!doctype` anywhere in the detail falls back to the type name (any upstream can wrap an HTML page in a `RuntimeError`), `@everyone`/`@here` neutralized with a zero-width space (delivery does not set `allowed_mentions`), whole-result capped at 200 chars, `str(exc)` itself raising falls back to the type name.
- Journal keeps full diagnostics via `exc_info`; the message argument is bounded so the HTML isn't duplicated into the journal either.
- Bonus: bare `TimeoutError` no longer renders as an empty `Tool execution timed out: `.

## What this changes in practice

The user-visible failure mode for tonight's incident class becomes: the turn **completes normally without a typing indicator**. For genuinely unexpected escapes: one bounded line (`Tool execution failed: Discord API error: HTTP 500 Internal Server Error`) instead of an HTML page, plus a trajectory record and clean channel state.

## Scope fences

- Loop pipeline untouched (repo-wide there are exactly two `.typing()` call sites, both chat path).
- Web path unaffected (`_WebChannel.typing()` is already a no-op).
- No config/template change. No guard/classifier/delivery changes.
- The crafted `LLM API error:` tuples were audited and left alone — `openai_codex` bounds every error body to ≤500 chars before raising.

## Test plan

`tests/test_typing_resilience.py` — 30 pins: helper never stops work (enter/constructor/exit failures), attempted-every-call (no cooldown), body-exception precedence over cleanup failure, cancellation propagation (enter + body), `__aexit__` skipped when `__aenter__` failed, bounded HTML-free logging; `_error_summary` + `_user_facing_error` (structured Discord branch, HTML sniffing incl. mid-line, first-line-only, empty-message/broken-`__str__` fallbacks, mention neutralization, control-char strip, total output bound); `run()` escape guard (records bounded error + clears + re-raises, cancellation without error trajectory, recorder failure masks nothing, no extra clear on success); both call sites complete with a dead typing endpoint.

Gates: full suite green, `ruff check src/ tests/` 0 findings, `mypy src/` 0 errors (227 files), characterization pins unchanged.
