### PR TITLE
fix: bound typing attempts at 1s — skip fast when the endpoint is down

### DIFF
--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -131,22 +131,37 @@ def _error_summary(exc: BaseException, limit: int = 200) -> str:
         return name
 
 
+# Per-phase ceiling for typing attempts. A healthy POST is ~100-300ms; a
+# dead endpoint used to burn discord.py's internal 5xx retry (~17s) per
+# attempt during the 2026-07-16 incident. Deliberately a private constant,
+# not config — a knob someone can raise would resurrect the incident.
+_TYPING_ATTEMPT_TIMEOUT = 1.0
+
+
 @asynccontextmanager
 async def _best_effort_typing(channel):
-    """Discord typing indicator that can never fail the wrapped work.
+    """Discord typing indicator that can never fail or stall the wrapped work.
 
     The indicator is attempted on every call — no failure memory, so a
-    Discord API outage degrades cosmetics, not behavior — and any ordinary
-    ``Exception`` from typing setup or cleanup is logged bounded and
-    swallowed. Cancellation and exceptions raised by the wrapped body
-    always propagate; a cleanup failure never replaces a body exception.
+    Discord API outage degrades cosmetics, not behavior — but each phase
+    (enter/exit) is bounded by ``_TYPING_ATTEMPT_TIMEOUT`` (read at call
+    time): wait briefly, then abandon the ornamentation and do the actual
+    work. Any ordinary ``Exception`` from typing setup or cleanup is logged
+    bounded and swallowed. Cancellation and exceptions raised by the wrapped
+    body always propagate; a cleanup failure never replaces a body exception.
     """
     cm = None
     try:
         cm = channel.typing()
-        await cm.__aenter__()
+        await asyncio.wait_for(cm.__aenter__(), timeout=_TYPING_ATTEMPT_TIMEOUT)
     except asyncio.CancelledError:
         raise
+    except TimeoutError:
+        log.warning(
+            "Typing indicator enter timed out after %.1fs (non-fatal)",
+            _TYPING_ATTEMPT_TIMEOUT,
+        )
+        cm = None
     except Exception as exc:
         log.warning("Typing indicator failed (non-fatal): %s", _error_summary(exc))
         cm = None
@@ -155,9 +170,16 @@ async def _best_effort_typing(channel):
     finally:
         if cm is not None:
             try:
-                await cm.__aexit__(None, None, None)
+                await asyncio.wait_for(
+                    cm.__aexit__(None, None, None), timeout=_TYPING_ATTEMPT_TIMEOUT
+                )
             except asyncio.CancelledError:
                 raise
+            except TimeoutError:
+                log.warning(
+                    "Typing indicator exit timed out after %.1fs (non-fatal)",
+                    _TYPING_ATTEMPT_TIMEOUT,
+                )
             except Exception as exc:
                 log.warning(
                     "Typing indicator cleanup failed (non-fatal): %s", _error_summary(exc)

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -18,6 +18,7 @@ surfaces were hardened, each pinned here:
 
 import asyncio
 import logging
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -623,3 +624,122 @@ class TestStructuredReasonSanitization:
     def test_error_summary_non_int_status_renders_safely(self):
         out = _error_summary(_http_exc_with_reason("ok", status="evil"))
         assert out == "HTTPException: HTTP ? ok"
+
+
+# ---------------------------------------------------------------------------
+# Follow-up (typing attempt timeout): a dead typing endpoint may cost at most
+# _TYPING_ATTEMPT_TIMEOUT per phase — wait briefly, then abandon the
+# ornamentation and do the actual work. Constant is read at call time so
+# these tests can shrink it.
+# ---------------------------------------------------------------------------
+
+
+class _SlowTypingCM:
+    def __init__(self, channel, slow_enter, slow_exit):
+        self._channel = channel
+        self._slow_enter = slow_enter
+        self._slow_exit = slow_exit
+
+    async def __aenter__(self):
+        self._channel.enters += 1
+        if self._slow_enter:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                self._channel.enter_cancelled = True
+                raise
+        self._channel.entered += 1
+        return self
+
+    async def __aexit__(self, *exc_info):
+        self._channel.exits += 1
+        if self._slow_exit:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                self._channel.exit_cancelled = True
+                raise
+        return False
+
+
+class SlowChannel:
+    """Channel whose typing enter/exit hangs far past any sane deadline."""
+
+    def __init__(self, slow_enter=False, slow_exit=False):
+        self.id = "c1"
+        self.typing_calls = 0
+        self.enters = 0
+        self.entered = 0
+        self.exits = 0
+        self.enter_cancelled = False
+        self.exit_cancelled = False
+        self._slow_enter = slow_enter
+        self._slow_exit = slow_exit
+
+    def typing(self):
+        self.typing_calls += 1
+        return _SlowTypingCM(self, self._slow_enter, self._slow_exit)
+
+
+class TestTypingAttemptTimeout:
+    async def test_slow_enter_abandoned_fast_and_body_runs(self, monkeypatch, caplog):
+        import src.discord.tool_loop as tl
+
+        monkeypatch.setattr(tl, "_TYPING_ATTEMPT_TIMEOUT", 0.05)
+        ch = SlowChannel(slow_enter=True)
+        ran = False
+        start = time.monotonic()
+        with caplog.at_level(logging.WARNING):
+            async with _best_effort_typing(ch):
+                ran = True
+        elapsed = time.monotonic() - start
+        assert ran
+        assert elapsed < 1.0
+        assert ch.enter_cancelled  # the hung enter received CancelledError
+        assert ch.exits == 0  # never entered -> exit never attempted
+        assert any("enter timed out" in r.getMessage() for r in caplog.records)
+
+    async def test_slow_exit_abandoned_fast(self, monkeypatch, caplog):
+        import src.discord.tool_loop as tl
+
+        monkeypatch.setattr(tl, "_TYPING_ATTEMPT_TIMEOUT", 0.05)
+        ch = SlowChannel(slow_exit=True)
+        ran = False
+        start = time.monotonic()
+        with caplog.at_level(logging.WARNING):
+            async with _best_effort_typing(ch):
+                ran = True
+        elapsed = time.monotonic() - start
+        assert ran
+        assert elapsed < 1.0
+        assert ch.exit_cancelled  # the hung exit received CancelledError
+        assert any("exit timed out" in r.getMessage() for r in caplog.records)
+
+    async def test_body_exception_wins_over_slow_exit_timeout(self, monkeypatch):
+        import src.discord.tool_loop as tl
+
+        monkeypatch.setattr(tl, "_TYPING_ATTEMPT_TIMEOUT", 0.05)
+        ch = SlowChannel(slow_exit=True)
+        with pytest.raises(ValueError, match="body boom"):
+            async with _best_effort_typing(ch):
+                raise ValueError("body boom")
+        assert ch.exit_cancelled
+
+    async def test_typing_still_attempted_every_call_after_timeouts(self, monkeypatch):
+        import src.discord.tool_loop as tl
+
+        monkeypatch.setattr(tl, "_TYPING_ATTEMPT_TIMEOUT", 0.05)
+        ch = SlowChannel(slow_enter=True)
+        async with _best_effort_typing(ch):
+            pass
+        async with _best_effort_typing(ch):
+            pass
+        assert ch.typing_calls == 2
+        assert ch.enters == 2
+
+    async def test_healthy_typing_unaffected(self):
+        ch = FakeChannel()
+        async with _best_effort_typing(ch):
+            pass
+        assert ch.entered == 1
+        assert ch.exits == 1


### PR DESCRIPTION
## Summary

Follow-up to #233, design-settled with Odin over the bridge. During a typing-endpoint outage each attempt burned discord.py's internal 5xx retry (~17s) before `_best_effort_typing` heard the failure — every LLM iteration and tool batch paid it, so multi-batch turns carried minutes of cosmetic latency during the 2026-07-16 incident (observed live).

Both typing phases are now bounded by `asyncio.wait_for` at `_TYPING_ATTEMPT_TIMEOUT = 1.0s`:
- **Private constant, deliberately not config** — a raisable knob would resurrect the incident. Healthy POSTs run ~100-300ms, so a false skip is harmless and rare.
- Constant read at call time (monkeypatchable); warnings phase-distinguished (`enter timed out` / `exit timed out`).
- Policy unchanged: attempted on every call, no failure memory, body exceptions and cancellation always propagate, no shielding (a shield would preserve exactly the background retrying this kills).
- `wait_for` cancels the in-flight enter; discord.py's refresh loop task is created only after the initial send completes, so nothing survives an abandoned attempt (at worst one naturally-expiring indicator).

## Test plan

Five new pins in `tests/test_typing_resilience.py` (53 total): hung enter/exit abandoned fast **with CancelledError delivered to the hung coroutine**, body executes after an enter timeout, body exception wins over a slow-exit timeout, re-attempted on every call after timeouts, healthy path unaffected.

Gates: full suite green, coverage gate findings=0 (87.2%), ruff 0, mypy 0 (227 files).