### PR TITLE
fix: open WebSockets can no longer hold shutdown past the stop window

### DIFF
--- a/src/health/server.py
+++ b/src/health/server.py
@@ -658,7 +658,13 @@ class HealthServer:
         return web.FileResponse(self._ui_dir / "index.html")
 
     async def start(self) -> None:
-        self._runner = web.AppRunner(self._app)
+        # shutdown_timeout bounds cleanup()'s wait for in-flight handlers
+        # (default 60s — far past systemd's stop window; an open handler
+        # can spend up to ~2x this between graceful wait and cancellation,
+        # still inside Mint's DefaultTimeoutStopSec=10s). WebSockets are
+        # closed separately via the app.on_shutdown hook, which cleanup()
+        # runs after the listener stops accepting.
+        self._runner = web.AppRunner(self._app, shutdown_timeout=3.0)
         await self._runner.setup()
         bind_host = getattr(self._web_config, "host", "0.0.0.0") or "0.0.0.0"
         site = web.TCPSite(self._runner, bind_host, self.port)
@@ -666,10 +672,18 @@ class HealthServer:
         log.info("Health server listening on %s:%d", bind_host, self.port)
 
     async def stop(self) -> None:
-        if self._slack_notifier:
-            await self._slack_notifier.close()
-        if self._runner:
-            await self._runner.cleanup()
+        # Quiesce the HTTP server first and independently — a notifier
+        # close failure must never leave the runner (and its open
+        # handlers) alive past the stop window.
+        try:
+            if self._runner:
+                await self._runner.cleanup()
+        finally:
+            if self._slack_notifier:
+                try:
+                    await self._slack_notifier.close()
+                except Exception:
+                    log.exception("Slack notifier close failed during shutdown")
 
     async def _health(self, request: web.Request) -> web.Response:
         """Combined health endpoint.

--- a/src/web/websocket.py
+++ b/src/web/websocket.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import aiohttp
-from aiohttp import web
+from aiohttp import WSCloseCode, web
 
 from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
@@ -251,6 +251,41 @@ class WebSocketManager:
             self._event_subscribers.discard(ws)
             self._clients.discard(ws)
 
+    async def close_all(self) -> int:
+        """Close every connected client — the app.on_shutdown hook.
+
+        ``AppRunner.cleanup()`` runs this after the listener stops accepting
+        (so a browser cannot reconnect behind the snapshot) and before
+        remaining handlers are cancelled. Closes run CONCURRENTLY with a 1s
+        per-client bound: ``ws.close()`` alone waits up to its own 10s
+        peer-handshake timeout, so serial unbounded closes would reinvent
+        the shutdown hang once per client. Subscriber sets are cleared in
+        guaranteed cleanup even when individual closes fail.
+        """
+        snapshot = list(self._clients)
+
+        async def _close_one(ws: web.WebSocketResponse) -> None:
+            try:
+                await asyncio.wait_for(
+                    ws.close(code=WSCloseCode.GOING_AWAY, message=b"server shutdown"),
+                    timeout=1.0,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                log.debug("WebSocket close failed (non-fatal): %s", type(exc).__name__)
+
+        try:
+            if snapshot:
+                await asyncio.gather(*(_close_one(ws) for ws in snapshot))
+        finally:
+            self._clients.clear()
+            self._log_subscribers.clear()
+            self._event_subscribers.clear()
+        if snapshot:
+            log.info("Closed %d WebSocket client(s) at shutdown", len(snapshot))
+        return len(snapshot)
+
     async def close_by_user_id(self, user_id: str) -> int:
         """Close all WebSocket connections for a given user_id."""
         to_close = []
@@ -329,5 +364,16 @@ def setup_websocket(
         web_config=web_config,
     )
     app.router.add_get("/api/ws", manager.handle)
+
+    # The manager owns its shutdown: aiohttp runs on_shutdown between
+    # stopping the listener and cancelling remaining handlers, which is the
+    # only race-free point to close live sockets (closing before cleanup
+    # lets a browser reconnect behind the snapshot). Without this, an open
+    # WebSocket held AppRunner.cleanup() until systemd's stop timeout
+    # SIGKILLed every shutdown with a WebUI tab open (found 2026-07-16).
+    async def _close_websockets_on_shutdown(_app: web.Application) -> None:
+        await manager.close_all()
+
+    app.on_shutdown.append(_close_websockets_on_shutdown)
     log.info("WebSocket endpoint registered at /api/ws")
     return manager

--- a/tests/test_health_shutdown.py
+++ b/tests/test_health_shutdown.py
@@ -1,0 +1,223 @@
+"""Pins for the shutdown-hang fix (found 2026-07-16).
+
+An open ``/api/ws`` WebSocket held ``AppRunner.cleanup()`` (60s default
+handler grace) past systemd's stop window (Mint's
+``DefaultTimeoutStopSec=10s``), so every ``systemctl stop`` with a WebUI
+tab open was SIGKILLed after "shutdown complete" — bypassing the
+``__main__`` loop-drain — and the self-update re-exec path could wedge the
+same way with no watchdog at all.
+
+Three surfaces:
+- ``WebSocketManager.close_all()``: concurrent, per-client-bounded closes;
+  subscriber sets cleared in guaranteed cleanup.
+- ``setup_websocket``: registers ``close_all`` as an ``app.on_shutdown``
+  hook so cleanup closes sockets after the listener stops accepting (no
+  reconnect race).
+- ``HealthServer``: bounded runner shutdown; ``stop()`` quiesces the HTTP
+  server independently of the Slack notifier.
+
+Plus the integration artifact: a real server with a live WebSocket stops
+promptly and the client sees the close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import aiohttp
+import pytest
+from aiohttp import WSCloseCode
+
+from src.config.schema import WebhookConfig
+from src.health.server import HealthServer
+from src.web.websocket import WebSocketManager, setup_websocket
+
+# ---------------------------------------------------------------------------
+# close_all
+# ---------------------------------------------------------------------------
+
+
+class _FakeWS:
+    def __init__(self, *, close_exc=None, hang=False):
+        self.closed_with = None
+        self._close_exc = close_exc
+        self._hang = hang
+
+    async def close(self, *, code=None, message=b""):
+        if self._hang:
+            await asyncio.sleep(30)
+        if self._close_exc is not None:
+            raise self._close_exc
+        self.closed_with = code
+        return True
+
+
+def _manager_with(clients):
+    manager = WebSocketManager(SimpleNamespace())
+    for ws in clients:
+        manager._clients.add(ws)
+        manager._log_subscribers.add(ws)
+        manager._event_subscribers.add(ws)
+    return manager
+
+
+class TestCloseAll:
+    async def test_closes_every_client_going_away_and_clears_sets(self):
+        clients = [_FakeWS(), _FakeWS(), _FakeWS()]
+        manager = _manager_with(clients)
+        closed = await manager.close_all()
+        assert closed == 3
+        assert all(ws.closed_with == WSCloseCode.GOING_AWAY for ws in clients)
+        assert not manager._clients
+        assert not manager._log_subscribers
+        assert not manager._event_subscribers
+
+    async def test_raising_close_does_not_stop_the_others(self):
+        good = _FakeWS()
+        bad = _FakeWS(close_exc=RuntimeError("peer gone"))
+        manager = _manager_with([good, bad])
+        closed = await manager.close_all()
+        assert closed == 2
+        assert good.closed_with == WSCloseCode.GOING_AWAY
+        assert not manager._clients
+
+    async def test_hanging_close_is_bounded_and_concurrent(self):
+        # Two hung peer handshakes: serial unbounded closes would take
+        # 60s (2 x ws.close()'s own 10s default, or worse); concurrent
+        # 1s-bounded closes finish together well under 2s.
+        manager = _manager_with([_FakeWS(hang=True), _FakeWS(hang=True)])
+        start = time.monotonic()
+        closed = await manager.close_all()
+        elapsed = time.monotonic() - start
+        assert closed == 2
+        assert elapsed < 2.0
+        assert not manager._clients
+
+    async def test_sets_cleared_even_when_every_close_fails(self):
+        manager = _manager_with([_FakeWS(close_exc=OSError("boom"))])
+        await manager.close_all()
+        assert not manager._clients
+        assert not manager._log_subscribers
+        assert not manager._event_subscribers
+
+    async def test_no_clients_is_a_quiet_noop(self):
+        manager = _manager_with([])
+        assert await manager.close_all() == 0
+
+    async def test_outer_cancellation_propagates_and_still_clears(self):
+        manager = _manager_with([_FakeWS(hang=True)])
+        task = asyncio.create_task(manager.close_all())
+        await asyncio.sleep(0.05)  # let it reach the close await
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not manager._clients
+        assert not manager._log_subscribers
+
+
+# ---------------------------------------------------------------------------
+# setup_websocket registers the shutdown hook
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownHookRegistration:
+    async def test_on_shutdown_hook_closes_clients(self):
+        app = aiohttp.web.Application()
+        manager = setup_websocket(app, SimpleNamespace())
+        ws = _FakeWS()
+        manager._clients.add(ws)
+        assert len(app.on_shutdown) == 1
+        await app.on_shutdown[0](app)
+        assert ws.closed_with == WSCloseCode.GOING_AWAY
+        assert not manager._clients
+
+
+# ---------------------------------------------------------------------------
+# HealthServer.stop() isolation
+# ---------------------------------------------------------------------------
+
+
+def _bare_server():
+    return HealthServer(port=0, webhook_config=WebhookConfig(enabled=False))
+
+
+class _Recorder:
+    def __init__(self, exc=None):
+        self.called = False
+        self._exc = exc
+
+    async def __call__(self):
+        self.called = True
+        if self._exc is not None:
+            raise self._exc
+
+
+class TestStopIsolation:
+    async def test_slack_close_failure_cannot_skip_runner_cleanup(self):
+        server = _bare_server()
+        cleanup = _Recorder()
+        slack_close = _Recorder(exc=RuntimeError("slack down"))
+        server._runner = SimpleNamespace(cleanup=cleanup)
+        server._slack_notifier = SimpleNamespace(close=slack_close)
+        await server.stop()  # must not raise
+        assert cleanup.called
+        assert slack_close.called
+
+    async def test_runner_cleanup_failure_still_closes_slack(self):
+        server = _bare_server()
+        cleanup = _Recorder(exc=RuntimeError("cleanup boom"))
+        slack_close = _Recorder()
+        server._runner = SimpleNamespace(cleanup=cleanup)
+        server._slack_notifier = SimpleNamespace(close=slack_close)
+        with pytest.raises(RuntimeError, match="cleanup boom"):
+            await server.stop()
+        assert slack_close.called
+
+    async def test_runner_gets_bounded_shutdown_timeout(self):
+        server = _bare_server()
+        await server.start()
+        try:
+            assert server._runner is not None
+            # aiohttp keeps the ctor arg private; this pins that start()
+            # actually passes the bound (the integration test below proves
+            # the resulting behavior).
+            assert server._runner._shutdown_timeout == 3.0
+        finally:
+            await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# The integration artifact: a live WebSocket cannot hold stop() hostage
+# ---------------------------------------------------------------------------
+
+
+class TestLiveShutdown:
+    async def test_stop_closes_live_websocket_and_completes_promptly(self):
+        server = _bare_server()
+        setup_websocket(server._app, SimpleNamespace(), api_token="")
+        await server.start()
+        assert server._runner is not None
+        port = next(
+            addr[1] for addr in server._runner.addresses if isinstance(addr, tuple)
+        )
+        session = aiohttp.ClientSession()
+        try:
+            ws = await session.ws_connect(f"http://127.0.0.1:{port}/api/ws")
+            start = time.monotonic()
+            stop_task = asyncio.create_task(server.stop())
+            msg = await ws.receive(timeout=5)
+            await asyncio.wait_for(stop_task, timeout=5)
+            elapsed = time.monotonic() - start
+            assert msg.type in (
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+                aiohttp.WSMsgType.CLOSED,
+            )
+            if msg.type == aiohttp.WSMsgType.CLOSE:
+                assert ws.close_code == WSCloseCode.GOING_AWAY
+            assert elapsed < 5.0
+            await ws.close()
+        finally:
+            await session.close()


### PR DESCRIPTION
## Summary

Root-caused tonight: every `systemctl stop` with a WebUI tab open was SIGKILLed at 10s. Odin's own `shutdown()` completes in milliseconds, then `health.stop()` → `runner.cleanup()` waits on the open `/api/ws` handler (aiohttp's 60s default handler grace) while the system-wide `DefaultTimeoutStopSec=10s` kills the process first. Stop history: clean through Jul 9, timing out since Jul 10–11 when the WebUI became the standing surface. Two knock-on effects: the SIGKILL bypasses `__main__`'s loop-drain entirely, and the self-update re-exec path — which runs only after shutdown completes — could wedge the same way with **no** watchdog.

Design-settled with Odin over the bridge; his amendments all adopted (on_shutdown hook instead of racy close-before-cleanup, concurrent bounded closes, `WSCloseCode.GOING_AWAY`, `shutdown_timeout` on `AppRunner` not `TCPSite`, Slack-close isolation, and the live-socket integration test).

## Changes

- **`WebSocketManager.close_all()`** — closes every client **concurrently** with a **1s per-client bound** (`ws.close()` alone waits its own 10s peer-handshake timeout; serial unbounded closes would reinvent the hang once per client), `GOING_AWAY`, subscriber sets cleared in guaranteed cleanup, cancellation propagates.
- **`setup_websocket` registers the `app.on_shutdown` hook** — the manager owns its lifecycle; `AppRunner.cleanup()` runs the hook *after* the listener stops accepting, so a reconnecting browser can't race behind the snapshot.
- **`HealthServer`** — `AppRunner(shutdown_timeout=3.0)` bounds cleanup for any other in-flight handler (worst case ~2× between graceful wait and cancellation, still inside the 10s budget); `stop()` quiesces the HTTP server first and independently — a Slack notifier close failure can no longer skip runner cleanup.

## Test plan

`tests/test_health_shutdown.py` — 11 pins: per-client close/clear semantics, raising close survived, **hung closes bounded and concurrent** (<2s for two 30s hangs), outer cancellation propagates with cleanup, sets cleared on total failure, on_shutdown hook registration+behavior, both stop()-isolation directions, the shutdown_timeout ctor pin, and the integration artifact — a real server + live `/api/ws` connection: client receives `GOING_AWAY`, `stop()` completes in well under 5s.

Gates: full suite green, coverage gate findings=0 (87.3%), ruff 0, mypy 0 (227 files). No config/template change, no `__main__.py` or unit-file changes.