### PR TITLE
fix: eight findings from the v3.65.1 adversarial review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,30 @@ jobs:
       - name: Run the suite
         run: pytest -q
 
+  browser-network-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install browser test dependencies
+        run: |
+          pip install -e ".[dev,browser]"
+          python -m playwright install --with-deps chromium
+      - name: Exercise real Chromium request guard paths
+        env:
+          # The tests may skip on developer machines without Chromium, but this
+          # job must fail rather than silently stop exercising the guard.
+          ODIN_REQUIRE_BROWSER_TESTS: '1'
+        run: |
+          pytest -q \
+            tests/test_browser_automation.py::test_real_public_page_loads_to_completion_through_request_guard \
+            tests/test_browser_automation.py::test_real_browser_blocks_redirects_and_subresources_to_private_loopback
+
   lint-no-new:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/src/discord/native_tools/media.py
+++ b/src/discord/native_tools/media.py
@@ -222,7 +222,7 @@ class MediaTools:
                 return f"URL does not point to an image (Content-Type: {ct})"
             image_bytes = resp.body
         elif host and path:
-            # Use executor to fetch from host via base64
+            # Fetch from host as bounded raw bytes
 
             resolved = self.tool_executor._resolve_host(host)
             if not resolved:

--- a/src/discord/native_tools/media.py
+++ b/src/discord/native_tools/media.py
@@ -223,24 +223,27 @@ class MediaTools:
             image_bytes = resp.body
         elif host and path:
             # Use executor to fetch from host via base64
-            import shlex
 
             resolved = self.tool_executor._resolve_host(host)
             if not resolved:
                 return f"Unknown or disallowed host: {host}"
             address, ssh_user, _os = resolved
-            safe_path = shlex.quote(path)
-            code, output = await self.tool_executor._exec_command(
+            # Same defect as analyze_pdf: base64 over the text pipeline is
+            # truncated at MAX_OUTPUT_CHARS, so any image over roughly 12KB
+            # arrived corrupt (adversarial review). Raw bounded bytes instead.
+            from ...tools.ssh import read_binary_file
+
+            cfg = self.tool_executor.config
+            image_bytes, read_error = await read_binary_file(
                 address,
-                f"base64 -w0 {safe_path}",
-                ssh_user,
+                path,
+                max_bytes=_ANALYZE_IMAGE_MAX_BYTES,
+                ssh_key_path=cfg.ssh_key_path,
+                known_hosts_path=cfg.ssh_known_hosts_path,
+                ssh_user=ssh_user,
             )
-            if code != 0:
-                return f"Failed to read image from host: {output}"
-            try:
-                image_bytes = base64.b64decode(output.strip())
-            except Exception as e:
-                return f"Failed to decode image data: {e}"
+            if read_error:
+                return f"Failed to read image from host: {read_error}"
         else:
             return "Provide either 'url' or both 'host' and 'path'."
 

--- a/src/discord/scheduled_events.py
+++ b/src/discord/scheduled_events.py
@@ -65,25 +65,29 @@ class ScheduledEventHandlers:
         """Run the daily infrastructure digest and post results."""
         channel_id = schedule.get("channel_id")
         if not channel_id:
-            log.warning("Digest has no channel_id: %s", schedule["id"])
-            return
+            raise RuntimeError(f"Digest {schedule['id']} has no channel_id")
 
         channel = self._get_channel(int(channel_id))
         if not channel:
-            log.warning("Digest channel %s not found", channel_id)
-            return
+            raise RuntimeError(f"Digest channel {channel_id} not found")
 
         log.info("Running daily digest for channel %s", channel_id)
         try:
             raw = await self._format_digest_raw()
         except Exception as e:
             log.error("Digest data collection failed: %s", e)
-            await channel.send(
-                scrub_response_secrets(
-                    f"**Daily Infrastructure Digest**\n\nFailed to collect data: {e}"
+            try:
+                await channel.send(
+                    scrub_response_secrets(
+                        f"**Daily Infrastructure Digest**\n\nFailed to collect data: {e}"
+                    )
                 )
-            )
-            return
+            except Exception as send_error:
+                raise RuntimeError(
+                    f"Digest data collection failed ({e}); failure notice delivery failed: "
+                    f"{send_error}"
+                ) from send_error
+            raise RuntimeError(f"Digest data collection failed: {e}") from e
 
         # Summarize the digest — prefer Codex (free), fall back to raw truncation
         digest_messages = [
@@ -328,7 +332,7 @@ class ScheduledEventHandlers:
         try:
             await channel.send(scrub_response_secrets(text))
         except Exception as e:
-            log.error("Failed to post workflow results: %s", e)
+            raise RuntimeError(f"Failed to post workflow results: {e}") from e
 
         return workflow_ok
 
@@ -371,13 +375,11 @@ class ScheduledEventHandlers:
             pass
         channel_id = schedule.get("channel_id")
         if not channel_id:
-            log.warning("Scheduled task has no channel_id: %s", schedule["id"])
-            return
+            raise RuntimeError(f"Scheduled task {schedule['id']} has no channel_id")
 
         channel = self._get_channel(int(channel_id))
         if not channel:
-            log.warning("Scheduled task channel %s not found", channel_id)
-            return
+            raise RuntimeError(f"Scheduled task channel {channel_id} not found")
 
         if schedule["action"] == "digest":
             await self._on_scheduled_digest(schedule)
@@ -390,7 +392,7 @@ class ScheduledEventHandlers:
             try:
                 await channel.send(f"**Scheduled reminder:** {msg}")
             except Exception as e:
-                log.warning("Failed to send scheduled reminder: %s", e)
+                raise RuntimeError(f"Failed to send scheduled reminder: {e}") from e
 
         elif schedule["action"] == "check":
             tool_name = schedule.get("tool_name")
@@ -439,8 +441,7 @@ class ScheduledEventHandlers:
                 )
 
         else:
-            log.warning(
-                "Unknown scheduled action type: %s (schedule %s)",
-                schedule["action"],
-                schedule.get("id"),
+            raise RuntimeError(
+                f"Unknown scheduled action type: {schedule['action']} "
+                f"(schedule {schedule.get('id')})"
             )

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -713,7 +713,16 @@ class Scheduler:
 
         log.info("Manual run: schedule %s (%s)", schedule_id, schedule.get("description", ""))
         failures_before = schedule.get("consecutive_failures", 0)
-        await self._execute_and_record(schedule)
+        executed = await self._execute_and_record(schedule)
+        if not executed:
+            skipped_result = {
+                "status": "skipped",
+                "schedule_id": schedule_id,
+                "error": "schedule is already executing",
+            }
+            if schedule.get("paused"):
+                skipped_result["warning"] = "schedule is paused — this was a manual override"
+            return skipped_result
 
         failed = schedule.get("consecutive_failures", 0) > failures_before
         result: dict = {
@@ -833,7 +842,7 @@ class Scheduler:
         retry_time = datetime.now(UTC) + timedelta(seconds=delay)
         return retry_time.isoformat()
 
-    async def _execute_and_record(self, schedule: dict) -> None:
+    async def _execute_and_record(self, schedule: dict) -> bool:
         """Execute the schedule callback and record the result in history.
 
         For 'webhook' actions, the built-in HTTP executor is used directly.
@@ -848,10 +857,11 @@ class Scheduler:
             log.warning(
                 "Schedule %s is already executing — skipping overlapping fire", sid,
             )
-            return
+            return False
         self._in_flight.add(sid)
         try:
             await self._execute_and_record_inner(schedule)
+            return True
         finally:
             self._in_flight.discard(sid)
 
@@ -1021,15 +1031,19 @@ class Scheduler:
                     log.error("Schedule save failed (in-memory state may diverge from disk): %s", e)
 
         # Execute callbacks OUTSIDE the lock so callbacks can safely
-        # call add()/delete()/update() without deadlocking.
+        # call add()/delete()/update() without deadlocking.  Keep only the
+        # executions this tick actually owned: an overlapping run_now may hold
+        # the in-flight guard, and a skipped one-time task is not completed.
+        executed: list[dict] = []
         for schedule in to_fire:
-            await self._execute_and_record(schedule)
+            if await self._execute_and_record(schedule):
+                executed.append(schedule)
 
         # Remove a one-time schedule only after confirmed success.  A failed
         # delivery remains persisted even when automatic retries are disabled,
         # so an operator can run it again instead of losing the reminder.
         one_time_done = [
-            s["id"] for s in to_fire
+            s["id"] for s in executed
             if s.get("one_time")
             and not s.get("retry_at")
             and not s.get("last_error")

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -724,6 +724,16 @@ class Scheduler:
             result["error"] = schedule.get("last_error", "unknown error")
         if schedule.get("paused"):
             result["warning"] = "schedule is paused — this was a manual override"
+
+        # Persist callback outcome.  A successful manual recovery completes a
+        # one-time schedule; a failed one remains inert and recoverable.
+        async with self._lock:
+            if not failed and schedule.get("one_time"):
+                self._schedules = [s for s in self._schedules if s["id"] != schedule_id]
+            try:
+                await asyncio.to_thread(self._save)
+            except Exception as e:
+                log.error("Schedule save failed after manual execution: %s", e)
         return result
 
     async def delete(self, schedule_id: str) -> bool:
@@ -915,6 +925,8 @@ class Scheduler:
         """Reset failure tracking after a successful execution."""
         schedule["consecutive_failures"] = 0
         schedule["retry_count"] = 0
+        schedule["last_error"] = None
+        schedule["last_error_at"] = None
         schedule.pop("retry_at", None)
 
     async def _handle_failure(self, schedule: dict, error: Exception) -> None:
@@ -937,6 +949,10 @@ class Scheduler:
             )
         else:
             schedule.pop("retry_at", None)
+            # A terminally failed one-time schedule must remain available for
+            # manual recovery without firing again on every scheduler tick.
+            if schedule.get("one_time"):
+                schedule.pop("next_run", None)
             if max_retries > 0:
                 log.error(
                     "Schedule %s exhausted all %d retries: %s",
@@ -1009,16 +1025,24 @@ class Scheduler:
         for schedule in to_fire:
             await self._execute_and_record(schedule)
 
-        # Remove completed one-time schedules AFTER callbacks have run
-        # (callbacks may set retry_at on failure, deferring removal).
+        # Remove a one-time schedule only after confirmed success.  A failed
+        # delivery remains persisted even when automatic retries are disabled,
+        # so an operator can run it again instead of losing the reminder.
         one_time_done = [
             s["id"] for s in to_fire
-            if s.get("one_time") and not s.get("retry_at")
+            if s.get("one_time")
+            and not s.get("retry_at")
+            and not s.get("last_error")
         ]
-        if one_time_done:
+        if to_fire:
             async with self._lock:
-                self._schedules = [s for s in self._schedules if s["id"] not in one_time_done]
+                if one_time_done:
+                    self._schedules = [
+                        s for s in self._schedules if s["id"] not in one_time_done
+                    ]
                 try:
+                    # Persist retries, terminal failure state, and successful
+                    # counter resets even when no one-time item was removed.
                     await asyncio.to_thread(self._save)
                 except Exception as e:
-                    log.error("Schedule save failed after one-time cleanup: %s", e)
+                    log.error("Schedule save failed after execution: %s", e)

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
 import re
@@ -599,13 +600,24 @@ class Scheduler:
         if cron_timezone is not None:
             self._validate_timezone(cron_timezone)
         async with self._lock:
-            target: dict | None = None
-            for s in self._schedules:
-                if s["id"] == schedule_id:
-                    target = s
+            target_index: int | None = None
+            for i, schedule in enumerate(self._schedules):
+                if schedule["id"] == schedule_id:
+                    target_index = i
                     break
-            if target is None:
+            if target_index is None:
                 return None
+
+            # Apply the complete update to a detached candidate. Validation of
+            # cron/trigger/webhook/timing fields occurs throughout this method;
+            # mutating the live dict first let ANY later ValueError leave
+            # rejected fields in memory, where a subsequent valid update would
+            # persist them. Commit only after every supplied field is valid.
+            original = self._schedules[target_index]
+            target = copy.deepcopy(original)
+            action = target["action"]
+            if steps is not None and action == "workflow":
+                self._validate_workflow_steps(steps)
 
             # --- simple text fields ---
             if description is not None:
@@ -618,7 +630,6 @@ class Scheduler:
                 target["paused"] = paused
 
             # --- action-specific payload fields ---
-            action = target["action"]
             if tool_name is not None:
                 if action == "check":
                     if tool_name not in ALLOWED_CHECK_TOOLS:
@@ -630,8 +641,6 @@ class Scheduler:
             if tool_input is not None:
                 target["tool_input"] = tool_input
             if steps is not None:
-                if action == "workflow":
-                    self._validate_workflow_steps(steps)
                 target["steps"] = steps
             if webhook_config is not None:
                 self._validate_webhook_config(webhook_config)
@@ -684,7 +693,14 @@ class Scheduler:
                 # Timezone changed on an existing cron schedule — recompute.
                 target["next_run"] = _cron_next_run(target["cron"], cron_timezone)
 
-            await asyncio.to_thread(self._save)
+            self._schedules[target_index] = target
+            try:
+                await asyncio.to_thread(self._save)
+            except Exception:
+                # Persistence failure must not leave an in-memory update that
+                # disagrees with disk and may be serialized by a later write.
+                self._schedules[target_index] = original
+                raise
             log.info("Updated schedule %s", schedule_id)
             return dict(target)
 

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -180,11 +180,7 @@ class Scheduler:
                 raise ValueError("'webhook_config' (dict) is required for 'webhook' actions")
             self._validate_webhook_config(webhook_config)
         elif action == "workflow":
-            if not steps or not isinstance(steps, list):
-                raise ValueError("'steps' (list) is required for 'workflow' actions")
-            for i, step in enumerate(steps):
-                if not isinstance(step, dict) or "tool_name" not in step:
-                    raise ValueError(f"Step {i}: must be a dict with 'tool_name'")
+            self._validate_workflow_steps(steps)
 
         if trigger is not None:
             self._validate_trigger(trigger)
@@ -275,6 +271,42 @@ class Scheduler:
             ZoneInfo(tz_name)
         except (ZoneInfoNotFoundError, ValueError) as e:
             raise ValueError(f"Invalid timezone {tz_name!r}: {e}") from e
+
+    # Required inputs for the command-executing tools. A workflow step naming
+    # run_command with no command is not a workflow step, it is a silent no-op
+    # that reports success — and update used to accept it (adversarial review).
+    _STEP_REQUIRED_INPUTS = {
+        "run_command": "command",
+        "run_script": "script",
+        "run_command_multi": "command",
+    }
+
+    @classmethod
+    def _validate_workflow_steps(cls, steps: Any) -> None:
+        """THE workflow-steps contract, shared by add() and update().
+
+        Creation enforced this and update did not, so an existing workflow
+        could be updated to an empty list, or to steps missing the input their
+        tool requires, and the invalid version was persisted (adversarial
+        review of v3.65.1, reproduced with [], [{"tool_name": "run_command",
+        "tool_input": {}}] and [{"tool_name": "run_command"}]).
+        """
+        if not steps or not isinstance(steps, list):
+            raise ValueError("'steps' (list) is required for 'workflow' actions")
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict) or "tool_name" not in step:
+                raise ValueError(f"Step {i}: must be a dict with 'tool_name'")
+            tool_name = step.get("tool_name")
+            required = cls._STEP_REQUIRED_INPUTS.get(str(tool_name))
+            if required:
+                tool_input = step.get("tool_input")
+                if not isinstance(tool_input, dict) or not str(
+                    tool_input.get(required, "")
+                ).strip():
+                    raise ValueError(
+                        f"Step {i}: {tool_name} requires "
+                        f"'tool_input.{required}'"
+                    )
 
     @staticmethod
     def _validate_trigger(trigger: dict) -> None:
@@ -599,9 +631,7 @@ class Scheduler:
                 target["tool_input"] = tool_input
             if steps is not None:
                 if action == "workflow":
-                    for i, step in enumerate(steps):
-                        if not isinstance(step, dict) or "tool_name" not in step:
-                            raise ValueError(f"Step {i}: must be a dict with 'tool_name'")
+                    self._validate_workflow_steps(steps)
                 target["steps"] = steps
             if webhook_config is not None:
                 self._validate_webhook_config(webhook_config)

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -8,6 +8,7 @@ after each call. Falls back to a remote CDP URL if configured.
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
@@ -33,6 +34,21 @@ _CONNECTION_ERROR_PATTERNS = (
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+_HTTP_URL_PATTERN = re.compile(r"^https?://", re.IGNORECASE)
+_WEBSOCKET_URL_PATTERN = re.compile(r"^wss?://", re.IGNORECASE)
+_REQUEST_HEADERS_TO_DROP = frozenset(
+    {"connection", "content-length", "host", "proxy-connection", "transfer-encoding", "upgrade"}
+)
+_RESPONSE_HEADERS_TO_DROP = frozenset(
+    {
+        "connection",
+        "content-encoding",
+        "content-length",
+        "proxy-connection",
+        "transfer-encoding",
+        "upgrade",
+    }
 )
 
 
@@ -131,9 +147,18 @@ class BrowserManager:
         context = await self._browser.new_context(  # type: ignore[union-attr]
             viewport=self._viewport,
             user_agent=DEFAULT_USER_AGENT,
+            # Service workers can issue requests outside normal page routing.
+            # Browser tools use disposable contexts, so blocking them costs no
+            # persistent functionality and closes that enforcement bypass.
+            service_workers="block",
         )
         context.set_default_timeout(timeout_ms or self._default_timeout_ms)
-        page = await context.new_page()
+        try:
+            await self._install_request_guard(context)
+            page = await context.new_page()
+        except Exception:
+            await context.close()
+            raise
         if not self._native:
             try:
                 cdp = await page.context.new_cdp_session(page)
@@ -149,6 +174,77 @@ class BrowserManager:
             except Exception:
                 pass
         return context, page
+
+
+    async def _install_request_guard(self, context) -> None:
+        """Route every browser network request through the SSRF-safe transport.
+
+        Validating only ``page.goto()`` is insufficient: Chromium follows
+        redirects and loads scripts, images, frames, fetches, and form targets
+        on its own.  The safe transport validates each request URL and uses a
+        connect-time validating resolver, so DNS resolution is bound to the
+        socket rather than checked in a separate, raceable lookup.
+        """
+        from .safe_fetch import SafeFetchError, safe_fetch
+
+        async def _route_http(route) -> None:
+            request = route.request
+            try:
+                request_headers = {
+                    key: value
+                    for key, value in (await request.all_headers()).items()
+                    if key.lower() not in _REQUEST_HEADERS_TO_DROP
+                }
+                # Chromium normally follows redirects inside one routed
+                # request and does not expose the redirect target as another
+                # context.route callback.  Follow the chain here instead: the
+                # safe transport validates every hop and pins DNS at connect
+                # time before we fulfill Chromium with only the final response.
+                response = await safe_fetch(
+                    request.url,
+                    method=request.method,
+                    headers=request_headers,
+                    data=request.post_data_buffer,
+                    follow_redirects=True,
+                    allowed_urls=self.allowed_urls,
+                    timeout=max(1.0, self._default_timeout_ms / 1000),
+                    user_agent=None,
+                )
+                # aiohttp decodes compressed bodies.  Let Playwright calculate
+                # framing for the fulfilled bytes instead of forwarding stale
+                # transport/content-encoding headers from the origin.
+                response_headers = {
+                    key: value
+                    for key, value in response.headers.items()
+                    if key.lower() not in _RESPONSE_HEADERS_TO_DROP
+                }
+                await route.fulfill(
+                    status=response.status,
+                    headers=response_headers,
+                    body=response.body,
+                )
+            except (SafeFetchError, OSError, TimeoutError) as exc:
+                log.warning("Blocked or failed browser request %s: %s", request.url, exc)
+                await route.abort("blockedbyclient")
+
+        await context.route(_HTTP_URL_PATTERN, _route_http)
+
+        # WebSocket routing was added after Playwright's original browser
+        # support.  Refuse to create an unguarded context on an older runtime;
+        # silently falling back would leave a direct network path around the
+        # HTTP request guard.
+        route_web_socket = getattr(context, "route_web_socket", None)
+        if route_web_socket is None:
+            raise RuntimeError(
+                "Browser security requires Playwright with WebSocket routing support; "
+                "upgrade the browser extra"
+            )
+
+        async def _block_websocket(websocket) -> None:
+            log.warning("Blocked browser WebSocket request: %s", websocket.url)
+            await websocket.close(code=1008, reason="Browser network policy")
+
+        await route_web_socket(_WEBSOCKET_URL_PATTERN, _block_websocket)
 
     @asynccontextmanager
     async def new_page(self, timeout_ms: int | None = None) -> AsyncIterator:
@@ -214,10 +310,11 @@ async def handle_browser_screenshot(
             await page.wait_for_timeout(wait_seconds * 1000)
         screenshot_bytes = await page.screenshot(full_page=full_page, type="png")
         title = await page.title()
+        final_url = page.url
         status = response.status if response else "unknown"
 
     size_kb = len(screenshot_bytes) // 1024
-    text = f"Screenshot of **{title}** ({url}) — HTTP {status}, {size_kb} KB"
+    text = f"Screenshot of **{title}** ({final_url}) — HTTP {status}, {size_kb} KB"
     return text, screenshot_bytes
 
 
@@ -246,12 +343,13 @@ async def handle_browser_read_page(
         else:
             text = await page.inner_text("body")
         title = await page.title()
+        final_url = page.url
 
     text = text.strip()
     if len(text) > max_chars:
         text = text[:max_chars] + "\n\n... (content truncated)"
 
-    return f"**{title}** ({url})\n\n{text}"
+    return f"**{title}** ({final_url})\n\n{text}"
 
 
 async def handle_browser_read_table(

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from ..odin_log import get_logger
 
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from playwright.async_api import Browser, Playwright
 
 log = get_logger("browser")
+
+_T = TypeVar("_T")
 
 ALLOWED_SCHEMES = ("http://", "https://")  # re-exported for tests
 _CONNECTION_ERROR_PATTERNS = (
@@ -50,6 +52,42 @@ _RESPONSE_HEADERS_TO_DROP = frozenset(
         "upgrade",
     }
 )
+_ROUTE_ACTION_TIMEOUT_SECONDS = 2.0
+_CONTEXT_CLOSE_TIMEOUT_SECONDS = 5.0
+_BROWSER_CLOSE_TIMEOUT_SECONDS = 5.0
+_PLAYWRIGHT_STOP_TIMEOUT_SECONDS = 5.0
+
+
+def _consume_future_exception(future: asyncio.Future) -> None:
+    """Retrieve a detached future's exception without delaying its caller."""
+    if future.cancelled():
+        return
+    try:
+        future.exception()
+    except (Exception, asyncio.CancelledError):
+        pass
+
+
+async def _await_bounded(awaitable: Awaitable[_T], timeout: float, operation: str) -> _T:
+    """Wait for a Playwright operation without trusting cancellation to settle.
+
+    ``asyncio.wait_for`` waits for a cancelled child to finish cancelling.  A
+    wedged Playwright route/context can therefore turn a nominal timeout into an
+    unbounded wait.  Observe the task for a fixed interval instead; on expiry,
+    request cancellation and detach it with exception retrieval.
+    """
+    future = asyncio.ensure_future(awaitable)
+    try:
+        done, _pending = await asyncio.wait({future}, timeout=timeout)
+    except BaseException:
+        future.cancel()
+        future.add_done_callback(_consume_future_exception)
+        raise
+    if future not in done:
+        future.cancel()
+        future.add_done_callback(_consume_future_exception)
+        raise TimeoutError(f"{operation} did not finish within {timeout:g}s")
+    return future.result()
 
 
 def _validate_url(url: str, allowed_urls: list[str] | None = None) -> None:
@@ -93,12 +131,17 @@ class BrowserManager:
     async def _force_reconnect(self) -> None:
         """Force-drop the current connection and reconnect."""
         async with self._lock:
-            try:
-                if self._browser:
-                    await self._browser.close()
-            except Exception:
-                pass
+            browser = self._browser
             self._browser = None
+            if browser:
+                try:
+                    await _await_bounded(
+                        browser.close(),
+                        _BROWSER_CLOSE_TIMEOUT_SECONDS,
+                        "closing browser before reconnect",
+                    )
+                except Exception as exc:
+                    log.warning("Browser close before reconnect did not complete: %s", exc)
         await self._ensure_connected()
 
     async def _ensure_connected(self) -> None:
@@ -156,25 +199,37 @@ class BrowserManager:
         try:
             await self._install_request_guard(context)
             page = await context.new_page()
-        except Exception:
-            await context.close()
-            raise
-        if not self._native:
+            if not self._native:
+                try:
+                    cdp = await page.context.new_cdp_session(page)
+                    await cdp.send(
+                        "Emulation.setDeviceMetricsOverride",
+                        {
+                            "width": self._viewport["width"],
+                            "height": self._viewport["height"],
+                            "deviceScaleFactor": 1,
+                            "mobile": False,
+                        },
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    # Device-metric emulation is best-effort for CDP mode.
+                    pass
+            return context, page
+        except BaseException:
             try:
-                cdp = await page.context.new_cdp_session(page)
-                await cdp.send(
-                    "Emulation.setDeviceMetricsOverride",
-                    {
-                        "width": self._viewport["width"],
-                        "height": self._viewport["height"],
-                        "deviceScaleFactor": 1,
-                        "mobile": False,
-                    },
+                await _await_bounded(
+                    context.close(),
+                    _CONTEXT_CLOSE_TIMEOUT_SECONDS,
+                    "closing browser context after page setup failure",
                 )
-            except Exception:
-                pass
-        return context, page
-
+            except BaseException as cleanup_exc:
+                log.warning(
+                    "Browser context cleanup after page setup failure did not complete: %s",
+                    cleanup_exc,
+                )
+            raise
 
     async def _install_request_guard(self, context) -> None:
         """Route every browser network request through the SSRF-safe transport.
@@ -184,55 +239,94 @@ class BrowserManager:
         on its own.  The safe transport validates each request URL and uses a
         connect-time validating resolver, so DNS resolution is bound to the
         socket rather than checked in a separate, raceable lookup.
-        """
-        import aiohttp
 
-        from .safe_fetch import SafeFetchError, safe_fetch
+        Every callback must also settle its intercepted route.  An exception
+        escaping before ``fulfill``/``abort`` leaves Chromium waiting outside
+        Playwright's page timeout; context cleanup can then wait on that route
+        forever.  This boundary catches all ordinary callback failures, aborts
+        fail-closed, and gives both transport and Playwright actions hard
+        deadlines shorter than the page timeout.
+        """
+        from .safe_fetch import safe_fetch
+
+        page_timeout = max(1.0, self._default_timeout_ms / 1000)
+        route_timeout = max(0.5, page_timeout * 0.9)
+        fetch_timeout = max(0.25, page_timeout * 0.8)
+
+        async def _abort_route(route, url: str) -> None:
+            try:
+                await _await_bounded(
+                    route.abort("blockedbyclient"),
+                    min(_ROUTE_ACTION_TIMEOUT_SECONDS, route_timeout),
+                    f"aborting browser request {url}",
+                )
+            except Exception as abort_exc:
+                # The callback still returns.  In particular, do not let a
+                # failed/late abort recreate the original unbounded route task.
+                log.warning("Failed to abort browser request %s: %s", url, abort_exc)
 
         async def _route_http(route) -> None:
-            request = route.request
+            url = "<unknown>"
             try:
-                request_headers = {
-                    key: value
-                    for key, value in (await request.all_headers()).items()
-                    if key.lower() not in _REQUEST_HEADERS_TO_DROP
-                }
-                # Chromium normally follows redirects inside one routed
-                # request and does not expose the redirect target as another
-                # context.route callback.  Follow the chain here instead: the
-                # safe transport validates every hop and pins DNS at connect
-                # time before we fulfill Chromium with only the final response.
-                response = await safe_fetch(
-                    request.url,
-                    method=request.method,
-                    headers=request_headers,
-                    data=request.post_data_buffer,
-                    follow_redirects=True,
-                    allowed_urls=self.allowed_urls,
-                    timeout=max(1.0, self._default_timeout_ms / 1000),
-                    user_agent=None,
-                )
-                # aiohttp decodes compressed bodies.  Let Playwright calculate
-                # framing for the fulfilled bytes instead of forwarding stale
-                # transport/content-encoding headers from the origin.
-                response_headers = {
-                    key: value
-                    for key, value in response.headers.items()
-                    if key.lower() not in _RESPONSE_HEADERS_TO_DROP
-                }
-                await route.fulfill(
-                    status=response.status,
-                    headers=response_headers,
-                    body=response.body,
-                )
-            except (SafeFetchError, aiohttp.ClientError, OSError, TimeoutError) as exc:
-                log.warning("Blocked or failed browser request %s: %s", request.url, exc)
-                await route.abort("blockedbyclient")
+                async with asyncio.timeout(route_timeout):
+                    request = route.request
+                    url = str(request.url)
+                    request_headers = {
+                        key: value
+                        for key, value in (await request.all_headers()).items()
+                        if key.lower() not in _REQUEST_HEADERS_TO_DROP
+                    }
+                    # Chromium normally follows redirects inside one routed
+                    # request and does not expose the redirect target as another
+                    # context.route callback. Follow the chain here instead: the
+                    # safe transport validates every hop and pins DNS at connect
+                    # time before we fulfill Chromium with only the final response.
+                    response = await _await_bounded(
+                        safe_fetch(
+                            request.url,
+                            method=request.method,
+                            headers=request_headers,
+                            data=request.post_data_buffer,
+                            follow_redirects=True,
+                            allowed_urls=self.allowed_urls,
+                            timeout=fetch_timeout,
+                            user_agent=None,
+                        ),
+                        fetch_timeout,
+                        f"fetching browser request {url}",
+                    )
+                    # aiohttp decodes compressed bodies. Let Playwright calculate
+                    # framing for the fulfilled bytes instead of forwarding stale
+                    # transport/content-encoding headers from the origin.
+                    response_headers = {
+                        key: value
+                        for key, value in response.headers.items()
+                        if key.lower() not in _RESPONSE_HEADERS_TO_DROP
+                    }
+                    await _await_bounded(
+                        route.fulfill(
+                            status=response.status,
+                            headers=response_headers,
+                            body=response.body,
+                        ),
+                        min(_ROUTE_ACTION_TIMEOUT_SECONDS, route_timeout),
+                        f"fulfilling browser request {url}",
+                    )
+            except asyncio.CancelledError:
+                await _abort_route(route, url)
+                raise
+            except Exception as exc:
+                # SafeFetchError/aiohttp failures are expected here, but this
+                # deliberately catches Playwright errors, malformed request
+                # metadata and future transport failures too.  No ordinary
+                # exception may escape while leaving an intercepted route open.
+                log.warning("Blocked or failed browser request %s: %s", url, exc)
+                await _abort_route(route, url)
 
         await context.route(_HTTP_URL_PATTERN, _route_http)
 
         # WebSocket routing was added after Playwright's original browser
-        # support.  Refuse to create an unguarded context on an older runtime;
+        # support. Refuse to create an unguarded context on an older runtime;
         # silently falling back would leave a direct network path around the
         # HTTP request guard.
         route_web_socket = getattr(context, "route_web_socket", None)
@@ -244,7 +338,14 @@ class BrowserManager:
 
         async def _block_websocket(websocket) -> None:
             log.warning("Blocked browser WebSocket request: %s", websocket.url)
-            await websocket.close(code=1008, reason="Browser network policy")
+            try:
+                await _await_bounded(
+                    websocket.close(code=1008, reason="Browser network policy"),
+                    min(_ROUTE_ACTION_TIMEOUT_SECONDS, route_timeout),
+                    f"closing browser WebSocket {websocket.url}",
+                )
+            except Exception as exc:
+                log.warning("Failed to close browser WebSocket %s: %s", websocket.url, exc)
 
         await route_web_socket(_WEBSOCKET_URL_PATTERN, _block_websocket)
 
@@ -270,24 +371,56 @@ class BrowserManager:
             yield page
         finally:
             try:
-                await context.close()
-            except Exception:
-                pass
+                await _await_bounded(
+                    context.close(),
+                    _CONTEXT_CLOSE_TIMEOUT_SECONDS,
+                    "closing browser context",
+                )
+            except Exception as exc:
+                # Cleanup must not turn a page timeout or cancelled tool into an
+                # immortal call.  The disposable context may leak until browser
+                # shutdown, but the caller regains control and the fault is visible.
+                log.warning("Browser context cleanup did not complete: %s", exc)
 
     async def shutdown(self) -> None:
-        """Clean shutdown of the browser."""
+        """Clean shutdown without trusting or abandoning driver teardown."""
+        browser = self._browser
+        playwright = self._playwright
+        cancellation: asyncio.CancelledError | None = None
         try:
-            if self._browser:
-                await self._browser.close()
-        except Exception:
-            pass
-        try:
-            if self._playwright:
-                await self._playwright.stop()
-        except Exception:
-            pass
-        self._browser = None
-        self._playwright = None
+            if browser:
+                try:
+                    await _await_bounded(
+                        browser.close(),
+                        _BROWSER_CLOSE_TIMEOUT_SECONDS,
+                        "closing browser during shutdown",
+                    )
+                except asyncio.CancelledError as exc:
+                    # Remember cancellation, but still give the Playwright
+                    # driver its bounded stop attempt before propagating it.
+                    cancellation = exc
+                except Exception as exc:
+                    log.warning("Browser shutdown did not complete: %s", exc)
+            if playwright:
+                try:
+                    await _await_bounded(
+                        playwright.stop(),
+                        _PLAYWRIGHT_STOP_TIMEOUT_SECONDS,
+                        "stopping Playwright",
+                    )
+                except asyncio.CancelledError as exc:
+                    cancellation = cancellation or exc
+                except Exception as exc:
+                    log.warning("Playwright shutdown did not complete: %s", exc)
+        finally:
+            # Clear only the generation this shutdown owned. A concurrent
+            # reconnect must not have its fresh pointers erased by old cleanup.
+            if self._browser is browser:
+                self._browser = None
+            if self._playwright is playwright:
+                self._playwright = None
+        if cancellation is not None:
+            raise cancellation
         log.info("Browser manager shut down")
 
 

--- a/src/tools/browser.py
+++ b/src/tools/browser.py
@@ -185,6 +185,8 @@ class BrowserManager:
         connect-time validating resolver, so DNS resolution is bound to the
         socket rather than checked in a separate, raceable lookup.
         """
+        import aiohttp
+
         from .safe_fetch import SafeFetchError, safe_fetch
 
         async def _route_http(route) -> None:
@@ -223,7 +225,7 @@ class BrowserManager:
                     headers=response_headers,
                     body=response.body,
                 )
-            except (SafeFetchError, OSError, TimeoutError) as exc:
+            except (SafeFetchError, aiohttp.ClientError, OSError, TimeoutError) as exc:
                 log.warning("Blocked or failed browser request %s: %s", request.url, exc)
                 await route.abort("blockedbyclient")
 

--- a/src/tools/git_ops.py
+++ b/src/tools/git_ops.py
@@ -34,6 +34,20 @@ def _sq(value: str) -> str:
     return shlex.quote(value)
 
 
+def _safe_ref(value: str, field: str) -> str:
+    """Reject option-like values used where Git expects a ref or remote.
+
+    Shell quoting prevents shell injection, but it does not stop Git itself
+    from parsing a positional value such as ``--help`` as an option.  Some Git
+    subcommands support ``--end-of-options`` while others give ``--`` a
+    different meaning (notably checkout and diff), so one explicit rule keeps
+    every builder safe and compatible.
+    """
+    if value.startswith("-"):
+        raise ValueError(f"{field} must not start with '-'")
+    return value
+
+
 def build_git_command(action: str, params: dict) -> str | list[str]:
     """Build one or more shell commands for a git action.
 
@@ -61,7 +75,7 @@ def _build_clone(params: dict) -> str:
 
     parts = ["git", "clone"]
     if branch:
-        parts += ["--branch", _sq(branch)]
+        parts += ["--branch", _sq(_safe_ref(branch, "branch"))]
     if depth is not None:
         try:
             d = int(depth)
@@ -101,7 +115,7 @@ def _build_diff(params: dict) -> str:
         except (TypeError, ValueError):
             pass
     if target:
-        parts.append(_sq(target))
+        parts.append(_sq(_safe_ref(target, "target")))
     return " ".join(parts)
 
 
@@ -114,9 +128,9 @@ def _build_branch(params: dict) -> str:
     if list_all or (not name and not delete):
         return f"git -C {_sq(repo)} branch -a --no-color"
     if delete and name:
-        return f"git -C {_sq(repo)} branch -d {_sq(name)}"
+        return f"git -C {_sq(repo)} branch -d -- {_sq(_safe_ref(name, 'name'))}"
     if name:
-        return f"git -C {_sq(repo)} branch {_sq(name)}"
+        return f"git -C {_sq(repo)} branch -- {_sq(_safe_ref(name, 'name'))}"
     return f"git -C {_sq(repo)} branch -a --no-color"
 
 
@@ -135,7 +149,7 @@ def _build_commit(params: dict) -> str:
         if isinstance(files, str):
             files = [files]
         quoted = " ".join(_sq(f) for f in files)
-        cmds.append(f"git -C {_sq(repo)} add {quoted}")
+        cmds.append(f"git -C {_sq(repo)} add -- {quoted}")
 
     cmds.append(f"git -C {_sq(repo)} commit -m {_sq(message)}")
     return " && ".join(cmds)
@@ -154,11 +168,16 @@ def _build_push(params: dict) -> list[str]:
     force = params.get("force", False)
     set_upstream = params.get("set_upstream", False)
 
+    if remote:
+        _safe_ref(remote, "remote")
+    if branch:
+        _safe_ref(branch, "branch")
+
     sq_repo = _sq(repo)
     sq_remote = _sq(remote)
 
     freshness_script = (
-        f"git -C {sq_repo} fetch {sq_remote} --quiet 2>&1 && "
+        f"git -C {sq_repo} fetch --quiet -- {sq_remote} 2>&1 && "
         f"LOCAL=$(git -C {sq_repo} rev-parse HEAD) && "
         f"MERGE_BASE=$(git -C {sq_repo} merge-base HEAD "
         f"{sq_remote}/$(git -C {sq_repo} rev-parse --abbrev-ref HEAD) 2>/dev/null || echo NONE) && "
@@ -202,7 +221,7 @@ def _build_log(params: dict) -> str:
     else:
         parts.append("--format=%h %s (%an, %ar)")
     if branch:
-        parts.append(_sq(branch))
+        parts.append(_sq(_safe_ref(branch, "branch")))
     return " ".join(parts)
 
 
@@ -215,9 +234,9 @@ def _build_pull(params: dict) -> str:
     parts = ["git", "-C", _sq(repo), "pull"]
     if rebase:
         parts.append("--rebase")
-    parts.append(_sq(remote))
+    parts.append(_sq(_safe_ref(remote, "remote")))
     if branch:
-        parts.append(_sq(branch))
+        parts.append(_sq(_safe_ref(branch, "branch")))
     return " ".join(parts)
 
 
@@ -231,7 +250,7 @@ def _build_checkout(params: dict) -> str:
     parts = ["git", "-C", _sq(repo), "checkout"]
     if create:
         parts.append("-b")
-    parts.append(_sq(target))
+    parts.append(_sq(_safe_ref(target, "target")))
     return " ".join(parts)
 
 
@@ -240,7 +259,7 @@ def _build_fetch(params: dict) -> str:
     remote = params.get("remote", "origin")
     prune = params.get("prune", False)
 
-    parts = ["git", "-C", _sq(repo), "fetch", _sq(remote)]
+    parts = ["git", "-C", _sq(repo), "fetch", _sq(_safe_ref(remote, "remote"))]
     if prune:
         parts.append("--prune")
     return " ".join(parts)

--- a/src/tools/handlers/browser_web.py
+++ b/src/tools/handlers/browser_web.py
@@ -13,6 +13,10 @@ from ..bulkhead import BulkheadFullError
 from ..tool_text import _truncate_lines
 from .deps import HandlerBase
 
+_BROWSER_DISABLED = (
+    "Browser automation is not enabled. Set browser.enabled=true in config."
+)
+
 
 class BrowserWebTools(HandlerBase):
     async def _browser_with_bulkhead(self, coro):
@@ -26,41 +30,41 @@ class BrowserWebTools(HandlerBase):
                 return "Error: browser bulkhead full — too many concurrent browser operations"
         return await coro
 
-    async def _handle_browser_read_page(self, inp: dict) -> str:
+    async def _handle_browser_read_page(self, inp: dict) -> str | tuple[str, int]:
         if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
+            return _BROWSER_DISABLED, 1
         from ..browser import handle_browser_read_page
 
         return await self._browser_with_bulkhead(
             handle_browser_read_page(self._browser_manager, inp)
         )
 
-    async def _handle_browser_read_table(self, inp: dict) -> str:
+    async def _handle_browser_read_table(self, inp: dict) -> str | tuple[str, int]:
         if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
+            return _BROWSER_DISABLED, 1
         from ..browser import handle_browser_read_table
 
         return await self._browser_with_bulkhead(
             handle_browser_read_table(self._browser_manager, inp)
         )
 
-    async def _handle_browser_click(self, inp: dict) -> str:
+    async def _handle_browser_click(self, inp: dict) -> str | tuple[str, int]:
         if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
+            return _BROWSER_DISABLED, 1
         from ..browser import handle_browser_click
 
         return await self._browser_with_bulkhead(handle_browser_click(self._browser_manager, inp))
 
-    async def _handle_browser_fill(self, inp: dict) -> str:
+    async def _handle_browser_fill(self, inp: dict) -> str | tuple[str, int]:
         if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
+            return _BROWSER_DISABLED, 1
         from ..browser import handle_browser_fill
 
         return await self._browser_with_bulkhead(handle_browser_fill(self._browser_manager, inp))
 
-    async def _handle_browser_evaluate(self, inp: dict) -> str:
+    async def _handle_browser_evaluate(self, inp: dict) -> str | tuple[str, int]:
         if not self._browser_manager:
-            return "Browser automation is not enabled. Set browser.enabled=true in config."
+            return _BROWSER_DISABLED, 1
         from ..browser import handle_browser_evaluate
 
         return await self._browser_with_bulkhead(
@@ -80,7 +84,7 @@ class BrowserWebTools(HandlerBase):
 
         return await fetch_url(inp["url"])
 
-    async def _handle_http_probe(self, inp: dict) -> str:
+    async def _handle_http_probe(self, inp: dict) -> str | tuple[str, int]:
         from ..http_probe_ops import build_http_probe_command
 
         host = inp.get("host", "")
@@ -99,6 +103,14 @@ class BrowserWebTools(HandlerBase):
             return f"http_probe error: {e}"
 
         code, output = await self._exec_command(address, cmd, ssh_user)
+        # curl's exit code is the ground truth and was being discarded: a
+        # connection failure (exit 7, status_code 000) returned prose that
+        # matched no error prefix, so the executor classified the probe as a
+        # SUCCESS and the audit log recorded it approved with no error
+        # (adversarial review, reproduced). Structured returns make the status
+        # a fact rather than an inference.
         if code != 0 and not output.strip():
-            return f"http_probe failed (exit {code}): curl returned no output"
-        return _truncate_lines(output) if output.strip() else "http_probe: no response received"
+            return f"http_probe failed (exit {code}): curl returned no output", code
+        if not output.strip():
+            return "http_probe: no response received", 1
+        return _truncate_lines(output), code

--- a/src/tools/handlers/browser_web.py
+++ b/src/tools/handlers/browser_web.py
@@ -100,7 +100,9 @@ class BrowserWebTools(HandlerBase):
         try:
             cmd = build_http_probe_command(inp)
         except ValueError as e:
-            return f"http_probe error: {e}"
+            # Invalid probe input is a failed tool call, not a successful probe
+            # whose prose happens to describe a rejection.
+            return f"http_probe error: {e}", 1
 
         code, output = await self._exec_command(address, cmd, ssh_user)
         # curl's exit code is the ground truth and was being discarded: a

--- a/src/tools/handlers/devops.py
+++ b/src/tools/handlers/devops.py
@@ -18,7 +18,11 @@ class DevOpsTools(HandlerBase):
 
         action = inp.get("action", "")
         if action not in ALLOWED_ACTIONS:
-            return f"Unknown git action: {action}. Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}"
+            return (
+                f"Unknown git action: {action}. "
+                f"Allowed: {', '.join(sorted(ALLOWED_ACTIONS))}",
+                1,
+            )
 
         host = inp.get("host", "")
         resolved = self._resolve_host(host)

--- a/src/tools/handlers/files_docs.py
+++ b/src/tools/handlers/files_docs.py
@@ -28,7 +28,12 @@ class FilesDocsTools(HandlerBase):
         if not host:
             return "Error: 'host' is required for read_file."
         try:
-            lines = min(int(inp.get("lines", 200)), 1000)
+            # Clamped to 1..1000, not just an upper bound. GNU head reads a
+            # NEGATIVE -n as "all but the last N", so lines=-2 silently
+            # returned the whole file minus two lines, and lines=0 returned
+            # nothing at all — neither is what a caller asking for N lines
+            # means (adversarial review).
+            lines = max(1, min(int(inp.get("lines", 200)), 1000))
         except (TypeError, ValueError):
             lines = 200
         safe_path = shlex.quote(path)
@@ -37,7 +42,7 @@ class FilesDocsTools(HandlerBase):
             f"head -n {lines} {safe_path}",
         )
 
-    async def _handle_write_file(self, inp: dict) -> str:
+    async def _handle_write_file(self, inp: dict) -> str | tuple[str, int]:
         path = inp.get("path")
         content = inp.get("content")
         host = inp.get("host")
@@ -57,7 +62,8 @@ class FilesDocsTools(HandlerBase):
             return (
                 f"Error: write_file requires an absolute path, got {path!r}. "
                 "A relative path would resolve against Odin's working directory "
-                "rather than where you intend."
+                "rather than where you intend.",
+                1,
             )
         path = str(path)
         safe_path = shlex.quote(path)
@@ -105,7 +111,7 @@ class FilesDocsTools(HandlerBase):
             except ValueError:
                 return list(range(total))
 
-    async def _handle_analyze_pdf(self, inp: dict) -> str:
+    async def _handle_analyze_pdf(self, inp: dict) -> str | tuple[str, int]:
         url = inp.get("url")
         host = inp.get("host")
         path = inp.get("path")
@@ -133,7 +139,8 @@ class FilesDocsTools(HandlerBase):
             return (
                 "PDF support unavailable: PyMuPDF could not be loaded "
                 f"({type(exc).__name__}: {exc}). Install the 'pdf' extra "
-                "(pip install '.[pdf]') and restart Odin."
+                "(pip install '.[pdf]') and restart Odin.",
+                1,
             )
 
         pdf_bytes: bytes | None = None
@@ -152,9 +159,9 @@ class FilesDocsTools(HandlerBase):
             except ResponseTooLargeError:
                 return f"PDF too large (max {_ANALYZE_PDF_MAX_BYTES} bytes)."
             except Exception as e:
-                return f"Failed to fetch PDF from URL: {e}"
+                return f"Failed to fetch PDF from URL: {e}", 1
             if resp.status != 200:
-                return f"Failed to fetch PDF from URL (HTTP {resp.status})"
+                return f"Failed to fetch PDF from URL (HTTP {resp.status})", 1
             pdf_bytes = resp.body
         elif host and path:
             # Fetch from host via base64
@@ -169,18 +176,18 @@ class FilesDocsTools(HandlerBase):
                 ssh_user,
             )
             if code != 0:
-                return f"Failed to read PDF from host: {output}"
+                return f"Failed to read PDF from host: {output}", 1
             try:
                 pdf_bytes = base64.b64decode(output.strip())
             except Exception as e:
-                return f"Failed to decode PDF data: {e}"
+                return f"Failed to decode PDF data: {e}", 1
         else:
             return "Provide either 'url' or both 'host' and 'path'."
 
         try:
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")
         except Exception as e:
-            return f"Failed to open PDF: {e}"
+            return f"Failed to open PDF: {e}", 1
 
         try:
             total = doc.page_count

--- a/src/tools/handlers/files_docs.py
+++ b/src/tools/handlers/files_docs.py
@@ -169,18 +169,21 @@ class FilesDocsTools(HandlerBase):
             if not resolved:
                 return f"Unknown or disallowed host: {host}"
             address, ssh_user, _os = resolved
-            safe_path = shlex.quote(path)
-            code, output = await self._exec_command(
+            # Binary payloads do NOT travel the text pipeline: base64 over
+            # stdout was truncated at MAX_OUTPUT_CHARS, so any PDF over roughly
+            # 12KB arrived corrupt and failed to decode (adversarial review).
+            from ..ssh import read_binary_file
+
+            pdf_bytes, read_error = await read_binary_file(
                 address,
-                f"base64 -w0 {safe_path}",
-                ssh_user,
+                path,
+                max_bytes=_ANALYZE_PDF_MAX_BYTES,
+                ssh_key_path=self.config.ssh_key_path,
+                known_hosts_path=self.config.ssh_known_hosts_path,
+                ssh_user=ssh_user,
             )
-            if code != 0:
-                return f"Failed to read PDF from host: {output}", 1
-            try:
-                pdf_bytes = base64.b64decode(output.strip())
-            except Exception as e:
-                return f"Failed to decode PDF data: {e}", 1
+            if read_error:
+                return f"Failed to read PDF from host: {read_error}", 1
         else:
             return "Provide either 'url' or both 'host' and 'path'."
 

--- a/src/tools/handlers/files_docs.py
+++ b/src/tools/handlers/files_docs.py
@@ -34,7 +34,7 @@ class FilesDocsTools(HandlerBase):
             # nothing at all — neither is what a caller asking for N lines
             # means (adversarial review).
             lines = max(1, min(int(inp.get("lines", 200)), 1000))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             lines = 200
         safe_path = shlex.quote(path)
         return await self._run_on_host(
@@ -119,7 +119,7 @@ class FilesDocsTools(HandlerBase):
 
         # Validate URL scheme early (before heavy imports) to prevent SSRF
         if url and not url.startswith(("http://", "https://")):
-            return "Only http:// and https:// URLs are supported."
+            return "Only http:// and https:// URLs are supported.", 1
         # Pre-flight block check before the heavy import so a blocked URL returns
         # the block message even on a host without PyMuPDF (safe_fetch below
         # re-validates every hop; this only preserves the original error order).
@@ -127,7 +127,7 @@ class FilesDocsTools(HandlerBase):
             from ..url_safety import is_url_blocked
 
             if is_url_blocked(url):
-                return "Error: blocked URL (localhost / private IP / cloud-metadata address)."
+                return "Error: blocked URL (localhost / private IP / cloud-metadata address).", 1
 
         # Structural gating hides this tool when PyMuPDF is missing, but the
         # handler must still degrade cleanly: find_spec proves the module is
@@ -155,19 +155,19 @@ class FilesDocsTools(HandlerBase):
             try:
                 resp = await safe_fetch(url, max_bytes=_ANALYZE_PDF_MAX_BYTES, timeout=30.0)
             except BlockedAddressError:
-                return "Error: blocked URL (localhost / private IP / cloud-metadata address)."
+                return "Error: blocked URL (localhost / private IP / cloud-metadata address).", 1
             except ResponseTooLargeError:
-                return f"PDF too large (max {_ANALYZE_PDF_MAX_BYTES} bytes)."
+                return f"PDF too large (max {_ANALYZE_PDF_MAX_BYTES} bytes).", 1
             except Exception as e:
                 return f"Failed to fetch PDF from URL: {e}", 1
             if resp.status != 200:
                 return f"Failed to fetch PDF from URL (HTTP {resp.status})", 1
             pdf_bytes = resp.body
         elif host and path:
-            # Fetch from host via base64
+            # Fetch from host as bounded raw bytes
             resolved = self._resolve_host(host)
             if not resolved:
-                return f"Unknown or disallowed host: {host}"
+                return f"Unknown or disallowed host: {host}", 1
             address, ssh_user, _os = resolved
             # Binary payloads do NOT travel the text pipeline: base64 over
             # stdout was truncated at MAX_OUTPUT_CHARS, so any PDF over roughly
@@ -185,7 +185,7 @@ class FilesDocsTools(HandlerBase):
             if read_error:
                 return f"Failed to read PDF from host: {read_error}", 1
         else:
-            return "Provide either 'url' or both 'host' and 'path'."
+            return "Provide either 'url' or both 'host' and 'path'.", 1
 
         try:
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")

--- a/src/tools/handlers/system.py
+++ b/src/tools/handlers/system.py
@@ -233,7 +233,7 @@ class SystemTools(HandlerBase):
 
     # --- Process management ---
 
-    async def _handle_manage_process(self, inp: dict) -> str:
+    async def _handle_manage_process(self, inp: dict) -> str | tuple[str, int]:
         action = inp.get("action", "list")
         registry = self._process_registry()
 
@@ -285,4 +285,4 @@ class SystemTools(HandlerBase):
         elif action == "list":
             return registry.list_all()
 
-        return f"Unknown action: {action}"
+        return f"Unknown action: {action}", 1

--- a/src/tools/handlers/system.py
+++ b/src/tools/handlers/system.py
@@ -241,48 +241,67 @@ class SystemTools(HandlerBase):
             command = inp.get("command")
             host = inp.get("host")
             if not command:
-                return "command is required for start action."
+                return "command is required for start action.", 1
             if not host:
-                return "host is required for start action."
+                return "host is required for start action.", 1
             allowed, denial, _ = self._govern_command(command, host)
             if not allowed:
-                return denial
+                return denial, 1
             # Validate host against configured hosts
             resolved = self._resolve_host(host)
             if not resolved:
-                return f"Unknown or disallowed host: {host}"
+                return f"Unknown or disallowed host: {host}", 1
             # Periodic cleanup
             registry.cleanup()
-            return await registry.start(host, command)
+            result = await registry.start(host, command)
+            if result.startswith(
+                ("Cannot start", "Failed to start", "Error:", "manage_process only")
+            ):
+                return result, 1
+            return result, 0
 
         elif action == "poll":
             pid = inp.get("pid")
             if pid is None:
-                return "pid is required for poll action."
-            return registry.poll(int(pid))
+                return "pid is required for poll action.", 1
+            result = registry.poll(int(pid))
+            if result.startswith("No process with PID"):
+                return result, 1
+            return result, 0
 
         elif action == "write":
             pid = inp.get("pid")
             text = inp.get("input_text", "")
             if pid is None:
-                return "pid is required for write action."
+                return "pid is required for write action.", 1
             if not text:
-                return "input_text is required for write action."
+                return "input_text is required for write action.", 1
             # Writing to a managed process's stdin can drive an interactive
             # shell — govern the input as a command so a `rm -rf /`-class line
             # is caught, matching run_command.
             allowed, denial, _ = self._govern_command(text)
             if not allowed:
-                return denial
-            return await registry.write(int(pid), text)
+                return denial, 1
+            result = await registry.write(int(pid), text)
+            if result.startswith(("No process with PID", "Process ", "Failed to write")):
+                # The only successful ProcessRegistry.write result starts
+                # "Wrote"; all Process-prefixed returns describe terminal/no-stdin states.
+                return result, 1
+            return result, 0
 
         elif action == "kill":
             pid = inp.get("pid")
             if pid is None:
-                return "pid is required for kill action."
-            return await registry.kill(int(pid))
+                return "pid is required for kill action.", 1
+            result = await registry.kill(int(pid))
+            if (
+                result.startswith(("No process with PID", "Failed to kill"))
+                or " already " in result
+            ):
+                return result, 1
+            return result, 0
 
         elif action == "list":
-            return registry.list_all()
+            return registry.list_all(), 0
 
         return f"Unknown action: {action}", 1

--- a/src/tools/http_probe_ops.py
+++ b/src/tools/http_probe_ops.py
@@ -182,12 +182,16 @@ def build_http_probe_command(params: dict) -> str:
         # POST into a bodyless POST that could look superficially successful,
         # hiding the caller's mistake — the same disease as the HEAD body case
         # (adversarial review; the previous test pinned the silence).
-        if isinstance(body, str) and len(body) > MAX_BODY_SIZE:
+        if not isinstance(body, str):
+            raise ValueError("Request body must be a string")
+        # The public contract is bytes, not Python code points. A 30,000-char
+        # non-ASCII body can exceed 50KB once curl receives its UTF-8 encoding.
+        body_bytes = len(body.encode("utf-8"))
+        if body_bytes > MAX_BODY_SIZE:
             raise ValueError(
-                f"Request body is {len(body)} bytes, over the {MAX_BODY_SIZE}-byte limit"
+                f"Request body is {body_bytes} bytes, over the {MAX_BODY_SIZE}-byte limit"
             )
-        if isinstance(body, str):
-            parts.append(f"-d {_sq(body)}")
+        parts.append(f"-d {_sq(body)}")
 
     # URL (always last)
     parts.append(_sq(url))

--- a/src/tools/http_probe_ops.py
+++ b/src/tools/http_probe_ops.py
@@ -178,7 +178,15 @@ def build_http_probe_command(params: dict) -> str:
     # Request body
     body = params.get("body")
     if body and method in ("POST", "PUT", "PATCH"):
-        if isinstance(body, str) and len(body) <= MAX_BODY_SIZE:
+        # Rejected, not silently dropped. Skipping an oversized body turned a
+        # POST into a bodyless POST that could look superficially successful,
+        # hiding the caller's mistake — the same disease as the HEAD body case
+        # (adversarial review; the previous test pinned the silence).
+        if isinstance(body, str) and len(body) > MAX_BODY_SIZE:
+            raise ValueError(
+                f"Request body is {len(body)} bytes, over the {MAX_BODY_SIZE}-byte limit"
+            )
+        if isinstance(body, str):
             parts.append(f"-d {_sq(body)}")
 
     # URL (always last)

--- a/src/tools/ssh.py
+++ b/src/tools/ssh.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
+import shlex
 import signal
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -396,3 +398,89 @@ async def run_ssh_command(
             return 1, f"SSH error: {e}"
 
     return last_exit_code, _truncate_output(last_output)
+
+
+# Binary payloads must NEVER travel the text pipeline. run_local_command and
+# run_ssh_command decode to str and truncate at MAX_OUTPUT_CHARS, so a
+# base64-over-stdout read silently lost its tail: base64 crosses 16,000 chars
+# at roughly 12,000 source bytes, and the caller got "Incorrect padding" for
+# any ordinary PDF or image on a managed host (adversarial review of v3.65.1,
+# reproduced with a valid 20,853-byte PDF). This path returns raw bytes with an
+# explicit size bound and no truncation.
+async def read_binary_file(
+    address: str,
+    path: str,
+    *,
+    max_bytes: int,
+    ssh_key_path: str = "",
+    known_hosts_path: str = "",
+    ssh_user: str = "root",
+    timeout: int = 60,
+) -> tuple[bytes | None, str]:
+    """Read a file as BYTES from a local or remote host.
+
+    Returns ``(data, "")`` on success or ``(None, error_message)``. Oversize is
+    an explicit error rather than a silent truncation, because a partial binary
+    is indistinguishable from a corrupt one.
+    """
+    if is_local_address(address):
+        def _read() -> tuple[bytes | None, str]:
+            try:
+                size = os.path.getsize(path)
+            except OSError as exc:
+                return None, f"cannot stat {path}: {exc}"
+            if size > max_bytes:
+                return None, f"file is {size} bytes, over the {max_bytes}-byte limit"
+            try:
+                with open(path, "rb") as handle:
+                    return handle.read(max_bytes + 1), ""
+            except OSError as exc:
+                return None, f"cannot read {path}: {exc}"
+
+        data, err = await asyncio.to_thread(_read)
+        if err:
+            return None, err
+        if data is not None and len(data) > max_bytes:
+            return None, f"file exceeds the {max_bytes}-byte limit"
+        return data, ""
+
+    # Remote: cat the file and capture stdout as raw bytes. `--` stops option
+    # parsing so a path beginning with '-' cannot become a cat flag.
+    quoted = shlex.quote(path)
+    ssh_args = [
+        "ssh",
+        "-i",
+        ssh_key_path,
+        "-o",
+        f"UserKnownHostsFile={known_hosts_path}",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "BatchMode=yes",
+        f"{ssh_user}@{address}",
+        f"cat -- {quoted}",
+    ]
+    log.info("SSH binary read from %s@%s: %s", ssh_user, address, path)
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *ssh_args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        if proc is not None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+        return None, f"timed out reading {path} after {timeout}s"
+    except OSError as exc:
+        return None, f"ssh failed: {exc}"
+    if proc.returncode != 0:
+        detail = stderr.decode("utf-8", errors="replace").strip()[:200]
+        return None, detail or f"remote read failed (exit {proc.returncode})"
+    if len(stdout) > max_bytes:
+        return None, f"file is {len(stdout)} bytes, over the {max_bytes}-byte limit"
+    return stdout, ""

--- a/src/tools/ssh.py
+++ b/src/tools/ssh.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import os
 import shlex
 import signal
@@ -423,6 +422,9 @@ async def read_binary_file(
     an explicit error rather than a silent truncation, because a partial binary
     is indistinguishable from a corrupt one.
     """
+    if max_bytes < 0:
+        return None, "max_bytes must be >= 0"
+
     if is_local_address(address):
         def _read() -> tuple[bytes | None, str]:
             try:
@@ -444,9 +446,13 @@ async def read_binary_file(
             return None, f"file exceeds the {max_bytes}-byte limit"
         return data, ""
 
-    # Remote: cat the file and capture stdout as raw bytes. `--` stops option
-    # parsing so a path beginning with '-' cannot become a cat flag.
+    # Remote: cap stdout at the SOURCE. `communicate()` buffers all output, so
+    # `cat` followed by a post-read length check still let an arbitrarily large
+    # remote file exhaust Odin's memory before being rejected. Reading exactly
+    # max+1 bytes bounds the transport and preserves an unambiguous oversize
+    # signal. `--` stops option parsing for option-like paths.
     quoted = shlex.quote(path)
+    remote_command = f"head -c {max_bytes + 1} -- {quoted}"
     ssh_args = [
         "ssh",
         "-i",
@@ -460,10 +466,10 @@ async def read_binary_file(
         "-o",
         "BatchMode=yes",
         f"{ssh_user}@{address}",
-        f"cat -- {quoted}",
+        remote_command,
     ]
     log.info("SSH binary read from %s@%s: %s", ssh_user, address, path)
-    proc = None
+    proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
             *ssh_args,
@@ -473,14 +479,17 @@ async def read_binary_file(
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
         if proc is not None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
+            await terminate_process_tree(proc)
         return None, f"timed out reading {path} after {timeout}s"
+    except asyncio.CancelledError:
+        if proc is not None:
+            await terminate_process_tree(proc)
+        raise
     except OSError as exc:
         return None, f"ssh failed: {exc}"
     if proc.returncode != 0:
         detail = stderr.decode("utf-8", errors="replace").strip()[:200]
         return None, detail or f"remote read failed (exit {proc.returncode})"
     if len(stdout) > max_bytes:
-        return None, f"file is {len(stdout)} bytes, over the {max_bytes}-byte limit"
+        return None, f"file is over the {max_bytes}-byte limit"
     return stdout, ""

--- a/tests/characterization/test_scheduled_events.py
+++ b/tests/characterization/test_scheduled_events.py
@@ -44,16 +44,18 @@ class TestScheduledTaskRouting:
         )
         assert channel.sent_texts == ["**Scheduled reminder:** water the servers"]
 
-    async def test_missing_channel_id_is_silently_skipped(self, bot_and_channel):
+    async def test_missing_channel_id_is_a_delivery_failure(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot.scheduled_events._on_scheduled_task(
-            schedule(action="reminder", channel_id="", message="x")
-        )
+        with pytest.raises(RuntimeError, match="has no channel_id"):
+            await bot.scheduled_events._on_scheduled_task(
+                schedule(action="reminder", channel_id="", message="x")
+            )
         assert channel.sent == []
 
-    async def test_unknown_action_is_ignored_without_raise(self, bot_and_channel):
+    async def test_unknown_action_is_a_failure(self, bot_and_channel):
         bot, channel = bot_and_channel
-        await bot.scheduled_events._on_scheduled_task(schedule(action="mystery"))
+        with pytest.raises(RuntimeError, match="Unknown scheduled action"):
+            await bot.scheduled_events._on_scheduled_task(schedule(action="mystery"))
         assert channel.sent == []
 
     async def test_check_success_posts_result(self, bot_and_channel):

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -230,22 +230,6 @@ class TestBackendGatedVisibility:
         visible = "analyze_pdf" in self._catalog_names()
         assert visible is (importlib.util.find_spec("fitz") is not None)
 
-    def test_analyze_pdf_missing_dependency_logs_hidden_reason(self):
-        """A missing optional dependency is both hidden and diagnosable."""
-        from unittest.mock import patch
-
-        with (
-            patch("src.discord.tool_catalog.importlib.util.find_spec", return_value=None),
-            patch("src.discord.tool_catalog.log.info") as info,
-        ):
-            names = self._catalog_names()
-
-        assert "analyze_pdf" not in names
-        assert any(
-            "analyze_pdf hidden from the tool catalog" in str(call.args[0])
-            for call in info.call_args_list
-        )
-
     def test_configured_claude_code_is_visible(self):
         names = self._catalog_names(
             tools={

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -230,6 +230,22 @@ class TestBackendGatedVisibility:
         visible = "analyze_pdf" in self._catalog_names()
         assert visible is (importlib.util.find_spec("fitz") is not None)
 
+    def test_analyze_pdf_missing_dependency_logs_hidden_reason(self):
+        """A missing optional dependency is both hidden and diagnosable."""
+        from unittest.mock import patch
+
+        with (
+            patch("src.discord.tool_catalog.importlib.util.find_spec", return_value=None),
+            patch("src.discord.tool_catalog.log.info") as info,
+        ):
+            names = self._catalog_names()
+
+        assert "analyze_pdf" not in names
+        assert any(
+            "analyze_pdf hidden from the tool catalog" in str(call.args[0])
+            for call in info.call_args_list
+        )
+
     def test_configured_claude_code_is_visible(self):
         names = self._catalog_names(
             tools={

--- a/tests/test_binary_host_read.py
+++ b/tests/test_binary_host_read.py
@@ -1,0 +1,209 @@
+"""Binary payloads must not travel the text pipeline.
+
+analyze_pdf and analyze_image pulled host files as base64 through
+``_exec_command``, whose output is truncated at ``MAX_OUTPUT_CHARS`` (16,000).
+Base64 crosses that at roughly 12,000 source bytes, so any ordinary PDF or
+image read from a managed host arrived truncated and failed to decode —
+"Incorrect padding". Found by adversarial review of v3.65.1 and reproduced with
+a valid 20,853-byte PDF.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.tools.ssh import MAX_OUTPUT_CHARS, read_binary_file
+
+
+async def test_reads_a_payload_larger_than_the_text_transport(tmp_path):
+    """The exact defect: bigger than base64-over-stdout could carry."""
+    payload = os.urandom(20_853)
+    target = tmp_path / "big.bin"
+    target.write_bytes(payload)
+
+    data, error = await read_binary_file("127.0.0.1", str(target), max_bytes=10_000_000)
+
+    assert error == ""
+    assert data == payload, "the payload must arrive byte-for-byte"
+    assert len(payload) * 4 // 3 > MAX_OUTPUT_CHARS, (
+        "fixture must exceed what the old text transport could carry"
+    )
+
+
+async def test_binary_content_survives_intact(tmp_path):
+    """Bytes that are not valid UTF-8 must not be mangled — the text path
+    decoded with errors='replace', which silently corrupts binary."""
+    payload = bytes(range(256)) * 8
+    target = tmp_path / "raw.bin"
+    target.write_bytes(payload)
+
+    data, error = await read_binary_file("127.0.0.1", str(target), max_bytes=100_000)
+
+    assert error == ""
+    assert data == payload
+
+
+async def test_oversize_is_an_explicit_error_not_a_truncation(tmp_path):
+    """A partial binary is indistinguishable from a corrupt one, so the limit
+    must produce an error rather than a short read."""
+    target = tmp_path / "big.bin"
+    target.write_bytes(b"x" * 5000)
+
+    data, error = await read_binary_file("127.0.0.1", str(target), max_bytes=1000)
+
+    assert data is None
+    assert "over the" in error and "1000" in error
+
+
+async def test_missing_file_reports_cleanly(tmp_path):
+    data, error = await read_binary_file(
+        "127.0.0.1", str(tmp_path / "nope"), max_bytes=1000
+    )
+    assert data is None
+    assert "cannot stat" in error
+
+
+@pytest.mark.parametrize("size", [0, 1, 4095, 4096, 4097])
+async def test_boundary_sizes_round_trip(tmp_path, size):
+    payload = os.urandom(size)
+    target = tmp_path / f"f{size}.bin"
+    target.write_bytes(payload)
+
+    data, error = await read_binary_file("127.0.0.1", str(target), max_bytes=1_000_000)
+
+    assert error == ""
+    assert data == payload
+
+
+# --- the remote branch -------------------------------------------------------
+
+
+async def _fake_proc(stdout: bytes, stderr: bytes = b"", returncode: int = 0):
+    class _P:
+        def __init__(self):
+            self.returncode = returncode
+
+        async def communicate(self):
+            return stdout, stderr
+
+        def kill(self):  # pragma: no cover - only used by the timeout path
+            pass
+
+    return _P()
+
+
+async def test_remote_read_returns_raw_bytes(monkeypatch):
+    """The remote path must capture stdout as BYTES — the text pipeline
+    decoded with errors='replace', which corrupts binary."""
+    import src.tools.ssh as ssh_module
+
+    payload = bytes(range(256))
+    captured: dict = {}
+
+    async def _exec(*args, **kwargs):
+        captured["argv"] = args
+        return await _fake_proc(payload)
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    data, error = await read_binary_file(
+        "example.host", "/tmp/f.bin", max_bytes=1_000_000,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert error == "" and data == payload
+    argv = captured["argv"]
+    assert argv[0] == "ssh"
+    # `--` stops option parsing so a path beginning with '-' cannot become a flag.
+    assert any("cat -- " in str(a) for a in argv), argv
+
+
+async def test_remote_oversize_is_rejected(monkeypatch):
+    import src.tools.ssh as ssh_module
+
+    async def _exec(*args, **kwargs):
+        return await _fake_proc(b"x" * 5000)
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    data, error = await read_binary_file(
+        "example.host", "/tmp/f.bin", max_bytes=100,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert data is None and "over the" in error
+
+
+async def test_remote_failure_reports_stderr(monkeypatch):
+    import src.tools.ssh as ssh_module
+
+    async def _exec(*args, **kwargs):
+        return await _fake_proc(b"", b"cat: /nope: No such file", returncode=1)
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    data, error = await read_binary_file(
+        "example.host", "/nope", max_bytes=1000,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert data is None and "No such file" in error
+
+
+async def test_remote_timeout_is_reported(monkeypatch):
+    import asyncio as _asyncio
+
+    import src.tools.ssh as ssh_module
+
+    async def _exec(*args, **kwargs):
+        class _Hanging:
+            returncode = None
+
+            async def communicate(self):  # pragma: no cover - never completes
+                await _asyncio.sleep(3600)
+
+            def kill(self):
+                pass
+
+        return _Hanging()
+
+    async def _timeout(coro, *args, **kwargs):
+        # Close the coroutine we are abandoning, or Python warns that it was
+        # never awaited — noise I have flagged in others' work and will not add.
+        coro.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    monkeypatch.setattr(ssh_module.asyncio, "wait_for", _timeout)
+    data, error = await read_binary_file(
+        "example.host", "/tmp/f.bin", max_bytes=1000, timeout=1,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert data is None and "timed out" in error
+    assert _asyncio is not None
+
+
+async def test_remote_ssh_launch_failure(monkeypatch):
+    import src.tools.ssh as ssh_module
+
+    async def _exec(*args, **kwargs):
+        raise OSError("ssh missing")
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    data, error = await read_binary_file(
+        "example.host", "/tmp/f.bin", max_bytes=1000,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert data is None and "ssh failed" in error
+
+
+async def test_file_growing_between_stat_and_read_is_rejected(tmp_path, monkeypatch):
+    """The size check and the read are not atomic: a file that grows in between
+    must still be rejected rather than returning a partial payload."""
+    import src.tools.ssh as ssh_module
+
+    target = tmp_path / "grows.bin"
+    target.write_bytes(b"x" * 10)
+    monkeypatch.setattr(ssh_module.os.path, "getsize", lambda _p: 10)
+    target.write_bytes(b"x" * 500)
+
+    data, error = await read_binary_file("127.0.0.1", str(target), max_bytes=100)
+
+    assert data is None
+    assert "exceeds" in error or "over the" in error

--- a/tests/test_binary_host_read.py
+++ b/tests/test_binary_host_read.py
@@ -10,6 +10,7 @@ a valid 20,853-byte PDF.
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 import pytest
@@ -114,8 +115,9 @@ async def test_remote_read_returns_raw_bytes(monkeypatch):
     assert error == "" and data == payload
     argv = captured["argv"]
     assert argv[0] == "ssh"
-    # `--` stops option parsing so a path beginning with '-' cannot become a flag.
-    assert any("cat -- " in str(a) for a in argv), argv
+    # The remote producer is capped at max+1 bytes; `--` protects option-like paths.
+    remote_cmd = str(argv[-1])
+    assert "head -c 1000001 -- " in remote_cmd, argv
 
 
 async def test_remote_oversize_is_rejected(monkeypatch):
@@ -130,6 +132,24 @@ async def test_remote_oversize_is_rejected(monkeypatch):
         ssh_key_path="/k", known_hosts_path="/kh",
     )
     assert data is None and "over the" in error
+
+
+async def test_remote_command_caps_output_before_buffering(monkeypatch):
+    import src.tools.ssh as ssh_module
+
+    captured = {}
+
+    async def _exec(*args, **kwargs):
+        captured["remote_command"] = args[-1]
+        return await _fake_proc(b"x" * 101)
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    data, error = await read_binary_file(
+        "example.host", "/tmp/huge.bin", max_bytes=100,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert data is None and "over the" in error
+    assert captured["remote_command"].startswith("head -c 101 -- ")
 
 
 async def test_remote_failure_reports_stderr(monkeypatch):
@@ -154,12 +174,20 @@ async def test_remote_timeout_is_reported(monkeypatch):
     async def _exec(*args, **kwargs):
         class _Hanging:
             returncode = None
+            pid = 999999
 
             async def communicate(self):  # pragma: no cover - never completes
                 await _asyncio.sleep(3600)
 
+            async def wait(self):
+                self.returncode = -9
+                return -9
+
+            def send_signal(self, _sig):
+                self.returncode = -9
+
             def kill(self):
-                pass
+                self.returncode = -9
 
         return _Hanging()
 
@@ -207,3 +235,77 @@ async def test_file_growing_between_stat_and_read_is_rejected(tmp_path, monkeypa
 
     assert data is None
     assert "exceeds" in error or "over the" in error
+
+
+async def test_local_read_failure_after_stat_reports_cleanly(tmp_path, monkeypatch):
+    import builtins
+
+    target = tmp_path / "exists.bin"
+    target.write_bytes(b"x")
+    real_open = builtins.open
+
+    def _deny(path, *args, **kwargs):
+        if str(path) == str(target):
+            raise PermissionError("denied after stat")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _deny)
+    data, error = await read_binary_file(
+        "127.0.0.1", str(target), max_bytes=100
+    )
+    assert data is None and "cannot read" in error
+
+
+async def test_negative_limit_is_rejected_locally(tmp_path):
+    target = tmp_path / "f.bin"
+    target.write_bytes(b"x")
+    data, error = await read_binary_file(
+        "127.0.0.1", str(target), max_bytes=-1
+    )
+    assert data is None and "must be >= 0" in error
+
+
+async def test_negative_limit_is_rejected_before_remote_spawn(monkeypatch):
+    import src.tools.ssh as ssh_module
+
+    called = False
+
+    async def _exec(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("must not spawn")
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    data, error = await read_binary_file(
+        "example.host", "/tmp/f", max_bytes=-1,
+        ssh_key_path="/k", known_hosts_path="/kh",
+    )
+    assert data is None and "must be >= 0" in error
+    assert called is False
+
+
+async def test_remote_cancellation_reaps_and_propagates(monkeypatch):
+    import src.tools.ssh as ssh_module
+
+    class _Cancelled:
+        returncode = None
+
+        async def communicate(self):
+            raise asyncio.CancelledError
+
+    reaped = []
+
+    async def _exec(*args, **kwargs):
+        return _Cancelled()
+
+    async def _reap(proc, *args, **kwargs):
+        reaped.append(proc)
+
+    monkeypatch.setattr(ssh_module.asyncio, "create_subprocess_exec", _exec)
+    monkeypatch.setattr(ssh_module, "terminate_process_tree", _reap)
+    with pytest.raises(asyncio.CancelledError):
+        await read_binary_file(
+            "example.host", "/tmp/f", max_bytes=100,
+            ssh_key_path="/k", known_hosts_path="/kh",
+        )
+    assert len(reaped) == 1

--- a/tests/test_browser_automation.py
+++ b/tests/test_browser_automation.py
@@ -273,3 +273,133 @@ class TestForceReconnect:
             await mgr._force_reconnect()
         # Old browser should have been closed
         old_browser.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Per-request browser network guard
+# ---------------------------------------------------------------------------
+
+class TestBrowserRequestGuard:
+    @pytest.mark.asyncio
+    async def test_context_is_hardened_before_page_creation(self):
+        mgr = BrowserManager()
+        browser = MagicMock()
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+        context.new_page = AsyncMock(return_value=MagicMock())
+        context.close = AsyncMock()
+        browser.new_context = AsyncMock(return_value=context)
+        mgr._browser = browser
+
+        await mgr._create_page()
+
+        assert browser.new_context.await_args.kwargs["service_workers"] == "block"
+        context.route.assert_awaited_once()
+        context.route_web_socket.assert_awaited_once()
+        context.new_page.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_http_route_uses_safe_fetch_and_never_direct_continue(self):
+        from src.tools.safe_fetch import SafeFetchResponse
+
+        mgr = BrowserManager(allow_private_targets=["http://internal.test/"])
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+
+        request = MagicMock()
+        request.url = "https://example.com/page"
+        request.method = "POST"
+        request.post_data_buffer = b"payload"
+        request.all_headers = AsyncMock(
+            return_value={"cookie": "session=x", "content-length": "7", "host": "example.com"}
+        )
+        route = MagicMock(request=request)
+        route.fulfill = AsyncMock()
+        route.abort = AsyncMock()
+        route.continue_ = AsyncMock()
+        response = SafeFetchResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/plain",
+                "Content-Encoding": "gzip",
+                "Content-Length": "3",
+            },
+            body=b"ok",
+            content_type="text/plain",
+            url=request.url,
+        )
+
+        with patch("src.tools.safe_fetch.safe_fetch", AsyncMock(return_value=response)) as fetch:
+            await mgr._install_request_guard(context)
+            handler = context.route.await_args.args[1]
+            await handler(route)
+
+        assert fetch.await_args.kwargs["follow_redirects"] is True
+        assert fetch.await_args.kwargs["data"] == b"payload"
+        assert fetch.await_args.kwargs["headers"] == {"cookie": "session=x"}
+        assert fetch.await_args.kwargs["allowed_urls"] == ["http://internal.test/"]
+        route.continue_.assert_not_awaited()
+        route.abort.assert_not_awaited()
+        assert route.fulfill.await_args.kwargs == {
+            "status": 200,
+            "headers": {"Content-Type": "text/plain"},
+            "body": b"ok",
+        }
+
+    @pytest.mark.asyncio
+    async def test_blocked_subresource_is_aborted_before_chromium_connects(self):
+        from src.tools.safe_fetch import BlockedAddressError
+
+        mgr = BrowserManager()
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+
+        request = MagicMock()
+        request.url = "http://127.0.0.1/secret"
+        request.method = "GET"
+        request.post_data_buffer = None
+        request.all_headers = AsyncMock(return_value={})
+        route = MagicMock(request=request)
+        route.fulfill = AsyncMock()
+        route.abort = AsyncMock()
+        route.continue_ = AsyncMock()
+
+        with patch(
+            "src.tools.safe_fetch.safe_fetch",
+            AsyncMock(side_effect=BlockedAddressError("private address")),
+        ):
+            await mgr._install_request_guard(context)
+            handler = context.route.await_args.args[1]
+            await handler(route)
+
+        route.abort.assert_awaited_once_with("blockedbyclient")
+        route.fulfill.assert_not_awaited()
+        route.continue_.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_websockets_are_blocked_without_connecting(self):
+        mgr = BrowserManager()
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+        await mgr._install_request_guard(context)
+        handler = context.route_web_socket.await_args.args[1]
+        websocket = MagicMock(url="ws://127.0.0.1/secret")
+        websocket.close = AsyncMock()
+
+        await handler(websocket)
+
+        websocket.close.assert_awaited_once_with(
+            code=1008, reason="Browser network policy"
+        )
+
+    @pytest.mark.asyncio
+    async def test_old_playwright_is_rejected_instead_of_running_unguarded(self):
+        mgr = BrowserManager()
+        context = MagicMock(spec=["route"])
+        context.route = AsyncMock()
+        with pytest.raises(RuntimeError, match="WebSocket routing"):
+            await mgr._install_request_guard(context)

--- a/tests/test_browser_automation.py
+++ b/tests/test_browser_automation.py
@@ -403,3 +403,83 @@ class TestBrowserRequestGuard:
         context.route = AsyncMock()
         with pytest.raises(RuntimeError, match="WebSocket routing"):
             await mgr._install_request_guard(context)
+
+
+@pytest.mark.asyncio
+async def test_real_browser_blocks_redirects_and_subresources_to_private_loopback():
+    """Exercise the original F1 bypass through a real disposable Chromium context."""
+    try:
+        from aiohttp import web
+        from playwright.async_api import async_playwright
+    except ImportError:
+        pytest.skip("Playwright browser test dependencies are not installed")
+
+    private_hits: list[str] = []
+
+    async def private_handler(request):
+        private_hits.append(request.path)
+        return web.Response(text="PRIVATE_SENTINEL")
+
+    private_app = web.Application()
+    private_app.router.add_get("/{tail:.*}", private_handler)
+    private_runner = web.AppRunner(private_app)
+    await private_runner.setup()
+    private_site = web.TCPSite(private_runner, "127.0.0.1", 0)
+    await private_site.start()
+    private_port = private_site._server.sockets[0].getsockname()[1]
+
+    async def public_page(_request):
+        return web.Response(
+            text=(
+                "<body>PUBLIC_SENTINEL"
+                f'<img src="http://127.0.0.1:{private_port}/image">'
+                f'<script>fetch("http://127.0.0.1:{private_port}/fetch")</script>'
+                "</body>"
+            ),
+            content_type="text/html",
+        )
+
+    async def public_redirect(_request):
+        raise web.HTTPFound(f"http://127.0.0.1:{private_port}/redirect")
+
+    public_app = web.Application()
+    public_app.router.add_get("/page", public_page)
+    public_app.router.add_get("/redirect", public_redirect)
+    public_runner = web.AppRunner(public_app)
+    await public_runner.setup()
+    public_site = web.TCPSite(public_runner, "127.0.0.1", 0)
+    await public_site.start()
+    public_port = public_site._server.sockets[0].getsockname()[1]
+
+    manager = BrowserManager(
+        allow_private_targets=[f"http://127.0.0.1:{public_port}/"],
+    )
+    try:
+        async with async_playwright() as playwright:
+            try:
+                manager._playwright = playwright
+                manager._browser = await playwright.chromium.launch(
+                    headless=True, args=["--no-sandbox"]
+                )
+            except Exception as exc:
+                pytest.skip(f"Chromium is not installed for Playwright: {exc}")
+
+            async with manager.new_page() as page:
+                await page.goto(
+                    f"http://127.0.0.1:{public_port}/page",
+                    wait_until="networkidle",
+                )
+                assert "PUBLIC_SENTINEL" in await page.inner_text("body")
+
+            async with manager.new_page() as page:
+                with pytest.raises(Exception, match="ERR_(FAILED|BLOCKED_BY_CLIENT)"):
+                    await page.goto(
+                        f"http://127.0.0.1:{public_port}/redirect",
+                        wait_until="domcontentloaded",
+                    )
+    finally:
+        await manager.shutdown()
+        await public_runner.cleanup()
+        await private_runner.cleanup()
+
+    assert private_hits == []

--- a/tests/test_browser_automation.py
+++ b/tests/test_browser_automation.py
@@ -18,6 +18,7 @@ from src.tools.browser import (
     ALLOWED_SCHEMES,
     DEFAULT_USER_AGENT,
     BrowserManager,
+    _await_bounded,
     _validate_url,
 )
 
@@ -89,6 +90,45 @@ class TestConstants:
     def test_connection_error_patterns(self):
         assert "connection closed" in _CONNECTION_ERROR_PATTERNS
         assert "browser has been closed" in _CONNECTION_ERROR_PATTERNS
+
+
+# ---------------------------------------------------------------------------
+# _await_bounded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_await_bounded_does_not_wait_for_cancel_suppressing_awaitable():
+    """A timed-out child must not extend the helper's own deadline."""
+    cancellation_seen = asyncio.Event()
+    release_child = asyncio.Event()
+
+    async def suppress_cancellation() -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            await release_child.wait()
+
+    async def safety_release() -> None:
+        # Prevent a regressed implementation from hanging the suite forever.
+        await asyncio.sleep(1.0)
+        release_child.set()
+
+    child_task = asyncio.create_task(suppress_cancellation())
+    safety_task = asyncio.create_task(safety_release())
+    started = asyncio.get_running_loop().time()
+    try:
+        with pytest.raises(TimeoutError, match="stuck operation did not finish within"):
+            await _await_bounded(child_task, 0.05, "stuck operation")
+        elapsed = asyncio.get_running_loop().time() - started
+        assert elapsed < 0.5
+        await asyncio.wait_for(cancellation_seen.wait(), timeout=0.5)
+        assert not child_task.done()
+    finally:
+        release_child.set()
+        safety_task.cancel()
+        await asyncio.gather(child_task, safety_task, return_exceptions=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_browser_automation.py
+++ b/tests/test_browser_automation.py
@@ -4,8 +4,11 @@ Covers _validate_url, BrowserManager connection logic and state,
 _is_connection_error, and ALLOWED_SCHEMES/DEFAULT_USER_AGENT constants.
 Browser tool handler functions are tested via mocked BrowserManager.
 """
+
 from __future__ import annotations
 
+import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,9 +21,19 @@ from src.tools.browser import (
     _validate_url,
 )
 
+
+def _skip_or_fail_browser_test(reason: str) -> None:
+    """Skip optional local runs, but never let the dedicated CI job go green
+    without actually exercising Chromium and the network guard."""
+    if os.environ.get("ODIN_REQUIRE_BROWSER_TESTS") == "1":
+        pytest.fail(reason, pytrace=False)
+    pytest.skip(reason)
+
+
 # ---------------------------------------------------------------------------
 # _validate_url
 # ---------------------------------------------------------------------------
+
 
 class TestValidateUrl:
     def test_http_allowed(self):
@@ -62,6 +75,7 @@ class TestValidateUrl:
 # Constants
 # ---------------------------------------------------------------------------
 
+
 class TestConstants:
     def test_allowed_schemes(self):
         assert "http://" in ALLOWED_SCHEMES
@@ -80,6 +94,7 @@ class TestConstants:
 # ---------------------------------------------------------------------------
 # BrowserManager init
 # ---------------------------------------------------------------------------
+
 
 class TestBrowserManagerInit:
     def test_default_params_native_mode(self):
@@ -112,6 +127,7 @@ class TestBrowserManagerInit:
 # _is_connection_error
 # ---------------------------------------------------------------------------
 
+
 class TestIsConnectionError:
     def test_connection_closed(self):
         assert BrowserManager._is_connection_error(Exception("Connection closed unexpectedly"))
@@ -142,6 +158,7 @@ class TestIsConnectionError:
 # BrowserManager._on_browser_disconnected
 # ---------------------------------------------------------------------------
 
+
 class TestOnBrowserDisconnected:
     def test_clears_browser(self):
         mgr = BrowserManager()
@@ -151,8 +168,49 @@ class TestOnBrowserDisconnected:
 
 
 # ---------------------------------------------------------------------------
+# BrowserManager._force_reconnect
+# ---------------------------------------------------------------------------
+
+
+class TestForceReconnect:
+    @pytest.mark.asyncio
+    async def test_hung_close_is_bounded_before_reconnect(self):
+        mgr = BrowserManager()
+        stuck_close = asyncio.get_running_loop().create_future()
+        mgr._browser = MagicMock()
+        mgr._browser.close = MagicMock(return_value=stuck_close)
+        mgr._ensure_connected = AsyncMock()
+
+        with patch("src.tools.browser._BROWSER_CLOSE_TIMEOUT_SECONDS", 0.01):
+            async with asyncio.timeout(0.5):
+                await mgr._force_reconnect()
+
+        assert stuck_close.cancelled()
+        mgr._ensure_connected.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_clears_and_reconnects(self):
+        mgr = BrowserManager()
+        old_browser = AsyncMock()
+        mgr._browser = old_browser
+
+        # Mock _ensure_connected to set a new browser
+        new_browser = MagicMock()
+        new_browser.is_connected.return_value = True
+
+        async def mock_ensure():
+            pass
+
+        with patch.object(mgr, "_ensure_connected", side_effect=mock_ensure):
+            await mgr._force_reconnect()
+        # Old browser should have been closed
+        old_browser.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # BrowserManager._ensure_connected
 # ---------------------------------------------------------------------------
+
 
 class TestEnsureConnected:
     @pytest.mark.asyncio
@@ -170,6 +228,7 @@ class TestEnsureConnected:
         """When playwright is not installed, _ensure_connected raises RuntimeError."""
         try:
             import playwright  # noqa: F401
+
             pytest.skip("playwright is installed — cannot test missing-import path")
         except ImportError:
             pass
@@ -185,13 +244,17 @@ class TestEnsureConnected:
         mgr._playwright = mock_pw
 
         import sys
+
         mock_module = MagicMock()
         mock_module.async_playwright = MagicMock(return_value=mock_pw)
 
-        with patch.dict(sys.modules, {
-            "playwright": MagicMock(),
-            "playwright.async_api": mock_module,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "playwright": MagicMock(),
+                "playwright.async_api": mock_module,
+            },
+        ):
             with pytest.raises(RuntimeError, match="Failed to launch Chromium"):
                 await mgr._ensure_connected()
 
@@ -203,13 +266,17 @@ class TestEnsureConnected:
         mgr._playwright = mock_pw
 
         import sys
+
         mock_module = MagicMock()
         mock_module.async_playwright = MagicMock(return_value=mock_pw)
 
-        with patch.dict(sys.modules, {
-            "playwright": MagicMock(),
-            "playwright.async_api": mock_module,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "playwright": MagicMock(),
+                "playwright.async_api": mock_module,
+            },
+        ):
             with pytest.raises(RuntimeError, match="Browser service unavailable"):
                 await mgr._ensure_connected()
 
@@ -217,6 +284,76 @@ class TestEnsureConnected:
 # ---------------------------------------------------------------------------
 # BrowserManager.shutdown
 # ---------------------------------------------------------------------------
+
+
+class TestNewPageCleanup:
+    @pytest.mark.asyncio
+    async def test_hung_context_close_after_page_setup_failure_is_bounded(self):
+        mgr = BrowserManager()
+        context = MagicMock()
+        stuck_close = asyncio.get_running_loop().create_future()
+        context.close = MagicMock(return_value=stuck_close)
+        context.new_page = AsyncMock(side_effect=RuntimeError("page creation failed"))
+        mgr._browser = MagicMock()
+        mgr._browser.new_context = AsyncMock(return_value=context)
+        mgr._install_request_guard = AsyncMock()
+
+        with patch("src.tools.browser._CONTEXT_CLOSE_TIMEOUT_SECONDS", 0.01):
+            async with asyncio.timeout(0.5):
+                with pytest.raises(RuntimeError, match="page creation failed"):
+                    await mgr._create_page()
+
+        assert stuck_close.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_page_setup_still_closes_context(self):
+        mgr = BrowserManager()
+        context = MagicMock()
+        context.close = AsyncMock()
+        context.new_page = AsyncMock(side_effect=asyncio.CancelledError())
+        mgr._browser = MagicMock()
+        mgr._browser.new_context = AsyncMock(return_value=context)
+        mgr._install_request_guard = AsyncMock()
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._create_page()
+
+        context.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_cdp_setup_still_closes_context(self):
+        mgr = BrowserManager(cdp_url="ws://browser:9222")
+        context = MagicMock()
+        context.close = AsyncMock()
+        page = MagicMock()
+        page.context.new_cdp_session = AsyncMock(side_effect=asyncio.CancelledError())
+        context.new_page = AsyncMock(return_value=page)
+        mgr._browser = MagicMock()
+        mgr._browser.new_context = AsyncMock(return_value=context)
+        mgr._install_request_guard = AsyncMock()
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._create_page()
+
+        context.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hung_context_close_cannot_make_tool_cleanup_unbounded(self):
+        mgr = BrowserManager()
+        mgr._ensure_connected = AsyncMock()
+        context = MagicMock()
+        stuck_close = asyncio.get_running_loop().create_future()
+        context.close = MagicMock(return_value=stuck_close)
+        page = MagicMock()
+        mgr._create_page = AsyncMock(return_value=(context, page))
+
+        with patch("src.tools.browser._CONTEXT_CLOSE_TIMEOUT_SECONDS", 0.01):
+            async with asyncio.timeout(0.5):
+                async with mgr.new_page() as yielded:
+                    assert yielded is page
+
+        assert stuck_close.cancelled()
+
 
 class TestShutdown:
     @pytest.mark.asyncio
@@ -240,6 +377,52 @@ class TestShutdown:
         assert mgr._playwright is None
 
     @pytest.mark.asyncio
+    async def test_shutdown_propagates_cancellation(self):
+        mgr = BrowserManager()
+        started = asyncio.Event()
+
+        async def never_close():
+            started.set()
+            await asyncio.Future()
+
+        mgr._browser = MagicMock()
+        mgr._browser.close = MagicMock(side_effect=never_close)
+        playwright = AsyncMock()
+        mgr._playwright = playwright
+        task = asyncio.create_task(mgr.shutdown())
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        playwright.stop.assert_awaited_once()
+        assert mgr._browser is None
+        assert mgr._playwright is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_bounds_hung_browser_and_playwright_teardown(self):
+        mgr = BrowserManager()
+        browser_close = asyncio.get_running_loop().create_future()
+        playwright_stop = asyncio.get_running_loop().create_future()
+        mgr._browser = MagicMock()
+        mgr._browser.close = MagicMock(return_value=browser_close)
+        mgr._playwright = MagicMock()
+        mgr._playwright.stop = MagicMock(return_value=playwright_stop)
+
+        with (
+            patch("src.tools.browser._BROWSER_CLOSE_TIMEOUT_SECONDS", 0.01),
+            patch("src.tools.browser._PLAYWRIGHT_STOP_TIMEOUT_SECONDS", 0.01),
+        ):
+            async with asyncio.timeout(0.5):
+                await mgr.shutdown()
+
+        assert browser_close.cancelled()
+        assert playwright_stop.cancelled()
+        assert mgr._browser is None
+        assert mgr._playwright is None
+
+    @pytest.mark.asyncio
     async def test_shutdown_handles_exception(self):
         mgr = BrowserManager()
         mock_browser = AsyncMock()
@@ -252,32 +435,9 @@ class TestShutdown:
 
 
 # ---------------------------------------------------------------------------
-# BrowserManager._force_reconnect
-# ---------------------------------------------------------------------------
-
-class TestForceReconnect:
-    @pytest.mark.asyncio
-    async def test_clears_and_reconnects(self):
-        mgr = BrowserManager()
-        old_browser = AsyncMock()
-        mgr._browser = old_browser
-
-        # Mock _ensure_connected to set a new browser
-        new_browser = MagicMock()
-        new_browser.is_connected.return_value = True
-
-        async def mock_ensure():
-            pass
-
-        with patch.object(mgr, "_ensure_connected", side_effect=mock_ensure):
-            await mgr._force_reconnect()
-        # Old browser should have been closed
-        old_browser.close.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
 # Per-request browser network guard
 # ---------------------------------------------------------------------------
+
 
 class TestBrowserRequestGuard:
     @pytest.mark.asyncio
@@ -349,6 +509,124 @@ class TestBrowserRequestGuard:
         }
 
     @pytest.mark.asyncio
+    async def test_unexpected_request_metadata_failure_still_aborts_route(self):
+        """No ordinary callback exception may leave an intercepted route open.
+
+        The first F1 implementation caught only named transport failures. An
+        exception while reading Playwright request metadata escaped before
+        fulfill/abort, leaving page navigation and context cleanup unbounded.
+        """
+        mgr = BrowserManager()
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+
+        request = MagicMock()
+        request.url = "https://example.com/"
+        request.all_headers = AsyncMock(side_effect=RuntimeError("metadata exploded"))
+        route = MagicMock(request=request)
+        route.fulfill = AsyncMock()
+        route.abort = AsyncMock()
+
+        await mgr._install_request_guard(context)
+        handler = context.route.await_args.args[1]
+        await handler(route)
+
+        route.abort.assert_awaited_once_with("blockedbyclient")
+        route.fulfill.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_abort_does_not_escape_or_leave_callback_running(self):
+        mgr = BrowserManager()
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+
+        request = MagicMock()
+        request.url = "https://example.com/"
+        request.all_headers = AsyncMock(side_effect=RuntimeError("metadata exploded"))
+        route = MagicMock(request=request)
+        route.fulfill = AsyncMock()
+        route.abort = AsyncMock(side_effect=RuntimeError("route already gone"))
+
+        await mgr._install_request_guard(context)
+        handler = context.route.await_args.args[1]
+        await asyncio.wait_for(handler(route), timeout=1)
+
+        route.abort.assert_awaited_once_with("blockedbyclient")
+        route.fulfill.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_hung_fulfill_is_bounded_then_aborted(self):
+        from src.tools.safe_fetch import SafeFetchResponse
+
+        mgr = BrowserManager(default_timeout_ms=1000)
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+
+        request = MagicMock()
+        request.url = "https://example.com/"
+        request.method = "GET"
+        request.post_data_buffer = None
+        request.all_headers = AsyncMock(return_value={})
+        route = MagicMock(request=request)
+        stuck_fulfill = asyncio.get_running_loop().create_future()
+        route.fulfill = MagicMock(return_value=stuck_fulfill)
+        route.abort = AsyncMock()
+        response = SafeFetchResponse(
+            status=200,
+            headers={"Content-Type": "text/plain"},
+            body=b"ok",
+            content_type="text/plain",
+            url=request.url,
+        )
+
+        with (
+            patch("src.tools.safe_fetch.safe_fetch", AsyncMock(return_value=response)),
+            patch("src.tools.browser._ROUTE_ACTION_TIMEOUT_SECONDS", 0.01),
+        ):
+            await mgr._install_request_guard(context)
+            handler = context.route.await_args.args[1]
+            await asyncio.wait_for(handler(route), timeout=0.5)
+
+        assert stuck_fulfill.cancelled()
+        route.abort.assert_awaited_once_with("blockedbyclient")
+
+    @pytest.mark.asyncio
+    async def test_hung_abort_is_bounded_and_callback_returns(self):
+        from src.tools.safe_fetch import BlockedAddressError
+
+        mgr = BrowserManager(default_timeout_ms=1000)
+        context = MagicMock()
+        context.route = AsyncMock()
+        context.route_web_socket = AsyncMock()
+
+        request = MagicMock()
+        request.url = "http://127.0.0.1/secret"
+        request.method = "GET"
+        request.post_data_buffer = None
+        request.all_headers = AsyncMock(return_value={})
+        route = MagicMock(request=request)
+        route.fulfill = AsyncMock()
+        stuck_abort = asyncio.get_running_loop().create_future()
+        route.abort = MagicMock(return_value=stuck_abort)
+
+        with (
+            patch(
+                "src.tools.safe_fetch.safe_fetch",
+                AsyncMock(side_effect=BlockedAddressError("private address")),
+            ),
+            patch("src.tools.browser._ROUTE_ACTION_TIMEOUT_SECONDS", 0.01),
+        ):
+            await mgr._install_request_guard(context)
+            handler = context.route.await_args.args[1]
+            await asyncio.wait_for(handler(route), timeout=0.5)
+
+        assert stuck_abort.cancelled()
+        route.fulfill.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_blocked_subresource_is_aborted_before_chromium_connects(self):
         from src.tools.safe_fetch import BlockedAddressError
 
@@ -392,9 +670,7 @@ class TestBrowserRequestGuard:
 
         await handler(websocket)
 
-        websocket.close.assert_awaited_once_with(
-            code=1008, reason="Browser network policy"
-        )
+        websocket.close.assert_awaited_once_with(code=1008, reason="Browser network policy")
 
     @pytest.mark.asyncio
     async def test_old_playwright_is_rejected_instead_of_running_unguarded(self):
@@ -406,13 +682,92 @@ class TestBrowserRequestGuard:
 
 
 @pytest.mark.asyncio
+async def test_real_public_page_loads_to_completion_through_request_guard():
+    """A deterministic allow-path page must finish through a real guard.
+
+    The first F1 tests exercised only private denial and never proved a normal
+    routed page could finish. This local public-side origin drives the same real
+    Chromium route/fulfill path without external DNS, TLS or content drift; a
+    hard outer deadline turns a stuck route into a fast test failure.
+    """
+    try:
+        from aiohttp import web
+        from playwright.async_api import async_playwright
+    except ImportError as exc:
+        _skip_or_fail_browser_test(f"Playwright browser test dependencies are not installed: {exc}")
+
+    hits: list[str] = []
+
+    async def page(_request):
+        hits.append("/page")
+        return web.Response(
+            text=(
+                "<!doctype html><title>Guard Pass</title><body>PUBLIC_PASS"
+                '<script src="/script.js"></script><img src="/image.png"></body>'
+            ),
+            content_type="text/html",
+        )
+
+    async def script(_request):
+        hits.append("/script.js")
+        return web.Response(
+            text='document.body.dataset.routed = "yes";',
+            content_type="application/javascript",
+        )
+
+    async def image(_request):
+        hits.append("/image.png")
+        # Chromium need not decode it; the request must traverse the guard.
+        return web.Response(body=b"not-a-real-png", content_type="image/png")
+
+    app = web.Application()
+    app.router.add_get("/page", page)
+    app.router.add_get("/script.js", script)
+    app.router.add_get("/image.png", image)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    manager = BrowserManager(
+        default_timeout_ms=5000,
+        allow_private_targets=[f"http://127.0.0.1:{port}/"],
+    )
+    try:
+        async with async_playwright() as playwright:
+            try:
+                manager._playwright = playwright
+                manager._browser = await playwright.chromium.launch(
+                    headless=True, args=["--no-sandbox"]
+                )
+            except Exception as exc:
+                _skip_or_fail_browser_test(
+                    f"Chromium could not launch for Playwright browser tests: {exc}"
+                )
+
+            async with asyncio.timeout(15):
+                async with manager.new_page() as browser_page:
+                    await browser_page.goto(
+                        f"http://127.0.0.1:{port}/page",
+                        wait_until="networkidle",
+                    )
+                    assert "PUBLIC_PASS" in await browser_page.inner_text("body")
+                    assert await browser_page.get_attribute("body", "data-routed") == "yes"
+    finally:
+        await manager.shutdown()
+        await runner.cleanup()
+
+    assert hits == ["/page", "/script.js", "/image.png"]
+
+
+@pytest.mark.asyncio
 async def test_real_browser_blocks_redirects_and_subresources_to_private_loopback():
     """Exercise the original F1 bypass through a real disposable Chromium context."""
     try:
         from aiohttp import web
         from playwright.async_api import async_playwright
-    except ImportError:
-        pytest.skip("Playwright browser test dependencies are not installed")
+    except ImportError as exc:
+        _skip_or_fail_browser_test(f"Playwright browser test dependencies are not installed: {exc}")
 
     private_hits: list[str] = []
 
@@ -462,7 +817,9 @@ async def test_real_browser_blocks_redirects_and_subresources_to_private_loopbac
                     headless=True, args=["--no-sandbox"]
                 )
             except Exception as exc:
-                pytest.skip(f"Chromium is not installed for Playwright: {exc}")
+                _skip_or_fail_browser_test(
+                    f"Chromium could not launch for Playwright browser tests: {exc}"
+                )
 
             async with manager.new_page() as page:
                 await page.goto(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -882,3 +882,36 @@ class TestEdgeCases:
         hosts = {"myserver": ToolHost(address="10.0.0.1")}
         config = ToolsConfig(hosts=hosts)
         return ToolExecutor(config=config)
+
+
+class TestOptionLikePositionalSafety:
+    """Shell quoting is not Git option-injection protection."""
+
+    @pytest.mark.parametrize(
+        ("action", "params", "field"),
+        [
+            ("clone", {"url": "https://example.invalid/r.git", "branch": "--help"}, "branch"),
+            ("diff", {"target": "--stat"}, "target"),
+            ("branch", {"name": "--help"}, "name"),
+            ("push", {"remote": "--help"}, "remote"),
+            ("push", {"branch": "--delete"}, "branch"),
+            ("log", {"branch": "--all"}, "branch"),
+            ("pull", {"remote": "--help"}, "remote"),
+            ("pull", {"branch": "--rebase"}, "branch"),
+            ("checkout", {"target": "--help"}, "target"),
+            ("fetch", {"remote": "--help"}, "remote"),
+        ],
+    )
+    def test_option_like_ref_or_remote_is_rejected(self, action, params, field):
+        with pytest.raises(ValueError, match=rf"{field} must not start"):
+            build_git_command(action, params)
+
+    def test_branch_and_add_use_option_terminators(self):
+        branch = shlex.split(build_git_command("branch", {"name": "safe"}))
+        add = shlex.split(build_git_command("commit", {"message": "m", "files": ["--help"]}))
+        assert branch[-2:] == ["--", "safe"]
+        assert add[3:6] == ["add", "--", "--help"]
+
+    def test_push_freshness_options_precede_remote_terminator(self):
+        freshness, _push = build_git_command("push", {"remote": "origin"})
+        assert "fetch --quiet -- origin" in freshness

--- a/tests/test_handlers_files_docs.py
+++ b/tests/test_handlers_files_docs.py
@@ -22,6 +22,13 @@ def _tools(run_ret="file contents", govern=(True, "", None),
     t._govern_command = MagicMock(return_value=govern)
     t._resolve_host = lambda host: resolve
     t._exec_command = AsyncMock(return_value=exec_ret)
+    # analyze_pdf reads host binaries directly (not via the text pipeline), so
+    # it needs the ssh paths config exposes.
+    t._deps = SimpleNamespace(
+        config=lambda: SimpleNamespace(
+            ssh_key_path="/dev/null", ssh_known_hosts_path="/dev/null"
+        )
+    )
     return t
 
 
@@ -180,53 +187,80 @@ class TestAnalyzePdf:
                     {"url": "http://ok/doc.pdf"})
 
     async def test_host_path(self):
-        b64 = base64.b64encode(b"%PDF fake").decode()
-        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["from host"])}):
-            t = _tools(exec_ret=(0, b64))
-            out = await t._handle_analyze_pdf({"host": "srv", "path": "/doc.pdf"})
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["from host"])}), _binary():
+            out = await _tools()._handle_analyze_pdf({"host": "srv", "path": "/doc.pdf"})
             assert "from host" in out
+
+    async def test_host_path_large_file(self):
+        """The actual defect: a payload larger than the old 16,000-char text
+        transport could carry. base64 crossed that at ~12,000 source bytes, so
+        an ordinary 20KB PDF returned "Incorrect padding"."""
+        big = b"%PDF" + b"x" * 20_000
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["big doc"])}), _binary(big):
+            out = await _tools()._handle_analyze_pdf({"host": "srv", "path": "/big.pdf"})
+            assert "big doc" in out
+
+    async def test_host_read_error_is_reported(self):
+        with patch.dict(sys.modules, {"fitz": _fake_fitz()}), _binary(error="denied"):
+            assert _failed(
+                await _tools()._handle_analyze_pdf({"host": "s", "path": "/p"}),
+                "Failed to read PDF from host",
+            )
 
     async def test_host_path_errors(self):
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
             assert "Unknown or disallowed host" in await _tools(
                 resolve=None)._handle_analyze_pdf({"host": "h", "path": "/p"})
-            assert _failed(await _tools(
-                exec_ret=(1, "denied"))._handle_analyze_pdf({"host": "s", "path": "/p"}),
-                "Failed to read PDF from host")
-            # malformed base64 (wrong padding) → decode raises → handled
-            assert _failed(await _tools(
-                exec_ret=(0, "YQ"))._handle_analyze_pdf({"host": "s", "path": "/p"}),
-                "Failed to decode PDF")
+            with _binary(error="denied"):
+                assert _failed(
+                    await _tools()._handle_analyze_pdf({"host": "s", "path": "/p"}),
+                    "Failed to read PDF from host",
+                )
 
     async def test_neither_source(self):
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
             assert "Provide either" in await _tools()._handle_analyze_pdf({})
 
     async def test_open_failure(self):
-        b64 = base64.b64encode(b"garbage").decode()
-        with patch.dict(sys.modules, {"fitz": _fake_fitz(error=RuntimeError("bad pdf"))}):
-            assert _failed(await _tools(
-                exec_ret=(0, b64))._handle_analyze_pdf({"host": "s", "path": "/p"}),
-                "Failed to open PDF")
+        with patch.dict(
+            sys.modules, {"fitz": _fake_fitz(error=RuntimeError("bad pdf"))}
+        ), _binary(b"garbage"):
+            assert _failed(
+                await _tools()._handle_analyze_pdf({"host": "s", "path": "/p"}),
+                "Failed to open PDF",
+            )
 
     async def test_page_selection_and_empty(self):
-        b64 = base64.b64encode(b"x").decode()
-        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["one", "two", "three"])}):
-            out = await _tools(exec_ret=(0, b64))._handle_analyze_pdf(
+        with patch.dict(
+            sys.modules, {"fitz": _fake_fitz(pages=["one", "two", "three"])}
+        ), _binary():
+            out = await _tools()._handle_analyze_pdf(
                 {"host": "s", "path": "/p", "pages": "2"})
             assert "Page 2" in out and "two" in out and "Page 1" not in out
         # a 0-page doc yields no parts → empty result → the no-text fallback
-        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=[])}):
-            out = await _tools(exec_ret=(0, b64))._handle_analyze_pdf(
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=[])}), _binary():
+            out = await _tools()._handle_analyze_pdf(
                 {"host": "s", "path": "/p"})
             assert "no extractable text" in out
 
     async def test_truncation(self):
-        b64 = base64.b64encode(b"x").decode()
-        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["x" * 13000])}):
-            out = await _tools(exec_ret=(0, b64))._handle_analyze_pdf(
+        with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["x" * 13000])}), _binary():
+            out = await _tools()._handle_analyze_pdf(
                 {"host": "s", "path": "/p"})
             assert "truncated" in out
+
+
+def _binary(data: bytes = b"%PDF fake", error: str = ""):
+    """Patch the BINARY host-read path.
+
+    analyze_pdf used to pull host files as base64 through the text exec
+    pipeline, which truncates at 16,000 chars — so anything over ~12KB arrived
+    corrupt. It now reads raw bytes, and these tests fake that path instead.
+    """
+    async def _read(address, path, **kwargs):
+        return (None, error) if error else (data, "")
+
+    return patch("src.tools.ssh.read_binary_file", _read)
 
 
 def _failed(result, needle: str) -> bool:

--- a/tests/test_handlers_files_docs.py
+++ b/tests/test_handlers_files_docs.py
@@ -164,11 +164,11 @@ class TestAnalyzePdf:
                 out = await _tools()._handle_analyze_pdf({"url": "http://ok/doc.pdf"})
                 assert "Page 1" in out and "hello pdf" in out
             with patch("src.tools.safe_fetch.safe_fetch", _ff(404)):
-                assert "HTTP 404" in await _tools()._handle_analyze_pdf(
-                    {"url": "http://ok/doc.pdf"})
+                assert _failed(await _tools()._handle_analyze_pdf(
+                    {"url": "http://ok/doc.pdf"}), "HTTP 404")
             with patch("src.tools.safe_fetch.safe_fetch", _raise):
-                assert "Failed to fetch PDF" in await _tools()._handle_analyze_pdf(
-                    {"url": "http://ok/doc.pdf"})
+                assert _failed(await _tools()._handle_analyze_pdf(
+                    {"url": "http://ok/doc.pdf"}), "Failed to fetch PDF")
 
             from src.tools.safe_fetch import ResponseTooLargeError
 
@@ -190,11 +190,13 @@ class TestAnalyzePdf:
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
             assert "Unknown or disallowed host" in await _tools(
                 resolve=None)._handle_analyze_pdf({"host": "h", "path": "/p"})
-            assert "Failed to read PDF from host" in await _tools(
-                exec_ret=(1, "denied"))._handle_analyze_pdf({"host": "s", "path": "/p"})
+            assert _failed(await _tools(
+                exec_ret=(1, "denied"))._handle_analyze_pdf({"host": "s", "path": "/p"}),
+                "Failed to read PDF from host")
             # malformed base64 (wrong padding) → decode raises → handled
-            assert "Failed to decode PDF" in await _tools(
-                exec_ret=(0, "YQ"))._handle_analyze_pdf({"host": "s", "path": "/p"})
+            assert _failed(await _tools(
+                exec_ret=(0, "YQ"))._handle_analyze_pdf({"host": "s", "path": "/p"}),
+                "Failed to decode PDF")
 
     async def test_neither_source(self):
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
@@ -203,8 +205,9 @@ class TestAnalyzePdf:
     async def test_open_failure(self):
         b64 = base64.b64encode(b"garbage").decode()
         with patch.dict(sys.modules, {"fitz": _fake_fitz(error=RuntimeError("bad pdf"))}):
-            assert "Failed to open PDF" in await _tools(
-                exec_ret=(0, b64))._handle_analyze_pdf({"host": "s", "path": "/p"})
+            assert _failed(await _tools(
+                exec_ret=(0, b64))._handle_analyze_pdf({"host": "s", "path": "/p"}),
+                "Failed to open PDF")
 
     async def test_page_selection_and_empty(self):
         b64 = base64.b64encode(b"x").decode()
@@ -226,6 +229,20 @@ class TestAnalyzePdf:
             assert "truncated" in out
 
 
+def _failed(result, needle: str) -> bool:
+    """A structured failure return: (message, nonzero_exit).
+
+    analyze_pdf's failures used to be bare strings whose text matched none of
+    the executor's error prefixes, so real failures were classified ok=True and
+    audited as approved (adversarial review). Asserting the STATUS as well as
+    the text is what pins that.
+    """
+    assert isinstance(result, tuple), f"expected a structured failure, got {result!r}"
+    message, code = result
+    assert code != 0, f"failure must carry a nonzero exit, got {code}"
+    return needle in message
+
+
 async def test_analyze_pdf_degrades_cleanly_without_pymupdf(monkeypatch):
     """find_spec proves the module is importable, not that its native library
     loads — and a direct call can reach the handler on an install whose catalog
@@ -245,5 +262,6 @@ async def test_analyze_pdf_degrades_cleanly_without_pymupdf(monkeypatch):
 
     tools = _tools()
     result = await tools._handle_analyze_pdf({"host": "localhost", "path": "/tmp/x.pdf"})
-    assert "PDF support unavailable" in result
-    assert "pdf" in result and "install" in result.lower(), "must name the remedy"
+    assert _failed(result, "PDF support unavailable")
+    message = result[0]
+    assert "pdf" in message and "install" in message.lower(), "must name the remedy"

--- a/tests/test_handlers_files_docs.py
+++ b/tests/test_handlers_files_docs.py
@@ -94,6 +94,10 @@ class TestReadFile:
         assert "head -n 200" in t._run_on_host.call_args.args[1]  # bad → default 200
         await t._handle_read_file({"path": "/etc/x", "host": "h", "lines": 5000})
         assert "head -n 1000" in t._run_on_host.call_args.args[1]  # clamped to 1000
+        await t._handle_read_file({"path": "/etc/x", "host": "h", "lines": -2})
+        assert "head -n 1" in t._run_on_host.call_args.args[1]  # clamped to lower bound
+        await t._handle_read_file({"path": "/etc/x", "host": "h", "lines": float("inf")})
+        assert "head -n 200" in t._run_on_host.call_args.args[1]  # overflow → default
 
 
 class TestWriteFile:
@@ -135,7 +139,9 @@ class TestAnalyzePdf:
         # "blocked URL" message. fitz is imported before the fetch, so fake it.
         from src.tools.safe_fetch import BlockedAddressError
 
-        assert "http://" in await _tools()._handle_analyze_pdf({"url": "ftp://x"})
+        assert _failed(
+            await _tools()._handle_analyze_pdf({"url": "ftp://x"}), "http://"
+        )
 
         async def _blocked(url, **kw):
             raise BlockedAddressError("blocked")
@@ -145,15 +151,21 @@ class TestAnalyzePdf:
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}), \
              patch("src.tools.url_safety.is_url_blocked", return_value=False), \
              patch("src.tools.safe_fetch.safe_fetch", _blocked):
-            assert "blocked URL" in await _tools()._handle_analyze_pdf(
-                {"url": "http://example.com/x"})
+            assert _failed(
+                await _tools()._handle_analyze_pdf({"url": "http://example.com/x"}),
+                "blocked URL",
+            )
 
     async def test_url_preflight_block_before_fitz(self):
         # The pre-flight is_url_blocked check returns the block message even on
         # a host without PyMuPDF (it runs before the fitz import).
         with patch("src.tools.url_safety.is_url_blocked", return_value=True):
-            assert "blocked URL" in await _tools()._handle_analyze_pdf(
-                {"url": "http://169.254.169.254/latest/meta-data"})
+            assert _failed(
+                await _tools()._handle_analyze_pdf(
+                    {"url": "http://169.254.169.254/latest/meta-data"}
+                ),
+                "blocked URL",
+            )
 
     async def test_url_success_and_http_error(self):
         from src.tools.safe_fetch import SafeFetchResponse
@@ -183,8 +195,10 @@ class TestAnalyzePdf:
                 raise ResponseTooLargeError("big")
 
             with patch("src.tools.safe_fetch.safe_fetch", _too_big):
-                assert "too large" in await _tools()._handle_analyze_pdf(
-                    {"url": "http://ok/doc.pdf"})
+                assert _failed(
+                    await _tools()._handle_analyze_pdf({"url": "http://ok/doc.pdf"}),
+                    "too large",
+                )
 
     async def test_host_path(self):
         with patch.dict(sys.modules, {"fitz": _fake_fitz(pages=["from host"])}), _binary():
@@ -209,8 +223,12 @@ class TestAnalyzePdf:
 
     async def test_host_path_errors(self):
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
-            assert "Unknown or disallowed host" in await _tools(
-                resolve=None)._handle_analyze_pdf({"host": "h", "path": "/p"})
+            assert _failed(
+                await _tools(resolve=None)._handle_analyze_pdf(
+                    {"host": "h", "path": "/p"}
+                ),
+                "Unknown or disallowed host",
+            )
             with _binary(error="denied"):
                 assert _failed(
                     await _tools()._handle_analyze_pdf({"host": "s", "path": "/p"}),
@@ -219,7 +237,7 @@ class TestAnalyzePdf:
 
     async def test_neither_source(self):
         with patch.dict(sys.modules, {"fitz": _fake_fitz()}):
-            assert "Provide either" in await _tools()._handle_analyze_pdf({})
+            assert _failed(await _tools()._handle_analyze_pdf({}), "Provide either")
 
     async def test_open_failure(self):
         with patch.dict(

--- a/tests/test_http_probe_ops.py
+++ b/tests/test_http_probe_ops.py
@@ -434,13 +434,24 @@ class TestBuildBody:
         })
         assert "-d" not in cmd
 
-    def test_oversized_body_ignored(self):
+    def test_oversized_body_rejected(self):
+        """CONTRACT CHANGE: an oversized body used to be silently omitted, so
+        the probe ran as a bodyless POST that could look successful. It is now
+        rejected, matching the HEAD-with-body behaviour."""
+        with pytest.raises(ValueError, match="over the"):
+            build_http_probe_command({
+                "url": "https://example.com",
+                "method": "POST",
+                "body": "x" * (MAX_BODY_SIZE + 1),
+            })
+
+    def test_body_at_the_limit_is_accepted(self):
         cmd = build_http_probe_command({
             "url": "https://example.com",
             "method": "POST",
-            "body": "x" * (MAX_BODY_SIZE + 1),
+            "body": "x" * MAX_BODY_SIZE,
         })
-        assert "-d" not in cmd
+        assert "-d " in cmd
 
     def test_body_at_limit_included(self):
         body = "x" * MAX_BODY_SIZE
@@ -798,27 +809,34 @@ class TestHandleHttpProbe:
     @pytest.mark.asyncio
     async def test_command_failure_with_output(self, executor):
         executor._exec_command.return_value = (7, "curl: (7) Failed to connect")
-        result = await executor.browser_web_tools._handle_http_probe({
+        message, code = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
-        assert "Failed to connect" in result
+        assert "Failed to connect" in message
+        # curl's exit code must survive to the executor: a connection failure
+        # classified as ok=True is how a dead probe got audited as approved
+        # (adversarial review).
+        assert code == 7
 
     @pytest.mark.asyncio
     async def test_command_failure_no_output(self, executor):
         executor._exec_command.return_value = (1, "")
-        result = await executor.browser_web_tools._handle_http_probe({
+        message, code = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
-        assert "http_probe failed" in result
-        assert "exit 1" in result
+        assert "http_probe failed" in message
+        assert "exit 1" in message
+        assert code == 1
 
     @pytest.mark.asyncio
     async def test_empty_success(self, executor):
         executor._exec_command.return_value = (0, "")
-        result = await executor.browser_web_tools._handle_http_probe({
+        message, code = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
-        assert "no response received" in result
+        assert "no response received" in message
+        # No response is a failure even though curl exited 0.
+        assert code != 0
 
     @pytest.mark.asyncio
     async def test_success_returns_output(self, executor):
@@ -826,11 +844,13 @@ class TestHandleHttpProbe:
             0,
             "HTTP/1.1 200 OK\nContent-Type: text/plain\n\nHello"
         )
-        result = await executor.browser_web_tools._handle_http_probe({
+        message, code = await executor.browser_web_tools._handle_http_probe({
             "url": "https://example.com",
         })
-        assert "HTTP/1.1 200 OK" in result
-        assert "Hello" in result
+        assert "HTTP/1.1 200 OK" in message
+        assert "Hello" in message
+        # A healthy probe must still be a success — the fix must not invert.
+        assert code == 0
 
     @pytest.mark.asyncio
     async def test_get_dispatch(self, executor):

--- a/tests/test_http_probe_ops.py
+++ b/tests/test_http_probe_ops.py
@@ -445,6 +445,15 @@ class TestBuildBody:
                 "body": "x" * (MAX_BODY_SIZE + 1),
             })
 
+    def test_body_limit_is_measured_in_utf8_bytes(self):
+        # 30k code points but 60k UTF-8 bytes: the public limit says bytes.
+        with pytest.raises(ValueError, match="60000 bytes"):
+            build_http_probe_command({
+                "url": "https://example.com",
+                "method": "POST",
+                "body": "é" * 30_000,
+            })
+
     def test_body_at_the_limit_is_accepted(self):
         cmd = build_http_probe_command({
             "url": "https://example.com",
@@ -796,15 +805,17 @@ class TestHandleHttpProbe:
 
     @pytest.mark.asyncio
     async def test_validation_error_returned(self, executor):
-        result = await executor.browser_web_tools._handle_http_probe({
+        message, code = await executor.browser_web_tools._handle_http_probe({
             "url": "ftp://example.com",
         })
-        assert "http_probe error" in result
+        assert "http_probe error" in message
+        assert code != 0
 
     @pytest.mark.asyncio
     async def test_missing_url_error(self, executor):
-        result = await executor.browser_web_tools._handle_http_probe({})
-        assert "http_probe error" in result
+        message, code = await executor.browser_web_tools._handle_http_probe({})
+        assert "http_probe error" in message
+        assert code != 0
 
     @pytest.mark.asyncio
     async def test_command_failure_with_output(self, executor):
@@ -933,13 +944,13 @@ class TestEdgeCases:
         cmd = build_http_probe_command({"url": "http://localhost:3000/health"})
         assert "http://localhost:3000/health" in cmd
 
-    def test_body_non_string_ignored(self):
-        cmd = build_http_probe_command({
-            "url": "https://example.com",
-            "method": "POST",
-            "body": 12345,
-        })
-        assert "-d" not in cmd
+    def test_body_non_string_rejected(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            build_http_probe_command({
+                "url": "https://example.com",
+                "method": "POST",
+                "body": 12345,
+            })
 
     def test_method_default_is_get(self):
         cmd = build_http_probe_command({"url": "https://example.com"})

--- a/tests/test_local_workspace.py
+++ b/tests/test_local_workspace.py
@@ -2071,8 +2071,11 @@ _CLASSIFIED_COMMAND_CALLERS: dict[tuple[str, str], str] = {
     ("src/tools/handlers/browser_web.py", "_handle_http_probe"): "fixed curl argv",
     ("src/tools/handlers/files_docs.py", "_handle_read_file"): "reads a caller-given path",
     ("src/tools/handlers/files_docs.py", "_handle_write_file"): "absolute path enforced",
-    ("src/tools/handlers/files_docs.py", "_handle_analyze_pdf"): "reads a caller-given path",
-    ("src/discord/native_tools/media.py", "_handle_analyze_image"): "base64 of a given path",
+
+    # analyze_pdf and analyze_image no longer appear here: they read host
+    # binaries through ssh.read_binary_file, not the text command pipeline,
+    # because base64 over that pipeline was truncated at MAX_OUTPUT_CHARS
+    # (adversarial review of v3.65.1).
     ("src/audit/diff_tracker.py", "capture_before"): "cat of a governed absolute path",
     # --- plumbing -----------------------------------------------------------
     ("src/tools/executor.py", "_run_on_host"): "CONDITIONAL",  # forwards its caller's decision

--- a/tests/test_native_media.py
+++ b/tests/test_native_media.py
@@ -206,6 +206,19 @@ class TestPostFile:
                 msg, {"host": "localhost", "path": str(f)})
 
 
+def _binary_image(data: bytes = b"", error: str = ""):
+    """Patch the BINARY host-read path used by analyze_image.
+
+    Host images used to arrive as base64 through the text pipeline, which
+    truncates at 16,000 chars — so anything over ~12KB was corrupt on arrival
+    (adversarial review of v3.65.1).
+    """
+    async def _read(address, path, **kwargs):
+        return (None, error) if error else (data, "")
+
+    return patch("src.tools.ssh.read_binary_file", _read)
+
+
 class TestAnalyzeImage:
     async def test_url_scheme_and_ssrf(self):
         assert "http://" in await _tools()._handle_analyze_image(_message(), {"url": "ftp://x"})
@@ -251,40 +264,55 @@ class TestAnalyzeImage:
                 _message(), {"url": "http://ok/x"})
 
     async def test_host_path(self):
-        ex = _executor(exec_ret=(0, base64.b64encode(PNG).decode()))
-        out = await _tools(tool_executor=ex)._handle_analyze_image(
-            _message(), {"host": "srv", "path": "/img.png"})
+        with _binary_image(PNG):
+            out = await _tools(tool_executor=_executor())._handle_analyze_image(
+                _message(), {"host": "srv", "path": "/img.png"})
         assert isinstance(out, dict) and "__image_block__" in out
 
     async def test_host_path_errors(self):
         assert "Unknown or disallowed host" in await _tools(
             tool_executor=_executor(resolve=None))._handle_analyze_image(
                 _message(), {"host": "h", "path": "/p"})
-        assert "Failed to read image" in await _tools(
-            tool_executor=_executor(exec_ret=(1, "err")))._handle_analyze_image(
-                _message(), {"host": "srv", "path": "/p"})
+        # Patched: without this the handler attempts a REAL ssh to the fake
+        # host and the test waits out a connection timeout.
+        with _binary_image(error="err"):
+            assert "Failed to read image" in await _tools(
+                tool_executor=_executor())._handle_analyze_image(
+                    _message(), {"host": "srv", "path": "/p"})
 
-    async def test_host_path_decode_error_and_empty(self):
-        # malformed base64 (wrong padding) from the host → decode raises → handled
-        assert "Failed to decode" in await _tools(
-            tool_executor=_executor(exec_ret=(0, "YQ")))._handle_analyze_image(
+    async def test_host_read_failure_and_empty(self):
+        # A read failure is reported with its reason (base64 decoding is gone:
+        # the binary path returns bytes, so there is nothing to mis-decode).
+        with _binary_image(error="permission denied"):
+            assert "Failed to read image from host" in await _tools(
+                tool_executor=_executor())._handle_analyze_image(
+                    _message(), {"host": "s", "path": "/p"})
+        with _binary_image(b""):
+            assert "No image data" in await _tools(
+                tool_executor=_executor())._handle_analyze_image(
+                    _message(), {"host": "s", "path": "/p"})
+
+    async def test_host_image_larger_than_the_text_transport(self):
+        """The defect: >12KB was truncated by the old base64-over-stdout path."""
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 60_000
+        with _binary_image(png):
+            out = await _tools(tool_executor=_executor())._handle_analyze_image(
                 _message(), {"host": "s", "path": "/p"})
-        # empty output decodes to no bytes
-        assert "No image data" in await _tools(
-            tool_executor=_executor(exec_ret=(0, "")))._handle_analyze_image(
-                _message(), {"host": "s", "path": "/p"})
+        assert "Failed to read" not in out and "No image data" not in out
 
     async def test_neither_source(self):
         assert "Provide either" in await _tools()._handle_analyze_image(_message(), {})
 
     async def test_size_and_format_limits(self):
         big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (5 * 1024 * 1024)
-        ex = _executor(exec_ret=(0, base64.b64encode(big).decode()))
-        assert "exceeds 5MB" in await _tools(tool_executor=ex)._handle_analyze_image(
-            _message(), {"host": "s", "path": "/p"})
-        ex2 = _executor(exec_ret=(0, base64.b64encode(b"notanimage!!").decode()))
-        assert "Unsupported image format" in await _tools(tool_executor=ex2)._handle_analyze_image(
-            _message(), {"host": "s", "path": "/p"})
+        with _binary_image(big):
+            assert "exceeds 5MB" in await _tools(
+                tool_executor=_executor())._handle_analyze_image(
+                    _message(), {"host": "s", "path": "/p"})
+        with _binary_image(b"notanimage!!"):
+            assert "Unsupported image format" in await _tools(
+                tool_executor=_executor())._handle_analyze_image(
+                    _message(), {"host": "s", "path": "/p"})
 
 
 class TestGenerateImage:

--- a/tests/test_schedule_workflow_validation.py
+++ b/tests/test_schedule_workflow_validation.py
@@ -1,0 +1,79 @@
+"""Workflow steps must obey ONE contract, on create and on update.
+
+Creation rejected empty and incomplete workflows; update did not, so an
+existing workflow could be updated to any of these and the invalid version was
+persisted (adversarial review of v3.65.1, reproduced):
+
+    []
+    [{"tool_name": "run_command", "tool_input": {}}]
+    [{"tool_name": "run_command"}]
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.scheduler.scheduler import Scheduler
+
+INVALID = [
+    pytest.param([], id="empty-list"),
+    pytest.param([{"tool_name": "run_command"}], id="no-tool-input"),
+    pytest.param([{"tool_name": "run_command", "tool_input": {}}], id="empty-tool-input"),
+    pytest.param([{"tool_input": {"command": "x"}}], id="no-tool-name"),
+    pytest.param("not-a-list", id="not-a-list"),
+]
+
+VALID = [{"tool_name": "run_command", "tool_input": {"command": "echo hi"}}]
+
+
+async def _scheduler(tmp_path) -> Scheduler:
+    return Scheduler(data_path=str(tmp_path / "schedules.json"))
+
+
+async def _workflow(sched: Scheduler) -> str:
+    created = await sched.add(
+        description="w", action="workflow", channel_id="1",
+        cron="0 0 * * *", steps=VALID,
+    )
+    return created["id"]
+
+
+@pytest.mark.parametrize("steps", INVALID)
+async def test_create_rejects_invalid_workflows(tmp_path, steps):
+    sched = await _scheduler(tmp_path)
+    with pytest.raises(ValueError):
+        await sched.add(
+            description="w", action="workflow", channel_id="1",
+            cron="0 0 * * *", steps=steps,
+        )
+
+
+@pytest.mark.parametrize("steps", INVALID)
+async def test_update_rejects_the_same_invalid_workflows(tmp_path, steps):
+    """The asymmetry itself: update must not accept what create rejects."""
+    sched = await _scheduler(tmp_path)
+    sid = await _workflow(sched)
+    with pytest.raises(ValueError):
+        await sched.update(sid, steps=steps)
+
+
+async def test_update_still_accepts_a_valid_workflow(tmp_path):
+    """The shared validator must not block legitimate edits."""
+    sched = await _scheduler(tmp_path)
+    sid = await _workflow(sched)
+    updated = await sched.update(
+        sid, steps=[{"tool_name": "run_command", "tool_input": {"command": "echo changed"}}]
+    )
+    assert updated is not None
+    assert updated["steps"][0]["tool_input"]["command"] == "echo changed"
+
+
+async def test_invalid_update_does_not_persist(tmp_path):
+    """A rejected update must leave the stored workflow untouched."""
+    sched = await _scheduler(tmp_path)
+    sid = await _workflow(sched)
+    with pytest.raises(ValueError):
+        await sched.update(sid, steps=[])
+    stored = await sched.get(sid) if hasattr(sched, "get") else None
+    if stored is not None:
+        assert stored["steps"] == VALID

--- a/tests/test_schedule_workflow_validation.py
+++ b/tests/test_schedule_workflow_validation.py
@@ -68,12 +68,74 @@ async def test_update_still_accepts_a_valid_workflow(tmp_path):
     assert updated["steps"][0]["tool_input"]["command"] == "echo changed"
 
 
-async def test_invalid_update_does_not_persist(tmp_path):
-    """A rejected update must leave the stored workflow untouched."""
+async def test_invalid_update_is_transactional(tmp_path):
+    """A rejected update must not partially mutate live state.
+
+    update() edits the stored dict in place. Before this pin, a description
+    supplied before invalid steps survived in memory and a later valid update
+    persisted it, despite the original call raising ValueError.
+    """
     sched = await _scheduler(tmp_path)
     sid = await _workflow(sched)
     with pytest.raises(ValueError):
-        await sched.update(sid, steps=[])
-    stored = await sched.get(sid) if hasattr(sched, "get") else None
-    if stored is not None:
-        assert stored["steps"] == VALID
+        await sched.update(sid, description="must not leak", steps=[])
+
+    stored = next(s for s in sched.list_all() if s["id"] == sid)
+    assert stored["description"] == "w"
+    assert stored["steps"] == VALID
+
+    # Prove a later save cannot serialize residue from the rejected update.
+    await sched.update(sid, paused=True)
+    reloaded = Scheduler(data_path=str(tmp_path / "schedules.json"))
+    persisted = next(s for s in reloaded.list_all() if s["id"] == sid)
+    assert persisted["description"] == "w"
+    assert persisted["steps"] == VALID
+
+
+async def test_invalid_timing_update_is_transactional(tmp_path):
+    sched = await _scheduler(tmp_path)
+    sid = await _workflow(sched)
+    before = next(s for s in sched.list_all() if s["id"] == sid)
+
+    with pytest.raises(ValueError, match="Invalid cron"):
+        await sched.update(sid, description="must not leak", cron="bad cron")
+
+    after = next(s for s in sched.list_all() if s["id"] == sid)
+    assert after["description"] == before["description"]
+    assert after["cron"] == before["cron"]
+    assert after["next_run"] == before["next_run"]
+
+
+async def test_failed_save_rolls_back_live_update(tmp_path, monkeypatch):
+    sched = await _scheduler(tmp_path)
+    sid = await _workflow(sched)
+
+    def _fail_save():
+        raise OSError("disk full")
+
+    monkeypatch.setattr(sched, "_save", _fail_save)
+    with pytest.raises(OSError, match="disk full"):
+        await sched.update(sid, description="must not remain")
+
+    stored = next(s for s in sched.list_all() if s["id"] == sid)
+    assert stored["description"] == "w"
+
+
+async def test_invalid_webhook_update_is_transactional(tmp_path):
+    sched = Scheduler(data_path=str(tmp_path / "schedules.json"))
+    created = await sched.add(
+        description="hook",
+        action="webhook",
+        channel_id="1",
+        cron="0 0 * * *",
+        webhook_config={"url": "https://example.com/hook"},
+    )
+    with pytest.raises(ValueError):
+        await sched.update(
+            created["id"],
+            description="must not leak",
+            webhook_config={"url": "file:///tmp/nope"},
+        )
+    stored = next(s for s in sched.list_all() if s["id"] == created["id"])
+    assert stored["description"] == "hook"
+    assert stored["webhook_config"]["url"] == "https://example.com/hook"

--- a/tests/test_scheduled_events.py
+++ b/tests/test_scheduled_events.py
@@ -57,11 +57,13 @@ def _handlers(**ov):
 class TestDigest:
     async def test_no_channel_id(self):
         h = _handlers()
-        await h._on_scheduled_digest({"id": "S1"})  # no channel_id → warn, no raise
+        with pytest.raises(RuntimeError, match="has no channel_id"):
+            await h._on_scheduled_digest({"id": "S1"})
 
     async def test_channel_not_found(self):
         h = _handlers(get_channel=lambda cid: None)
-        await h._on_scheduled_digest({"id": "S1", "channel_id": "1"})
+        with pytest.raises(RuntimeError, match="channel 1 not found"):
+            await h._on_scheduled_digest({"id": "S1", "channel_id": "1"})
 
     async def test_success_with_llm(self):
         ch = _channel()
@@ -94,8 +96,19 @@ class TestDigest:
         # force the raw collection itself to raise by breaking get_config
         h = _handlers(get_channel=lambda cid: ch,
                       get_config=MagicMock(side_effect=RuntimeError("cfg gone")))
-        await h._on_scheduled_digest({"id": "S1", "channel_id": "1"})
+        with pytest.raises(RuntimeError, match="Digest data collection failed"):
+            await h._on_scheduled_digest({"id": "S1", "channel_id": "1"})
         assert "Failed to collect data" in ch.send.await_args.args[0]
+
+    async def test_collect_failure_and_notice_delivery_failure_propagate(self):
+        ch = _channel()
+        ch.send = AsyncMock(side_effect=RuntimeError("discord down"))
+        h = _handlers(
+            get_channel=lambda cid: ch,
+            get_config=MagicMock(side_effect=RuntimeError("cfg gone")),
+        )
+        with pytest.raises(RuntimeError, match="failure notice delivery failed"):
+            await h._on_scheduled_digest({"id": "S1", "channel_id": "1"})
 
 
 class TestFormatDigestRaw:
@@ -235,13 +248,14 @@ class TestWorkflow:
             {"tool_name": "t1"}, {"tool_name": "t2"}, {"tool_name": "t3"}]})
         assert ok is True and "truncated" in ch.send.await_args.args[0]
 
-    async def test_workflow_send_error_swallowed(self):
+    async def test_workflow_send_error_propagates(self):
         ch = _channel()
         ch.send = AsyncMock(side_effect=RuntimeError("post failed"))
         h = _handlers()
-        ok = await h._run_scheduled_workflow(ch, {"description": "wf",
-                                                  "steps": [{"tool_name": "t"}]})
-        assert ok is True  # send failure swallowed
+        with pytest.raises(RuntimeError, match="Failed to post workflow results"):
+            await h._run_scheduled_workflow(
+                ch, {"description": "wf", "steps": [{"tool_name": "t"}]}
+            )
 
 
 class TestScheduleFailureAndTask:
@@ -276,7 +290,10 @@ class TestScheduleFailureAndTask:
 
     async def test_task_channel_not_found(self):
         h = _handlers(get_channel=lambda cid: None)
-        await h._on_scheduled_task({"id": "S1", "channel_id": "1", "action": "reminder"})
+        with pytest.raises(RuntimeError, match="channel 1 not found"):
+            await h._on_scheduled_task(
+                {"id": "S1", "channel_id": "1", "action": "reminder"}
+            )
 
     async def test_task_digest_dispatch(self):
         ch = _channel()
@@ -288,9 +305,11 @@ class TestScheduleFailureAndTask:
         ch = _channel()
         ch.send = AsyncMock(side_effect=RuntimeError("net"))
         h = _handlers(get_channel=lambda cid: ch)
-        await h._on_scheduled_task(
-            {"id": "S1", "channel_id": "1", "action": "reminder",
-             "message": "m", "description": "d"})  # swallowed
+        with pytest.raises(RuntimeError, match="Failed to send scheduled reminder"):
+            await h._on_scheduled_task(
+                {"id": "S1", "channel_id": "1", "action": "reminder",
+                 "message": "m", "description": "d"}
+            )
 
     async def test_task_check_fail_send_exception(self):
         # failing check tries to post the failure text; if that send raises it's
@@ -329,7 +348,8 @@ class TestScheduleFailureAndTask:
 
     async def test_task_no_channel_id(self):
         h = _handlers()
-        await h._on_scheduled_task({"id": "S1", "action": "reminder"})  # no channel_id
+        with pytest.raises(RuntimeError, match="has no channel_id"):
+            await h._on_scheduled_task({"id": "S1", "action": "reminder"})
 
     async def test_task_reminder(self):
         ch = _channel()
@@ -361,6 +381,8 @@ class TestScheduleFailureAndTask:
         await h._on_scheduled_task(
             {"id": "S1", "channel_id": "1", "action": "workflow", "description": "wf",
              "steps": [{"tool_name": "t1"}]})
-        # unknown action → warn, no send
         h2 = _handlers(get_channel=lambda cid: ch)
-        await h2._on_scheduled_task({"id": "S1", "channel_id": "1", "action": "mystery"})
+        with pytest.raises(RuntimeError, match="Unknown scheduled action"):
+            await h2._on_scheduled_task(
+                {"id": "S1", "channel_id": "1", "action": "mystery"}
+            )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -513,9 +513,10 @@ class TestSchedulerRetry:
 
         await s._tick()
 
-        # Schedule was one-time with no retries, so it's removed
-        # But let's test with cron to see state
-        s2 = _make_scheduler(tmp_path)
+        # Use an independent persistence file for the recurring case.
+        recurring_path = tmp_path / "recurring"
+        recurring_path.mkdir()
+        s2 = _make_scheduler(recurring_path)
         s2._callback = AsyncMock(side_effect=RuntimeError("disk full"))
         await s2.add("cron fail", "reminder", "chan1", cron="*/5 * * * *")
 
@@ -1242,3 +1243,44 @@ class TestSchedulerRunNow:
         entries = await s.history.query(sched["id"])
         assert len(entries) == 1
         assert entries[0]["status"] == "failure"
+
+
+class TestOneTimeDeliveryCorrectness:
+    async def test_failed_one_time_without_retries_survives_and_is_persisted(self, tmp_path):
+        s = _make_scheduler(tmp_path)
+        s._callback = AsyncMock(side_effect=RuntimeError("discord unavailable"))
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        sched = await s.add("keep me", "reminder", "chan1", run_at=past)
+
+        await s._tick()
+
+        remaining = s.list_all()
+        assert [item["id"] for item in remaining] == [sched["id"]]
+        assert remaining[0]["consecutive_failures"] == 1
+        assert remaining[0]["last_error"] == "discord unavailable"
+        assert "next_run" not in remaining[0]
+        reloaded = _make_scheduler(tmp_path)
+        assert [item["id"] for item in reloaded.list_all()] == [sched["id"]]
+        assert reloaded.list_all()[0]["last_error"] == "discord unavailable"
+        assert "next_run" not in reloaded.list_all()[0]
+        history = await s.history.query(sched["id"])
+        assert history[-1]["status"] == "failure"
+
+    async def test_failed_one_time_is_removed_after_later_success(self, tmp_path):
+        s = _make_scheduler(tmp_path)
+        callback = AsyncMock(side_effect=[RuntimeError("offline"), None])
+        s._callback = callback
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        sched = await s.add("eventually", "reminder", "chan1", run_at=past)
+
+        await s._tick()
+        assert s.list_all()[0]["last_error"] == "offline"
+        assert "next_run" not in s.list_all()[0]
+        await s._tick()
+        assert callback.await_count == 1
+
+        result = await s.run_now(sched["id"])
+        assert result["status"] == "success"
+        assert s.list_all() == []
+        history = await s.history.query(sched["id"])
+        assert [entry["status"] for entry in reversed(history)] == ["failure", "success"]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1229,6 +1229,37 @@ class TestSchedulerRunNow:
         assert len(entries) == 1
         assert entries[0]["status"] == "success"
 
+
+
+    async def test_tick_does_not_complete_one_time_already_in_flight(self, tmp_path):
+        s = _make_scheduler(tmp_path)
+        s._callback = AsyncMock()
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        sched = await s.add("busy tick", "reminder", "chan1", run_at=past)
+        s._in_flight.add(sched["id"])
+
+        await s._tick()
+
+        assert [item["id"] for item in s.list_all()] == [sched["id"]]
+        s._callback.assert_not_awaited()
+
+    async def test_run_now_does_not_complete_one_time_already_in_flight(self, tmp_path):
+        s = _make_scheduler(tmp_path)
+        s._callback = AsyncMock()
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        sched = await s.add("busy", "reminder", "chan1", run_at=future)
+        s._in_flight.add(sched["id"])
+
+        result = await s.run_now(sched["id"])
+
+        assert result == {
+            "status": "skipped",
+            "schedule_id": sched["id"],
+            "error": "schedule is already executing",
+        }
+        assert [item["id"] for item in s.list_all()] == [sched["id"]]
+        s._callback.assert_not_awaited()
+
     async def test_run_now_reports_failure(self, tmp_path):
         """run_now returns failure status when callback raises."""
         s = _make_scheduler(tmp_path)

--- a/tests/test_tool_catalog_dependency_gate.py
+++ b/tests/test_tool_catalog_dependency_gate.py
@@ -1,0 +1,27 @@
+"""Environment-gated tool-catalog coverage independent of installed extras."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.config.schema import Config
+from src.discord.tool_catalog import ToolCatalog
+
+
+def test_missing_pdf_dependency_is_hidden_with_actionable_log():
+    config = Config(discord={"token": "pin"}, permissions={"default_tier": "admin"})
+    catalog = ToolCatalog(
+        get_config=lambda: config,
+        skill_manager=MagicMock(get_tool_definitions=lambda: []),
+    )
+
+    with (
+        patch("src.discord.tool_catalog.importlib.util.find_spec", return_value=None),
+        patch("src.discord.tool_catalog.log.info") as info,
+    ):
+        names = {tool["name"] for tool in catalog.merged_definitions()}
+
+    assert "analyze_pdf" not in names
+    assert any(
+        "analyze_pdf hidden from the tool catalog" in str(call.args[0])
+        for call in info.call_args_list
+    )

--- a/tests/test_tool_failure_reporting.py
+++ b/tests/test_tool_failure_reporting.py
@@ -44,6 +44,22 @@ def _executor(tmp_path):
         # An action the tool does not implement is a failure, not a result.
         ("git_ops", {"action": "not_a_real_action", "host": "localhost"}, "Unknown git action"),
         ("manage_process", {"action": "not_a_real_action", "host": "localhost"}, "Unknown action"),
+        # Bad/missing process state was the original reproduction, not merely an
+        # unknown action. Every operation must preserve that failure status.
+        ("manage_process", {"action": "poll", "pid": 999_999_999}, "No process"),
+        (
+            "manage_process",
+            {"action": "write", "pid": 999_999_999, "input_text": "x"},
+            "No process",
+        ),
+        ("manage_process", {"action": "kill", "pid": 999_999_999}, "No process"),
+        ("http_probe", {"url": "https://example.com", "method": "TRACE"}, "http_probe error"),
+        (
+            "http_probe",
+            {"url": "https://example.com", "method": "POST", "body": "x" * 50_001},
+            "over the",
+        ),
+        ("analyze_pdf", {"url": "file:///tmp/nope.pdf"}, "Only http"),
     ],
 )
 async def test_failures_are_reported_as_failures(tmp_path, tool, params, needle):

--- a/tests/test_tool_failure_reporting.py
+++ b/tests/test_tool_failure_reporting.py
@@ -1,0 +1,74 @@
+"""Tool failures must be structurally reported as failures.
+
+The executor classifies a bare-string handler return by matching a short list
+of prose prefixes ("Error", "Command failed", ...). Any failure phrased
+differently was reported as ok=True with no exit code — so the model saw a
+success, workflows and schedules continued past the failed step, and the audit
+log recorded the action approved with no error.
+
+Found by adversarial review of v3.65.1 and reproduced through the real
+executor. These pins drive the PRODUCTION dispatch path, not the handlers
+directly, because the classification happens in the executor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.config.schema import ToolHost, ToolsConfig
+from src.tools.executor import ToolExecutor
+
+
+def _executor(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir(mode=0o700)
+    ex = ToolExecutor(
+        config=ToolsConfig(
+            local_working_dir=str(ws),
+            hosts={"localhost": ToolHost(address="127.0.0.1")},
+        )
+    )
+    ex._protected_roots = lambda: [str(tmp_path / "install")]
+    return ex
+
+
+@pytest.mark.parametrize(
+    "tool,params,needle",
+    [
+        # curl cannot connect: exit 7, status_code 000. Previously ok=True.
+        (
+            "http_probe",
+            {"url": "http://127.0.0.1:9/", "host": "localhost", "retries": 0, "timeout": 2},
+            "",
+        ),
+        # An action the tool does not implement is a failure, not a result.
+        ("git_ops", {"action": "not_a_real_action", "host": "localhost"}, "Unknown git action"),
+        ("manage_process", {"action": "not_a_real_action", "host": "localhost"}, "Unknown action"),
+    ],
+)
+async def test_failures_are_reported_as_failures(tmp_path, tool, params, needle):
+    result = await _executor(tmp_path).execute(tool, params)
+    assert result.ok is False, (
+        f"{tool} reported ok=True for a genuine failure — the model, the audit "
+        f"log and any workflow step would all treat this as success: {result.output!r}"
+    )
+    if needle:
+        assert needle in str(result.output)
+
+
+async def test_successful_probe_is_still_ok(tmp_path):
+    """The fix must not turn healthy probes into failures."""
+    result = await _executor(tmp_path).execute(
+        "http_probe", {"url": "https://odin-bot.net/", "host": "localhost", "timeout": 20}
+    )
+    assert result.ok is True, result.output
+    assert "status_code: 200" in str(result.output)
+
+
+async def test_browser_tools_report_disabled_as_failure(tmp_path):
+    """A disabled backend is not a successful page read."""
+    result = await _executor(tmp_path).execute(
+        "browser_read_page", {"url": "https://example.com"}
+    )
+    assert result.ok is False, result.output
+    assert "not enabled" in str(result.output)


### PR DESCRIPTION
Eight of the nine findings from Odin's adversarial review of `51c2dee`. Split between us and cross-reviewed: he took the three needing live harnesses, I took the four that are code-structural plus the binary-transport fix. Zero file overlap between our halves.

Every finding was **verified before being worked**, not taken on trust.

## Odin's half (browser, scheduler, git)

**F1 — browser redirect/subresource SSRF (high).** Browser tools validated only the initial URL; Chromium then followed redirects and loaded scripts, images, frames and fetches on its own. Every browser network request now routes through the already-hardened `safe_fetch`, which validates each hop and pins the connect IP so DNS rebinding cannot race the check. Service workers are blocked (they can issue requests outside normal routing), and a Playwright without WebSocket routing now **refuses to build a context** rather than silently leaving an unguarded path.

**F4 — failed reminder delivery recorded as success (high).** A failed Discord send was caught and logged; the scheduler then recorded `status: success` and deleted the one-time reminder. Delivery failures now propagate. A terminally failed one-time schedule is **retained but has `next_run` popped**, so it stays recoverable without re-firing on every tick, and is removed only after a confirmed later success.

**F9 — git positional refs could become options.** `checkout --help` printed the manual instead of checking out a target.

## My half

**F2 — tool failures reported as successes (high).** The executor classifies bare-string returns by matching five prose prefixes, so any failure worded differently arrived as `ok=True`: the model saw success, workflows and schedules continued past the failed step, and the audit log recorded the action approved with no error. Reproduced through the real executor:

```
http_probe unreachable   ok=True  exit=None  "curl: (7) Failed to connect..."
git_ops unknown action   ok=True  exit=None  "Unknown git action: ..."
manage_process bad pid   ok=True  exit=None  "Unknown action: status"
```

The executor already honours `(output, exit_code)`; the handlers weren't using it. `http_probe` now carries curl's exit code instead of discarding it, and browser-disabled, unknown actions and every `analyze_pdf` failure path return nonzero. New tests drive the **production dispatch path**, since that is where the misclassification lives.

**Scoped deliberately:** this fixes the confirmed cases and nets the class. It does *not* convert all 28 handlers to structured returns — that is an architectural change deserving its own PR, not a rider on this one.

**F3 — host binaries corrupted above ~12KB (high).** PDF and image host reads went through base64 over the text pipeline, which truncates at `MAX_OUTPUT_CHARS` (16,000) — so anything over ~12,000 source bytes failed to decode. The v3.65.1 soak only ever exercised the tiny-file branch. New `ssh.read_binary_file` returns raw bounded bytes: direct read locally, `cat --` over ssh remotely, oversize an explicit error rather than a short read. Verified at Odin's exact 20,853-byte reproduction size, and with 256-value binary content that the old `errors='replace'` decode would have corrupted.

**F6 — schedule updates accepted invalid workflows.** Create rejected them; update never checked emptiness at all. One shared validator now, which also requires the input a command tool actually needs.

**F7 — oversized HTTP bodies silently discarded.** Now rejected, matching the HEAD-body behaviour from v3.65.1. The old test pinned the silence and is replaced.

**F8 — `read_file(lines=-2)`** hit GNU `head`'s "all but the last N". Clamped to 1..1000.

## Not in this PR (one finding, F5)

- **F5 (issue_tracker advertised without a client)** needs a small plumbing decision — the catalog cannot see the executor's client today, so gating on live readiness requires wiring that is a design choice rather than a fix.

## Cross-review

I reviewed Odin's commits to full bar: read the whole diff, confirmed his `safe_fetch` calls match the existing contract exactly (he changed nothing there), and mutation-tested his fixes — removing the request guard, removing the WebSocket-routing refusal, or re-swallowing a delivery failure each fails a test. I also independently reproduced that a failed one-time reminder is now retained.

Two of my own guardrails fired during this work, which is what they are for:

- The caller-classification contract from #239 caught `analyze_pdf`/`analyze_image` no longer calling the command helpers, failing until their table entries were removed.
- Several existing tests were coupled to the *broken* transport and, once the fake stopped matching, began attempting **real SSH connections to a fake host** — one file spent 40s in connection timeouts. Now 0.51s.

## Verification

- Mutation-verified on both halves: seven distinct mutations each fail their test.
- Full suite: **7,706 passed / 5 skipped**.
- Gates: lint-no-new 0, types-no-new 0, coverage-no-drop 0, `git diff --check` clean, warnings back to the 119 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BDkRoJv6pTMTTYrh1SPzy
