### PR TITLE
Wait-aware polling + mention-aware resume trigger

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -79,6 +79,27 @@ def _wire_observability(health, bot, log) -> None:
     log.info("Observability wired: metric sources and component health checks registered")
 
 
+def _enable_process_containment(log) -> None:
+    """Become a child subreaper so escaped descendants stay ours.
+
+    Process-wide state, so it is set ONCE here at the application
+    boundary rather than by any library constructor. Without it, a
+    background descendant that double-forks and calls ``setsid()``
+    reparents to PID 1 and becomes unattributable — and the process
+    manager then refuses to claim its cleanup is complete (PR #244).
+    """
+    from .tools.process_manager import set_child_subreaper
+
+    if set_child_subreaper(True):
+        log.debug("Child-subreaper containment active")
+    else:
+        log.error(
+            "Could not become a child subreaper — escaped background "
+            "descendants would be unattributable; cleanup will refuse to "
+            "report success and in-place restarts will be blocked"
+        )
+
+
 def main() -> None:
     # ``--version`` short-circuit
     if "--version" in sys.argv or "-V" in sys.argv:
@@ -112,6 +133,7 @@ def main() -> None:
     )
     log = get_logger("main")
     log.info("Starting Odin")
+    _enable_process_containment(log)
 
     # STARTUP MIGRATION — must run after the real configuration is loaded and
     # before any command service begins.

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -10,6 +10,7 @@ between the two bots stays predictable.
 from __future__ import annotations
 
 import asyncio
+import os
 import signal
 import sys
 from pathlib import Path
@@ -88,7 +89,16 @@ def _enable_process_containment(log) -> None:
     reparents to PID 1 and becomes unattributable — and the process
     manager then refuses to claim its cleanup is complete (PR #244).
     """
-    from .tools.process_manager import set_child_subreaper
+    import secrets
+
+    from .tools.process_manager import PROC_TOKEN_ENV, set_child_subreaper
+
+    # Process-wide provenance: stamped into os.environ BEFORE any
+    # subprocess is spawned, so every child Odin creates inherits it and
+    # background-job cleanup can tell another subsystem's child (decided
+    # not-ours) from one that discarded its environment (ambiguous, fails
+    # closed).
+    os.environ.setdefault(PROC_TOKEN_ENV, secrets.token_hex(8))
 
     if set_child_subreaper(True):
         log.debug("Child-subreaper containment active")

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -132,6 +132,17 @@ def _enable_process_containment(log) -> bool:
 _FINALIZE_STEP_TIMEOUT = 3.0
 
 
+# Objects caught on the emergency path are parked here FOREVER — the
+# process exits moments later. CPython clears an `except ... as exc`
+# binding when the handler ends; if that drops the final reference, a
+# user-defined __del__ runs synchronously on the main thread BEFORE
+# os._exit is reached (round-22, reproduced on all three failure
+# paths). Parking keeps the reference alive so no finalizer can ever
+# run on this path. Never cleared, never capped: eviction would drop
+# references, which is exactly the hazard.
+_PARKED_FOR_EXIT: list[object] = []
+
+
 def _safe_repr(exc: BaseException) -> str:
     """Identity of ``exc`` without executing ANY of its code (round-21).
 
@@ -181,11 +192,13 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
     """
     owners_stopped = False
     failure = ""
+    pending: list = []
+    done: set = set()
+    refused: set = set()
     try:
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
         for task in pending:
             task.cancel()
-        refused: set = set()
         if pending:
             done, refused = loop.run_until_complete(
                 asyncio.wait(pending, timeout=_FINALIZE_STEP_TIMEOUT)
@@ -205,17 +218,22 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
                     asyncio.wait({hook}, timeout=_FINALIZE_STEP_TIMEOUT)
                 )
                 if hung:
+                    _PARKED_FOR_EXIT.append(hook)
                     failure = f"{label} shutdown did not finish"
                     break
                 if hook.exception() is not None:
                     # A hook that RAISED is as unproven as one that hung
                     # — asyncio.wait reports it done, but done-with-error
-                    # is not a completed barrier.
+                    # is not a completed barrier. Park the task: its
+                    # exception (and coroutine frame) must not be freed
+                    # on this path (round-22).
+                    _PARKED_FOR_EXIT.append(hook)
                     failure = f"{label} shutdown failed"
                     break
             else:
                 owners_stopped = True
     except Exception as exc:
+        _PARKED_FOR_EXIT.append(exc)  # a dropped ref could run __del__
         failure = "exception during loop drain: " + _safe_repr(exc)
     if not owners_stopped:
         # UNPROVEN verdict. From here to os._exit there must be NO
@@ -226,6 +244,10 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
         # veto record (restart.block_reexec logs), not even
         # loop.close() (pending-task warnings go through logging): the
         # caller's emergency path says all of it from a bounded scribe.
+        # The task collections are parked too — releasing them at frame
+        # exit would free coroutine frames whose locals can carry
+        # user-defined finalizers (round-22).
+        _PARKED_FOR_EXIT.extend((pending, done, refused))
         return failure or "owner barrier unproven"
     try:
         drained, verified = zombie_reaper.drain_at_teardown()
@@ -233,7 +255,9 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
         # A failing drain is a FAILURE VERDICT like any other: no
         # synchronous logging, no veto record here — a blocking handler
         # would hang the main thread before the emergency exit is
-        # reachable (round-20 #1). The reason travels to the scribe.
+        # reachable (round-20 #1). The reason travels to the scribe;
+        # the exception is parked so no __del__ fires here (round-22).
+        _PARKED_FOR_EXIT.append(exc)
         return "final zombie drain failed: " + _safe_repr(exc)
     if not verified:
         return "final zombie drain could not verify a clean process table"
@@ -267,7 +291,9 @@ def _finalize_and_exit(
         # unproven — resurfacing the exception would resurrect ordinary
         # interpreter shutdown and the round-17 hang with it. The repr
         # is guarded too: a broken __repr__ raising HERE would escape
-        # this very handler (round-20 #2).
+        # this very handler (round-20 #2), and the exception is parked
+        # so clearing this binding cannot run a __del__ (round-22).
+        _PARKED_FOR_EXIT.append(exc)
         failure = "finalize crashed: " + _safe_repr(exc)
     if failure is None:
         return
@@ -324,8 +350,8 @@ def _emergency_exit(log, exit_code: int, reason: str) -> None:
         )
         scribe.start()
         scribe.join(timeout=1.0)
-    except BaseException:  # noqa: BLE001 — os._exit is unconditional
-        pass
+    except BaseException as exc:  # noqa: BLE001 — os._exit is unconditional
+        _PARKED_FOR_EXIT.append(exc)
     os._exit(exit_code or 1)
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -132,7 +132,7 @@ def _enable_process_containment(log) -> bool:
 _FINALIZE_STEP_TIMEOUT = 3.0
 
 
-def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
+def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> bool:
     """Teardown tail in the exact round-15 §3.3 order.
 
     Drain before close: cancel stragglers, then run the loop's async
@@ -150,6 +150,12 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
     (``restart.block_reexec``): exec'ing over an unverified process
     table hands invisible survivors to the new image, while exiting
     lets the supervisor start clean and PID 1 reap whatever remains.
+
+    Returns True when the owner barrier completed (tasks, async
+    generators and the default executor all provably stopped). False
+    means unproven owners MAY include blocked non-daemon threads — the
+    caller must then leave via :func:`_finalize_and_exit`'s immediate
+    path, never via ordinary interpreter shutdown (round-17).
     """
     owners_stopped = False
     failure = ""
@@ -212,6 +218,42 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
         )
     loop.close()
     log.info("Odin stopped")
+    return owners_stopped
+
+
+def _finalize_and_exit(
+    loop, zombie_reaper: AdoptedZombieReaper, log, exit_code: int
+) -> None:
+    """Run the finalize barrier; on unproven owners, LEAVE immediately.
+
+    A genuinely blocked default-executor worker is a NON-DAEMON thread:
+    the bounded barrier correctly returns and vetoes re-exec, but
+    ordinary interpreter shutdown then joins that thread forever —
+    ``sys.exit`` never reaches the supervisor and systemd has to
+    SIGKILL (round-17, real-process repro RC=124). ``os._exit`` is the
+    exit path that does not rely on Python shutdown: buffers are
+    flushed explicitly, and skipping atexit is the point — nothing
+    behind an unproven barrier can be trusted to finish.
+
+    Returns normally when the barrier completed; the caller then owns
+    the ordinary restart/exit tail.
+    """
+    import logging
+
+    if _finalize_loop(loop, zombie_reaper, log):
+        return
+    log.error(
+        "Exiting without interpreter shutdown: unproven subprocess "
+        "owners may include blocked non-daemon threads"
+    )
+    for handler in logging.getLogger().handlers:
+        try:
+            handler.flush()
+        except Exception:
+            pass
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exit_code or 1)
 
 
 def main() -> None:
@@ -446,7 +488,7 @@ def main() -> None:
         except Exception:
             log.exception("Cleanup after fatal startup error failed")
     finally:
-        _finalize_loop(loop, zombie_reaper, log)
+        _finalize_and_exit(loop, zombie_reaper, log, exit_code)
 
     if restart.restart_requested():
         veto = restart.reexec_blocked()

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -122,6 +122,59 @@ def _enable_process_containment(log) -> bool:
     return False
 
 
+def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
+    """Teardown tail in the exact round-15 §3.3 order.
+
+    Drain before close: cancel stragglers, then run the loop's async
+    generator and default-executor shutdown hooks — closing without this
+    destroys still-pending work mid-await, and an in-place restart would
+    exec over half-finished writes. Only AFTER that barrier has every
+    subprocess owner provably stopped, so only then may the final
+    no-grace zombie drain run (a drain any earlier could consume an exit
+    status a still-running owner legitimately awaits — round-15
+    blocker #1).
+
+    Failure anywhere on this path VETOES the in-place re-exec
+    (``restart.block_reexec``): exec'ing over an unverified process
+    table hands invisible survivors to the new image, while exiting
+    lets the supervisor start clean and PID 1 reap whatever remains.
+    """
+    owners_stopped = False
+    try:
+        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True)
+            )
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(loop.shutdown_default_executor())
+        owners_stopped = True
+    except Exception:
+        log.exception("Event-loop drain failed")
+    if owners_stopped:
+        try:
+            drained, verified = zombie_reaper.drain_at_teardown()
+            if drained:
+                log.info("Reaped %d adopted zombie(s) at teardown", drained)
+            if not verified:
+                restart.block_reexec(
+                    "final zombie drain could not verify a clean process "
+                    "table"
+                )
+        except Exception:
+            log.exception("adopted-zombie teardown drain error")
+            restart.block_reexec("final zombie drain failed")
+    else:
+        restart.block_reexec(
+            "event-loop drain failed — subprocess owners not proven "
+            "stopped, final zombie drain skipped"
+        )
+    loop.close()
+    log.info("Odin stopped")
+
+
 def main() -> None:
     # ``--version`` short-circuit
     if "--version" in sys.argv or "-V" in sys.argv:
@@ -289,6 +342,15 @@ def main() -> None:
 
     async def shutdown() -> None:
         log.info("Shutting down…")
+        # Teardown order (PR #244 round-15 §3.3, step 1): stop the periodic
+        # reaper FIRST. The final no-grace drain does NOT run here — it runs
+        # in _finalize_loop, after remaining tasks, async generators and the
+        # default executor have all stopped, because only then has every
+        # subprocess owner provably finished.
+        try:
+            await zombie_reaper.stop()
+        except Exception:
+            log.exception("zombie reaper stop error")
         for label, action in (
             # The getattr-and-call lambdas short-circuit on absent/None
             # managers; mypy can't relate the getattr probe to the direct
@@ -319,18 +381,6 @@ def main() -> None:
             await health.stop()
         except Exception:
             log.exception("health stop error")
-        # Containment reparents escaped descendants to US, so nothing else
-        # will ever wait on them. Stop the periodic reaper, then drain once
-        # without grace — every subprocess-owning subsystem has closed by
-        # here, so no legitimate future wait remains and no zombie can
-        # survive an in-place execve.
-        try:
-            await zombie_reaper.stop()
-            drained = zombie_reaper.drain_at_teardown()
-            if drained:
-                log.info("Reaped %d adopted zombie(s) at teardown", drained)
-        except Exception:
-            log.exception("adopted-zombie teardown drain error")
 
     try:
         loop.run_until_complete(run())
@@ -357,24 +407,7 @@ def main() -> None:
         except Exception:
             log.exception("Cleanup after fatal startup error failed")
     finally:
-        # Drain before close: cancel stragglers, then run the loop's async
-        # generator and default-executor shutdown hooks. Closing without this
-        # destroys still-pending work mid-await — and an in-place restart
-        # would exec over half-finished writes.
-        try:
-            pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
-            for task in pending:
-                task.cancel()
-            if pending:
-                loop.run_until_complete(
-                    asyncio.gather(*pending, return_exceptions=True)
-                )
-            loop.run_until_complete(loop.shutdown_asyncgens())
-            loop.run_until_complete(loop.shutdown_default_executor())
-        except Exception:
-            log.exception("Event-loop drain failed")
-        loop.close()
-        log.info("Odin stopped")
+        _finalize_loop(loop, zombie_reaper, log)
 
     if restart.restart_requested():
         veto = restart.reexec_blocked()

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -132,6 +132,23 @@ def _enable_process_containment(log) -> bool:
 _FINALIZE_STEP_TIMEOUT = 3.0
 
 
+def _safe_repr(exc: BaseException) -> str:
+    """repr() that cannot raise (round-20 #2).
+
+    A failure reason is built INSIDE exception handlers on the
+    emergency path — a hostile or broken ``__repr__`` raising there
+    would escape the very guard that exists to make ``os._exit``
+    unconditional.
+    """
+    try:
+        return repr(exc)
+    except BaseException:
+        try:
+            return type(exc).__name__
+        except BaseException:
+            return "unrepresentable exception"
+
+
 def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
     """Teardown tail in the exact round-15 §3.3 order.
 
@@ -196,7 +213,7 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
             else:
                 owners_stopped = True
     except Exception as exc:
-        failure = f"exception during loop drain: {exc!r}"
+        failure = f"exception during loop drain: {_safe_repr(exc)}"
     if not owners_stopped:
         # UNPROVEN verdict. From here to os._exit there must be NO
         # synchronous I/O: a blocking logging handler would hang the
@@ -209,16 +226,16 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
         return failure or "owner barrier unproven"
     try:
         drained, verified = zombie_reaper.drain_at_teardown()
-        if drained:
-            log.info("Reaped %d adopted zombie(s) at teardown", drained)
-        if not verified:
-            restart.block_reexec(
-                "final zombie drain could not verify a clean process "
-                "table"
-            )
-    except Exception:
-        log.exception("adopted-zombie teardown drain error")
-        restart.block_reexec("final zombie drain failed")
+    except Exception as exc:
+        # A failing drain is a FAILURE VERDICT like any other: no
+        # synchronous logging, no veto record here — a blocking handler
+        # would hang the main thread before the emergency exit is
+        # reachable (round-20 #1). The reason travels to the scribe.
+        return f"final zombie drain failed: {_safe_repr(exc)}"
+    if not verified:
+        return "final zombie drain could not verify a clean process table"
+    if drained:
+        log.info("Reaped %d adopted zombie(s) at teardown", drained)
     loop.close()
     log.info("Odin stopped")
     return None
@@ -245,8 +262,10 @@ def _finalize_and_exit(
     except BaseException as exc:  # noqa: BLE001 — nothing may escape this path
         # Whatever leaked out of finalize, the process state is at best
         # unproven — resurfacing the exception would resurrect ordinary
-        # interpreter shutdown and the round-17 hang with it.
-        failure = f"finalize crashed: {exc!r}"
+        # interpreter shutdown and the round-17 hang with it. The repr
+        # is guarded too: a broken __repr__ raising HERE would escape
+        # this very handler (round-20 #2).
+        failure = f"finalize crashed: {_safe_repr(exc)}"
     if failure is None:
         return
     _emergency_exit(log, exit_code, failure)
@@ -271,16 +290,16 @@ def _emergency_exit(log, exit_code: int, reason: str) -> None:
     def _last_words() -> None:
         try:
             restart.block_reexec(
-                "event-loop drain failed — subprocess owners not proven "
-                f"stopped, final zombie drain skipped ({reason})"
+                "teardown could not prove a clean process state — "
+                f"in-place re-exec unsafe ({reason})"
             )
         except Exception:
             pass
         try:
             log.error(
-                "Event-loop drain incomplete (%s) — exiting without "
-                "interpreter shutdown: unproven subprocess owners may "
-                "include blocked non-daemon threads",
+                "Teardown unproven (%s) — exiting without interpreter "
+                "shutdown: state may include blocked non-daemon threads "
+                "or unreaped children",
                 reason,
             )
         except Exception:
@@ -302,7 +321,7 @@ def _emergency_exit(log, exit_code: int, reason: str) -> None:
         )
         scribe.start()
         scribe.join(timeout=1.0)
-    except Exception:
+    except BaseException:  # noqa: BLE001 — os._exit is unconditional
         pass
     os._exit(exit_code or 1)
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+import select
 import signal
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import NoReturn
 
 from src import restart
 from src.tools.process_manager import AdoptedZombieReaper
@@ -122,14 +126,21 @@ def _enable_process_containment(log) -> bool:
     return False
 
 
-# Per-step ceiling for the finalize barrier. Every await in
-# _finalize_loop is bounded by it: a cancellation-resistant task (or a
-# wedged executor thread) must never be able to hold teardown hostage —
-# an unbounded wait here made the final drain and the re-exec veto
-# UNREACHABLE (round-16 #2), which is the v3.62.3 shutdown-hang class
-# reinvented at the last barrier. Bounds only bite in that pathological
-# case; the normal path completes in milliseconds.
+# Cooperative per-step ceiling for the ordinary finalize barrier. It keeps
+# well-behaved async work bounded, but it is NOT a hard wall-clock guarantee:
+# cancellation may enter synchronous user code and prevent the loop from ever
+# servicing asyncio.wait()'s timeout (round-23 #2).
 _FINALIZE_STEP_TIMEOUT = 3.0
+
+# Hard process-level ceiling, armed in an isolated helper process BEFORE
+# finalization begins. The ordinary barrier has at most three cooperative 3s
+# phases (task drain, async generators, default executor); the remaining margin
+# covers the final zombie proof and clean close. If the main process blocks
+# anywhere — including with the GIL retained in cancellation/finalization or in
+# loop.close() — the helper SIGKILLs that exact incarnation via pidfd. This is
+# deliberately out-of-process: once teardown starts, no code in Odin's process
+# is trusted to make progress.
+_FINALIZE_WATCHDOG_TIMEOUT = 12.0
 
 
 # Objects caught on the emergency path are parked here FOREVER — the
@@ -175,9 +186,11 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
     status a still-running owner legitimately awaits — round-15
     blocker #1).
 
-    Every step is BOUNDED (``asyncio.wait`` returns at its timeout no
-    matter how cancellation-resistant a task is — ``gather`` does not),
-    and failure anywhere on this path VETOES the in-place re-exec
+    Cooperative steps use bounded ``asyncio.wait`` calls. They are backed by
+    the process-level watchdog armed by :func:`_finalize_and_exit`, because no
+    event-loop timeout can fire while cancellation/finalization is executing
+    blocking synchronous code (round-23). Failure anywhere on this path VETOES
+    the in-place re-exec
     (``restart.block_reexec``): exec'ing over an unverified process
     table hands invisible survivors to the new image, while exiting
     lets the supervisor start clean and PID 1 reap whatever remains.
@@ -268,22 +281,150 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
     return None
 
 
+_FINALIZE_WATCHDOG_PROGRAM = r"""
+import os
+import select
+import signal
+import sys
+
+control_fd = int(sys.argv[1])
+ready_fd = int(sys.argv[2])
+parent_pidfd = int(sys.argv[3])
+deadline = float(sys.argv[4])
+try:
+    os.write(ready_fd, b"R")
+    os.close(ready_fd)
+    readable, _, _ = select.select([control_fd], [], [], deadline)
+    if not readable:
+        signal.pidfd_send_signal(parent_pidfd, signal.SIGKILL)
+finally:
+    os._exit(0)
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class _FinalizeWatchdog:
+    """Kernel-backed finalization deadline and captured disarm primitives."""
+
+    control_fd: int
+    pid: int
+    hard_exit: Callable[[int], NoReturn]
+    write: Callable[[int, bytes], int]
+    close: Callable[[int], None]
+    waitpid: Callable[[int, int], tuple[int, int]]
+
+
+def _arm_finalize_watchdog(exit_code: int) -> _FinalizeWatchdog:
+    """Arm an out-of-process, GIL-independent finalization deadline.
+
+    A Python thread cannot be a hard wall-clock boundary: synchronous teardown
+    can retain the GIL forever. The isolated helper process owns a pidfd for
+    this exact parent incarnation and sends SIGKILL if the control pipe is not
+    disarmed before the deadline. The helper acknowledges startup before this
+    function returns, so finalize never begins without an active guard.
+
+    The helper does no logging or cleanup at expiry. Its signal is deliberately
+    uncatchable and pidfd-targeted, so user callbacks cannot intercept it and
+    PID reuse cannot redirect it. Arm failure exits immediately rather than
+    attempting unguarded finalization.
+    """
+    code = exit_code or 1
+    # Capture every primitive before teardown can run arbitrary callbacks.
+    hard_exit = os._exit
+    pipe = os.pipe
+    close = os.close
+    read = os.read
+    write = os.write
+    waitpid = os.waitpid
+    set_inheritable = os.set_inheritable
+    pidfd_open = os.pidfd_open
+    spawn = os.posix_spawn
+    select_ready = select.select
+    control_r = control_w = ready_r = ready_w = parent_pidfd = -1
+    try:
+        control_r, control_w = pipe()
+        ready_r, ready_w = pipe()
+        parent_pidfd = pidfd_open(os.getpid())
+        for fd in (control_r, ready_w, parent_pidfd):
+            set_inheritable(fd, True)
+        argv = (
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            _FINALIZE_WATCHDOG_PROGRAM,
+            str(control_r),
+            str(ready_w),
+            str(parent_pidfd),
+            str(_FINALIZE_WATCHDOG_TIMEOUT),
+        )
+        pid = spawn(sys.executable, argv, os.environ)
+        for fd in (control_r, ready_w, parent_pidfd):
+            close(fd)
+        control_r = ready_w = parent_pidfd = -1
+
+        readable, _, _ = select_ready([ready_r], [], [], 2.0)
+        if not readable or read(ready_r, 1) != b"R":
+            hard_exit(code)
+            raise AssertionError("os._exit returned")  # test doubles only
+        close(ready_r)
+        ready_r = -1
+        return _FinalizeWatchdog(
+            control_fd=control_w,
+            pid=pid,
+            hard_exit=hard_exit,
+            write=write,
+            close=close,
+            waitpid=waitpid,
+        )
+    except BaseException:  # noqa: BLE001 — no unguarded finalize is allowed
+        for fd in (control_r, control_w, ready_r, ready_w, parent_pidfd):
+            if fd >= 0:
+                try:
+                    close(fd)
+                except BaseException:
+                    pass
+        hard_exit(code)
+        raise AssertionError("os._exit returned")  # test doubles only
+
+
+def _disarm_finalize_watchdog(
+    watchdog: _FinalizeWatchdog, exit_code: int
+) -> None:
+    """Disarm and reap the helper after fully clean finalization.
+
+    Only captured C-backed primitives run here. Any failure is unsafe: a live
+    helper or uncertain child status must not be carried into ordinary exit or
+    in-place exec, so the already-captured hard exit is used.
+    """
+    try:
+        if watchdog.write(watchdog.control_fd, b"D") != 1:
+            watchdog.hard_exit(exit_code or 1)
+        watchdog.close(watchdog.control_fd)
+        waited, status = watchdog.waitpid(watchdog.pid, 0)
+        if waited != watchdog.pid or status != 0:
+            watchdog.hard_exit(exit_code or 1)
+    except BaseException:  # noqa: BLE001 — clean completion is now unprovable
+        watchdog.hard_exit(exit_code or 1)
+
+
 def _finalize_and_exit(
     loop, zombie_reaper: AdoptedZombieReaper, log, exit_code: int
 ) -> None:
-    """Run the finalize barrier; on unproven owners, LEAVE immediately.
+    """Run the finalize barrier under a pre-armed hard deadline.
 
     A genuinely blocked default-executor worker is a NON-DAEMON thread:
-    the bounded barrier correctly returns and vetoes re-exec, but
-    ordinary interpreter shutdown then joins that thread forever —
-    ``sys.exit`` never reaches the supervisor and systemd has to
-    SIGKILL (round-17, real-process repro RC=124). Skipping atexit is
-    the point — nothing behind an unproven barrier can be trusted to
-    finish.
+    ordinary interpreter shutdown joins it forever. More generally, arbitrary
+    finalizers may run while cancellation frames, completed task frames, or
+    loop callback handles are released. Those callbacks can block before the
+    cooperative barrier returns (round-23). The external watchdog is therefore
+    armed *before* any finalize work and remains armed until the entire clean
+    barrier has returned. It does not depend on event-loop progress.
 
-    Returns normally when the barrier completed; the caller then owns
-    the ordinary restart/exit tail.
+    Returns normally only when the complete barrier finished cleanly; the
+    caller then owns the ordinary restart/exit tail.
     """
+    watchdog = _arm_finalize_watchdog(exit_code)
     try:
         failure = _finalize_loop(loop, zombie_reaper, log)
     except BaseException as exc:  # noqa: BLE001 — nothing may escape this path
@@ -296,11 +437,21 @@ def _finalize_and_exit(
         _PARKED_FOR_EXIT.append(exc)
         failure = "finalize crashed: " + _safe_repr(exc)
     if failure is None:
+        _disarm_finalize_watchdog(watchdog, exit_code)
         return
-    _emergency_exit(log, exit_code, failure)
+    _emergency_exit(log, exit_code, failure, hard_exit=watchdog.hard_exit)
+    # os._exit never returns in production. Test doubles do; disarm there so a
+    # unit test cannot inherit a live watchdog that fires in a later test.
+    _disarm_finalize_watchdog(watchdog, exit_code)
 
 
-def _emergency_exit(log, exit_code: int, reason: str) -> None:
+def _emergency_exit(
+    log,
+    exit_code: int,
+    reason: str,
+    *,
+    hard_exit: Callable[[int], NoReturn] | None = None,
+) -> None:
     """Leave NOW, depending on no ordinary I/O whatsoever (round-18/19).
 
     Behind an unproven barrier even the last words are best-effort: a
@@ -315,6 +466,11 @@ def _emergency_exit(log, exit_code: int, reason: str) -> None:
     """
     import logging
     import threading
+
+    # Direct unit callers use the current function so their test double still
+    # works. _finalize_and_exit passes the pre-finalize captured C function,
+    # which hostile teardown callbacks cannot replace.
+    exit_now = hard_exit if hard_exit is not None else os._exit
 
     def _last_words() -> None:
         try:
@@ -352,7 +508,7 @@ def _emergency_exit(log, exit_code: int, reason: str) -> None:
         scribe.join(timeout=1.0)
     except BaseException as exc:  # noqa: BLE001 — os._exit is unconditional
         _PARKED_FOR_EXIT.append(exc)
-    os._exit(exit_code or 1)
+    exit_now(exit_code or 1)
 
 
 def main() -> None:

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -230,29 +230,61 @@ def _finalize_and_exit(
     the bounded barrier correctly returns and vetoes re-exec, but
     ordinary interpreter shutdown then joins that thread forever —
     ``sys.exit`` never reaches the supervisor and systemd has to
-    SIGKILL (round-17, real-process repro RC=124). ``os._exit`` is the
-    exit path that does not rely on Python shutdown: buffers are
-    flushed explicitly, and skipping atexit is the point — nothing
-    behind an unproven barrier can be trusted to finish.
+    SIGKILL (round-17, real-process repro RC=124). Skipping atexit is
+    the point — nothing behind an unproven barrier can be trusted to
+    finish.
 
     Returns normally when the barrier completed; the caller then owns
     the ordinary restart/exit tail.
     """
-    import logging
-
     if _finalize_loop(loop, zombie_reaper, log):
         return
-    log.error(
-        "Exiting without interpreter shutdown: unproven subprocess "
-        "owners may include blocked non-daemon threads"
-    )
-    for handler in logging.getLogger().handlers:
+    _emergency_exit(log, exit_code)
+
+
+def _emergency_exit(log, exit_code: int) -> None:
+    """Leave NOW, depending on no ordinary I/O whatsoever (round-18).
+
+    Behind an unproven barrier even the last words are best-effort: a
+    logging sink or stream flush can itself RAISE — or BLOCK forever on
+    a wedged pipe — and either kept ``os._exit`` from ever running (the
+    round-18 repro: a raising ``stdout.flush`` unwound into ordinary
+    interpreter shutdown, which then hung on the blocked worker until
+    SIGKILL). All output therefore happens in a daemon thread with a
+    bounded join: whatever it cannot say within the bound is abandoned
+    with it at exit, and the exit itself depends on nothing.
+    """
+    import logging
+    import threading
+
+    def _last_words() -> None:
         try:
-            handler.flush()
+            log.error(
+                "Exiting without interpreter shutdown: unproven "
+                "subprocess owners may include blocked non-daemon "
+                "threads"
+            )
         except Exception:
             pass
-    sys.stdout.flush()
-    sys.stderr.flush()
+        try:
+            flushes = [h.flush for h in logging.getLogger().handlers]
+            flushes += [sys.stdout.flush, sys.stderr.flush]
+        except Exception:
+            return
+        for flush in flushes:
+            try:
+                flush()
+            except Exception:
+                pass
+
+    try:
+        scribe = threading.Thread(
+            target=_last_words, name="emergency-exit-flush", daemon=True
+        )
+        scribe.start()
+        scribe.join(timeout=1.0)
+    except Exception:
+        pass
     os._exit(exit_code or 1)
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 from src import restart
+from src.tools.process_manager import AdoptedZombieReaper
 
 
 def _wire_observability(health, bot, log) -> None:
@@ -80,7 +81,7 @@ def _wire_observability(health, bot, log) -> None:
     log.info("Observability wired: metric sources and component health checks registered")
 
 
-def _enable_process_containment(log) -> None:
+def _enable_process_containment(log) -> bool:
     """Become a child subreaper so escaped descendants stay ours.
 
     Process-wide state, so it is set ONCE here at the application
@@ -111,12 +112,14 @@ def _enable_process_containment(log) -> None:
 
     if set_child_subreaper(True):
         log.debug("Child-subreaper containment active")
+        return True
     else:
         log.error(
             "Could not become a child subreaper — escaped background "
             "descendants would be unattributable; cleanup will refuse to "
             "report success and in-place restarts will be blocked"
         )
+    return False
 
 
 def main() -> None:
@@ -152,7 +155,11 @@ def main() -> None:
     )
     log = get_logger("main")
     log.info("Starting Odin")
-    _enable_process_containment(log)
+    containment = _enable_process_containment(log)
+    # Containment makes escaped descendants OURS, so we owe them a reaper:
+    # nothing else will wait on an adopted orphan, and without this they
+    # accumulate as zombies for the process lifetime (PR #244 soak).
+    zombie_reaper = AdoptedZombieReaper()
 
     # STARTUP MIGRATION — must run after the real configuration is loaded and
     # before any command service begins.
@@ -239,6 +246,8 @@ def main() -> None:
     async def run() -> None:
         nonlocal exit_code
         try:
+            if containment:
+                zombie_reaper.start()
             await health.start()
 
             async def _webhook_send(channel_id: str, text: str) -> None:
@@ -310,6 +319,18 @@ def main() -> None:
             await health.stop()
         except Exception:
             log.exception("health stop error")
+        # Containment reparents escaped descendants to US, so nothing else
+        # will ever wait on them. Stop the periodic reaper, then drain once
+        # without grace — every subprocess-owning subsystem has closed by
+        # here, so no legitimate future wait remains and no zombie can
+        # survive an in-place execve.
+        try:
+            await zombie_reaper.stop()
+            drained = zombie_reaper.drain_at_teardown()
+            if drained:
+                log.info("Reaped %d adopted zombie(s) at teardown", drained)
+        except Exception:
+            log.exception("adopted-zombie teardown drain error")
 
     try:
         loop.run_until_complete(run())

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -133,20 +133,23 @@ _FINALIZE_STEP_TIMEOUT = 3.0
 
 
 def _safe_repr(exc: BaseException) -> str:
-    """repr() that cannot raise (round-20 #2).
+    """Identity of ``exc`` without executing ANY of its code (round-21).
 
-    A failure reason is built INSIDE exception handlers on the
-    emergency path — a hostile or broken ``__repr__`` raising there
-    would escape the very guard that exists to make ``os._exit``
-    unconditional.
+    ``repr()``/``str()``/f-string interpolation all re-enter
+    user-controlled methods: a blocking ``__repr__`` hung the main
+    thread on the emergency path, and a repr returning a ``str``
+    SUBCLASS smuggled a hostile ``__format__`` into the f-string that
+    consumed it. ``object.__repr__`` is C-level — it never calls back
+    into the exception, reads the type's name from the type dict
+    without the descriptor protocol, and returns an EXACT ``str`` that
+    concatenates and formats inertly. The message (``args``) is
+    deliberately dropped: it is user-controlled data of user-controlled
+    type.
     """
     try:
-        return repr(exc)
+        return object.__repr__(exc)
     except BaseException:
-        try:
-            return type(exc).__name__
-        except BaseException:
-            return "unrepresentable exception"
+        return "unrepresentable exception"
 
 
 def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
@@ -213,7 +216,7 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
             else:
                 owners_stopped = True
     except Exception as exc:
-        failure = f"exception during loop drain: {_safe_repr(exc)}"
+        failure = "exception during loop drain: " + _safe_repr(exc)
     if not owners_stopped:
         # UNPROVEN verdict. From here to os._exit there must be NO
         # synchronous I/O: a blocking logging handler would hang the
@@ -231,7 +234,7 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
         # synchronous logging, no veto record here — a blocking handler
         # would hang the main thread before the emergency exit is
         # reachable (round-20 #1). The reason travels to the scribe.
-        return f"final zombie drain failed: {_safe_repr(exc)}"
+        return "final zombie drain failed: " + _safe_repr(exc)
     if not verified:
         return "final zombie drain could not verify a clean process table"
     if drained:
@@ -265,7 +268,7 @@ def _finalize_and_exit(
         # interpreter shutdown and the round-17 hang with it. The repr
         # is guarded too: a broken __repr__ raising HERE would escape
         # this very handler (round-20 #2).
-        failure = f"finalize crashed: {_safe_repr(exc)}"
+        failure = "finalize crashed: " + _safe_repr(exc)
     if failure is None:
         return
     _emergency_exit(log, exit_code, failure)

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -315,6 +315,17 @@ def main() -> None:
         log.info("Odin stopped")
 
     if restart.restart_requested():
+        veto = restart.reexec_blocked()
+        if veto:
+            # Teardown could not prove it terminated everything it owned
+            # (PR #244 round-8 #3). Exec would hand those survivors to the
+            # new image invisibly; exiting nonzero lets the supervisor
+            # start a clean one instead.
+            log.error(
+                "Restart requested but in-place re-exec is vetoed (%s) — "
+                "exiting for a supervisor restart instead", veto,
+            )
+            sys.exit(exit_code or 1)
         # In-place restart (self-update / setup wizard): replace the process
         # image instead of exiting so recovery does not depend on the unit's
         # Restart= policy. Exec failure exits nonzero — a clean-exit fallback

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -91,7 +91,12 @@ def _enable_process_containment(log) -> None:
     """
     import secrets
 
-    from .tools.process_manager import PROC_TOKEN_ENV, set_child_subreaper
+    from .tools.process_manager import (
+        DEFAULT_JOB_TOKEN,
+        JOB_TOKEN_ENV,
+        PROC_TOKEN_ENV,
+        set_child_subreaper,
+    )
 
     # Process-wide provenance: stamped into os.environ BEFORE any
     # subprocess is spawned, so every child Odin creates inherits it and
@@ -99,6 +104,10 @@ def _enable_process_containment(log) -> None:
     # not-ours) from one that discarded its environment (ambiguous, fails
     # closed).
     os.environ.setdefault(PROC_TOKEN_ENV, secrets.token_hex(8))
+    # Every child inherits a job token; background jobs override it with
+    # their own. A child that has the process marker but NO job token
+    # deleted it, which is tampering — not foreign ownership.
+    os.environ.setdefault(JOB_TOKEN_ENV, DEFAULT_JOB_TOKEN)
 
     if set_child_subreaper(True):
         log.debug("Child-subreaper containment active")

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -132,7 +132,7 @@ def _enable_process_containment(log) -> bool:
 _FINALIZE_STEP_TIMEOUT = 3.0
 
 
-def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> bool:
+def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> str | None:
     """Teardown tail in the exact round-15 §3.3 order.
 
     Drain before close: cancel stragglers, then run the loop's async
@@ -151,11 +151,13 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> bool:
     table hands invisible survivors to the new image, while exiting
     lets the supervisor start clean and PID 1 reap whatever remains.
 
-    Returns True when the owner barrier completed (tasks, async
-    generators and the default executor all provably stopped). False
-    means unproven owners MAY include blocked non-daemon threads — the
-    caller must then leave via :func:`_finalize_and_exit`'s immediate
-    path, never via ordinary interpreter shutdown (round-17).
+    Returns None when the owner barrier completed (tasks, async
+    generators and the default executor all provably stopped), else the
+    failure reason. An unproven verdict means owners MAY include
+    blocked non-daemon threads — the caller must then leave via the
+    emergency path, never via ordinary interpreter shutdown (round-17)
+    — and the unproven return path itself performs NO synchronous I/O,
+    not even logging or the veto record (round-19).
     """
     owners_stopped = False
     failure = ""
@@ -193,32 +195,33 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> bool:
                     break
             else:
                 owners_stopped = True
-        if failure:
-            log.error("Event-loop drain incomplete: %s", failure)
+    except Exception as exc:
+        failure = f"exception during loop drain: {exc!r}"
+    if not owners_stopped:
+        # UNPROVEN verdict. From here to os._exit there must be NO
+        # synchronous I/O: a blocking logging handler would hang the
+        # main thread before the emergency exit is ever reachable, and
+        # a raising one would unwind into ordinary interpreter shutdown
+        # — the exact round-17 hang again (round-19). No log line, no
+        # veto record (restart.block_reexec logs), not even
+        # loop.close() (pending-task warnings go through logging): the
+        # caller's emergency path says all of it from a bounded scribe.
+        return failure or "owner barrier unproven"
+    try:
+        drained, verified = zombie_reaper.drain_at_teardown()
+        if drained:
+            log.info("Reaped %d adopted zombie(s) at teardown", drained)
+        if not verified:
+            restart.block_reexec(
+                "final zombie drain could not verify a clean process "
+                "table"
+            )
     except Exception:
-        failure = "exception during loop drain"
-        log.exception("Event-loop drain failed")
-    if owners_stopped:
-        try:
-            drained, verified = zombie_reaper.drain_at_teardown()
-            if drained:
-                log.info("Reaped %d adopted zombie(s) at teardown", drained)
-            if not verified:
-                restart.block_reexec(
-                    "final zombie drain could not verify a clean process "
-                    "table"
-                )
-        except Exception:
-            log.exception("adopted-zombie teardown drain error")
-            restart.block_reexec("final zombie drain failed")
-    else:
-        restart.block_reexec(
-            "event-loop drain failed — subprocess owners not proven "
-            f"stopped, final zombie drain skipped ({failure})"
-        )
+        log.exception("adopted-zombie teardown drain error")
+        restart.block_reexec("final zombie drain failed")
     loop.close()
     log.info("Odin stopped")
-    return owners_stopped
+    return None
 
 
 def _finalize_and_exit(
@@ -237,32 +240,48 @@ def _finalize_and_exit(
     Returns normally when the barrier completed; the caller then owns
     the ordinary restart/exit tail.
     """
-    if _finalize_loop(loop, zombie_reaper, log):
+    try:
+        failure = _finalize_loop(loop, zombie_reaper, log)
+    except BaseException as exc:  # noqa: BLE001 — nothing may escape this path
+        # Whatever leaked out of finalize, the process state is at best
+        # unproven — resurfacing the exception would resurrect ordinary
+        # interpreter shutdown and the round-17 hang with it.
+        failure = f"finalize crashed: {exc!r}"
+    if failure is None:
         return
-    _emergency_exit(log, exit_code)
+    _emergency_exit(log, exit_code, failure)
 
 
-def _emergency_exit(log, exit_code: int) -> None:
-    """Leave NOW, depending on no ordinary I/O whatsoever (round-18).
+def _emergency_exit(log, exit_code: int, reason: str) -> None:
+    """Leave NOW, depending on no ordinary I/O whatsoever (round-18/19).
 
     Behind an unproven barrier even the last words are best-effort: a
-    logging sink or stream flush can itself RAISE — or BLOCK forever on
-    a wedged pipe — and either kept ``os._exit`` from ever running (the
-    round-18 repro: a raising ``stdout.flush`` unwound into ordinary
-    interpreter shutdown, which then hung on the blocked worker until
-    SIGKILL). All output therefore happens in a daemon thread with a
-    bounded join: whatever it cannot say within the bound is abandoned
-    with it at exit, and the exit itself depends on nothing.
+    logging HANDLER or stream flush can itself RAISE — or BLOCK forever
+    on a wedged pipe — and either kept ``os._exit`` from ever running
+    (round-18: a raising ``stdout.flush``; round-19: a blocking
+    ``log.error`` before the verdict even returned). ALL remaining
+    output — the veto record included, since ``restart.block_reexec``
+    logs — therefore happens in a daemon thread with a bounded join:
+    whatever it cannot say within the bound is abandoned with it at
+    exit, and the exit itself depends on nothing.
     """
     import logging
     import threading
 
     def _last_words() -> None:
         try:
+            restart.block_reexec(
+                "event-loop drain failed — subprocess owners not proven "
+                f"stopped, final zombie drain skipped ({reason})"
+            )
+        except Exception:
+            pass
+        try:
             log.error(
-                "Exiting without interpreter shutdown: unproven "
-                "subprocess owners may include blocked non-daemon "
-                "threads"
+                "Event-loop drain incomplete (%s) — exiting without "
+                "interpreter shutdown: unproven subprocess owners may "
+                "include blocked non-daemon threads",
+                reason,
             )
         except Exception:
             pass

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -122,6 +122,16 @@ def _enable_process_containment(log) -> bool:
     return False
 
 
+# Per-step ceiling for the finalize barrier. Every await in
+# _finalize_loop is bounded by it: a cancellation-resistant task (or a
+# wedged executor thread) must never be able to hold teardown hostage —
+# an unbounded wait here made the final drain and the re-exec veto
+# UNREACHABLE (round-16 #2), which is the v3.62.3 shutdown-hang class
+# reinvented at the last barrier. Bounds only bite in that pathological
+# case; the normal path completes in milliseconds.
+_FINALIZE_STEP_TIMEOUT = 3.0
+
+
 def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
     """Teardown tail in the exact round-15 §3.3 order.
 
@@ -134,24 +144,53 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
     status a still-running owner legitimately awaits — round-15
     blocker #1).
 
-    Failure anywhere on this path VETOES the in-place re-exec
+    Every step is BOUNDED (``asyncio.wait`` returns at its timeout no
+    matter how cancellation-resistant a task is — ``gather`` does not),
+    and failure anywhere on this path VETOES the in-place re-exec
     (``restart.block_reexec``): exec'ing over an unverified process
     table hands invisible survivors to the new image, while exiting
     lets the supervisor start clean and PID 1 reap whatever remains.
     """
     owners_stopped = False
+    failure = ""
     try:
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
         for task in pending:
             task.cancel()
+        refused: set = set()
         if pending:
-            loop.run_until_complete(
-                asyncio.gather(*pending, return_exceptions=True)
+            done, refused = loop.run_until_complete(
+                asyncio.wait(pending, timeout=_FINALIZE_STEP_TIMEOUT)
             )
-        loop.run_until_complete(loop.shutdown_asyncgens())
-        loop.run_until_complete(loop.shutdown_default_executor())
-        owners_stopped = True
+            for settled in done:
+                if not settled.cancelled():
+                    settled.exception()  # retrieve; parity with gather()
+        if refused:
+            failure = f"{len(refused)} task(s) survived cancellation"
+        else:
+            for label, factory in (
+                ("async-generator", loop.shutdown_asyncgens),
+                ("default-executor", loop.shutdown_default_executor),
+            ):
+                hook = loop.create_task(factory())
+                _done, hung = loop.run_until_complete(
+                    asyncio.wait({hook}, timeout=_FINALIZE_STEP_TIMEOUT)
+                )
+                if hung:
+                    failure = f"{label} shutdown did not finish"
+                    break
+                if hook.exception() is not None:
+                    # A hook that RAISED is as unproven as one that hung
+                    # — asyncio.wait reports it done, but done-with-error
+                    # is not a completed barrier.
+                    failure = f"{label} shutdown failed"
+                    break
+            else:
+                owners_stopped = True
+        if failure:
+            log.error("Event-loop drain incomplete: %s", failure)
     except Exception:
+        failure = "exception during loop drain"
         log.exception("Event-loop drain failed")
     if owners_stopped:
         try:
@@ -169,7 +208,7 @@ def _finalize_loop(loop, zombie_reaper: AdoptedZombieReaper, log) -> None:
     else:
         restart.block_reexec(
             "event-loop drain failed — subprocess owners not proven "
-            "stopped, final zombie drain skipped"
+            f"stopped, final zombie drain skipped ({failure})"
         )
     loop.close()
     log.info("Odin stopped")

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -812,7 +812,15 @@ class AgentTaskTools:
             content = result_text or error_text or "(no output)"
             if len(content) > 800:
                 content = content[:800] + "..."
-            lines.append(f"**{label}** (`{aid}`): {status}\n{content}")
+            # iterations is the stable progress marker for the wait-class
+            # stuck signature (PR #244 round-1): a silently-progressing
+            # agent must not render identically to a hung one. Runtime
+            # stays excluded — hashing elapsed time would make a hung
+            # agent immortal.
+            iters = r.get("iteration_count", 0)
+            lines.append(
+                f"**{label}** (`{aid}`): {status} [iterations={iters}]\n{content}"
+            )
 
         return "\n\n".join(lines) if lines else "No results."
 

--- a/src/discord/response_guards.py
+++ b/src/discord/response_guards.py
@@ -614,6 +614,12 @@ class StuckLoopTracker:
         """Number of iterations recorded so far."""
         return len(self._fingerprints)
 
+    @property
+    def last_fingerprint(self) -> str:
+        """The most recent fingerprint ('' when none) — lets entry-time
+        judgment of a RESTORED tracker pick the right nudge family."""
+        return self._fingerprints[-1] if self._fingerprints else ""
+
     def reset(self) -> None:
         """Clear all recorded iterations and the warned flag."""
         self._fingerprints.clear()

--- a/src/discord/response_guards.py
+++ b/src/discord/response_guards.py
@@ -686,7 +686,7 @@ def wait_target_alive(tool_name: str, result_text: str) -> bool:
     text = result_text or ""
     if tool_name == "manage_process":
         m = _WAIT_MP_STATUS.search(text)
-        return bool(m) and m.group(2) == "running"
+        return m is not None and m.group(2) == "running"
     return ": running" in text or "status=running" in text
 
 

--- a/src/discord/response_guards.py
+++ b/src/discord/response_guards.py
@@ -582,6 +582,18 @@ class StuckLoopTracker:
         fp = _fingerprint_tool_calls(tool_calls, names_only=self._names_only)
         self._fingerprints.append(fp)
 
+    def record_fingerprint(self, fingerprint: str) -> None:
+        """Record one iteration under a caller-computed fingerprint.
+
+        Used by the post-execution wait-class path: those iterations carry
+        a ``wait:``-prefixed result-aware fingerprint instead of the
+        argument fingerprint, in the SAME window and order — the prefix
+        keeps the two families disjoint so cross-comparisons can never
+        match ambiguously. Every iteration records exactly once, through
+        exactly one of these two methods.
+        """
+        self._fingerprints.append(fingerprint)
+
     def check(self) -> bool:
         """Return True if recent iterations form a stuck pattern."""
         fps = list(self._fingerprints)
@@ -606,6 +618,97 @@ class StuckLoopTracker:
         """Clear all recorded iterations and the warned flag."""
         self._fingerprints.clear()
         self.warned = False
+
+
+# ---------------------------------------------------------------------------
+# Wait-class iterations (design settled with Odin, 2026-07-31)
+# ---------------------------------------------------------------------------
+# An iteration consisting of EXACTLY ONE wait-class call (manage_process
+# poll / wait_for_agents) is judged on a RESULT-AWARE fingerprint after
+# execution instead of the argument-only pre-execution detector: identical
+# wait-polls are the CORRECT shape while the target progresses. Mixed
+# batches — a changing poll result must never bless a repeated
+# side-effecting call riding beside it — keep the strict detector.
+
+_WAIT_MP_STATUS = re.compile(
+    r"\[PID (\d+)\] status=(\w+)(?: exit_code=(-?\d+))?"
+    r"(?: uptime=\d+s)?(?: output_bytes=(\d+))?"
+)
+_WAIT_FP_PREFIX = "wait:"  # disjoint from argument fingerprints by prefix
+
+
+def is_wait_iteration(tool_calls: list[dict]) -> bool:
+    """True iff the iteration is exactly one wait-class call."""
+    if len(tool_calls) != 1:
+        return False
+    tc = tool_calls[0]
+    name = tc.get("name", "")
+    if name == "wait_for_agents":
+        return True
+    if name == "manage_process":
+        args = tc.get("input", tc.get("arguments", {})) or {}
+        return isinstance(args, dict) and args.get("action") == "poll"
+    return False
+
+
+def wait_iteration_fingerprint(tool_name: str, tool_input: dict, result_text: str) -> str:
+    """Canonical semantic progress signature for one wait-class call.
+
+    Volatile fields (uptime, runtimes, timestamps) are EXCLUDED — hashing
+    them would make a genuinely hung target immortal. Status transitions
+    and output-byte growth count as progress; a frozen signature three
+    iterations running means nothing is happening.
+    """
+    text = result_text or ""
+    if tool_name == "manage_process":
+        m = _WAIT_MP_STATUS.search(text)
+        if m:
+            pid, status, exit_code, out_bytes = m.groups()
+            return (
+                f"{_WAIT_FP_PREFIX}mp:{pid}:{status}:"
+                f"{exit_code or ''}:{out_bytes or ''}"
+            )
+        # Non-report results ("No process with PID …", executor errors)
+        # are stable text — identical failures repeating should trip.
+        digest = hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:16]
+        return f"{_WAIT_FP_PREFIX}mp-raw:{digest}"
+    # wait_for_agents: the rendered result is volatile-free by construction
+    # (label/status/content only — no runtimes or timestamps), so agent
+    # identity + a text digest is the semantic signature.
+    args_ids = tool_input.get("agent_ids") if isinstance(tool_input, dict) else None
+    ids = ",".join(str(a) for a in args_ids) if isinstance(args_ids, list) else ""
+    digest = hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:16]
+    return f"{_WAIT_FP_PREFIX}agents:{ids}:{digest}"
+
+
+def wait_target_alive(tool_name: str, result_text: str) -> bool:
+    """Whether the waited-on target is still running (drives nudge choice)."""
+    text = result_text or ""
+    if tool_name == "manage_process":
+        m = _WAIT_MP_STATUS.search(text)
+        return bool(m) and m.group(2) == "running"
+    return ": running" in text or "status=running" in text
+
+
+_WAIT_PROCESS_NUDGE = {
+    "role": "developer",
+    "content": (
+        "The process is still running but has produced NO new output since "
+        "your last poll. Do not repeat the identical poll immediately: poll "
+        "again with wait_seconds (60 is a good default), check on it a "
+        "different way (e.g. ps / CPU usage), do other useful work first, "
+        "or kill it if you judge it hung."
+    ),
+}
+
+_WAIT_AGENTS_NUDGE = {
+    "role": "developer",
+    "content": (
+        "The agents are still running with no new results. Wait again with "
+        "a meaningful timeout rather than immediately re-calling, or check "
+        "individual agents with get_agent_results."
+    ),
+}
 
 
 _STUCK_LOOP_RETRY_MSG = {

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -72,13 +72,18 @@ from .response_guards import (
     _HEDGING_RETRY_MSG,
     _PROMISE_RETRY_MSG,
     _TOOL_UNAVAIL_RETRY_MSG,
+    _WAIT_AGENTS_NUDGE,
+    _WAIT_PROCESS_NUDGE,
     detect_code_hedging,
     detect_fabrication,
     detect_hedging,
     detect_premature_failure,
     detect_promise_without_action,
     detect_tool_unavailable,
+    is_wait_iteration,
     truncate_tool_output,
+    wait_iteration_fingerprint,
+    wait_target_alive,
 )
 from .tool_loop_helpers import (
     _ALLOWED_WEBHOOK_IDS,
@@ -597,6 +602,20 @@ class ToolLoopRunner:
             if outcome is not None:
                 return outcome[1]
 
+            # Wait-class stuck judgment runs POST-execution, after WI-4 has
+            # checkpointed the settled batch — a confirmed-frozen kill never
+            # discards the result that proved the freeze (Odin's ordering,
+            # 2026-07-31).
+            outcome = await self._check_wait_stuck(st, tool_calls, tool_results)
+            if outcome is not None:
+                kind, val = outcome
+                if kind == "done":
+                    return val
+                # WI-5: the wait-aware nudge + consumed warned flag go
+                # durable before the retry generation.
+                await st.durability.on_guard_injection(st)
+                continue
+
             handoff = self._check_skill_handoff(st, tool_calls, tool_results)
             if handoff is not None:
                 return handoff[1]
@@ -979,6 +998,14 @@ class ToolLoopRunner:
                 reasoning_effort=getattr(llm_resp, "provenance_reasoning_effort", None),
             )
         )
+        if is_wait_iteration(iter_tool_calls):
+            # Deferred judgment (design settled with Odin, 2026-07-31):
+            # identical wait-polls are the CORRECT shape while the target
+            # progresses, and results do not exist yet at this point.
+            # _check_wait_stuck records a result-aware fingerprint for this
+            # iteration AFTER execution — exactly one record per iteration,
+            # same window, same order. Mixed batches never take this path.
+            return None
         st.stuck_tracker.record(iter_tool_calls)
         if st.stuck_tracker.check():
             if st.stuck_tracker.warned:
@@ -1021,6 +1048,86 @@ class ToolLoopRunner:
                 )
                 return ("retry", None)
         return None
+
+    async def _check_wait_stuck(self, st: _ChatTurn, tool_calls, tool_results):
+        """Post-execution stuck judgment for wait-class iterations.
+
+        Runs ONLY for an iteration that was exactly one wait-class call
+        (``_check_stuck_and_record`` deferred it). Records a ``wait:``-
+        prefixed result-aware fingerprint — status transitions and
+        output-byte growth are progress; a frozen signature is not — then
+        applies the same warn-once-then-terminate ladder. ``warned`` stays
+        one-shot: later progress never re-arms it.
+
+        Returns None to proceed, ("retry", None) after the wait-aware
+        nudge, or ("done", <run() return tuple>) on confirmed frozen
+        repetition.
+        """
+        iter_tool_calls = [
+            {"id": tc.id, "name": tc.name, "input": tc.input} for tc in tool_calls
+        ]
+        if not is_wait_iteration(iter_tool_calls):
+            return None
+        tc = tool_calls[0]
+        result_text = ""
+        for r in tool_results:
+            if isinstance(r, dict) and r.get("tool_use_id") == tc.id:
+                result_text = str(r.get("content", ""))
+                break
+        st.stuck_tracker.record_fingerprint(
+            wait_iteration_fingerprint(tc.name, tc.input or {}, result_text)
+        )
+        if not st.stuck_tracker.check():
+            return None
+        if st.stuck_tracker.warned:
+            log.warning(
+                "Frozen wait repetition confirmed after warning — terminating tool loop"
+            )
+            await self._turn_recorder._save_turn_trajectory(st._trajectory, trace=st.trace)
+            await self._turn_recorder._emit_lifecycle_event(
+                "loop.stuck",
+                {
+                    "channel_id": str(st.message.channel.id),
+                    "iteration": st.iteration,
+                    "tools_used": st.tools_used_in_loop,
+                },
+            )
+            self._clear_active(st)
+            return (
+                "done",
+                (
+                    (
+                        f"Stopped after {st.iteration + 1} iterations: repeated "
+                        f"waiting on {tc.name} with no observable progress "
+                        f"(no status change, no new output). The background "
+                        f"work itself was not touched."
+                    ),
+                    False,
+                    True,
+                    st.tools_used_in_loop,
+                    False,
+                ),
+            )
+        st.stuck_tracker.warned = True
+        if wait_target_alive(tc.name, result_text):
+            nudge = (
+                _WAIT_PROCESS_NUDGE if tc.name == "manage_process" else _WAIT_AGENTS_NUDGE
+            )
+            log.info("Frozen wait pattern detected (target alive) — injecting wait nudge")
+        else:
+            # Terminal/error results repeating: the target is NOT alive, so
+            # the wait-specific advice would be a lie — ordinary guidance.
+            nudge = {
+                "role": "developer",
+                "content": (
+                    "You are repeating the same call against a finished or "
+                    "missing target and getting the same result. Act on the "
+                    "result you already have, or report and stop."
+                ),
+            }
+            log.info("Frozen wait pattern detected (target not alive) — injecting nudge")
+        st.messages.append(dict(nudge))
+        return ("retry", None)
 
     async def _finalize_or_retry(self, st: _ChatTurn, llm_resp):
         """The text-only-response branch: validation enforcement, the

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -598,23 +598,27 @@ class ToolLoopRunner:
 
             tool_results = await self._execute_tool_calls(st, tool_calls)
 
+            # Wait-class fingerprints record BEFORE WI-4 so the checkpoint
+            # carries the stuck observation with the result it observed;
+            # judgment (nudge/kill) runs only AFTER WI-4 succeeded — a
+            # confirmed-frozen kill never discards the result that proved
+            # the freeze, and a crash never forgets it (PR #244 round-1).
+            wait_iteration = self._record_wait_fingerprint(st, tool_calls, tool_results)
+
             outcome = await self._post_iteration(st, tool_calls, tool_results)
             if outcome is not None:
                 return outcome[1]
 
-            # Wait-class stuck judgment runs POST-execution, after WI-4 has
-            # checkpointed the settled batch — a confirmed-frozen kill never
-            # discards the result that proved the freeze (Odin's ordering,
-            # 2026-07-31).
-            outcome = await self._check_wait_stuck(st, tool_calls, tool_results)
-            if outcome is not None:
-                kind, val = outcome
-                if kind == "done":
-                    return val
-                # WI-5: the wait-aware nudge + consumed warned flag go
-                # durable before the retry generation.
-                await st.durability.on_guard_injection(st)
-                continue
+            if wait_iteration:
+                outcome = await self._judge_wait_stuck(st, tool_calls, tool_results)
+                if outcome is not None:
+                    kind, val = outcome
+                    if kind == "done":
+                        return val
+                    # WI-5: the wait-aware nudge + consumed warned flag go
+                    # durable before the retry generation.
+                    await st.durability.on_guard_injection(st)
+                    continue
 
             handoff = self._check_skill_handoff(st, tool_calls, tool_results)
             if handoff is not None:
@@ -1049,34 +1053,51 @@ class ToolLoopRunner:
                 return ("retry", None)
         return None
 
-    async def _check_wait_stuck(self, st: _ChatTurn, tool_calls, tool_results):
-        """Post-execution stuck judgment for wait-class iterations.
+    @staticmethod
+    def _wait_result_text(tool_calls, tool_results) -> str:
+        tc = tool_calls[0]
+        for r in tool_results:
+            if isinstance(r, dict) and r.get("tool_use_id") == tc.id:
+                return str(r.get("content", ""))
+        return ""
 
-        Runs ONLY for an iteration that was exactly one wait-class call
-        (``_check_stuck_and_record`` deferred it). Records a ``wait:``-
-        prefixed result-aware fingerprint — status transitions and
-        output-byte growth are progress; a frozen signature is not — then
-        applies the same warn-once-then-terminate ladder. ``warned`` stays
-        one-shot: later progress never re-arms it.
+    def _record_wait_fingerprint(self, st: _ChatTurn, tool_calls, tool_results) -> bool:
+        """Record (ONLY record) the result-aware fingerprint for a
+        wait-class iteration. Runs BEFORE WI-4 so the checkpoint carries
+        the stuck observation — a crash after the settled batch must not
+        restore the result while forgetting what it proved (PR #244
+        round-1 blocker #1). Judgment and termination are deferred to
+        ``_judge_wait_stuck``, which runs only after WI-4 succeeded.
 
-        Returns None to proceed, ("retry", None) after the wait-aware
-        nudge, or ("done", <run() return tuple>) on confirmed frozen
-        repetition.
+        Returns True iff this was a wait-class iteration.
         """
         iter_tool_calls = [
             {"id": tc.id, "name": tc.name, "input": tc.input} for tc in tool_calls
         ]
         if not is_wait_iteration(iter_tool_calls):
-            return None
+            return False
         tc = tool_calls[0]
-        result_text = ""
-        for r in tool_results:
-            if isinstance(r, dict) and r.get("tool_use_id") == tc.id:
-                result_text = str(r.get("content", ""))
-                break
         st.stuck_tracker.record_fingerprint(
-            wait_iteration_fingerprint(tc.name, tc.input or {}, result_text)
+            wait_iteration_fingerprint(
+                tc.name, tc.input or {}, self._wait_result_text(tool_calls, tool_results)
+            )
         )
+        return True
+
+    async def _judge_wait_stuck(self, st: _ChatTurn, tool_calls, tool_results):
+        """Post-checkpoint stuck judgment for a wait-class iteration whose
+        fingerprint ``_record_wait_fingerprint`` already recorded.
+
+        Status transitions and output-byte growth are progress; a frozen
+        signature walks the same warn-once-then-terminate ladder.
+        ``warned`` stays one-shot: later progress never re-arms it.
+
+        Returns None to proceed, ("retry", None) after the wait-aware
+        nudge, or ("done", <run() return tuple>) on confirmed frozen
+        repetition.
+        """
+        tc = tool_calls[0]
+        result_text = self._wait_result_text(tool_calls, tool_results)
         if not st.stuck_tracker.check():
             return None
         if st.stuck_tracker.warned:

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -548,6 +548,14 @@ class ToolLoopRunner:
         Starts from ``st.iteration``: 0 for a fresh turn (unchanged), the
         interrupted generation's index for a resumed one — the restored
         transcript already carries everything before it."""
+        entry_outcome = await self._judge_entry_stuck(st)
+        if entry_outcome is not None:
+            kind, val = entry_outcome
+            if kind == "done":
+                return val
+            # WI-5: the entry nudge + consumed warned flag go durable
+            # before the first generation consumes them.
+            await st.durability.on_guard_injection(st)
         for iteration in range(st.iteration, st.chat_cap):
             st.iteration = iteration
             if st._cancel.is_set():
@@ -1052,6 +1060,76 @@ class ToolLoopRunner:
                 )
                 return ("retry", None)
         return None
+
+    async def _judge_entry_stuck(self, st: _ChatTurn):
+        """Judge a tracker that is ALREADY tripped at loop entry.
+
+        The wait fingerprint is recorded before WI-4 but judged after it —
+        a crash in that window restores a tripped tracker whose judgment
+        never ran (PR #244 round-2 blocker #2). Without this, the resumed
+        turn gets a free generation-plus-poll before the ladder acts.
+        A fresh turn's tracker is empty, so this is a no-op everywhere
+        except that restored window. ``warned`` semantics are identical to
+        in-turn judgment: consumed flag → terminate with zero generations;
+        unconsumed → nudge before the first generation.
+        """
+        if not st.stuck_tracker.check():
+            return None
+        last_fp = st.stuck_tracker.last_fingerprint
+        if st.stuck_tracker.warned:
+            log.warning(
+                "Restored tracker already confirmed-stuck — terminating before generation"
+            )
+            await self._turn_recorder._save_turn_trajectory(st._trajectory, trace=st.trace)
+            await self._turn_recorder._emit_lifecycle_event(
+                "loop.stuck",
+                {
+                    "channel_id": str(st.message.channel.id),
+                    "iteration": st.iteration,
+                    "tools_used": st.tools_used_in_loop,
+                },
+            )
+            self._clear_active(st)
+            return (
+                "done",
+                (
+                    (
+                        "Stopped on resume: the preserved iterations were already "
+                        "repeating with no observable progress and the warning was "
+                        "already consumed. The background work itself was not touched."
+                    ),
+                    False,
+                    True,
+                    st.tools_used_in_loop,
+                    False,
+                ),
+            )
+        st.stuck_tracker.warned = True
+        if last_fp.startswith("wait:mp"):
+            # Alive-ness rides IN the fingerprint (wait:mp:<pid>:<status>:…).
+            parts = last_fp.split(":")
+            alive = len(parts) > 3 and parts[3] == "running"
+            nudge = dict(_WAIT_PROCESS_NUDGE) if alive else {
+                "role": "developer",
+                "content": (
+                    "You are repeating the same call against a finished or "
+                    "missing target and getting the same result. Act on the "
+                    "result you already have, or report and stop."
+                ),
+            }
+        elif last_fp.startswith("wait:"):
+            nudge = dict(_WAIT_AGENTS_NUDGE)
+        else:
+            nudge = {
+                "role": "developer",
+                "content": (
+                    "You appear to be repeating the same tool-call sequence. "
+                    "Try a different approach or summarise progress and stop."
+                ),
+            }
+        log.info("Restored tracker tripped at entry — injecting nudge before generation")
+        st.messages.append(nudge)
+        return ("retry", None)
 
     @staticmethod
     def _wait_result_text(tool_calls, tool_results) -> str:

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -324,6 +324,13 @@ class _ChatTurn:
     hedging_retried: bool = False
     code_hedging_retried: bool = False
     premature_failure_retried: bool = False
+    # True between a wait-class fingerprint's WI-4 (recorded) and its
+    # judgment (nudge/kill/clear). Persisted: a crash in that window must
+    # resume INTO the judgment — while a nudge already delivered before a
+    # later suspension must NOT be re-judged into a zero-generation kill
+    # (PR #244 round-3 blocker #1: the phase is explicit, never inferred
+    # from historical fingerprints).
+    wait_judgment_pending: bool = False
     pending_image_blocks: list = field(default_factory=list)
     _op_tool_details: list = field(default_factory=list)
     _pending_validations: list = field(default_factory=list)
@@ -1062,17 +1069,22 @@ class ToolLoopRunner:
         return None
 
     async def _judge_entry_stuck(self, st: _ChatTurn):
-        """Judge a tracker that is ALREADY tripped at loop entry.
+        """Complete a PENDING wait judgment at loop entry.
 
         The wait fingerprint is recorded before WI-4 but judged after it —
         a crash in that window restores a tripped tracker whose judgment
-        never ran (PR #244 round-2 blocker #2). Without this, the resumed
-        turn gets a free generation-plus-poll before the ladder acts.
-        A fresh turn's tracker is empty, so this is a no-op everywhere
-        except that restored window. ``warned`` semantics are identical to
-        in-turn judgment: consumed flag → terminate with zero generations;
-        unconsumed → nudge before the first generation.
+        never ran (round-2 blocker #2). The pending phase is EXPLICIT
+        persisted state, never inferred from historical fingerprints
+        (round-3 blocker #1): a nudge already delivered before a later
+        suspension resumes with the phase clear and gets its post-nudge
+        generation — only a genuinely undelivered judgment is completed
+        here. ``warned`` semantics are identical to in-turn judgment:
+        consumed flag → terminate with zero generations; unconsumed →
+        nudge before the first generation.
         """
+        if not st.wait_judgment_pending:
+            return None
+        st.wait_judgment_pending = False
         if not st.stuck_tracker.check():
             return None
         last_fp = st.stuck_tracker.last_fingerprint
@@ -1117,17 +1129,11 @@ class ToolLoopRunner:
                     "result you already have, or report and stop."
                 ),
             }
-        elif last_fp.startswith("wait:"):
-            nudge = dict(_WAIT_AGENTS_NUDGE)
         else:
-            nudge = {
-                "role": "developer",
-                "content": (
-                    "You appear to be repeating the same tool-call sequence. "
-                    "Try a different approach or summarise progress and stop."
-                ),
-            }
-        log.info("Restored tracker tripped at entry — injecting nudge before generation")
+            # Pending is set only by wait iterations, so the last
+            # fingerprint is always wait:* — mp handled above, agents here.
+            nudge = dict(_WAIT_AGENTS_NUDGE)
+        log.info("Pending wait judgment tripped at entry — injecting nudge before generation")
         st.messages.append(nudge)
         return ("retry", None)
 
@@ -1160,6 +1166,9 @@ class ToolLoopRunner:
                 tc.name, tc.input or {}, self._wait_result_text(tool_calls, tool_results)
             )
         )
+        # Explicit pending-judgment phase (round-3 blocker #1): rides the
+        # same WI-4 as the fingerprint; cleared by the judgment itself.
+        st.wait_judgment_pending = True
         return True
 
     async def _judge_wait_stuck(self, st: _ChatTurn, tool_calls, tool_results):
@@ -1176,6 +1185,10 @@ class ToolLoopRunner:
         """
         tc = tool_calls[0]
         result_text = self._wait_result_text(tool_calls, tool_results)
+        # Judgment is happening NOW — the pending phase ends whatever the
+        # outcome (the retry path persists this via WI-5; the no-trip path
+        # via the next WI-4; the kill is terminal).
+        st.wait_judgment_pending = False
         if not st.stuck_tracker.check():
             return None
         if st.stuck_tracker.warned:

--- a/src/discord/turn_resume.py
+++ b/src/discord/turn_resume.py
@@ -66,6 +66,7 @@ class TurnResumeManager:
         fetch_message: Callable,
         auto_resume_enabled: bool = True,
         resume_ttl_hours: float = 24.0,
+        get_bot_user: Callable | None = None,
     ) -> None:
         self._store = store
         self._tool_loop = tool_loop
@@ -79,6 +80,8 @@ class TurnResumeManager:
         self._fetch_message = fetch_message  # async (channel_id, message_id) -> msg|None
         self._auto_resume_enabled = auto_resume_enabled
         self._resume_ttl_hours = resume_ttl_hours
+        # Live root (None-tolerant): the bot user exists only after login.
+        self._get_bot_user = get_bot_user
         self._waiters: dict[TurnKey, asyncio.Task] = {}
 
     # ── queries ──────────────────────────────────────────────────────
@@ -252,7 +255,29 @@ class TurnResumeManager:
 
     @staticmethod
     def is_resume_trigger(content: str) -> bool:
+        # Deliberately exact: the bare command word, tolerating only trailing
+        # `!`/`.` — sentences containing "resume"/"continue" are never
+        # commands. This contract predates the mention tolerance below and
+        # is preserved unchanged.
         return (content or "").strip().lower().rstrip("!.") in RESUME_TRIGGERS
+
+    def _resume_candidate(self, raw: str) -> str:
+        """The lexical text a resume trigger is recognized against.
+
+        Mention-required channels force ``@bot resume``, so ONE leading
+        anchored bot mention is stripped before matching. Anchored only:
+        ``resume @bot`` (mention elsewhere) must NOT become a command, which
+        is why this never reuses intake's strip-anywhere cleaned content.
+        Identity/admission checks elsewhere keep the raw message untouched.
+        """
+        user = self._get_bot_user() if self._get_bot_user is not None else None
+        if user is None:
+            return raw
+        stripped = raw.lstrip()
+        for mention in (f"<@{user.id}>", f"<@!{user.id}>"):
+            if stripped.startswith(mention):
+                return stripped[len(mention):]
+        return raw
 
     @staticmethod
     def _unresolved_ops(row: dict) -> list[dict]:
@@ -284,7 +309,7 @@ class TurnResumeManager:
         normal turn.
         """
         content = getattr(message, "content", "") or ""
-        if not self.is_resume_trigger(content):
+        if not self.is_resume_trigger(self._resume_candidate(content)):
             return None
         # From lexical trigger recognition onward, every store read lives
         # inside this no-raise boundary. In particular, failure of the

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -914,15 +914,18 @@ async def shutdown_services(bot) -> None:
     if process_registry is not None:
         try:
             await process_registry.shutdown()
-        except ProcessCleanupError:
-            # Teardown could not PROVE the owned session is empty (PR #244
-            # round-7 #3). Surfaced at ERROR with the registry's detail
-            # rather than swallowed as ordinary noise: an in-place re-exec
-            # after this may inherit surviving descendants.
+        except ProcessCleanupError as cleanup_err:
+            # Teardown could not PROVE the owned session is empty. Reported
+            # loudly AND used to VETO the in-place re-exec (round-8 #3):
+            # exec would hand the survivors to the new image invisibly.
+            # The rest of teardown still runs.
             log.exception(
                 "Process cleanup could not be verified — surviving "
                 "descendants may outlive this process"
             )
+            from ..restart import block_reexec
+
+            block_reexec(f"process cleanup unverified: {cleanup_err}")
         except Exception:
             log.exception("Error shutting down process_registry")
 

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -817,6 +817,7 @@ def build_components(bot, services: BotServices) -> BotComponents:
             fetch_message=_fetch_message,
             auto_resume_enabled=bot.config.turn_state.auto_resume,
             resume_ttl_hours=bot.config.turn_state.resume_ttl_hours,
+            get_bot_user=lambda: bot.user,
         )
         # Late instance-attr wiring: the runner exists before the manager
         # (the manager needs the runner), so the suspension callback is

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -48,6 +48,7 @@ from ..search import LocalEmbedder, SessionVectorStore
 from ..sessions import SessionManager
 from ..tools import SkillManager, ToolExecutor
 from ..tools.autonomous_loop import LoopManager
+from ..tools.process_manager import ProcessCleanupError
 from ..tools.workspace import DEFAULT_MEMORY_PATH
 from ..trajectories.saver import TrajectorySaver
 from ..turn_state import TurnStateStore
@@ -913,6 +914,15 @@ async def shutdown_services(bot) -> None:
     if process_registry is not None:
         try:
             await process_registry.shutdown()
+        except ProcessCleanupError:
+            # Teardown could not PROVE the owned session is empty (PR #244
+            # round-7 #3). Surfaced at ERROR with the registry's detail
+            # rather than swallowed as ordinary noise: an in-place re-exec
+            # after this may inherit surviving descendants.
+            log.exception(
+                "Process cleanup could not be verified — surviving "
+                "descendants may outlive this process"
+            )
         except Exception:
             log.exception("Error shutting down process_registry")
 

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -914,20 +914,24 @@ async def shutdown_services(bot) -> None:
     if process_registry is not None:
         try:
             await process_registry.shutdown()
-        except ProcessCleanupError as cleanup_err:
-            # Teardown could not PROVE the owned session is empty. Reported
-            # loudly AND used to VETO the in-place re-exec (round-8 #3):
-            # exec would hand the survivors to the new image invisibly.
-            # The rest of teardown still runs.
+        except Exception as cleanup_err:
+            # ANY process-registry teardown failure vetoes the in-place
+            # re-exec (round-9 #2): an unexpected error is exactly as
+            # unproven as an explicit ProcessCleanupError, and exec would
+            # hand survivors to the new image invisibly. The rest of
+            # teardown still runs.
             log.exception(
                 "Process cleanup could not be verified — surviving "
                 "descendants may outlive this process"
             )
             from ..restart import block_reexec
 
-            block_reexec(f"process cleanup unverified: {cleanup_err}")
-        except Exception:
-            log.exception("Error shutting down process_registry")
+            detail = (
+                str(cleanup_err)
+                if isinstance(cleanup_err, ProcessCleanupError)
+                else f"{type(cleanup_err).__name__}: {cleanup_err}"
+            )
+            block_reexec(f"process cleanup unverified: {detail}")
 
     knowledge = getattr(bot, "knowledge", None)
     if knowledge is not None:

--- a/src/restart.py
+++ b/src/restart.py
@@ -17,8 +17,13 @@ import os
 import sys
 from typing import NoReturn
 
+from .odin_log import get_logger
+
+log = get_logger("restart")
+
 _requested: bool = False
 _env_overrides: dict[str, str] = {}
+_reexec_blocked: str | None = None
 
 
 def request_restart(env_overrides: dict[str, str] | None = None) -> None:
@@ -41,6 +46,24 @@ def restart_requested() -> bool:
     return _requested
 
 
+def block_reexec(reason: str) -> None:
+    """Veto the in-place restart (PR #244 round-8 #3).
+
+    Teardown that cannot PROVE it terminated everything it owned must not
+    be followed by ``execve``: the new image would inherit surviving
+    descendants of the old one with no record of them. The process exits
+    instead, so the supervisor starts a clean image.
+    """
+    global _reexec_blocked
+    _reexec_blocked = reason
+    log.error("In-place restart vetoed: %s", reason)
+
+
+def reexec_blocked() -> str | None:
+    """The veto reason, or None when re-exec may proceed."""
+    return _reexec_blocked
+
+
 def pending_env_overrides() -> dict[str, str]:
     """Copy of the exec-time environment overrides (inspection/test hook)."""
     return dict(_env_overrides)
@@ -48,8 +71,9 @@ def pending_env_overrides() -> dict[str, str]:
 
 def reset() -> None:
     """Clear restart state (test hygiene)."""
-    global _requested
+    global _requested, _reexec_blocked
     _requested = False
+    _reexec_blocked = None
     _env_overrides.clear()
 
 

--- a/src/tools/defs/channel_process_loops.py
+++ b/src/tools/defs/channel_process_loops.py
@@ -77,7 +77,10 @@ TOOLS_SECTION: list[dict] = [
         "description": (
             "Manages background processes (start/poll/write/kill/list). "
             "Start spawns a command, returns PID. Poll gets output. Write sends stdin. "
-            "Max 20 concurrent, auto-killed after 1hr."
+            "Max 20 concurrent, auto-killed after 1hr. When monitoring a "
+            "long-running process (build, test suite, download), poll with "
+            "wait_seconds (60 is a good default) — one call waits server-side "
+            "until exit or the deadline, instead of many rapid polls."
         ),
         "input_schema": {
             "type": "object",
@@ -102,6 +105,14 @@ TOOLS_SECTION: list[dict] = [
                 "input_text": {
                     "type": "string",
                     "description": "Text to send to stdin (required for write)",
+                },
+                "wait_seconds": {
+                    "type": "number",
+                    "description": (
+                        "Poll only: wait up to this many seconds (0-120) for "
+                        "the process to exit before reporting. 0 (default) "
+                        "reports immediately. Exit ends the wait early."
+                    ),
                 },
             },
             "required": ["action"],

--- a/src/tools/handlers/system.py
+++ b/src/tools/handlers/system.py
@@ -19,6 +19,7 @@ import os
 import shlex
 
 from ..branch_freshness import is_test_command, is_test_failure
+from ..process_manager import MAX_POLL_WAIT_SECONDS
 from ..tool_text import _ERROR_RESULT_PREFIXES, _truncate_lines
 from .deps import HandlerBase
 
@@ -264,7 +265,24 @@ class SystemTools(HandlerBase):
             pid = inp.get("pid")
             if pid is None:
                 return "pid is required for poll action.", 1
-            result = registry.poll(int(pid))
+            wait_raw = inp.get("wait_seconds", 0)
+            # Reject invalid values rather than clamping — a silently-moved
+            # wait surprises the caller (same rule as reasoning-effort
+            # validation). bool is an int subtype and is nonsense here.
+            if (
+                isinstance(wait_raw, bool)
+                or not isinstance(wait_raw, (int, float))
+                or wait_raw != wait_raw  # NaN
+                or wait_raw in (float("inf"), float("-inf"))
+                or wait_raw < 0
+                or wait_raw > MAX_POLL_WAIT_SECONDS
+            ):
+                return (
+                    f"wait_seconds must be a number between 0 and "
+                    f"{MAX_POLL_WAIT_SECONDS}, got {wait_raw!r}.",
+                    1,
+                )
+            result = await registry.poll(int(pid), wait_seconds=float(wait_raw))
             if result.startswith("No process with PID"):
                 return result, 1
             return result, 0

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -640,6 +640,25 @@ def _proc_starttime(pid: int) -> int | None:
         return None
 
 
+def _proc_live_starttime(pid: int) -> int | None:
+    """Starttime of a LIVE (non-zombie) incarnation, else None.
+
+    A zombie still shows its starttime until it is reaped, so starttime
+    alone cannot distinguish "this process is alive" from "this is a
+    corpse awaiting reap" (round-16 #1: a cached ssh-master record must
+    not treat its own zombie as proof of liveness — the replacement
+    master would silently bypass registration and leak until teardown).
+    """
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_bytes()
+        rest = raw.rsplit(b")", 1)[1].split()
+        if rest[0] == b"Z":
+            return None
+        return int(rest[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
 def _proc_session(pid: int) -> int | None | str:
     """Session id alone (see :func:`_proc_ids` for the sentinel contract)."""
     ids = _proc_ids(pid)

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -22,6 +22,10 @@ log = get_logger("process_manager")
 MAX_CONCURRENT = 20
 MAX_LIFETIME_SECONDS = 3600  # 1 hour
 OUTPUT_BUFFER_LINES = 500
+# Ceiling for one poll's server-side wait: comfortably under the executor's
+# 300s per-tool wall (an unbounded wait would die THERE as a tool error).
+# Monitoring longer work = chained poll calls, each ≤ this.
+MAX_POLL_WAIT_SECONDS = 120.0
 # Upper bound on awaiting an in-flight group reap at shutdown before giving up
 # and cancelling it — comfortably exceeds a reader's TERM-grace + KILL-grace so
 # a compliant descendant always finishes, while a wedged one can't hang re-exec.
@@ -41,6 +45,10 @@ class ProcessInfo:
     process: asyncio.subprocess.Process | None = None
     _reader_task: asyncio.Task | None = field(default=None, repr=False)
     exit_code: int | None = None
+    # Monotonic progress signal: total bytes ever read from the process,
+    # NOT bounded by the ring buffer — a full ring of repeated lines can
+    # look frozen while output is still arriving; this counter cannot.
+    total_output_bytes: int = 0
 
 
 class ProcessRegistry:
@@ -131,11 +139,38 @@ class ProcessRegistry:
         log.info("Started process PID %d: %s", pid, command[:80])
         return f"Process started (PID {pid}): {command[:120]}"
 
-    def poll(self, pid: int) -> str:
-        """Return recent output lines from a process."""
+    async def poll(self, pid: int, wait_seconds: float = 0.0) -> str:
+        """Return recent output lines from a process.
+
+        ``wait_seconds > 0`` waits server-side until the process EXITS or
+        the deadline elapses, then reports — never an error, never a wake
+        on intermediate output (early-output wakeup would return almost
+        immediately on a streaming build and defeat the purpose; design
+        settled with Odin, 2026-07-31). A terminal process reports
+        immediately. Cancellation aborts only this wait — the detached
+        process is never touched.
+        """
         info = self._processes.get(pid)
         if not info:
             return f"No process with PID {pid}."
+
+        if wait_seconds > 0 and info.status == "running" and info.process is not None:
+            try:
+                await asyncio.wait_for(info.process.wait(), timeout=wait_seconds)
+            except asyncio.TimeoutError:
+                pass  # deadline reached — report current state
+            else:
+                # The process exited during the wait: give the reader task a
+                # bounded moment to drain the tail and settle status/exit_code
+                # so the report reflects the terminal state, not a torn one.
+                # Shielded — OUR bound must not cancel the reader itself.
+                if info._reader_task is not None:
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.shield(info._reader_task), timeout=5.0
+                        )
+                    except asyncio.TimeoutError:
+                        pass
 
         lines = list(info.output_buffer)
         status_line = f"[PID {pid}] status={info.status}"
@@ -143,6 +178,7 @@ class ProcessRegistry:
             status_line += f" exit_code={info.exit_code}"
         elapsed = time.time() - info.start_time
         status_line += f" uptime={elapsed:.0f}s"
+        status_line += f" output_bytes={info.total_output_bytes}"
 
         if not lines:
             return f"{status_line}\n(no output yet)"
@@ -276,6 +312,7 @@ class ProcessRegistry:
                 line = await info.process.stdout.readline()
                 if not line:
                     break
+                info.total_output_bytes += len(line)
                 info.output_buffer.append(line.decode("utf-8", errors="replace"))
         except Exception:
             pass

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -67,48 +67,71 @@ def _utf8_boundary_split(buf: bytes) -> tuple[bytes, bytes]:
 
 
 
-def _stat_fields(pid: int) -> tuple[int, int] | None:
+def _stat_fields(pid: int) -> tuple[int, int] | None | str:
     """(pgrp, session) from /proc/<pid>/stat, parsed after the comm parens
-    (comm may embed spaces/parens). None when the process vanished."""
+    (comm may embed spaces/parens).
+
+    Returns None when the process is provably GONE (ENOENT/malformed —
+    a vanished process is not a member), or the sentinel ``"unknown"``
+    when inspection FAILED for another reason, which the caller must
+    treat as an incomplete scan rather than as absence (round-6 #2).
+    """
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
+    except FileNotFoundError:
+        return None  # exited between listdir and read — genuinely gone
+    except OSError:
+        return "unknown"  # EMFILE/EACCES/… — we do NOT know
+    try:
         rest = stat.rsplit(")", 1)[1].split()
         return int(rest[2]), int(rest[3])
-    except (OSError, IndexError, ValueError):
+    except (IndexError, ValueError):
         return None
 
 
-def _pinned_group_members(pgid: int) -> list[tuple[int, int]]:
+def _scan_group_members(pgid: int) -> tuple[list[tuple[int, int]], bool]:
     """Enumerate the group's members, each PINNED with a pidfd.
 
-    The pin happens BEFORE membership is verified, so the verification and
-    every later signal act on the exact process the fd names — pid reuse
-    between steps is structurally impossible (PR #244 round-5 blocker #2).
-    Membership = pgrp == pgid AND session == pgid: our leader was spawned
-    with start_new_session, its descendants inherit that session, and
-    setpgid cannot move a foreign process into it (same-session rule).
-    Candidates that cannot be pinned or verified are skipped — fail-safe.
-    Caller owns the returned fds.
+    Returns ``(pinned, complete)``. The pin happens BEFORE membership is
+    verified, so verification and every later signal act on the exact
+    process the fd names — pid reuse between steps is structurally
+    impossible (round-5 #2). Membership = pgrp == session == pgid: our
+    leader was spawned with start_new_session, its descendants inherit
+    that session, and setpgid cannot move a foreign process into it.
+
+    ``complete`` is False whenever ANY candidate could not be inspected
+    or pinned for a reason other than "it exited" — an unreadable /proc
+    or an fd-exhausted pidfd_open must never be mistaken for an empty
+    group (round-6 #2). Caller owns the returned fds.
     """
     pinned: list[tuple[int, int]] = []
     try:
         entries = os.listdir("/proc")
     except OSError:
-        return pinned
+        return pinned, False
+    complete = True
     for entry in entries:
         if not entry.isdigit():
             continue
         pid = int(entry)
         try:
             fd = os.pidfd_open(pid)
+        except ProcessLookupError:
+            continue  # exited — not a member
         except OSError:
+            # EMFILE/ENFILE/EPERM: we could not pin it, so its membership
+            # is UNKNOWN unless the process is provably gone.
+            if _stat_fields(pid) is not None:
+                complete = False
             continue
         fields = _stat_fields(pid)
-        if fields is not None and fields == (pgid, pgid):
+        if fields == (pgid, pgid):
             pinned.append((pid, fd))
-        else:
-            os.close(fd)
-    return pinned
+            continue
+        if fields == "unknown":
+            complete = False
+        os.close(fd)
+    return pinned, complete
 
 
 def _signal_pinned(pinned: list[tuple[int, int]], sig: int) -> None:
@@ -127,30 +150,6 @@ def _close_pinned(pinned: list[tuple[int, int]]) -> None:
             pass
 
 
-async def _reap_group_racefree(pgid: int, grace: float = 2.0) -> None:
-    """TERM → bounded grace → KILL for every surviving group member,
-    delivered exclusively through pinned pidfds. Replaces killpg for the
-    post-leader-exit sweeps, where a numeric pgid can go stale."""
-    pinned = _pinned_group_members(pgid)
-    if not pinned:
-        return
-    try:
-        _signal_pinned(pinned, signal.SIGTERM)
-        deadline = time.monotonic() + grace
-        while time.monotonic() < deadline:
-            if all(_stat_fields(pid) is None or os.path.exists(f"/proc/{pid}") is False
-                   for pid, _fd in pinned):
-                break
-            # pidfds poll readable at exit; a cheap sleep-poll keeps this
-            # dependency-free and the bound tight.
-            await asyncio.sleep(0.1)
-            if all(_pidfd_exited(fd) for _pid, fd in pinned):
-                break
-        _signal_pinned(pinned, signal.SIGKILL)
-    finally:
-        _close_pinned(pinned)
-
-
 def _pidfd_exited(fd: int) -> bool:
     """A pidfd polls readable exactly when its process has exited."""
     import select
@@ -162,15 +161,40 @@ def _pidfd_exited(fd: int) -> bool:
         return True
 
 
-def _kill_group_racefree_sync(pgid: int) -> int:
-    """Immediate SIGKILL of every pinned member — the synchronous
-    last-resort used by the shutdown barrier. Returns members signalled."""
-    pinned = _pinned_group_members(pgid)
-    try:
-        _signal_pinned(pinned, signal.SIGKILL)
-        return len(pinned)
-    finally:
-        _close_pinned(pinned)
+async def _terminate_group_until_empty(
+    pgid: int, *, grace: float = 2.0, timeout: float = 10.0, term_first: bool = True
+) -> bool:
+    """Drive an owned process group to provably empty.
+
+    Every pass RE-ENUMERATES (round-6 #1): a TERM handler that forks a
+    fresh same-session child is caught by the next pass, where a
+    one-shot pinned set would miss it entirely. TERM is offered once per
+    pid (when ``term_first``), then the passes escalate to KILL, which
+    cannot be caught or forked around.
+
+    Returns True ONLY on an affirmative observation of an empty group
+    from a COMPLETE scan — an unreadable /proc or fd exhaustion returns
+    False, never a false success (round-6 #2).
+    """
+    deadline = time.monotonic() + timeout
+    termed: set[int] = set()
+    escalate_at = time.monotonic() + grace if term_first else 0.0
+    while True:
+        pinned, complete = _scan_group_members(pgid)
+        try:
+            if complete and not pinned:
+                return True
+            if term_first and time.monotonic() < escalate_at:
+                fresh = [(p, fd) for p, fd in pinned if p not in termed]
+                _signal_pinned(fresh, signal.SIGTERM)
+                termed.update(p for p, _fd in fresh)
+            else:
+                _signal_pinned(pinned, signal.SIGKILL)
+        finally:
+            _close_pinned(pinned)
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0.1)
 
 
 async def _wait_leader_exit(
@@ -508,39 +532,36 @@ class ProcessRegistry:
     # ------------------------------------------------------------------
 
     async def _kill_group_until_gone(
-        self, info: ProcessInfo, timeout: float = 6.0
+        self, info: ProcessInfo, timeout: float = 8.0
     ) -> bool:
         """Bounded, race-free termination of everything we still own.
 
-        The shutdown completion barrier (round-4 #1, hardened round-5 #1):
-        repeatedly pin the surviving group members by pidfd, SIGKILL them,
-        and re-enumerate until the group is empty or the bound elapses —
-        every signal aimed at a process pinned BEFORE its membership was
-        verified, so pid reuse cannot misdirect one. The leader is reaped
-        in the same loop so no zombie crosses the exec.
+        The shutdown completion barrier: drive the owned session empty
+        with repeated COMPLETE enumeration (fork-on-signal descendants
+        are caught by the next pass) and reap the leader, then return
+        only on an AFFIRMATIVE observation — an unreadable /proc or fd
+        exhaustion yields False, never assumed success (round-6).
 
-        Returns True when the group is provably gone. A False return is
-        LOUD (error, not debug) and is what the caller reports.
+        A False return is LOUD (error) and is what the caller reports.
         """
         proc = info.process
         if proc is None:
             return True
-        deadline = time.monotonic() + timeout
-        while True:
-            survivors = _kill_group_racefree_sync(proc.pid)
-            if proc.returncode is None:
-                # Reap the leader (bounded) so it cannot linger as a zombie.
-                await _wait_leader_exit(proc, timeout=0.5)
-            if survivors == 0 and proc.returncode is not None:
-                return True
-            if time.monotonic() >= deadline:
-                log.error(
-                    "Shutdown could not confirm PID %d's group is gone "
-                    "(%d member(s) still present, leader rc=%r)",
-                    info.pid, survivors, proc.returncode,
-                )
-                return False
-            await asyncio.sleep(0.1)
+        gone = await _terminate_group_until_empty(
+            proc.pid, timeout=timeout, term_first=False
+        )
+        if proc.returncode is None:
+            # Reap the leader (bounded) so no zombie crosses the exec.
+            await _wait_leader_exit(proc, timeout=1.0)
+        if gone and proc.returncode is not None:
+            return True
+        log.error(
+            "Shutdown could not confirm PID %d's owned group is gone "
+            "(group_empty_observed=%s, leader_rc=%r) — re-exec may inherit "
+            "orphaned descendants",
+            info.pid, gone, proc.returncode,
+        )
+        return False
 
     async def _read_output(self, info: ProcessInfo) -> None:
         """Drain stdout into the ring buffer. Pure drainage — terminal
@@ -613,7 +634,9 @@ class ProcessRegistry:
         # signal now goes through pidfds pinned BEFORE membership
         # verification: TERM, bounded grace, then KILL for survivors.
         try:
-            await _reap_group_racefree(info.process.pid, grace=2.0)
+            await _terminate_group_until_empty(
+                info.process.pid, grace=2.0, timeout=10.0
+            )
         except Exception:
             log.debug("group reap after PID %d exit failed", info.pid, exc_info=True)
 

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -76,20 +76,13 @@ def _utf8_boundary_split(buf: bytes) -> tuple[bytes, bytes]:
 
 
 
-def _proc_session(pid: int) -> int | None | str:
-    """The SESSION id from /proc/<pid>/stat.
+def _proc_ids(pid: int) -> tuple[int, int] | None | str:
+    """``(ppid, session)`` from /proc/<pid>/stat.
 
-    Session — not process group — is the ownership fence (round-7 #1): a
-    descendant may call ``setpgid(0, 0)`` and leave the original group
-    while remaining in our session, and the only way OUT of a session is
-    ``setsid()``, which makes the caller a NEW session leader (so it can
-    never join ours from outside either).
-
-    Returns the sid, ``None`` only when the process is PROVABLY gone
+    Returns ``None`` only when the process is PROVABLY gone
     (ENOENT/ESRCH), or the sentinel ``"unknown"`` for any other failure —
-    a malformed or unreadable stat must never read as absence
-    (round-7 #2). Parsing is done on BYTES: ``comm`` may hold arbitrary
-    non-UTF-8, which decoding would raise on.
+    a malformed or unreadable stat must never read as absence. Parsing is
+    done on BYTES: ``comm`` may hold arbitrary non-UTF-8.
     """
     try:
         raw = Path(f"/proc/{pid}/stat").read_bytes()
@@ -99,34 +92,49 @@ def _proc_session(pid: int) -> int | None | str:
         return "unknown"  # EMFILE/EACCES/… — we do NOT know
     try:
         rest = raw.rsplit(b")", 1)[1].split()
-        return int(rest[3])  # field 6 (session), 0-indexed after comm
+        return int(rest[1]), int(rest[3])  # ppid, session
     except (IndexError, ValueError):
         return "unknown"  # malformed — never treated as absence
 
 
-def _scan_session_members(sid: int) -> tuple[list[tuple[int, int]], bool]:
-    """Enumerate the owned SESSION's members, each PINNED with a pidfd.
+def _proc_session(pid: int) -> int | None | str:
+    """Session id alone (see :func:`_proc_ids` for the sentinel contract)."""
+    ids = _proc_ids(pid)
+    if isinstance(ids, tuple):
+        return ids[1]
+    return ids
+
+
+def _scan_owned_members(
+    sid: int, leader_pid: int | None = None
+) -> tuple[list[tuple[int, int]], bool]:
+    """Enumerate every process we own, each PINNED with a pidfd.
+
+    Ownership is the UNION of two relations, because neither alone is
+    sufficient:
+
+    - **Session** ``session == sid``: our leader was spawned with
+      ``start_new_session`` (so ``sid == leader_pid``); descendants
+      inherit it and cannot be joined from outside.
+    - **Ancestry** (round-8 #1): a descendant that calls ``setsid()``
+      leaves the session, but while its parent chain still reaches our
+      leader it remains provably ours. The walk is bounded and
+      cycle-safe.
 
     The pin happens BEFORE membership is verified, so verification and
     every later signal act on the exact process the fd names — pid reuse
-    between steps is structurally impossible (round-5 #2). Membership is
-    ``session == sid`` (round-7 #1): our leader was spawned with
-    ``start_new_session``, so it IS the session leader (sid == its pid),
-    descendants inherit the session, and a process can only leave by
-    becoming its own session leader — never join ours.
-
-    ``complete`` is False whenever ANY candidate could not be inspected
-    or pinned for a reason other than provable disappearance — an
-    unreadable /proc, an fd-exhausted pidfd_open, or a malformed stat
-    must never be mistaken for an empty session (round-6 #2, round-7 #2).
-    Caller owns the returned fds.
+    between steps is structurally impossible. ``complete`` is False
+    whenever any candidate could not be inspected or pinned for a reason
+    other than provable disappearance. Caller owns the returned fds.
     """
     pinned: list[tuple[int, int]] = []
     try:
         entries = os.listdir("/proc")
     except OSError:
         return pinned, False
+    ids: dict[int, tuple[int, int]] = {}
     complete = True
+    candidates: list[tuple[int, int]] = []
     for entry in entries:
         if not entry.isdigit():
             continue
@@ -137,16 +145,41 @@ def _scan_session_members(sid: int) -> tuple[list[tuple[int, int]], bool]:
             continue  # exited — not a member
         except OSError:
             # Could not pin: membership UNKNOWN unless provably gone.
-            if _proc_session(pid) is not None:
+            if _proc_ids(pid) is not None:
                 complete = False
             continue
-        session = _proc_session(pid)
-        if session == sid:
-            pinned.append((pid, fd))
+        info = _proc_ids(pid)
+        if isinstance(info, tuple):
+            ids[pid] = info
+            candidates.append((pid, fd))
             continue
-        if session == "unknown":
+        if info == "unknown":
             complete = False
         os.close(fd)
+
+    def _owned(pid: int) -> bool:
+        seen: set[int] = set()
+        cur = pid
+        for _ in range(64):  # bounded: no unbounded walk, no cycles
+            if cur in seen or cur <= 1:
+                return False
+            seen.add(cur)
+            entry = ids.get(cur)
+            if entry is None:
+                return False  # chain left our snapshot — not provably ours
+            ppid, session = entry
+            if session == sid:
+                return True
+            if leader_pid is not None and (cur == leader_pid or ppid == leader_pid):
+                return True
+            cur = ppid
+        return False
+
+    for pid, fd in candidates:
+        if _owned(pid):
+            pinned.append((pid, fd))
+        else:
+            os.close(fd)
     return pinned, complete
 
 
@@ -178,40 +211,56 @@ def _pidfd_exited(fd: int) -> bool:
 
 
 async def _terminate_session_until_empty(
-    sid: int, *, grace: float = 2.0, timeout: float = 10.0, term_first: bool = True
+    sid: int,
+    *,
+    grace: float = 2.0,
+    timeout: float = 10.0,
+    term_first: bool = True,
+    settle_scans: int = 2,
+    settle_delay: float = 0.2,
 ) -> bool:
-    """Drive the owned SESSION to provably empty.
+    """Drive everything we own to provably empty.
 
-    Every pass RE-ENUMERATES (round-6 #1): a TERM handler that forks a
-    fresh child — or one that calls ``setpgid`` to leave the original
-    group (round-7 #1) — is caught by the next pass, where a one-shot
-    pinned set would miss it. TERM is offered once per pid (when
-    ``term_first``), then the passes escalate to KILL, which cannot be
-    caught or forked around.
+    Every pass RE-ENUMERATES (round-6 #1), so a signal handler that forks
+    a fresh child — or one that changes its process group (round-7 #1) —
+    is caught by the next pass. TERM is offered once per pid (when
+    ``term_first``), then passes escalate to KILL, which cannot be caught
+    or forked around.
 
-    Returns True ONLY on an affirmative observation of an empty session
-    from a COMPLETE scan — an unreadable /proc, fd exhaustion, or a
-    malformed stat returns False, never a false success.
+    Emptiness requires ``settle_scans`` CONSECUTIVE complete-and-empty
+    scans separated by ``settle_delay`` (round-8 #2): a single snapshot
+    can miss a member that forked after enumeration and exited before the
+    scan finished, leaving a child behind. The repeated scans also give
+    any such child time to appear in /proc.
+
+    Returns True only on that repeated affirmative observation — an
+    unreadable /proc, fd exhaustion, or a malformed stat returns False,
+    never a false success.
     """
     deadline = time.monotonic() + timeout
     termed: set[int] = set()
     escalate_at = time.monotonic() + grace if term_first else 0.0
+    clean_scans = 0
     while True:
-        pinned, complete = _scan_session_members(sid)
+        pinned, complete = _scan_owned_members(sid, leader_pid=sid)
         try:
             if complete and not pinned:
-                return True
-            if term_first and time.monotonic() < escalate_at:
-                fresh = [(p, fd) for p, fd in pinned if p not in termed]
-                _signal_pinned(fresh, signal.SIGTERM)
-                termed.update(p for p, _fd in fresh)
+                clean_scans += 1
+                if clean_scans >= settle_scans:
+                    return True
             else:
-                _signal_pinned(pinned, signal.SIGKILL)
+                clean_scans = 0
+                if term_first and time.monotonic() < escalate_at:
+                    fresh = [(p, fd) for p, fd in pinned if p not in termed]
+                    _signal_pinned(fresh, signal.SIGTERM)
+                    termed.update(p for p, _fd in fresh)
+                else:
+                    _signal_pinned(pinned, signal.SIGKILL)
         finally:
             _close_pinned(pinned)
         if time.monotonic() >= deadline:
             return False
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(settle_delay if clean_scans else 0.1)
 
 
 async def _wait_leader_exit(

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -8,6 +8,7 @@ output lines (max 500) and is auto-killed after 1 hour.
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import os
 import re
 import signal
@@ -21,6 +22,70 @@ from ..odin_log import get_logger
 from .workspace import WorkspaceError, workspace_env
 
 log = get_logger("process_manager")
+
+
+_PR_SET_CHILD_SUBREAPER = 36
+_PR_GET_CHILD_SUBREAPER = 37
+
+
+def child_subreaper_active() -> bool:
+    """Whether THIS process is already a child subreaper (read-only)."""
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        value = ctypes.c_int(0)
+        if libc.prctl(_PR_GET_CHILD_SUBREAPER, ctypes.byref(value), 0, 0, 0) != 0:
+            return False
+        return value.value == 1
+    except Exception:
+        return False
+
+
+def set_child_subreaper(enabled: bool = True) -> bool:
+    """Set (or clear) the child-subreaper flag; returns the verified state."""
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1 if enabled else 0, 0, 0, 0) != 0:
+            return child_subreaper_active()
+    except Exception:
+        log.exception("Could not change child-subreaper containment")
+        return child_subreaper_active()
+    return child_subreaper_active()
+
+
+def reap_adopted_zombies(known_own_children: frozenset[int] = frozenset()) -> int:
+    """Reap zombies WE adopted as subreaper. Returns the count reaped.
+
+    Adoption makes us the parent of escaped descendants, so once they die
+    they linger until someone waits on them. Only pids we did NOT
+    deliberately spawn are touched: asyncio's child watcher owns the
+    statuses of our own children, and stealing one would break it. Never
+    ``waitpid(-1)`` for the same reason.
+    """
+    reaped = 0
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return 0
+    mypid = os.getpid()
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid in known_own_children:
+            continue
+        try:
+            raw = Path(f"/proc/{pid}/stat").read_bytes()
+            rest = raw.rsplit(b")", 1)[1].split()
+            if rest[0] != b"Z" or int(rest[1]) != mypid:
+                continue
+        except (OSError, IndexError, ValueError):
+            continue
+        try:
+            if os.waitpid(pid, os.WNOHANG)[0]:
+                reaped += 1
+        except (ChildProcessError, OSError):
+            pass
+    return reaped
 
 
 class ProcessCleanupError(RuntimeError):
@@ -92,6 +157,8 @@ def _proc_ids(pid: int) -> tuple[int, int] | None | str:
         return "unknown"  # EMFILE/EACCES/… — we do NOT know
     try:
         rest = raw.rsplit(b")", 1)[1].split()
+        if rest[0] == b"Z":
+            return None  # zombie: dead, awaiting reap — not a live member
         return int(rest[1]), int(rest[3])  # ppid, session
     except (IndexError, ValueError):
         return "unknown"  # malformed — never treated as absence
@@ -106,26 +173,34 @@ def _proc_session(pid: int) -> int | None | str:
 
 
 def _scan_owned_members(
-    sid: int, leader_pid: int | None = None
+    sid: int,
+    leader_pid: int | None = None,
+    *,
+    adopted_by: int | None = None,
+    known_own_children: frozenset[int] = frozenset(),
 ) -> tuple[list[tuple[int, int]], bool]:
     """Enumerate every process we own, each PINNED with a pidfd.
 
-    Ownership is the UNION of two relations, because neither alone is
-    sufficient:
+    Ownership is the union of THREE relations, because no one of them
+    covers every escape:
 
-    - **Session** ``session == sid``: our leader was spawned with
-      ``start_new_session`` (so ``sid == leader_pid``); descendants
-      inherit it and cannot be joined from outside.
-    - **Ancestry** (round-8 #1): a descendant that calls ``setsid()``
-      leaves the session, but while its parent chain still reaches our
-      leader it remains provably ours. The walk is bounded and
-      cycle-safe.
+    - **Session** ``session == sid`` — the default for descendants of a
+      leader spawned with ``start_new_session``.
+    - **Ancestry** — a descendant that called ``setsid()`` left the
+      session but is still ours while its parent chain reaches the
+      leader (round-8 #1).
+    - **Adoption** ``ppid == adopted_by`` — a descendant that ALSO
+      double-forked left the ancestry chain too; as a child subreaper we
+      adopt it instead of PID 1 (round-9 #1), so it is ours again. Our
+      own deliberate children (``known_own_children``) are excluded:
+      those belong to other subsystems, not to this session.
 
     The pin happens BEFORE membership is verified, so verification and
-    every later signal act on the exact process the fd names — pid reuse
-    between steps is structurally impossible. ``complete`` is False
-    whenever any candidate could not be inspected or pinned for a reason
-    other than provable disappearance. Caller owns the returned fds.
+    every later signal act on the exact process the fd names. ``complete``
+    is False whenever any candidate could not be inspected or pinned for
+    a reason other than provable disappearance, AND whenever an ancestry
+    walk exhausts its bound — uncertainty is never non-ownership
+    (round-9 #3). Caller owns the returned fds.
     """
     pinned: list[tuple[int, int]] = []
     try:
@@ -157,30 +232,59 @@ def _scan_owned_members(
             complete = False
         os.close(fd)
 
-    def _owned(pid: int) -> bool:
+    def _owned(pid: int) -> bool | None:
+        """True/False, or None when the walk could not decide."""
         seen: set[int] = set()
         cur = pid
         for _ in range(64):  # bounded: no unbounded walk, no cycles
-            if cur in seen or cur <= 1:
+            if cur in seen:
+                return False  # cycle — cannot be a chain to our leader
+            if cur <= 1:
                 return False
-            seen.add(cur)
             entry = ids.get(cur)
             if entry is None:
                 return False  # chain left our snapshot — not provably ours
+            seen.add(cur)
             ppid, session = entry
             if session == sid:
                 return True
             if leader_pid is not None and (cur == leader_pid or ppid == leader_pid):
                 return True
+            if (
+                adopted_by is not None
+                and ppid == adopted_by
+                and cur not in known_own_children
+            ):
+                return True  # orphan we adopted as subreaper
             cur = ppid
-        return False
+        return None  # bound exhausted — UNKNOWN, never "not ours"
 
     for pid, fd in candidates:
-        if _owned(pid):
+        verdict = _owned(pid)
+        if verdict:
             pinned.append((pid, fd))
-        else:
-            os.close(fd)
+            continue
+        if verdict is None:
+            complete = False
+        os.close(fd)
     return pinned, complete
+
+
+def _reap_adopted(pids: list[int], known_own_children: frozenset[int]) -> None:
+    """Non-blocking reap of orphans WE adopted as subreaper.
+
+    Adoption makes us the parent of escaped descendants, so once killed
+    they linger as zombies until someone waits on them. Only pids we did
+    NOT deliberately spawn are reaped here: asyncio's child watcher owns
+    the statuses of our own children, and stealing one would break it.
+    """
+    for pid in pids:
+        if pid in known_own_children:
+            continue
+        try:
+            os.waitpid(pid, os.WNOHANG)
+        except (ChildProcessError, OSError):
+            pass  # not our child, or already reaped
 
 
 def _signal_pinned(pinned: list[tuple[int, int]], sig: int) -> None:
@@ -218,6 +322,9 @@ async def _terminate_session_until_empty(
     term_first: bool = True,
     settle_scans: int = 2,
     settle_delay: float = 0.2,
+    adopted_by: int | None = None,
+    known_own_children: frozenset[int] = frozenset(),
+    containment: bool = True,
 ) -> bool:
     """Drive everything we own to provably empty.
 
@@ -234,17 +341,25 @@ async def _terminate_session_until_empty(
     any such child time to appear in /proc.
 
     Returns True only on that repeated affirmative observation — an
-    unreadable /proc, fd exhaustion, or a malformed stat returns False,
-    never a false success.
+    unreadable /proc, fd exhaustion, a malformed stat, or an exhausted
+    ancestry walk returns False, never a false success. ``containment``
+    False (child-subreaper unavailable) means a double-fork+setsid
+    escape would be undetectable, so emptiness is never claimed at all
+    (round-9 #1).
     """
     deadline = time.monotonic() + timeout
     termed: set[int] = set()
     escalate_at = time.monotonic() + grace if term_first else 0.0
     clean_scans = 0
     while True:
-        pinned, complete = _scan_owned_members(sid, leader_pid=sid)
+        pinned, complete = _scan_owned_members(
+            sid,
+            leader_pid=sid,
+            adopted_by=adopted_by,
+            known_own_children=known_own_children,
+        )
         try:
-            if complete and not pinned:
+            if complete and not pinned and containment:
                 clean_scans += 1
                 if clean_scans >= settle_scans:
                     return True
@@ -256,9 +371,19 @@ async def _terminate_session_until_empty(
                     termed.update(p for p, _fd in fresh)
                 else:
                     _signal_pinned(pinned, signal.SIGKILL)
+                    # Adopted orphans become zombies once killed — reap
+                    # them so a long-running process does not accumulate
+                    # entries (our own children stay with asyncio).
+                    _reap_adopted([p for p, _fd in pinned], known_own_children)
         finally:
             _close_pinned(pinned)
         if time.monotonic() >= deadline:
+            if not containment:
+                log.error(
+                    "Cannot prove session %d is empty: child-subreaper "
+                    "containment is unavailable, so an escaped descendant "
+                    "would be undetectable", sid,
+                )
             return False
         await asyncio.sleep(settle_delay if clean_scans else 0.1)
 
@@ -323,6 +448,21 @@ class ProcessRegistry:
         # round-3 review — a cached path accepted a directory later replaced
         # by a symlink into the install).
         self._workspace = workspace
+        # Kernel-backed containment for escaped descendants (round-9 #1):
+        # as a child subreaper the PROCESS adopts orphans instead of PID
+        # 1, so a double-fork+setsid escape stays attributable. Enabled
+        # once at application startup (``src/__main__``) — a library
+        # constructor must not flip process-wide state — and only READ
+        # here. Its absence makes the terminator refuse to claim
+        # emptiness rather than report a false success.
+        # Pids WE deliberately spawned here: an adopted orphan is any
+        # child of ours that is NOT one of these.
+        self._own_children: set[int] = set()
+
+    @property
+    def _containment(self) -> bool:
+        """Live read — containment is process state, not construction state."""
+        return child_subreaper_active()
 
     def _resolve_workspace(self) -> str | None:
         if callable(self._workspace):
@@ -381,6 +521,7 @@ class ProcessRegistry:
             process=proc,
         )
         self._processes[pid] = info
+        self._own_children.add(pid)
 
         # Drainage and terminal-state publication are SEPARATE tasks:
         # the reader drains stdout; the watcher publishes status at
@@ -617,6 +758,9 @@ class ProcessRegistry:
         ]
         for pid in to_remove:
             self._processes.pop(pid)
+        # Adopted orphans die as zombies (nothing else will wait on them);
+        # sweep them here so a long-running process cannot accumulate.
+        reap_adopted_zombies(frozenset(self._own_children))
         return len(to_remove)
 
     # ------------------------------------------------------------------
@@ -640,7 +784,12 @@ class ProcessRegistry:
         if proc is None:
             return True
         gone = await _terminate_session_until_empty(
-            proc.pid, timeout=timeout, term_first=False
+            proc.pid,
+            timeout=timeout,
+            term_first=False,
+            adopted_by=os.getpid(),
+            known_own_children=frozenset(self._own_children),
+            containment=self._containment,
         )
         info.session_confirmed_empty = gone
         if proc.returncode is None:
@@ -728,7 +877,12 @@ class ProcessRegistry:
         # verification: TERM, bounded grace, then KILL for survivors.
         try:
             info.session_confirmed_empty = await _terminate_session_until_empty(
-                info.process.pid, grace=2.0, timeout=10.0
+                info.process.pid,
+                grace=2.0,
+                timeout=10.0,
+                adopted_by=os.getpid(),
+                known_own_children=frozenset(self._own_children),
+                containment=self._containment,
             )
         except Exception:
             info.session_confirmed_empty = False

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -36,6 +36,34 @@ SHUTDOWN_REAP_TIMEOUT = 12.0
 _SEGMENT_SPLIT = re.compile(rb"[\r\n]")
 
 
+def _utf8_boundary_split(buf: bytes) -> tuple[bytes, bytes]:
+    """Split ``buf`` so the head never ends mid-UTF-8-sequence.
+
+    Backs off past trailing continuation bytes (0b10xxxxxx) and, if the
+    byte before them is a multibyte lead whose sequence is incomplete,
+    past the lead too. Arbitrary binary output degrades gracefully: at
+    most 3 bytes are carried, everything else flushes with
+    errors='replace' as before.
+    """
+    i = len(buf)
+    while i > 0 and (len(buf) - i) < 3 and (buf[i - 1] & 0xC0) == 0x80:
+        i -= 1
+    if i > 0:
+        lead = buf[i - 1]
+        expected = 0
+        if (lead & 0xE0) == 0xC0:
+            expected = 2
+        elif (lead & 0xF0) == 0xE0:
+            expected = 3
+        elif (lead & 0xF8) == 0xF0:
+            expected = 4
+        if expected and (len(buf) - (i - 1)) < expected:
+            # Incomplete trailing sequence: carry lead + continuations.
+            return buf[: i - 1], buf[i - 1 :]
+    # Trailing unit is complete (or not UTF-8 at all): flush everything.
+    return buf, b""
+
+
 async def _wait_leader_exit(
     proc: asyncio.subprocess.Process, timeout: float | None = None
 ) -> bool:
@@ -182,23 +210,25 @@ class ProcessRegistry:
         if not info:
             return f"No process with PID {pid}."
 
-        if wait_seconds > 0 and info.status == "running" and info.process is not None:
-            if not await _wait_leader_exit(info.process, timeout=wait_seconds):
-                pass  # deadline reached — report current state
-            else:
-                # The leader exited during the wait: give the watcher a
-                # bounded moment to publish status/exit_code and reap the
-                # group (closing the pipe), then the reader to drain the
-                # tail — so the report reflects the terminal state, not a
-                # torn one. Shielded — OUR bound must not cancel either.
-                for settling in (info._exit_task, info._reader_task):
-                    if settling is not None:
-                        try:
-                            await asyncio.wait_for(
-                                asyncio.shield(settling), timeout=5.0
-                            )
-                        except TimeoutError:
-                            pass
+        exited = info.status != "running"
+        if wait_seconds > 0 and not exited and info.process is not None:
+            exited = await _wait_leader_exit(info.process, timeout=wait_seconds)
+        if exited:
+            # Terminal report discipline (PR #244 round-2 blocker #3): the
+            # leader is gone — whether it exited during OUR wait or before
+            # this poll — so give the watcher a bounded moment to publish
+            # status/exit_code and reap the group (closing the pipe), then
+            # the reader to drain the tail. Without this, a poll landing
+            # between status publication and drain completion reports a
+            # terminal process with its final output missing. Shielded —
+            # our bound must not cancel either task; normally both are
+            # already done and this costs nothing.
+            for settling in (info._exit_task, info._reader_task):
+                if settling is not None and not settling.done():
+                    try:
+                        await asyncio.wait_for(asyncio.shield(settling), timeout=5.0)
+                    except TimeoutError:
+                        pass
 
         lines = list(info.output_buffer)
         status_line = f"[PID {pid}] status={info.status}"
@@ -321,18 +351,29 @@ class ProcessRegistry:
         return killed
 
     def cleanup(self) -> int:
-        """Remove dead processes older than 1 hour. Returns count removed."""
+        """Remove dead processes older than 1 hour. Returns count removed.
+
+        NEVER cancels lifecycle tasks (PR #244 round-2 blocker #1): the
+        exit watcher may be mid-group-reap, and cancellation propagates
+        through ``terminate_process_tree`` — stranding a TERM-immune
+        descendant is exactly the v3.59.1 shutdown bug reinvented. A
+        record whose tasks are still running simply stays until the next
+        cycle; the reap is self-terminating (TERM grace then KILL), so
+        deferral is bounded by nature, not by us.
+        """
         now = time.time()
         to_remove = [
             pid
             for pid, info in self._processes.items()
-            if info.status != "running" and (now - info.start_time) > MAX_LIFETIME_SECONDS
+            if info.status != "running"
+            and (now - info.start_time) > MAX_LIFETIME_SECONDS
+            and all(
+                t is None or t.done()
+                for t in (info._reader_task, info._exit_task)
+            )
         ]
         for pid in to_remove:
-            info = self._processes.pop(pid)
-            for task in (info._reader_task, info._exit_task):
-                if task and not task.done():
-                    task.cancel()
+            self._processes.pop(pid)
         return len(to_remove)
 
     # ------------------------------------------------------------------
@@ -370,10 +411,14 @@ class ProcessRegistry:
                             seg.decode("utf-8", errors="replace") + "\n"
                         )
                 if len(pending) > 4096:
-                    info.output_buffer.append(
-                        pending.decode("utf-8", errors="replace") + "\n"
-                    )
-                    pending = b""
+                    # Forced flush of an unterminated tail must not split a
+                    # multibyte sequence (PR #244 round-2 blocker #4): cut
+                    # at a UTF-8 boundary and carry the partial sequence.
+                    flush, pending = _utf8_boundary_split(pending)
+                    if flush:
+                        info.output_buffer.append(
+                            flush.decode("utf-8", errors="replace") + "\n"
+                        )
         except Exception:
             pass
         if pending:

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -22,6 +22,15 @@ from .workspace import WorkspaceError, workspace_env
 
 log = get_logger("process_manager")
 
+
+class ProcessCleanupError(RuntimeError):
+    """Shutdown could not affirmatively prove the owned session is empty.
+
+    Raised so the caller — which re-execs in place after teardown — sees
+    that descendants may survive, rather than shutdown returning normally
+    on unverified state (round-7 #3).
+    """
+
 MAX_CONCURRENT = 20
 MAX_LIFETIME_SECONDS = 3600  # 1 hour
 OUTPUT_BUFFER_LINES = 500
@@ -67,42 +76,50 @@ def _utf8_boundary_split(buf: bytes) -> tuple[bytes, bytes]:
 
 
 
-def _stat_fields(pid: int) -> tuple[int, int] | None | str:
-    """(pgrp, session) from /proc/<pid>/stat, parsed after the comm parens
-    (comm may embed spaces/parens).
+def _proc_session(pid: int) -> int | None | str:
+    """The SESSION id from /proc/<pid>/stat.
 
-    Returns None when the process is provably GONE (ENOENT/malformed —
-    a vanished process is not a member), or the sentinel ``"unknown"``
-    when inspection FAILED for another reason, which the caller must
-    treat as an incomplete scan rather than as absence (round-6 #2).
+    Session — not process group — is the ownership fence (round-7 #1): a
+    descendant may call ``setpgid(0, 0)`` and leave the original group
+    while remaining in our session, and the only way OUT of a session is
+    ``setsid()``, which makes the caller a NEW session leader (so it can
+    never join ours from outside either).
+
+    Returns the sid, ``None`` only when the process is PROVABLY gone
+    (ENOENT/ESRCH), or the sentinel ``"unknown"`` for any other failure —
+    a malformed or unreadable stat must never read as absence
+    (round-7 #2). Parsing is done on BYTES: ``comm`` may hold arbitrary
+    non-UTF-8, which decoding would raise on.
     """
     try:
-        stat = Path(f"/proc/{pid}/stat").read_text()
-    except FileNotFoundError:
+        raw = Path(f"/proc/{pid}/stat").read_bytes()
+    except (FileNotFoundError, ProcessLookupError):
         return None  # exited between listdir and read — genuinely gone
     except OSError:
         return "unknown"  # EMFILE/EACCES/… — we do NOT know
     try:
-        rest = stat.rsplit(")", 1)[1].split()
-        return int(rest[2]), int(rest[3])
+        rest = raw.rsplit(b")", 1)[1].split()
+        return int(rest[3])  # field 6 (session), 0-indexed after comm
     except (IndexError, ValueError):
-        return None
+        return "unknown"  # malformed — never treated as absence
 
 
-def _scan_group_members(pgid: int) -> tuple[list[tuple[int, int]], bool]:
-    """Enumerate the group's members, each PINNED with a pidfd.
+def _scan_session_members(sid: int) -> tuple[list[tuple[int, int]], bool]:
+    """Enumerate the owned SESSION's members, each PINNED with a pidfd.
 
-    Returns ``(pinned, complete)``. The pin happens BEFORE membership is
-    verified, so verification and every later signal act on the exact
-    process the fd names — pid reuse between steps is structurally
-    impossible (round-5 #2). Membership = pgrp == session == pgid: our
-    leader was spawned with start_new_session, its descendants inherit
-    that session, and setpgid cannot move a foreign process into it.
+    The pin happens BEFORE membership is verified, so verification and
+    every later signal act on the exact process the fd names — pid reuse
+    between steps is structurally impossible (round-5 #2). Membership is
+    ``session == sid`` (round-7 #1): our leader was spawned with
+    ``start_new_session``, so it IS the session leader (sid == its pid),
+    descendants inherit the session, and a process can only leave by
+    becoming its own session leader — never join ours.
 
     ``complete`` is False whenever ANY candidate could not be inspected
-    or pinned for a reason other than "it exited" — an unreadable /proc
-    or an fd-exhausted pidfd_open must never be mistaken for an empty
-    group (round-6 #2). Caller owns the returned fds.
+    or pinned for a reason other than provable disappearance — an
+    unreadable /proc, an fd-exhausted pidfd_open, or a malformed stat
+    must never be mistaken for an empty session (round-6 #2, round-7 #2).
+    Caller owns the returned fds.
     """
     pinned: list[tuple[int, int]] = []
     try:
@@ -119,16 +136,15 @@ def _scan_group_members(pgid: int) -> tuple[list[tuple[int, int]], bool]:
         except ProcessLookupError:
             continue  # exited — not a member
         except OSError:
-            # EMFILE/ENFILE/EPERM: we could not pin it, so its membership
-            # is UNKNOWN unless the process is provably gone.
-            if _stat_fields(pid) is not None:
+            # Could not pin: membership UNKNOWN unless provably gone.
+            if _proc_session(pid) is not None:
                 complete = False
             continue
-        fields = _stat_fields(pid)
-        if fields == (pgid, pgid):
+        session = _proc_session(pid)
+        if session == sid:
             pinned.append((pid, fd))
             continue
-        if fields == "unknown":
+        if session == "unknown":
             complete = False
         os.close(fd)
     return pinned, complete
@@ -161,26 +177,27 @@ def _pidfd_exited(fd: int) -> bool:
         return True
 
 
-async def _terminate_group_until_empty(
-    pgid: int, *, grace: float = 2.0, timeout: float = 10.0, term_first: bool = True
+async def _terminate_session_until_empty(
+    sid: int, *, grace: float = 2.0, timeout: float = 10.0, term_first: bool = True
 ) -> bool:
-    """Drive an owned process group to provably empty.
+    """Drive the owned SESSION to provably empty.
 
     Every pass RE-ENUMERATES (round-6 #1): a TERM handler that forks a
-    fresh same-session child is caught by the next pass, where a
-    one-shot pinned set would miss it entirely. TERM is offered once per
-    pid (when ``term_first``), then the passes escalate to KILL, which
-    cannot be caught or forked around.
+    fresh child — or one that calls ``setpgid`` to leave the original
+    group (round-7 #1) — is caught by the next pass, where a one-shot
+    pinned set would miss it. TERM is offered once per pid (when
+    ``term_first``), then the passes escalate to KILL, which cannot be
+    caught or forked around.
 
-    Returns True ONLY on an affirmative observation of an empty group
-    from a COMPLETE scan — an unreadable /proc or fd exhaustion returns
-    False, never a false success (round-6 #2).
+    Returns True ONLY on an affirmative observation of an empty session
+    from a COMPLETE scan — an unreadable /proc, fd exhaustion, or a
+    malformed stat returns False, never a false success.
     """
     deadline = time.monotonic() + timeout
     termed: set[int] = set()
     escalate_at = time.monotonic() + grace if term_first else 0.0
     while True:
-        pinned, complete = _scan_group_members(pgid)
+        pinned, complete = _scan_session_members(sid)
         try:
             if complete and not pinned:
                 return True
@@ -235,6 +252,10 @@ class ProcessInfo:
     # NOT bounded by the ring buffer — a full ring of repeated lines can
     # look frozen while output is still arriving; this counter cannot.
     total_output_bytes: int = 0
+    # Affirmative cleanup proof (round-7 #3): True only once the owned
+    # session was OBSERVED empty by a complete scan. shutdown() requires
+    # this before it may report clean teardown / permit re-exec.
+    session_confirmed_empty: bool = False
 
 
 class ProcessRegistry:
@@ -497,8 +518,30 @@ class ProcessRegistry:
                     log.debug(
                         "Reaper for PID %d errored during shutdown", pid, exc_info=True
                     )
+        # 3) FINAL AFFIRMATIVE PROOF (round-7 #3). A completed watcher is
+        #    not proof by itself: it may have recorded a FAILED reap, and
+        #    the timeout fallback's verdict must not be discarded either.
+        #    Every record that has not been OBSERVED session-empty is
+        #    re-verified here; anything still unproven is escalated to the
+        #    caller, which owns the re-exec decision.
+        unproven: list[int] = []
+        for pid, info in list(self._processes.items()):
+            if info.session_confirmed_empty or info.process is None:
+                continue
+            try:
+                if not await self._kill_group_until_gone(info):
+                    unproven.append(pid)
+            except Exception:
+                log.exception("Final cleanup verification failed for PID %d", pid)
+                unproven.append(pid)
         if killed:
             log.info("Shutdown: terminated %d running process(es)", killed)
+        if unproven:
+            raise ProcessCleanupError(
+                "could not confirm the owned session is empty for "
+                f"PID(s) {sorted(unproven)} — descendants may survive a "
+                "re-exec"
+            )
         return killed
 
     def cleanup(self) -> int:
@@ -547,9 +590,10 @@ class ProcessRegistry:
         proc = info.process
         if proc is None:
             return True
-        gone = await _terminate_group_until_empty(
+        gone = await _terminate_session_until_empty(
             proc.pid, timeout=timeout, term_first=False
         )
+        info.session_confirmed_empty = gone
         if proc.returncode is None:
             # Reap the leader (bounded) so no zombie crosses the exec.
             await _wait_leader_exit(proc, timeout=1.0)
@@ -634,11 +678,17 @@ class ProcessRegistry:
         # signal now goes through pidfds pinned BEFORE membership
         # verification: TERM, bounded grace, then KILL for survivors.
         try:
-            await _terminate_group_until_empty(
+            info.session_confirmed_empty = await _terminate_session_until_empty(
                 info.process.pid, grace=2.0, timeout=10.0
             )
         except Exception:
-            log.debug("group reap after PID %d exit failed", info.pid, exc_info=True)
+            info.session_confirmed_empty = False
+            log.debug("session reap after PID %d exit failed", info.pid, exc_info=True)
+        if not info.session_confirmed_empty:
+            log.error(
+                "Could not confirm PID %d's owned session is empty after "
+                "leader exit — shutdown will re-verify", info.pid,
+            )
 
     async def _enforce_lifetime(self, pid: int, max_seconds: int) -> None:
         """Auto-kill process after max lifetime."""

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -11,6 +11,7 @@ import asyncio
 import ctypes
 import os
 import re
+import secrets
 import signal
 import time
 from collections import deque
@@ -23,6 +24,8 @@ from .workspace import WorkspaceError, workspace_env
 
 log = get_logger("process_manager")
 
+
+_UNKNOWN = object()  # "could not determine" — never means "absent"
 
 _PR_SET_CHILD_SUBREAPER = 36
 _PR_GET_CHILD_SUBREAPER = 37
@@ -52,27 +55,20 @@ def set_child_subreaper(enabled: bool = True) -> bool:
     return child_subreaper_active()
 
 
-def reap_adopted_zombies(known_own_children: frozenset[int] = frozenset()) -> int:
-    """Reap zombies WE adopted as subreaper. Returns the count reaped.
+def reap_adopted_zombies(adopted_pids: frozenset[int] = frozenset()) -> int:
+    """Reap zombies among orphans we previously VERIFIED as ours.
 
-    Adoption makes us the parent of escaped descendants, so once they die
-    they linger until someone waits on them. Only pids we did NOT
-    deliberately spawn are touched: asyncio's child watcher owns the
-    statuses of our own children, and stealing one would break it. Never
-    ``waitpid(-1)`` for the same reason.
+    Attribution happened while each process was alive (a zombie's
+    environment is unreadable), so this works from recorded pids. Only
+    zombies parented to us are touched, and ``waitpid`` on anything that
+    is not our child raises and is swallowed — another subsystem's status
+    is never taken.
     """
-    reaped = 0
-    try:
-        entries = os.listdir("/proc")
-    except OSError:
+    if not adopted_pids:
         return 0
+    reaped = 0
     mypid = os.getpid()
-    for entry in entries:
-        if not entry.isdigit():
-            continue
-        pid = int(entry)
-        if pid in known_own_children:
-            continue
+    for pid in adopted_pids:
         try:
             raw = Path(f"/proc/{pid}/stat").read_bytes()
             rest = raw.rsplit(b")", 1)[1].split()
@@ -178,6 +174,8 @@ def _scan_owned_members(
     *,
     adopted_by: int | None = None,
     known_own_children: frozenset[int] = frozenset(),
+    job_token: str | None = None,
+    adopted_sink: set[int] | None = None,
 ) -> tuple[list[tuple[int, int]], bool]:
     """Enumerate every process we own, each PINNED with a pidfd.
 
@@ -189,11 +187,17 @@ def _scan_owned_members(
     - **Ancestry** — a descendant that called ``setsid()`` left the
       session but is still ours while its parent chain reaches the
       leader (round-8 #1).
-    - **Adoption** ``ppid == adopted_by`` — a descendant that ALSO
-      double-forked left the ancestry chain too; as a child subreaper we
-      adopt it instead of PID 1 (round-9 #1), so it is ours again. Our
-      own deliberate children (``known_own_children``) are excluded:
-      those belong to other subsystems, not to this session.
+    - **Adoption + provenance** — a descendant that ALSO double-forked
+      left the ancestry chain too; as a child subreaper we adopt it
+      instead of PID 1 (round-9 #1). Adoption alone is NOT attribution:
+      other Odin subsystems have direct children too, and killing those
+      would be collateral damage (round-10). An adopted process must
+      ALSO carry this job's ``ODIN_BG_JOB`` token, injected at spawn and
+      inherited across fork, exec and setsid.
+
+    A direct child whose provenance cannot be established is left
+    UNTOUCHED and makes the scan incomplete — ambiguity never authorizes
+    a kill, and never permits affirmative emptiness either.
 
     The pin happens BEFORE membership is verified, so verification and
     every later signal act on the exact process the fd names. ``complete``
@@ -255,7 +259,20 @@ def _scan_owned_members(
                 and ppid == adopted_by
                 and cur not in known_own_children
             ):
-                return True  # orphan we adopted as subreaper
+                if job_token is None:
+                    return None  # cannot attribute — ambiguous, never killed
+                token = _read_job_token(cur)
+                if token == job_token:
+                    # Record provenance NOW: a zombie has no address
+                    # space, so /proc/<pid>/environ becomes unreadable the
+                    # moment it dies — identification must happen while it
+                    # is alive, and reaping later goes by recorded pid.
+                    if adopted_sink is not None:
+                        adopted_sink.add(cur)
+                    return True  # our escapee: adopted AND provably ours
+                if token is _UNKNOWN:
+                    return None  # unreadable provenance — ambiguous
+                return False  # another subsystem's child — NOT ours
             cur = ppid
         return None  # bound exhausted — UNKNOWN, never "not ours"
 
@@ -270,15 +287,45 @@ def _scan_owned_members(
     return pinned, complete
 
 
-def _reap_adopted(pids: list[int], known_own_children: frozenset[int]) -> None:
-    """Non-blocking reap of orphans WE adopted as subreaper.
+JOB_TOKEN_ENV = "ODIN_BG_JOB"
 
-    Adoption makes us the parent of escaped descendants, so once killed
-    they linger as zombies until someone waits on them. Only pids we did
-    NOT deliberately spawn are reaped here: asyncio's child watcher owns
-    the statuses of our own children, and stealing one would break it.
+
+def _read_job_token(pid: int) -> str | None | object:
+    """This process's managed-job token from /proc/<pid>/environ.
+
+    Returns the token, ``None`` when the process carries none (or is
+    gone), or :data:`_UNKNOWN` when the environment could not be read —
+    ambiguity, never absence.
+
+    The token is injected at spawn and inherited across fork AND exec, so
+    it follows a descendant that double-forks or calls ``setsid()``. It
+    is per-JOB, which process-wide subreaping cannot provide: adoption
+    alone cannot tell OUR escapee from an unrelated subprocess another
+    Odin subsystem started (round-10).
     """
-    for pid in pids:
+    try:
+        raw = Path(f"/proc/{pid}/environ").read_bytes()
+    except (FileNotFoundError, ProcessLookupError):
+        return None
+    except OSError:
+        return _UNKNOWN
+    marker = JOB_TOKEN_ENV.encode() + b"="
+    for item in raw.split(b"\0"):
+        if item.startswith(marker):
+            return item[len(marker):].decode("utf-8", "replace")
+    return None
+
+
+def _reap_adopted(pids: set[int], known_own_children: frozenset[int]) -> None:
+    """Non-blocking reap of orphans already VERIFIED as ours.
+
+    ``pids`` were attributed to this job by provenance while they were
+    alive — a zombie has no address space, so its environment cannot be
+    re-read afterwards. Pids we deliberately spawned are still excluded:
+    asyncio's child watcher owns those statuses and stealing one would
+    break it. Never ``waitpid(-1)`` for the same reason.
+    """
+    for pid in list(pids):
         if pid in known_own_children:
             continue
         try:
@@ -325,6 +372,8 @@ async def _terminate_session_until_empty(
     adopted_by: int | None = None,
     known_own_children: frozenset[int] = frozenset(),
     containment: bool = True,
+    job_token: str | None = None,
+    adopted_sink: set[int] | None = None,
 ) -> bool:
     """Drive everything we own to provably empty.
 
@@ -348,6 +397,7 @@ async def _terminate_session_until_empty(
     (round-9 #1).
     """
     deadline = time.monotonic() + timeout
+    adopted: set[int] = adopted_sink if adopted_sink is not None else set()
     termed: set[int] = set()
     escalate_at = time.monotonic() + grace if term_first else 0.0
     clean_scans = 0
@@ -357,6 +407,8 @@ async def _terminate_session_until_empty(
             leader_pid=sid,
             adopted_by=adopted_by,
             known_own_children=known_own_children,
+            job_token=job_token,
+            adopted_sink=adopted,
         )
         try:
             if complete and not pinned and containment:
@@ -374,7 +426,7 @@ async def _terminate_session_until_empty(
                     # Adopted orphans become zombies once killed — reap
                     # them so a long-running process does not accumulate
                     # entries (our own children stay with asyncio).
-                    _reap_adopted([p for p, _fd in pinned], known_own_children)
+                    _reap_adopted(adopted, known_own_children)
         finally:
             _close_pinned(pinned)
         if time.monotonic() >= deadline:
@@ -430,6 +482,11 @@ class ProcessInfo:
     # session was OBSERVED empty by a complete scan. shutdown() requires
     # this before it may report clean teardown / permit re-exec.
     session_confirmed_empty: bool = False
+    # Per-job provenance (round-10): injected into the spawn environment
+    # and inherited across fork/exec/setsid, so an escaped descendant is
+    # attributable to THIS job and never confused with another
+    # subsystem's direct child.
+    job_token: str = ""
 
 
 class ProcessRegistry:
@@ -458,6 +515,10 @@ class ProcessRegistry:
         # Pids WE deliberately spawned here: an adopted orphan is any
         # child of ours that is NOT one of these.
         self._own_children: set[int] = set()
+        # Orphans verified as OURS by provenance while alive — reaping
+        # goes by recorded pid because a zombie's environment is
+        # unreadable (round-10).
+        self._adopted_pids: set[int] = set()
 
     @property
     def _containment(self) -> bool:
@@ -493,7 +554,9 @@ class ProcessRegistry:
             # group, so kill()/shutdown() can take out descendants
             # (`sh -c 'x & ...'`) instead of just the shell leader.
             workspace = self._resolve_workspace()
-            env = workspace_env(Path(workspace)) if workspace else None
+            job_token = secrets.token_hex(8)
+            env = dict(workspace_env(Path(workspace))) if workspace else dict(os.environ)
+            env[JOB_TOKEN_ENV] = job_token
         except WorkspaceError as e:
             # The workspace is unusable. This is a REFUSAL, not a spawn error:
             # it must read as a failure to the tool loop, not as a started
@@ -519,6 +582,7 @@ class ProcessRegistry:
             host=host,
             start_time=time.time(),
             process=proc,
+            job_token=job_token,
         )
         self._processes[pid] = info
         self._own_children.add(pid)
@@ -760,7 +824,7 @@ class ProcessRegistry:
             self._processes.pop(pid)
         # Adopted orphans die as zombies (nothing else will wait on them);
         # sweep them here so a long-running process cannot accumulate.
-        reap_adopted_zombies(frozenset(self._own_children))
+        reap_adopted_zombies(frozenset(self._adopted_pids))
         return len(to_remove)
 
     # ------------------------------------------------------------------
@@ -790,6 +854,8 @@ class ProcessRegistry:
             adopted_by=os.getpid(),
             known_own_children=frozenset(self._own_children),
             containment=self._containment,
+            job_token=info.job_token or None,
+            adopted_sink=self._adopted_pids,
         )
         info.session_confirmed_empty = gone
         if proc.returncode is None:
@@ -883,6 +949,8 @@ class ProcessRegistry:
                 adopted_by=os.getpid(),
                 known_own_children=frozenset(self._own_children),
                 containment=self._containment,
+                job_token=info.job_token or None,
+                adopted_sink=self._adopted_pids,
             )
         except Exception:
             info.session_confirmed_empty = False

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -348,15 +348,28 @@ class ProcessRegistry:
                     )
                 except TimeoutError:
                     # A wedged async reap must not strand TERM-immune
-                    # descendants across re-exec (round-3 blocker #2):
-                    # hard-KILL the owned group SYNCHRONOUSLY — bounded, no
-                    # await — before abandoning the task.
+                    # descendants across re-exec (round-3 blocker #2) — but
+                    # the fallback may only signal a PGID that is provably
+                    # still ours (round-4 blocker #1), and must leave a
+                    # COMPLETION BARRIER behind: cancellation awaited, the
+                    # leader reaped, group disappearance confirmed.
                     log.warning(
                         "Reaper for PID %d did not finish; hard-killing group "
                         "before abandoning", pid,
                     )
-                    self._hard_kill_group(info)
+                    if self._pgid_safe_to_signal(info):
+                        self._hard_kill_group(info)
                     task.cancel()
+                    try:
+                        await asyncio.wait_for(task, timeout=2.0)
+                    except (TimeoutError, asyncio.CancelledError):
+                        pass
+                    except Exception:
+                        log.debug("abandoned reaper errored", exc_info=True)
+                    if info.process is not None and info.process.returncode is None:
+                        # Reap the leader so no zombie crosses the exec.
+                        await _wait_leader_exit(info.process, timeout=3.0)
+                    await self._confirm_group_gone(info)
                 except Exception:
                     log.debug(
                         "Reaper for PID %d errored during shutdown", pid, exc_info=True
@@ -394,6 +407,50 @@ class ProcessRegistry:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _pgid_safe_to_signal(info: ProcessInfo) -> bool:
+        """Whether ``info``'s recorded PGID still provably names OUR group.
+
+        An unreaped leader (``returncode is None``) pins its pid — the
+        value cannot be recycled while the process (or its zombie) exists.
+        After the leader is reaped, POSIX keeps the pgid VALUE unusable
+        while any group member survives, and a NEW group can only claim it
+        via a new leader process occupying exactly that pid — which would
+        appear in /proc. So: /proc/<pgid> PRESENT after reap ⇒ recycled ⇒
+        never signal; ABSENT ⇒ killpg reaches our surviving members or
+        raises ESRCH — both safe (round-4 blocker #1).
+        """
+        proc = info.process
+        if proc is None:
+            return False
+        if proc.returncode is None:
+            return True
+        return not Path(f"/proc/{proc.pid}").exists()
+
+    async def _confirm_group_gone(self, info: ProcessInfo, timeout: float = 3.0) -> None:
+        """Bounded confirmation that the owned group has dissolved.
+
+        Part of the shutdown completion barrier: signal-0 existence probes
+        (deliver nothing) until ESRCH or the bound — a still-present group
+        at the bound is LOGGED loudly rather than silently abandoned.
+        """
+        proc = info.process
+        if proc is None or not self._pgid_safe_to_signal(info):
+            return
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                os.killpg(proc.pid, 0)
+            except ProcessLookupError:
+                return
+            except Exception:
+                return
+            await asyncio.sleep(0.1)
+        log.warning(
+            "Process group %d still present after shutdown hard-kill window",
+            proc.pid,
+        )
 
     @staticmethod
     def _hard_kill_group(info: ProcessInfo) -> None:

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -8,6 +8,7 @@ output lines (max 500) and is auto-killed after 1 hour.
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from collections import deque
 from collections.abc import Callable
@@ -30,6 +31,29 @@ MAX_POLL_WAIT_SECONDS = 120.0
 # and cancelling it — comfortably exceeds a reader's TERM-grace + KILL-grace so
 # a compliant descendant always finishes, while a wedged one can't hang re-exec.
 SHUTDOWN_REAP_TIMEOUT = 12.0
+# Display segmentation for the ring buffer: newline AND carriage return
+# both end a display segment (progress bars redraw with bare \r).
+_SEGMENT_SPLIT = re.compile(rb"[\r\n]")
+
+
+async def _wait_leader_exit(
+    proc: asyncio.subprocess.Process, timeout: float | None = None
+) -> bool:
+    """Pipe-independent wait for LEADER exit.
+
+    ``Process.wait()`` resolves only after every pipe transport closes
+    (asyncio ``_try_finish``), so a ``&``-descendant holding stdout blocks
+    it long past leader death — the PR #244 round-1 repro. ``returncode``
+    is published at SIGCHLD reap regardless of pipes, so poll it. Returns
+    True when the leader exited, False on deadline. Cancellation
+    propagates (the sleep is the await point).
+    """
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while proc.returncode is None:
+        if deadline is not None and time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0.25)
+    return True
 
 
 @dataclass
@@ -44,6 +68,7 @@ class ProcessInfo:
     output_buffer: deque = field(default_factory=lambda: deque(maxlen=OUTPUT_BUFFER_LINES))
     process: asyncio.subprocess.Process | None = None
     _reader_task: asyncio.Task | None = field(default=None, repr=False)
+    _exit_task: asyncio.Task | None = field(default=None, repr=False)
     exit_code: int | None = None
     # Monotonic progress signal: total bytes ever read from the process,
     # NOT bounded by the ring buffer — a full ring of repeated lines can
@@ -126,8 +151,11 @@ class ProcessRegistry:
         )
         self._processes[pid] = info
 
-        # Background reader task to drain stdout into the ring buffer
+        # Drainage and terminal-state publication are SEPARATE tasks:
+        # the reader drains stdout; the watcher publishes status at
+        # leader exit and reaps the group (which closes the pipe).
         info._reader_task = asyncio.create_task(self._read_output(info))
+        info._exit_task = asyncio.create_task(self._watch_exit(info))
 
         # Auto-kill after max lifetime
         from ..async_utils import fire_and_forget
@@ -155,22 +183,22 @@ class ProcessRegistry:
             return f"No process with PID {pid}."
 
         if wait_seconds > 0 and info.status == "running" and info.process is not None:
-            try:
-                await asyncio.wait_for(info.process.wait(), timeout=wait_seconds)
-            except TimeoutError:
+            if not await _wait_leader_exit(info.process, timeout=wait_seconds):
                 pass  # deadline reached — report current state
             else:
-                # The process exited during the wait: give the reader task a
-                # bounded moment to drain the tail and settle status/exit_code
-                # so the report reflects the terminal state, not a torn one.
-                # Shielded — OUR bound must not cancel the reader itself.
-                if info._reader_task is not None:
-                    try:
-                        await asyncio.wait_for(
-                            asyncio.shield(info._reader_task), timeout=5.0
-                        )
-                    except TimeoutError:
-                        pass
+                # The leader exited during the wait: give the watcher a
+                # bounded moment to publish status/exit_code and reap the
+                # group (closing the pipe), then the reader to drain the
+                # tail — so the report reflects the terminal state, not a
+                # torn one. Shielded — OUR bound must not cancel either.
+                for settling in (info._exit_task, info._reader_task):
+                    if settling is not None:
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.shield(settling), timeout=5.0
+                            )
+                        except TimeoutError:
+                            pass
 
         lines = list(info.output_buffer)
         status_line = f"[PID {pid}] status={info.status}"
@@ -262,8 +290,9 @@ class ProcessRegistry:
         terminate_process_tree and would strand the descendant across the exec).
         """
         killed = 0
-        # 1) TERM/KILL every still-running leader. This also unblocks its reader
-        #    (readline hits EOF), which then reaps any surviving group members.
+        # 1) TERM/KILL every still-running leader. Its exit watcher then
+        #    publishes terminal state and reaps surviving group members,
+        #    which closes the pipe and unblocks the drainer.
         for pid, info in list(self._processes.items()):
             if info.status == "running":
                 try:
@@ -273,16 +302,20 @@ class ProcessRegistry:
                     log.warning("Failed to kill PID %d during shutdown", pid)
         # 2) Let every reader/reaper finish so no group cleanup is left pending.
         for pid, info in list(self._processes.items()):
-            task = info._reader_task
-            if task is None or task.done():
-                continue
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=SHUTDOWN_REAP_TIMEOUT)
-            except TimeoutError:
-                log.warning("Reaper for PID %d did not finish; cancelling", pid)
-                task.cancel()
-            except Exception:
-                log.debug("Reaper for PID %d errored during shutdown", pid, exc_info=True)
+            for task in (info._exit_task, info._reader_task):
+                if task is None or task.done():
+                    continue
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(task), timeout=SHUTDOWN_REAP_TIMEOUT
+                    )
+                except TimeoutError:
+                    log.warning("Reaper for PID %d did not finish; cancelling", pid)
+                    task.cancel()
+                except Exception:
+                    log.debug(
+                        "Reaper for PID %d errored during shutdown", pid, exc_info=True
+                    )
         if killed:
             log.info("Shutdown: terminated %d running process(es)", killed)
         return killed
@@ -297,8 +330,9 @@ class ProcessRegistry:
         ]
         for pid in to_remove:
             info = self._processes.pop(pid)
-            if info._reader_task and not info._reader_task.done():
-                info._reader_task.cancel()
+            for task in (info._reader_task, info._exit_task):
+                if task and not task.done():
+                    task.cancel()
         return len(to_remove)
 
     # ------------------------------------------------------------------
@@ -306,39 +340,76 @@ class ProcessRegistry:
     # ------------------------------------------------------------------
 
     async def _read_output(self, info: ProcessInfo) -> None:
-        """Continuously read stdout and append to the output buffer."""
+        """Drain stdout into the ring buffer. Pure drainage — terminal
+        status and group reaping live in ``_watch_exit`` (PR #244 round-1:
+        a ``&``-descendant holding the stdout pipe kept EOF from arriving,
+        so an exited leader reported ``running`` forever and the reap
+        stalled behind drainage).
+
+        Bounded RAW reads, not ``readline()``: newline-free output and
+        carriage-return progress bars must still advance
+        ``total_output_bytes`` (it is the wait-poll progress signal), and
+        an over-limit line must not kill drainage (``readline`` raises on
+        lines beyond the stream limit; ``read(n)`` cannot).
+        """
+        pending = b""
         try:
             while info.process and info.process.stdout:
-                line = await info.process.stdout.readline()
-                if not line:
+                chunk = await info.process.stdout.read(4096)
+                if not chunk:
                     break
-                info.total_output_bytes += len(line)
-                info.output_buffer.append(line.decode("utf-8", errors="replace"))
+                info.total_output_bytes += len(chunk)
+                pending += chunk
+                # Display buffering: split on both \n and \r so progress
+                # bars render as lines; keep the unterminated tail bounded.
+                segments = _SEGMENT_SPLIT.split(pending)
+                pending = segments.pop()
+                for seg in segments:
+                    if seg:
+                        info.output_buffer.append(
+                            seg.decode("utf-8", errors="replace") + "\n"
+                        )
+                if len(pending) > 4096:
+                    info.output_buffer.append(
+                        pending.decode("utf-8", errors="replace") + "\n"
+                    )
+                    pending = b""
         except Exception:
             pass
+        if pending:
+            info.output_buffer.append(pending.decode("utf-8", errors="replace") + "\n")
 
-        # Process finished — update status
-        if info.process:
-            try:
-                await info.process.wait()
-                info.exit_code = info.process.returncode
+    async def _watch_exit(self, info: ProcessInfo) -> None:
+        """Publish terminal state at LEADER exit, then reap the group.
+
+        Separated from stdout drainage (PR #244 round-1): ``process.wait()``
+        returns when the leader exits regardless of who still holds the
+        pipe, so status/exit_code publication never waits on EOF, and the
+        reap (which kills lingering descendants — the v3.59.1 contract:
+        managed descendants are reaped when their leader exits) is what
+        CLOSES the pipe and lets the drainer finish naturally.
+        """
+        if info.process is None:
+            return
+        try:
+            await _wait_leader_exit(info.process)
+            info.exit_code = info.process.returncode
+            if info.status == "running":
                 info.status = "completed" if info.exit_code == 0 else "failed"
-            except Exception:
+        except Exception:
+            if info.status == "running":
                 info.status = "failed"
 
-            # The leader has exited, but `&`-backgrounded descendants can still
-            # be alive in its process group — a redirected one that doesn't hold
-            # stdout lets this task finish while it lingers. Reap the group NOW,
-            # while ownership is fresh: a non-empty group keeps the leader pid
-            # from being recycled, so owned_pgid still uniquely names OUR group.
-            # After this, shutdown() need not (and must not) signal a stale,
-            # possibly-recycled pgid for an already-terminal record.
-            from ..tools.ssh import terminate_process_tree
+        # Reap while ownership is fresh: a non-empty group keeps the leader
+        # pid from being recycled, so owned_pgid still uniquely names OUR
+        # group. After this, shutdown() need not (and must not) signal a
+        # stale, possibly-recycled pgid for an already-terminal record.
+        from ..tools.ssh import terminate_process_tree
 
-            try:
-                await terminate_process_tree(info.process, grace=2.0, owned_pgid=info.process.pid)
-            except Exception:
-                log.debug("group reap after PID %d exit failed", info.pid, exc_info=True)
+        try:
+            await terminate_process_tree(info.process, grace=2.0, owned_pgid=info.process.pid)
+        except Exception:
+            log.debug("group reap after PID %d exit failed", info.pid, exc_info=True)
 
     async def _enforce_lifetime(self, pid: int, max_seconds: int) -> None:
         """Auto-kill process after max lifetime."""

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -157,7 +157,7 @@ class ProcessRegistry:
         if wait_seconds > 0 and info.status == "running" and info.process is not None:
             try:
                 await asyncio.wait_for(info.process.wait(), timeout=wait_seconds)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pass  # deadline reached — report current state
             else:
                 # The process exited during the wait: give the reader task a
@@ -169,7 +169,7 @@ class ProcessRegistry:
                         await asyncio.wait_for(
                             asyncio.shield(info._reader_task), timeout=5.0
                         )
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         pass
 
         lines = list(info.output_buffer)

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -105,11 +105,15 @@ def _pidfd_owned_pids() -> set[int] | None:
 
     The runtime uses ``PidfdChildWatcher``, so an open pidfd means the
     event loop still owns that child's exit status and nobody else may
-    consume it — the decisive ownership signal (round-14 design, Odin:
+    consume it — the decisive exclusion signal (round-14 design, Odin:
     "age alone is not proof that nobody owns the exit status").
 
-    Returns None when the fd table cannot be read: the caller must then
-    prove nothing and reap nothing.
+    Fail-closed inspection rule (round-15 blocker #2): a malformed or
+    unreadable **pidfd** entry makes the WHOLE pass incomplete (``None``)
+    — a partial owned-set once let a real asyncio-owned child be reaped.
+    An entry that PROVABLY closed between enumeration and inspection is
+    gone, not ambiguous. Ordinary descriptors (files, sockets — no
+    ``Pid:`` line in fdinfo) are classifiable and never poison the pass.
     """
     try:
         entries = os.listdir("/proc/self/fd")
@@ -119,38 +123,201 @@ def _pidfd_owned_pids() -> set[int] | None:
     for entry in entries:
         try:
             info = Path(f"/proc/self/fdinfo/{entry}").read_text()
+        except FileNotFoundError:
+            continue  # provably closed between enumeration and inspection
         except OSError:
-            continue  # fd closed under us — not evidence either way
+            return None  # unreadable: could be a pidfd — prove nothing
         for line in info.splitlines():
             if line.startswith("Pid:"):
                 try:
                     owned.add(int(line.split()[1]))
                 except (IndexError, ValueError):
-                    pass
+                    # A pidfd we cannot attribute: the inspection is
+                    # incomplete, and a partial owned-set must never
+                    # authorize reaping.
+                    return None
                 break
     return owned
 
 
-def _zombie_children(parent: int) -> dict[tuple[int, int], None]:
-    """``(pid, starttime)`` of every zombie whose parent is ``parent``."""
-    found: dict[tuple[int, int], None] = {}
+def _scan_process_table() -> tuple[dict[int, tuple[int, int, bytes]], bool]:
+    """``pid -> (ppid, starttime, state)`` for every readable process.
+
+    ``complete`` is False when the table may be MISSING a live process:
+    an unreadable /proc, an unreadable stat (non-ENOENT), or a malformed
+    stat line. An incomplete table still carries positive observations,
+    but absence must not be inferred from it and reaping must not be
+    authorized on it (round-15 design §3.4). Parsing is done on BYTES:
+    ``comm`` may hold arbitrary non-UTF-8.
+    """
+    table: dict[int, tuple[int, int, bytes]] = {}
     try:
         entries = os.listdir("/proc")
     except OSError:
-        return found
+        return table, False
+    complete = True
     for entry in entries:
         if not entry.isdigit():
             continue
         pid = int(entry)
         try:
             raw = Path(f"/proc/{pid}/stat").read_bytes()
-            rest = raw.rsplit(b")", 1)[1].split()
-            if rest[0] != b"Z" or int(rest[1]) != parent:
-                continue
-            found[(pid, int(rest[19]))] = None
-        except (OSError, IndexError, ValueError):
+        except (FileNotFoundError, ProcessLookupError):
+            continue  # exited between listdir and read — provably gone
+        except OSError:
+            complete = False
             continue
+        try:
+            rest = raw.rsplit(b")", 1)[1].split()
+            table[pid] = (int(rest[1]), int(rest[19]), rest[0])
+        except (IndexError, ValueError):
+            complete = False
+    return table, complete
+
+
+def _descendants_of(
+    table: dict[int, tuple[int, int, bytes]], root: int
+) -> set[int]:
+    """Transitive descendants of ``root`` within one table snapshot.
+
+    Everything containment can ever hand us is in here: subreaper
+    adoption applies only to descendants, and a process that already
+    reparented to us appears as our direct child in the same snapshot.
+    """
+    children: dict[int, list[int]] = {}
+    for pid, (ppid, _start, _state) in table.items():
+        children.setdefault(ppid, []).append(pid)
+    found: set[int] = set()
+    stack = [root]
+    while stack:
+        for child in children.get(stack.pop(), ()):
+            if child not in found:
+                found.add(child)
+                stack.append(child)
     return found
+
+
+def _reap_identity(pid: int, starttime: int, parent: int) -> bool | None:
+    """Identity-stable consumption of ONE verified zombie (design §3.5).
+
+    Sequence: ``pidfd_open`` FIRST, then re-verify ``(starttime, state=Z,
+    ppid==parent)`` from /proc — the fd and that read name the same
+    current occupant of the pid, so pid reuse between any earlier
+    snapshot and the open cannot redirect the reap — then
+    ``waitid(P_PIDFD)`` through the fd, which stays pinned to that exact
+    incarnation no matter what the pid later names.
+
+    Returns True (status consumed), None (identity provably gone —
+    reaped elsewhere or pid reused), or False (must not / could not act;
+    nothing was consumed).
+    """
+    try:
+        fd = os.pidfd_open(pid)
+    except ProcessLookupError:
+        return None
+    except OSError:
+        return False
+    try:
+        try:
+            raw = Path(f"/proc/{pid}/stat").read_bytes()
+        except (FileNotFoundError, ProcessLookupError):
+            return None
+        except OSError:
+            return False
+        try:
+            rest = raw.rsplit(b")", 1)[1].split()
+            state, ppid, start = rest[0], int(rest[1]), int(rest[19])
+        except (IndexError, ValueError):
+            return False
+        if start != starttime:
+            return None  # pid reused — the recorded incarnation is gone
+        if state != b"Z" or ppid != parent:
+            return False
+        try:
+            result = os.waitid(os.P_PIDFD, fd, os.WEXITED | os.WNOHANG)
+        except ChildProcessError:
+            return None  # consumed by someone else — not ours to take
+        except OSError:
+            return False
+        return result is not None
+    finally:
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Positive-ownership registration (round-15 design §3.1.2)
+#
+# Observed reparenting cannot cover a descendant whose intermediate parent
+# exits entirely between scans — an ssh ControlPersist master daemonizes in
+# milliseconds, so its first observation is already ``ppid == us`` with no
+# recorded transition. Subsystems that KNOW a process is theirs therefore
+# register its identity while it is alive. Process-global on purpose: there
+# is exactly one subreaper per process, and registration must reach it from
+# any subsystem without threading an instance through every constructor.
+# ---------------------------------------------------------------------------
+
+_REAP_REGISTRY_CAP = 256
+_reap_registry: dict[tuple[int, int], tuple[float, str]] = {}
+_reap_registry_evictions = 0
+
+
+def register_reap_identity(pid: int, starttime: int, *, source: str) -> None:
+    """Register ``(pid, starttime)`` as ours-to-reap once it dies.
+
+    Registration is EVIDENCE, not action: the reaper still requires the
+    identity to be observed as our own zombie, to survive the grace
+    period, and to pass the pidfd exclusion. Re-registering refreshes
+    the entry's age. Saturation evicts the oldest entry — losing
+    evidence defers that reap to teardown; it can never create
+    eligibility (design §3.4).
+    """
+    global _reap_registry_evictions
+    if (pid, starttime) not in _reap_registry:
+        while len(_reap_registry) >= _REAP_REGISTRY_CAP:
+            oldest = min(_reap_registry, key=lambda k: _reap_registry[k][0])
+            del _reap_registry[oldest]
+            _reap_registry_evictions += 1
+            log.warning(
+                "Reap registry saturated: evicted %r (evidence lost — its "
+                "zombie defers to the teardown drain)", oldest,
+            )
+    _reap_registry[(pid, starttime)] = (time.monotonic(), source)
+
+
+def register_reap_candidate(pid: int, *, source: str) -> int | None:
+    """Verify ``pid`` against /proc and register its LIVE identity.
+
+    Returns the starttime that was registered, or None when the process
+    could not be identified (gone, or /proc unreadable) — a guess must
+    never enter the registry.
+    """
+    starttime = _proc_starttime(pid)
+    if starttime is None:
+        return None
+    register_reap_identity(pid, starttime, source=source)
+    return starttime
+
+
+def registered_reap_identities() -> frozenset[tuple[int, int]]:
+    """Snapshot of the currently registered identities."""
+    return frozenset(_reap_registry)
+
+
+def _reset_reap_registry() -> None:
+    """Test hygiene only: drop all registrations and counters."""
+    global _reap_registry_evictions
+    _reap_registry.clear()
+    _reap_registry_evictions = 0
+
+
+@dataclass
+class _Candidate:
+    """Bounded per-descendant history (round-15 design §3.4)."""
+
+    last_seen_ppid: int
+    last_seen_at: float
+    adoption_observed: bool = False
+    zombie_since: float | None = None
 
 
 class AdoptedZombieReaper:
@@ -159,46 +326,64 @@ class AdoptedZombieReaper:
 
     Containment reparents escaped grandchildren to this process instead
     of PID 1, so nothing else will ever wait on them — an ``ssh``
-    ControlPersist master or a job shell's forked child otherwise lingers
-    as a zombie forever. Ownership is decided by evidence, never by
-    guesswork:
+    ControlPersist master or a job shell's forked child otherwise
+    lingers as a zombie forever. Eligibility is a union of POSITIVE
+    evidence only (round-15 design §3.1):
 
-    - an open **pidfd** for that pid means asyncio still owns the status
-      (never reaped);
-    - an explicitly **registered** child identity is skipped;
-    - a candidate must be observed as the same ``(pid, starttime)``
-      zombie across at least ``grace`` seconds, and re-verified
-      immediately before the ``waitpid(pid, WNOHANG)``.
+    - **observed reparenting** — the same ``(pid, starttime)`` was seen
+      alive with ``ppid != us`` and later with ``ppid == us``; a
+      directly spawned child has us as parent from birth and can never
+      satisfy this, which is the safety property that keeps ordinary
+      ``subprocess.Popen`` children untouchable;
+    - **explicit registration** while alive by the spawning subsystem
+      (ssh ControlPersist masters, background-job descendants);
+    - **final teardown** (:meth:`drain_at_teardown`) — after every
+      subprocess owner has stopped, every remaining zombie child is
+      ours by construction.
 
-    An unreadable fd table proves nothing, so the pass reaps nothing.
+    A candidate must additionally survive :attr:`GRACE` measured from
+    its first observation AS A ZOMBIE (adoption age proves nothing
+    about status interest — §3.2), must not be pidfd-owned by asyncio,
+    and is consumed only through the identity-stable §3.5 sequence.
+    Incomplete evidence — an unreadable fd table, a malformed pidfd
+    entry, an incomplete /proc scan — authorizes nothing.
     """
 
     SCAN_INTERVAL = 15.0
     GRACE = 30.0
+    # History bounds (§3.4): a fork storm or prolonged /proc failure must
+    # not grow tracking without limit. Eviction only loses evidence — an
+    # evicted identity re-enters as a fresh candidate and its reap defers.
+    MAX_TRACKED = 512
+    MAX_AGE = 3600.0
 
     def __init__(
         self,
         *,
-        registered: Callable[[], frozenset[tuple[int, int]]] | None = None,
         scan_interval: float = SCAN_INTERVAL,
         grace: float = GRACE,
     ) -> None:
-        self._registered = registered
         self._scan_interval = scan_interval
         self._grace = grace
-        self._first_seen: dict[tuple[int, int], float] = {}
+        self._candidates: dict[tuple[int, int], _Candidate] = {}
         self._task: asyncio.Task | None = None
         self.reaped_total = 0
+        self.evicted_total = 0
 
     @property
     def pending_zombies(self) -> int:
-        return len(self._first_seen)
+        return sum(
+            1 for c in self._candidates.values() if c.zombie_since is not None
+        )
 
     @property
     def stats(self) -> dict[str, int]:
         return {
             "pending_zombies": self.pending_zombies,
             "reaped_total": self.reaped_total,
+            "tracked_candidates": len(self._candidates),
+            "registered_candidates": len(_reap_registry),
+            "evicted_total": self.evicted_total + _reap_registry_evictions,
         }
 
     def start(self) -> None:
@@ -229,49 +414,138 @@ class AdoptedZombieReaper:
                 # A failing pass must never silently kill the task.
                 log.exception("Adopted-zombie sweep failed (continuing)")
 
-    def sweep_once(self, *, ignore_grace: bool = False) -> int:
-        """One pass. Returns the number reaped."""
+    def sweep_once(self) -> int:
+        """One observe → prune → reap pass. Returns the number reaped."""
+        mypid = os.getpid()
+        now = time.monotonic()
+        table, complete = _scan_process_table()
+        evicted = 0
+        for pid in _descendants_of(table, mypid):
+            ppid, start, state = table[pid]
+            identity = (pid, start)
+            cand = self._candidates.get(identity)
+            if cand is None:
+                if len(self._candidates) >= self.MAX_TRACKED:
+                    oldest = min(
+                        self._candidates,
+                        key=lambda k: self._candidates[k].last_seen_at,
+                    )
+                    del self._candidates[oldest]
+                    evicted += 1
+                cand = _Candidate(last_seen_ppid=ppid, last_seen_at=now)
+                self._candidates[identity] = cand
+            else:
+                if ppid == mypid and cand.last_seen_ppid != mypid:
+                    # Same incarnation, previously under another parent,
+                    # now under us: kernel-observed adoption. A first
+                    # sighting that is ALREADY ours records ppid == us
+                    # and can never flip this flag (§3.6 pin 1).
+                    cand.adoption_observed = True
+                cand.last_seen_ppid = ppid
+                cand.last_seen_at = now
+            if state == b"Z" and ppid == mypid and cand.zombie_since is None:
+                # Grace runs from the first observation AS A ZOMBIE —
+                # time spent adopted-but-alive must not pre-spend it
+                # (§3.2: a long-lived ControlPersist master would
+                # otherwise exhaust its grace before it dies).
+                cand.zombie_since = now
+        if complete:
+            # Only a COMPLETE table may infer absence (§3.4): identities
+            # that disappeared or changed incarnation are forgotten, in
+            # both the candidate history and the registration registry.
+            for identity in list(self._candidates):
+                entry = table.get(identity[0])
+                if entry is None or entry[1] != identity[1]:
+                    del self._candidates[identity]
+            for identity in list(_reap_registry):
+                entry = table.get(identity[0])
+                if entry is None or entry[1] != identity[1]:
+                    del _reap_registry[identity]
+        # Age bound: the backstop for prolonged /proc failure, where the
+        # completeness-gated pruning above never runs.
+        for identity, cand in list(self._candidates.items()):
+            if (now - cand.last_seen_at) > self.MAX_AGE:
+                del self._candidates[identity]
+                evicted += 1
+        if evicted:
+            self.evicted_total += evicted
+            log.warning(
+                "Zombie-candidate history evicted %d entry(ies) (cap/age) — "
+                "affected reaps defer to teardown", evicted,
+            )
+        if not complete:
+            return 0  # an incomplete scan authorizes nothing (§3.4)
         owned = _pidfd_owned_pids()
         if owned is None:
             return 0  # cannot prove abandonment — reap nothing
-        mypid = os.getpid()
-        registered = self._registered() if self._registered else frozenset()
-        current = _zombie_children(mypid)
-        # Forget identities that are no longer zombies of ours.
-        for identity in list(self._first_seen):
-            if identity not in current:
-                del self._first_seen[identity]
-        now = time.monotonic()
         reaped = 0
-        for identity in current:
+        for identity, cand in list(self._candidates.items()):
             pid, start = identity
-            if pid in owned or identity in registered:
-                self._first_seen.pop(identity, None)
+            if cand.zombie_since is None or pid in owned:
                 continue
-            first = self._first_seen.setdefault(identity, now)
-            if not ignore_grace and (now - first) < self._grace:
+            if (now - cand.zombie_since) < self._grace:
                 continue
-            # Re-verify the exact incarnation immediately before reaping.
-            if identity not in _zombie_children(mypid):
-                self._first_seen.pop(identity, None)
-                continue
-            try:
-                if os.waitpid(pid, os.WNOHANG)[0]:
-                    reaped += 1
-                    self.reaped_total += 1
-            except (ChildProcessError, OSError):
-                pass  # someone else owned it after all
-            self._first_seen.pop(identity, None)
+            if not (cand.adoption_observed or identity in _reap_registry):
+                continue  # no positive evidence — age alone never reaps
+            verdict = _reap_identity(pid, start, mypid)
+            if verdict is True:
+                reaped += 1
+                self.reaped_total += 1
+            if verdict is not False:
+                del self._candidates[identity]
+                _reap_registry.pop(identity, None)
         return reaped
 
-    def drain_at_teardown(self) -> int:
-        """Final exact-PID drain, no grace.
+    def drain_at_teardown(self) -> tuple[int, bool]:
+        """Final no-grace drain (design §3.3 step 5).
 
-        Runs after every subprocess-owning subsystem has closed, so no
-        legitimate future wait remains — and it keeps zombies from
-        surviving an in-place ``execve`` (Odin's teardown amendment).
+        Returns ``(reaped, verified)``. Runs after the periodic reaper
+        is stopped, loop tasks are done, async generators are shut and
+        the default executor has joined — every subprocess owner has
+        stopped, so EVERY remaining zombie child is ours: transition
+        history and registration are unnecessary (nobody can
+        legitimately wait later), and the pidfd exclusion does not
+        apply (asyncio will never run its callbacks again; the same
+        fact is what keeps zombies from surviving an in-place
+        ``execve``).
+
+        ``verified`` is True only when a COMPLETE scan observed zero
+        remaining zombie children. The caller must treat False as a
+        VETO for in-place re-exec (§3.3): exec'ing over unproven state
+        hands invisible survivors to the new image.
         """
-        return self.sweep_once(ignore_grace=True)
+        mypid = os.getpid()
+        total = 0
+
+        def _remaining() -> tuple[list[tuple[int, int]], bool]:
+            table, complete = _scan_process_table()
+            return (
+                [
+                    (pid, entry[1])
+                    for pid, entry in table.items()
+                    if entry[2] == b"Z" and entry[0] == mypid
+                ],
+                complete,
+            )
+
+        # A still-live adopted child may die mid-drain and add a fresh
+        # zombie; bounded re-scans converge on the settled table.
+        for _attempt in range(4):
+            zombies, complete = _remaining()
+            if complete and not zombies:
+                return total, True
+            progressed = False
+            for pid, start in zombies:
+                verdict = _reap_identity(pid, start, mypid)
+                if verdict is True:
+                    total += 1
+                    self.reaped_total += 1
+                if verdict is not False:
+                    progressed = True
+            if not progressed:
+                return total, False
+        zombies, complete = _remaining()
+        return total, (complete and not zombies)
 
 
 class ProcessCleanupError(RuntimeError):
@@ -525,6 +799,18 @@ def _scan_owned_members(
                         start = _proc_starttime(cur)
                         if start is not None:
                             adopted_sink.add((cur, start))
+                            if not teardown:
+                                # Positive ownership, proven while alive:
+                                # its exit status will land on us, and the
+                                # central reaper may consume it (§3.1.2).
+                                # (Usually redundant with the direct-child
+                                # registration below — this arm still
+                                # covers an adopted ancestor reached from
+                                # a descendant's walk when the ancestor's
+                                # own candidate pin failed.)
+                                register_reap_identity(
+                                    cur, start, source="job-escapee"
+                                )
                     return True  # our escapee: adopted AND provably ours
                 # Carries OUR process marker but a different job (or
                 # none): another Odin subsystem's child — decidedly not
@@ -537,6 +823,25 @@ def _scan_owned_members(
         verdict = _owned(pid)
         if verdict:
             pinned.append((pid, fd))
+            if (
+                not teardown
+                and adopted_sink is not None
+                and adopted_by is not None
+                and pid not in known_own_children
+                and ids[pid][0] == adopted_by
+            ):
+                # A verified-ours member that is ALREADY our direct child
+                # was ADOPTED — its original parent died — so its exit
+                # status will land on us and nothing else will ever wait
+                # on it. Capture the identity while it is alive: a zombie
+                # can no longer be attributed. (Round-15: the soak's
+                # job-shell `sleep` was exactly this — killed as a
+                # session member but never recorded as adopted, so its
+                # zombie lingered for the process lifetime.)
+                start = _proc_starttime(pid)
+                if start is not None:
+                    adopted_sink.add((pid, start))
+                    register_reap_identity(pid, start, source="job-adopted")
             continue
         if verdict is None:
             complete = False

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -55,20 +55,33 @@ def set_child_subreaper(enabled: bool = True) -> bool:
     return child_subreaper_active()
 
 
-def reap_adopted_zombies(adopted_pids: frozenset[int] = frozenset()) -> int:
+def reap_adopted_zombies(
+    adopted: set[tuple[int, int]] | frozenset[tuple[int, int]] = frozenset(),
+) -> int:
     """Reap zombies among orphans we previously VERIFIED as ours.
 
     Attribution happened while each process was alive (a zombie's
-    environment is unreadable), so this works from recorded pids. Only
-    zombies parented to us are touched, and ``waitpid`` on anything that
-    is not our child raises and is swallowed — another subsystem's status
-    is never taken.
+    environment is unreadable), so this works from recorded
+    ``(pid, starttime)`` identities — the starttime is re-checked so pid
+    reuse can never redirect a ``waitpid`` at an unrelated child
+    (round-11 #2). Only zombies parented to us are touched, and settled
+    entries are pruned from a mutable record.
     """
-    if not adopted_pids:
+    if not adopted:
         return 0
     reaped = 0
     mypid = os.getpid()
-    for pid in adopted_pids:
+    mutable = adopted if isinstance(adopted, set) else None
+    for pid, start in list(adopted):
+        current = _proc_starttime(pid)
+        if current is None:
+            if mutable is not None:
+                mutable.discard((pid, start))
+            continue
+        if current != start:
+            if mutable is not None:
+                mutable.discard((pid, start))  # pid reused — not ours
+            continue
         try:
             raw = Path(f"/proc/{pid}/stat").read_bytes()
             rest = raw.rsplit(b")", 1)[1].split()
@@ -79,6 +92,8 @@ def reap_adopted_zombies(adopted_pids: frozenset[int] = frozenset()) -> int:
         try:
             if os.waitpid(pid, os.WNOHANG)[0]:
                 reaped += 1
+                if mutable is not None:
+                    mutable.discard((pid, start))
         except (ChildProcessError, OSError):
             pass
     return reaped
@@ -160,6 +175,22 @@ def _proc_ids(pid: int) -> tuple[int, int] | None | str:
         return "unknown"  # malformed — never treated as absence
 
 
+def _proc_starttime(pid: int) -> int | None:
+    """Field 22 of /proc/<pid>/stat — the incarnation discriminator.
+
+    A bare pid is not an identity: after reuse it names a different
+    process entirely (round-11 #2). ``(pid, starttime)`` is stable and
+    unique for the life of one incarnation, so a recorded escapee can
+    never be confused with whatever later occupies its pid.
+    """
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_bytes()
+        rest = raw.rsplit(b")", 1)[1].split()
+        return int(rest[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
 def _proc_session(pid: int) -> int | None | str:
     """Session id alone (see :func:`_proc_ids` for the sentinel contract)."""
     ids = _proc_ids(pid)
@@ -175,7 +206,8 @@ def _scan_owned_members(
     adopted_by: int | None = None,
     known_own_children: frozenset[int] = frozenset(),
     job_token: str | None = None,
-    adopted_sink: set[int] | None = None,
+    proc_token: str | None = None,
+    adopted_sink: set[tuple[int, int]] | None = None,
 ) -> tuple[list[tuple[int, int]], bool]:
     """Enumerate every process we own, each PINNED with a pidfd.
 
@@ -261,18 +293,35 @@ def _scan_owned_members(
             ):
                 if job_token is None:
                     return None  # cannot attribute — ambiguous, never killed
-                token = _read_job_token(cur)
+                tokens = _read_env_tokens(cur)
+                if tokens is _UNKNOWN or tokens is None:
+                    return None  # unreadable — ambiguous, fail closed
+                assert isinstance(tokens, dict)
+                if PROC_TOKEN_ENV not in tokens or (
+                    proc_token is not None
+                    and tokens.get(PROC_TOKEN_ENV) != proc_token
+                ):
+                    # No Odin process marker at all: the environment was
+                    # DISCARDED (`env -i`, execve with an empty env), so
+                    # "not ours" cannot be concluded — an escapee could
+                    # erase its own provenance and be certified gone while
+                    # alive (round-11 #1). Fail closed.
+                    return None
+                token = tokens.get(JOB_TOKEN_ENV)
                 if token == job_token:
                     # Record provenance NOW: a zombie has no address
                     # space, so /proc/<pid>/environ becomes unreadable the
                     # moment it dies — identification must happen while it
                     # is alive, and reaping later goes by recorded pid.
                     if adopted_sink is not None:
-                        adopted_sink.add(cur)
+                        start = _proc_starttime(cur)
+                        if start is not None:
+                            adopted_sink.add((cur, start))
                     return True  # our escapee: adopted AND provably ours
-                if token is _UNKNOWN:
-                    return None  # unreadable provenance — ambiguous
-                return False  # another subsystem's child — NOT ours
+                # Carries OUR process marker but a different job (or
+                # none): another Odin subsystem's child — decidedly not
+                # this job's, and killing it would be collateral damage.
+                return False
             cur = ppid
         return None  # bound exhausted — UNKNOWN, never "not ours"
 
@@ -288,20 +337,28 @@ def _scan_owned_members(
 
 
 JOB_TOKEN_ENV = "ODIN_BG_JOB"
+# Process-wide provenance: stamped into os.environ at startup, so EVERY
+# subprocess Odin spawns inherits it — background jobs, ssh/run_command
+# children, browser workers alike. It is what lets a direct child with a
+# DIFFERENT job (or none) be decided "another subsystem's, not ours"
+# instead of ambiguous; only a child that deliberately discarded its
+# environment lacks it, and that is exactly the case that must fail
+# closed (round-11 #1).
+PROC_TOKEN_ENV = "ODIN_PROC"
 
 
-def _read_job_token(pid: int) -> str | None | object:
-    """This process's managed-job token from /proc/<pid>/environ.
+def _read_env_tokens(pid: int) -> dict[str, str] | None | object:
+    """This process's Odin provenance markers from /proc/<pid>/environ.
 
-    Returns the token, ``None`` when the process carries none (or is
-    gone), or :data:`_UNKNOWN` when the environment could not be read —
-    ambiguity, never absence.
+    Returns a dict with whichever of ``ODIN_PROC``/``ODIN_BG_JOB`` are
+    present, ``None`` when the process is gone, or :data:`_UNKNOWN` when
+    the environment could not be read — ambiguity, never absence.
 
-    The token is injected at spawn and inherited across fork AND exec, so
-    it follows a descendant that double-forks or calls ``setsid()``. It
-    is per-JOB, which process-wide subreaping cannot provide: adoption
-    alone cannot tell OUR escapee from an unrelated subprocess another
-    Odin subsystem started (round-10).
+    The markers are inherited across fork AND exec, so they follow a
+    descendant that double-forks or calls ``setsid()``. They are NOT a
+    security boundary: a child can discard its environment, which is why
+    a missing process marker fails closed rather than reading as "not
+    ours" (round-11 #1).
     """
     try:
         raw = Path(f"/proc/{pid}/environ").read_bytes()
@@ -309,27 +366,49 @@ def _read_job_token(pid: int) -> str | None | object:
         return None
     except OSError:
         return _UNKNOWN
-    marker = JOB_TOKEN_ENV.encode() + b"="
-    for item in raw.split(b"\0"):
-        if item.startswith(marker):
-            return item[len(marker):].decode("utf-8", "replace")
-    return None
+    found: dict[str, str] = {}
+    for key in (PROC_TOKEN_ENV, JOB_TOKEN_ENV):
+        marker = key.encode() + b"="
+        for item in raw.split(b"\0"):
+            if item.startswith(marker):
+                found[key] = item[len(marker):].decode("utf-8", "replace")
+                break
+    return found
 
 
-def _reap_adopted(pids: set[int], known_own_children: frozenset[int]) -> None:
+def _read_job_token(pid: int) -> str | None | object:
+    """Just this job's token (see :func:`_read_env_tokens`)."""
+    tokens = _read_env_tokens(pid)
+    if tokens is None or tokens is _UNKNOWN:
+        return tokens
+    assert isinstance(tokens, dict)
+    return tokens.get(JOB_TOKEN_ENV)
+
+
+def _reap_adopted(
+    identities: set[tuple[int, int]], known_own_children: frozenset[int]
+) -> None:
     """Non-blocking reap of orphans already VERIFIED as ours.
 
-    ``pids`` were attributed to this job by provenance while they were
-    alive — a zombie has no address space, so its environment cannot be
-    re-read afterwards. Pids we deliberately spawned are still excluded:
-    asyncio's child watcher owns those statuses and stealing one would
-    break it. Never ``waitpid(-1)`` for the same reason.
+    Entries are ``(pid, starttime)``: a bare pid is not an identity after
+    reuse (round-11 #2), so the incarnation is re-checked before any
+    ``waitpid``. Pids we deliberately spawned are still excluded —
+    asyncio's child watcher owns those statuses. Never ``waitpid(-1)``.
+    Settled entries are pruned so the record cannot grow without bound.
     """
-    for pid in list(pids):
+    for pid, start in list(identities):
         if pid in known_own_children:
             continue
+        current = _proc_starttime(pid)
+        if current is None:
+            identities.discard((pid, start))  # provably gone
+            continue
+        if current != start:
+            identities.discard((pid, start))  # pid reused — not our process
+            continue
         try:
-            os.waitpid(pid, os.WNOHANG)
+            if os.waitpid(pid, os.WNOHANG)[0]:
+                identities.discard((pid, start))
         except (ChildProcessError, OSError):
             pass  # not our child, or already reaped
 
@@ -373,7 +452,8 @@ async def _terminate_session_until_empty(
     known_own_children: frozenset[int] = frozenset(),
     containment: bool = True,
     job_token: str | None = None,
-    adopted_sink: set[int] | None = None,
+    proc_token: str | None = None,
+    adopted_sink: set[tuple[int, int]] | None = None,
 ) -> bool:
     """Drive everything we own to provably empty.
 
@@ -397,7 +477,9 @@ async def _terminate_session_until_empty(
     (round-9 #1).
     """
     deadline = time.monotonic() + timeout
-    adopted: set[int] = adopted_sink if adopted_sink is not None else set()
+    adopted: set[tuple[int, int]] = (
+        adopted_sink if adopted_sink is not None else set()
+    )
     termed: set[int] = set()
     escalate_at = time.monotonic() + grace if term_first else 0.0
     clean_scans = 0
@@ -408,6 +490,7 @@ async def _terminate_session_until_empty(
             adopted_by=adopted_by,
             known_own_children=known_own_children,
             job_token=job_token,
+            proc_token=proc_token,
             adopted_sink=adopted,
         )
         try:
@@ -518,7 +601,7 @@ class ProcessRegistry:
         # Orphans verified as OURS by provenance while alive — reaping
         # goes by recorded pid because a zombie's environment is
         # unreadable (round-10).
-        self._adopted_pids: set[int] = set()
+        self._adopted_pids: set[tuple[int, int]] = set()
 
     @property
     def _containment(self) -> bool:
@@ -824,7 +907,7 @@ class ProcessRegistry:
             self._processes.pop(pid)
         # Adopted orphans die as zombies (nothing else will wait on them);
         # sweep them here so a long-running process cannot accumulate.
-        reap_adopted_zombies(frozenset(self._adopted_pids))
+        reap_adopted_zombies(self._adopted_pids)
         return len(to_remove)
 
     # ------------------------------------------------------------------
@@ -855,6 +938,7 @@ class ProcessRegistry:
             known_own_children=frozenset(self._own_children),
             containment=self._containment,
             job_token=info.job_token or None,
+            proc_token=os.environ.get(PROC_TOKEN_ENV),
             adopted_sink=self._adopted_pids,
         )
         info.session_confirmed_empty = gone
@@ -950,6 +1034,7 @@ class ProcessRegistry:
                 known_own_children=frozenset(self._own_children),
                 containment=self._containment,
                 job_token=info.job_token or None,
+                proc_token=os.environ.get(PROC_TOKEN_ENV),
                 adopted_sink=self._adopted_pids,
             )
         except Exception:

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -208,6 +208,7 @@ def _scan_owned_members(
     job_token: str | None = None,
     proc_token: str | None = None,
     adopted_sink: set[tuple[int, int]] | None = None,
+    teardown: bool = False,
 ) -> tuple[list[tuple[int, int]], bool]:
     """Enumerate every process we own, each PINNED with a pidfd.
 
@@ -227,9 +228,17 @@ def _scan_owned_members(
       ALSO carry this job's ``ODIN_BG_JOB`` token, injected at spawn and
       inherited across fork, exec and setsid.
 
-    A direct child whose provenance cannot be established is left
-    UNTOUCHED and makes the scan incomplete — ambiguity never authorizes
-    a kill, and never permits affirmative emptiness either.
+    Environment markers are CHILD-CONTROLLED: a descendant can delete or
+    FORGE them, so they can never prove a process foreign. During normal
+    operation that means ambiguity is left UNTOUCHED and makes the scan
+    incomplete — never a kill, never affirmative emptiness.
+
+    ``teardown=True`` (the shutdown barrier only) resolves that ambiguity
+    the other way, on kernel facts alone: every adopted orphan is ours to
+    end. There is no collateral concern at that point — the whole process
+    is going away, every subsystem's children are being torn down with
+    it, and the alternative is exec'"'"'ing over survivors we cannot see
+    (round-13).
 
     The pin happens BEFORE membership is verified, so verification and
     every later signal act on the exact process the fd names. ``complete``
@@ -239,6 +248,10 @@ def _scan_owned_members(
     (round-9 #3). Caller owns the returned fds.
     """
     pinned: list[tuple[int, int]] = []
+    try:
+        own_session = os.getsid(0)
+    except OSError:
+        own_session = -1
     try:
         entries = os.listdir("/proc")
     except OSError:
@@ -297,6 +310,19 @@ def _scan_owned_members(
                 if tokens is _UNKNOWN or tokens is None:
                     return None  # unreadable — ambiguous, fail closed
                 assert isinstance(tokens, dict)
+                if teardown and session != own_session:
+                    # Shutdown: an adopted orphan that LEFT our session is
+                    # an escapee — only `setsid()` gets a process out, and
+                    # no forged or deleted environment marker can buy it
+                    # survival past our own teardown. Ordinary subsystem
+                    # children (ssh, run_command, browser) stay IN our
+                    # session, so they are never swept by this arm — the
+                    # round-10 collateral-damage rule still holds.
+                    if adopted_sink is not None:
+                        start = _proc_starttime(cur)
+                        if start is not None:
+                            adopted_sink.add((cur, start))
+                    return True
                 if PROC_TOKEN_ENV not in tokens or (
                     proc_token is not None
                     and tokens.get(PROC_TOKEN_ENV) != proc_token
@@ -466,6 +492,7 @@ async def _terminate_session_until_empty(
     job_token: str | None = None,
     proc_token: str | None = None,
     adopted_sink: set[tuple[int, int]] | None = None,
+    teardown: bool = False,
 ) -> bool:
     """Drive everything we own to provably empty.
 
@@ -504,6 +531,7 @@ async def _terminate_session_until_empty(
             job_token=job_token,
             proc_token=proc_token,
             adopted_sink=adopted,
+            teardown=teardown,
         )
         try:
             if complete and not pinned and containment:
@@ -952,6 +980,7 @@ class ProcessRegistry:
             job_token=info.job_token or None,
             proc_token=os.environ.get(PROC_TOKEN_ENV),
             adopted_sink=self._adopted_pids,
+            teardown=True,  # shutdown barrier: adoption is sufficient
         )
         info.session_confirmed_empty = gone
         if proc.returncode is None:

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -8,7 +8,9 @@ output lines (max 500) and is auto-killed after 1 hour.
 from __future__ import annotations
 
 import asyncio
+import os
 import re
+import signal
 import time
 from collections import deque
 from collections.abc import Callable
@@ -210,7 +212,12 @@ class ProcessRegistry:
         if not info:
             return f"No process with PID {pid}."
 
-        exited = info.status != "running"
+        # Exit detection must not depend on the watcher having PUBLISHED
+        # yet (round-3 blocker #3): returncode is set at SIGCHLD reap, so a
+        # zero-wait poll landing in the publication window still settles.
+        exited = info.status != "running" or (
+            info.process is not None and info.process.returncode is not None
+        )
         if wait_seconds > 0 and not exited and info.process is not None:
             exited = await _wait_leader_exit(info.process, timeout=wait_seconds)
         if exited:
@@ -340,7 +347,15 @@ class ProcessRegistry:
                         asyncio.shield(task), timeout=SHUTDOWN_REAP_TIMEOUT
                     )
                 except TimeoutError:
-                    log.warning("Reaper for PID %d did not finish; cancelling", pid)
+                    # A wedged async reap must not strand TERM-immune
+                    # descendants across re-exec (round-3 blocker #2):
+                    # hard-KILL the owned group SYNCHRONOUSLY — bounded, no
+                    # await — before abandoning the task.
+                    log.warning(
+                        "Reaper for PID %d did not finish; hard-killing group "
+                        "before abandoning", pid,
+                    )
+                    self._hard_kill_group(info)
                     task.cancel()
                 except Exception:
                     log.debug(
@@ -379,6 +394,29 @@ class ProcessRegistry:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _hard_kill_group(info: ProcessInfo) -> None:
+        """Synchronous last-resort SIGKILL of the OWNED process group.
+
+        Only ever called for a group our start() created with
+        start_new_session=True, so the leader pid IS the pgid. Same
+        signallable guard shape as terminate_process_tree: pgid must be
+        real (>1) and never our own group — a broadcast is impossible by
+        construction (the v3.59.1 rail).
+        """
+        proc = info.process
+        if proc is None:
+            return
+        pgid = proc.pid
+        try:
+            if pgid > 1 and pgid != os.getpgrp():
+                os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass  # group already gone — the goal state
+        except Exception:
+            log.debug("hard group kill for PID %d failed", info.pid, exc_info=True)
+
 
     async def _read_output(self, info: ProcessInfo) -> None:
         """Drain stdout into the ring buffer. Pure drainage — terminal

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -99,6 +99,181 @@ def reap_adopted_zombies(
     return reaped
 
 
+
+def _pidfd_owned_pids() -> set[int] | None:
+    """PIDs for which THIS process holds an open pidfd.
+
+    The runtime uses ``PidfdChildWatcher``, so an open pidfd means the
+    event loop still owns that child's exit status and nobody else may
+    consume it — the decisive ownership signal (round-14 design, Odin:
+    "age alone is not proof that nobody owns the exit status").
+
+    Returns None when the fd table cannot be read: the caller must then
+    prove nothing and reap nothing.
+    """
+    try:
+        entries = os.listdir("/proc/self/fd")
+    except OSError:
+        return None
+    owned: set[int] = set()
+    for entry in entries:
+        try:
+            info = Path(f"/proc/self/fdinfo/{entry}").read_text()
+        except OSError:
+            continue  # fd closed under us — not evidence either way
+        for line in info.splitlines():
+            if line.startswith("Pid:"):
+                try:
+                    owned.add(int(line.split()[1]))
+                except (IndexError, ValueError):
+                    pass
+                break
+    return owned
+
+
+def _zombie_children(parent: int) -> dict[tuple[int, int], None]:
+    """``(pid, starttime)`` of every zombie whose parent is ``parent``."""
+    found: dict[tuple[int, int], None] = {}
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return found
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        try:
+            raw = Path(f"/proc/{pid}/stat").read_bytes()
+            rest = raw.rsplit(b")", 1)[1].split()
+            if rest[0] != b"Z" or int(rest[1]) != parent:
+                continue
+            found[(pid, int(rest[19]))] = None
+        except (OSError, IndexError, ValueError):
+            continue
+    return found
+
+
+class AdoptedZombieReaper:
+    """Reaps orphaned descendants that child-subreaper containment made
+    ours (PR #244 soak finding).
+
+    Containment reparents escaped grandchildren to this process instead
+    of PID 1, so nothing else will ever wait on them — an ``ssh``
+    ControlPersist master or a job shell's forked child otherwise lingers
+    as a zombie forever. Ownership is decided by evidence, never by
+    guesswork:
+
+    - an open **pidfd** for that pid means asyncio still owns the status
+      (never reaped);
+    - an explicitly **registered** child identity is skipped;
+    - a candidate must be observed as the same ``(pid, starttime)``
+      zombie across at least ``grace`` seconds, and re-verified
+      immediately before the ``waitpid(pid, WNOHANG)``.
+
+    An unreadable fd table proves nothing, so the pass reaps nothing.
+    """
+
+    SCAN_INTERVAL = 15.0
+    GRACE = 30.0
+
+    def __init__(
+        self,
+        *,
+        registered: Callable[[], frozenset[tuple[int, int]]] | None = None,
+        scan_interval: float = SCAN_INTERVAL,
+        grace: float = GRACE,
+    ) -> None:
+        self._registered = registered
+        self._scan_interval = scan_interval
+        self._grace = grace
+        self._first_seen: dict[tuple[int, int], float] = {}
+        self._task: asyncio.Task | None = None
+        self.reaped_total = 0
+
+    @property
+    def pending_zombies(self) -> int:
+        return len(self._first_seen)
+
+    @property
+    def stats(self) -> dict[str, int]:
+        return {
+            "pending_zombies": self.pending_zombies,
+            "reaped_total": self.reaped_total,
+        }
+
+    def start(self) -> None:
+        """Begin sweeping. Only meaningful once containment is active —
+        without it, orphans go to PID 1 and are never ours."""
+        if self._task is not None or not child_subreaper_active():
+            return
+        self._task = asyncio.create_task(self._run(), name="zombie-reaper")
+
+    async def stop(self) -> None:
+        task, self._task = self._task, None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(self._scan_interval)
+            try:
+                self.sweep_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A failing pass must never silently kill the task.
+                log.exception("Adopted-zombie sweep failed (continuing)")
+
+    def sweep_once(self, *, ignore_grace: bool = False) -> int:
+        """One pass. Returns the number reaped."""
+        owned = _pidfd_owned_pids()
+        if owned is None:
+            return 0  # cannot prove abandonment — reap nothing
+        mypid = os.getpid()
+        registered = self._registered() if self._registered else frozenset()
+        current = _zombie_children(mypid)
+        # Forget identities that are no longer zombies of ours.
+        for identity in list(self._first_seen):
+            if identity not in current:
+                del self._first_seen[identity]
+        now = time.monotonic()
+        reaped = 0
+        for identity in current:
+            pid, start = identity
+            if pid in owned or identity in registered:
+                self._first_seen.pop(identity, None)
+                continue
+            first = self._first_seen.setdefault(identity, now)
+            if not ignore_grace and (now - first) < self._grace:
+                continue
+            # Re-verify the exact incarnation immediately before reaping.
+            if identity not in _zombie_children(mypid):
+                self._first_seen.pop(identity, None)
+                continue
+            try:
+                if os.waitpid(pid, os.WNOHANG)[0]:
+                    reaped += 1
+                    self.reaped_total += 1
+            except (ChildProcessError, OSError):
+                pass  # someone else owned it after all
+            self._first_seen.pop(identity, None)
+        return reaped
+
+    def drain_at_teardown(self) -> int:
+        """Final exact-PID drain, no grace.
+
+        Runs after every subprocess-owning subsystem has closed, so no
+        legitimate future wait remains — and it keeps zombies from
+        surviving an in-place ``execve`` (Odin's teardown amendment).
+        """
+        return self.sweep_once(ignore_grace=True)
+
+
 class ProcessCleanupError(RuntimeError):
     """Shutdown could not affirmatively prove the owned session is empty.
 

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -66,6 +66,113 @@ def _utf8_boundary_split(buf: bytes) -> tuple[bytes, bytes]:
     return buf, b""
 
 
+
+def _stat_fields(pid: int) -> tuple[int, int] | None:
+    """(pgrp, session) from /proc/<pid>/stat, parsed after the comm parens
+    (comm may embed spaces/parens). None when the process vanished."""
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        rest = stat.rsplit(")", 1)[1].split()
+        return int(rest[2]), int(rest[3])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _pinned_group_members(pgid: int) -> list[tuple[int, int]]:
+    """Enumerate the group's members, each PINNED with a pidfd.
+
+    The pin happens BEFORE membership is verified, so the verification and
+    every later signal act on the exact process the fd names — pid reuse
+    between steps is structurally impossible (PR #244 round-5 blocker #2).
+    Membership = pgrp == pgid AND session == pgid: our leader was spawned
+    with start_new_session, its descendants inherit that session, and
+    setpgid cannot move a foreign process into it (same-session rule).
+    Candidates that cannot be pinned or verified are skipped — fail-safe.
+    Caller owns the returned fds.
+    """
+    pinned: list[tuple[int, int]] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return pinned
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        try:
+            fd = os.pidfd_open(pid)
+        except OSError:
+            continue
+        fields = _stat_fields(pid)
+        if fields is not None and fields == (pgid, pgid):
+            pinned.append((pid, fd))
+        else:
+            os.close(fd)
+    return pinned
+
+
+def _signal_pinned(pinned: list[tuple[int, int]], sig: int) -> None:
+    for pid, fd in pinned:
+        try:
+            signal.pidfd_send_signal(fd, sig)
+        except OSError:
+            log.debug("pidfd signal %d to PID %d failed", sig, pid)
+
+
+def _close_pinned(pinned: list[tuple[int, int]]) -> None:
+    for _pid, fd in pinned:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+async def _reap_group_racefree(pgid: int, grace: float = 2.0) -> None:
+    """TERM → bounded grace → KILL for every surviving group member,
+    delivered exclusively through pinned pidfds. Replaces killpg for the
+    post-leader-exit sweeps, where a numeric pgid can go stale."""
+    pinned = _pinned_group_members(pgid)
+    if not pinned:
+        return
+    try:
+        _signal_pinned(pinned, signal.SIGTERM)
+        deadline = time.monotonic() + grace
+        while time.monotonic() < deadline:
+            if all(_stat_fields(pid) is None or os.path.exists(f"/proc/{pid}") is False
+                   for pid, _fd in pinned):
+                break
+            # pidfds poll readable at exit; a cheap sleep-poll keeps this
+            # dependency-free and the bound tight.
+            await asyncio.sleep(0.1)
+            if all(_pidfd_exited(fd) for _pid, fd in pinned):
+                break
+        _signal_pinned(pinned, signal.SIGKILL)
+    finally:
+        _close_pinned(pinned)
+
+
+def _pidfd_exited(fd: int) -> bool:
+    """A pidfd polls readable exactly when its process has exited."""
+    import select
+
+    try:
+        r, _w, _x = select.select([fd], [], [], 0)
+        return bool(r)
+    except OSError:
+        return True
+
+
+def _kill_group_racefree_sync(pgid: int) -> int:
+    """Immediate SIGKILL of every pinned member — the synchronous
+    last-resort used by the shutdown barrier. Returns members signalled."""
+    pinned = _pinned_group_members(pgid)
+    try:
+        _signal_pinned(pinned, signal.SIGKILL)
+        return len(pinned)
+    finally:
+        _close_pinned(pinned)
+
+
 async def _wait_leader_exit(
     proc: asyncio.subprocess.Process, timeout: float | None = None
 ) -> bool:
@@ -283,9 +390,12 @@ class ProcessRegistry:
                 # Group-aware TERM → bounded grace → KILL → reap. Descendants
                 # of the managed shell die with it instead of leaking (they
                 # would otherwise outlive an in-place restart's exec).
-                # owned_pgid: start() spawns with start_new_session=True, so
-                # the group stays signallable after the leader exits.
-                await terminate_process_tree(info.process, grace=5.0, owned_pgid=info.process.pid)
+                # No owned_pgid (round-5 blocker #2): kill() runs only
+                # while status is running, so terminate_process_tree
+                # discovers and VERIFIES the group against the live leader
+                # rather than trusting a stale-capable number; the exit
+                # watcher's race-free pidfd sweep finishes any survivors.
+                await terminate_process_tree(info.process, grace=5.0)
             info.status = "failed"
             info.exit_code = -9
             log.info("Killed process PID %d", pid)
@@ -348,28 +458,17 @@ class ProcessRegistry:
                     )
                 except TimeoutError:
                     # A wedged async reap must not strand TERM-immune
-                    # descendants across re-exec (round-3 blocker #2) — but
-                    # the fallback may only signal a PGID that is provably
-                    # still ours (round-4 blocker #1), and must leave a
-                    # COMPLETION BARRIER behind: cancellation awaited, the
-                    # leader reaped, group disappearance confirmed.
+                    # descendants across re-exec. The BARRIER is ordered so
+                    # that the process state — not the task — decides when
+                    # shutdown may return (round-5 blocker #1): a
+                    # cancellation-resistant task can never hold us, because
+                    # we never await it unboundedly.
                     log.warning(
                         "Reaper for PID %d did not finish; hard-killing group "
                         "before abandoning", pid,
                     )
-                    if self._pgid_safe_to_signal(info):
-                        self._hard_kill_group(info)
-                    task.cancel()
-                    try:
-                        await asyncio.wait_for(task, timeout=2.0)
-                    except (TimeoutError, asyncio.CancelledError):
-                        pass
-                    except Exception:
-                        log.debug("abandoned reaper errored", exc_info=True)
-                    if info.process is not None and info.process.returncode is None:
-                        # Reap the leader so no zombie crosses the exec.
-                        await _wait_leader_exit(info.process, timeout=3.0)
-                    await self._confirm_group_gone(info)
+                    task.cancel()  # best effort; NEVER awaited unbounded
+                    await self._kill_group_until_gone(info)
                 except Exception:
                     log.debug(
                         "Reaper for PID %d errored during shutdown", pid, exc_info=True
@@ -408,72 +507,40 @@ class ProcessRegistry:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _pgid_safe_to_signal(info: ProcessInfo) -> bool:
-        """Whether ``info``'s recorded PGID still provably names OUR group.
+    async def _kill_group_until_gone(
+        self, info: ProcessInfo, timeout: float = 6.0
+    ) -> bool:
+        """Bounded, race-free termination of everything we still own.
 
-        An unreaped leader (``returncode is None``) pins its pid — the
-        value cannot be recycled while the process (or its zombie) exists.
-        After the leader is reaped, POSIX keeps the pgid VALUE unusable
-        while any group member survives, and a NEW group can only claim it
-        via a new leader process occupying exactly that pid — which would
-        appear in /proc. So: /proc/<pgid> PRESENT after reap ⇒ recycled ⇒
-        never signal; ABSENT ⇒ killpg reaches our surviving members or
-        raises ESRCH — both safe (round-4 blocker #1).
+        The shutdown completion barrier (round-4 #1, hardened round-5 #1):
+        repeatedly pin the surviving group members by pidfd, SIGKILL them,
+        and re-enumerate until the group is empty or the bound elapses —
+        every signal aimed at a process pinned BEFORE its membership was
+        verified, so pid reuse cannot misdirect one. The leader is reaped
+        in the same loop so no zombie crosses the exec.
+
+        Returns True when the group is provably gone. A False return is
+        LOUD (error, not debug) and is what the caller reports.
         """
         proc = info.process
         if proc is None:
-            return False
-        if proc.returncode is None:
             return True
-        return not Path(f"/proc/{proc.pid}").exists()
-
-    async def _confirm_group_gone(self, info: ProcessInfo, timeout: float = 3.0) -> None:
-        """Bounded confirmation that the owned group has dissolved.
-
-        Part of the shutdown completion barrier: signal-0 existence probes
-        (deliver nothing) until ESRCH or the bound — a still-present group
-        at the bound is LOGGED loudly rather than silently abandoned.
-        """
-        proc = info.process
-        if proc is None or not self._pgid_safe_to_signal(info):
-            return
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            try:
-                os.killpg(proc.pid, 0)
-            except ProcessLookupError:
-                return
-            except Exception:
-                return
+        while True:
+            survivors = _kill_group_racefree_sync(proc.pid)
+            if proc.returncode is None:
+                # Reap the leader (bounded) so it cannot linger as a zombie.
+                await _wait_leader_exit(proc, timeout=0.5)
+            if survivors == 0 and proc.returncode is not None:
+                return True
+            if time.monotonic() >= deadline:
+                log.error(
+                    "Shutdown could not confirm PID %d's group is gone "
+                    "(%d member(s) still present, leader rc=%r)",
+                    info.pid, survivors, proc.returncode,
+                )
+                return False
             await asyncio.sleep(0.1)
-        log.warning(
-            "Process group %d still present after shutdown hard-kill window",
-            proc.pid,
-        )
-
-    @staticmethod
-    def _hard_kill_group(info: ProcessInfo) -> None:
-        """Synchronous last-resort SIGKILL of the OWNED process group.
-
-        Only ever called for a group our start() created with
-        start_new_session=True, so the leader pid IS the pgid. Same
-        signallable guard shape as terminate_process_tree: pgid must be
-        real (>1) and never our own group — a broadcast is impossible by
-        construction (the v3.59.1 rail).
-        """
-        proc = info.process
-        if proc is None:
-            return
-        pgid = proc.pid
-        try:
-            if pgid > 1 and pgid != os.getpgrp():
-                os.killpg(pgid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass  # group already gone — the goal state
-        except Exception:
-            log.debug("hard group kill for PID %d failed", info.pid, exc_info=True)
-
 
     async def _read_output(self, info: ProcessInfo) -> None:
         """Drain stdout into the ring buffer. Pure drainage — terminal
@@ -541,13 +608,12 @@ class ProcessRegistry:
                 info.status = "failed"
 
         # Reap while ownership is fresh: a non-empty group keeps the leader
-        # pid from being recycled, so owned_pgid still uniquely names OUR
-        # group. After this, shutdown() need not (and must not) signal a
-        # stale, possibly-recycled pgid for an already-terminal record.
-        from ..tools.ssh import terminate_process_tree
-
+        # pid from being recycled — but ONLY while a member survives, so a
+        # numeric pgid is stale-capable here (round-5 blocker #2). Every
+        # signal now goes through pidfds pinned BEFORE membership
+        # verification: TERM, bounded grace, then KILL for survivors.
         try:
-            await terminate_process_tree(info.process, grace=2.0, owned_pgid=info.process.pid)
+            await _reap_group_racefree(info.process.pid, grace=2.0)
         except Exception:
             log.debug("group reap after PID %d exit failed", info.pid, exc_info=True)
 

--- a/src/tools/process_manager.py
+++ b/src/tools/process_manager.py
@@ -308,6 +308,13 @@ def _scan_owned_members(
                     # alive (round-11 #1). Fail closed.
                     return None
                 token = tokens.get(JOB_TOKEN_ENV)
+                if token is None:
+                    # Process marker present but the JOB token deleted —
+                    # selective erasure (round-12). Every legitimate Odin
+                    # child inherits a job token (a default one is stamped
+                    # at startup), so its absence is evidence of tampering,
+                    # not of foreign ownership. Fail closed.
+                    return None
                 if token == job_token:
                     # Record provenance NOW: a zombie has no address
                     # space, so /proc/<pid>/environ becomes unreadable the
@@ -345,6 +352,11 @@ JOB_TOKEN_ENV = "ODIN_BG_JOB"
 # environment lacks it, and that is exactly the case that must fail
 # closed (round-11 #1).
 PROC_TOKEN_ENV = "ODIN_PROC"
+# Default job token stamped at startup so EVERY Odin child carries one.
+# It is what makes another subsystem's child DECIDABLE (its token differs
+# from the background job's) while a child that deleted its job token is
+# evidence of tampering and must fail closed (round-12).
+DEFAULT_JOB_TOKEN = "odin-main"
 
 
 def _read_env_tokens(pid: int) -> dict[str, str] | None | object:

--- a/src/tools/ssh.py
+++ b/src/tools/ssh.py
@@ -338,6 +338,13 @@ async def run_ssh_command(
                 output = stdout.decode("utf-8", errors="replace")
                 exit_code = proc.returncode or 0
 
+            if pool is not None:
+                # This command may have just forked a ControlPersist master
+                # (daemonized, so containment adopts it and its exit status
+                # becomes ours). Register its identity while it is alive —
+                # its zombie cannot be attributed later (PR #244).
+                await pool.ensure_master_registered(host, ssh_user)
+
             if exit_code == 0 or not _is_ssh_transient_failure(exit_code, output):
                 return exit_code, _truncate_output(output)
 
@@ -372,6 +379,11 @@ async def run_ssh_command(
             # next attempt.
             if proc is not None:
                 await terminate_process_tree(proc)
+            if pool is not None:
+                # Even a timed-out client may have established the master
+                # first — an unregistered master is exactly the zombie the
+                # soak found (PR #244).
+                await pool.ensure_master_registered(host, ssh_user)
             if attempt < max_retries - 1:
                 wait = compute_backoff(attempt, retry_base_delay, retry_max_delay)
                 log.warning(

--- a/src/tools/ssh.py
+++ b/src/tools/ssh.py
@@ -288,13 +288,7 @@ async def run_ssh_command(
     command itself) are NOT retried — they represent valid remote results.
     """
     if pool is not None:
-        ssh_args = pool.get_ssh_args(
-            host,
-            command,
-            ssh_key_path,
-            known_hosts_path,
-            ssh_user,
-        )
+        ssh_args: list[str] = []
     else:
         ssh_args = [
             "ssh",
@@ -318,7 +312,24 @@ async def run_ssh_command(
 
     for attempt in range(max_retries):
         proc: asyncio.subprocess.Process | None = None
+        pool_acquired = False
         try:
+            if pool is not None:
+                # Establish a foreground, asyncio-owned master before the
+                # command. The lease survives every return/exception arm via
+                # finally; release starts the configured idle-expiry timer.
+                was_connected = pool.is_connected(host, ssh_user)
+                pool_acquired = await pool.acquire(
+                    host, ssh_key_path, known_hosts_path, ssh_user
+                )
+                ssh_args = pool.get_ssh_args(
+                    host,
+                    command,
+                    ssh_key_path,
+                    known_hosts_path,
+                    ssh_user,
+                    was_connected=was_connected,
+                )
             # The ssh client is a direct child (no new session: killing the
             # client is sufficient — the remote side is ssh's own domain, and
             # ControlMaster mux masters must stay untouched).
@@ -339,10 +350,9 @@ async def run_ssh_command(
                 exit_code = proc.returncode or 0
 
             if pool is not None:
-                # This command may have just forked a ControlPersist master
-                # (daemonized, so containment adopts it and its exit status
-                # becomes ours). Register its identity while it is alive —
-                # its zombie cannot be attributed later (PR #244).
+                # Compatibility with a live socket inherited from the old
+                # daemonizing pool during an in-place update. New explicit
+                # masters are direct asyncio children and return immediately.
                 await pool.ensure_master_registered(host, ssh_user)
 
             if exit_code == 0 or not _is_ssh_transient_failure(exit_code, output):
@@ -380,9 +390,8 @@ async def run_ssh_command(
             if proc is not None:
                 await terminate_process_tree(proc)
             if pool is not None:
-                # Even a timed-out client may have established the master
-                # first — an unregistered master is exactly the zombie the
-                # soak found (PR #244).
+                # A legacy socket may still name a detached master; preserve
+                # its positive registration evidence until it is replaced.
                 await pool.ensure_master_registered(host, ssh_user)
             if attempt < max_retries - 1:
                 wait = compute_backoff(attempt, retry_base_delay, retry_max_delay)
@@ -407,6 +416,9 @@ async def run_ssh_command(
         except Exception as e:
             log.error("SSH command failed: %s", e)
             return 1, f"SSH error: {e}"
+        finally:
+            if pool is not None and pool_acquired:
+                pool.release(host, ssh_user)
 
     return last_exit_code, _truncate_output(last_output)
 

--- a/src/tools/ssh_pool.py
+++ b/src/tools/ssh_pool.py
@@ -23,9 +23,13 @@ def _socket_path(socket_dir: str, host: str, ssh_user: str) -> str:
 class SSHConnectionPool:
     """Manages persistent SSH connections via OpenSSH ControlMaster.
 
-    Each unique (host, ssh_user) pair gets a single multiplexed master
-    connection. Subsequent SSH commands to the same host reuse the
-    existing TCP connection — no new handshake, key exchange, or auth.
+    Masters are explicit foreground asyncio children. OpenSSH's built-in
+    ``ControlPersist`` detachment double-forks; under Odin's child-subreaper
+    containment its short-lived setsid intermediate is adopted after it has
+    already exited, so neither transition observation nor ``ssh -O check``
+    can positively identify it. Keeping the master in the foreground avoids
+    that unobservable orphan entirely. This class implements the configured
+    idle lifetime and closes/reaps the direct master itself.
     """
 
     def __init__(
@@ -36,9 +40,14 @@ class SSHConnectionPool:
         self.control_persist = control_persist
         self.socket_dir = socket_dir
         self._connections: dict[str, float] = {}
-        # Masters whose (pid, starttime) identity is registered with the
-        # adopted-zombie reaper — see ensure_master_registered (PR #244).
+        # Legacy/detached masters whose identity was captured by -O check.
+        # Explicit masters below are direct asyncio children and do not need
+        # adopted-zombie registration.
         self._registered_masters: dict[str, tuple[int, int]] = {}
+        self._masters: dict[str, asyncio.subprocess.Process] = {}
+        self._master_locks: dict[str, asyncio.Lock] = {}
+        self._active_leases: dict[str, int] = {}
+        self._expiry_tasks: dict[str, asyncio.Task] = {}
         self._total_reused: int = 0
         self._total_opened: int = 0
         os.makedirs(self.socket_dir, mode=0o700, exist_ok=True)
@@ -46,27 +55,22 @@ class SSHConnectionPool:
     def _key(self, host: str, ssh_user: str) -> str:
         return f"{ssh_user}@{host}"
 
+    def _lock(self, key: str) -> asyncio.Lock:
+        lock = self._master_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._master_locks[key] = lock
+        return lock
+
     def get_socket_path(self, host: str, ssh_user: str) -> str:
         return _socket_path(self.socket_dir, host, ssh_user)
 
-    def get_ssh_args(
-        self,
-        host: str,
-        command: str,
+    @staticmethod
+    def _base_args(
         ssh_key_path: str,
         known_hosts_path: str,
-        ssh_user: str = "root",
+        socket: str,
     ) -> list[str]:
-        """Build SSH command args with ControlMaster multiplexing."""
-        socket = self.get_socket_path(host, ssh_user)
-        key = self._key(host, ssh_user)
-
-        if self.is_connected(host, ssh_user):
-            self._total_reused += 1
-        else:
-            self._total_opened += 1
-            self._connections[key] = time.monotonic()
-
         return [
             "ssh",
             "-i",
@@ -80,11 +84,47 @@ class SSHConnectionPool:
             "-o",
             "BatchMode=yes",
             "-o",
+            f"ControlPath={socket}",
+        ]
+
+    def get_ssh_args(
+        self,
+        host: str,
+        command: str,
+        ssh_key_path: str,
+        known_hosts_path: str,
+        ssh_user: str = "root",
+        *,
+        was_connected: bool | None = None,
+    ) -> list[str]:
+        """Build SSH command args using an explicitly managed master.
+
+        ``ControlPersist=no`` is a safety boundary, not an optimization
+        toggle: if the explicit master disappears between acquisition and
+        command spawn, ``ControlMaster=auto`` may temporarily make the
+        command the master, but it must never daemonize and create an
+        unattributable fast-double-fork zombie.
+        """
+        socket = self.get_socket_path(host, ssh_user)
+        key = self._key(host, ssh_user)
+
+        connected = (
+            self.is_connected(host, ssh_user)
+            if was_connected is None
+            else was_connected
+        )
+        if connected:
+            self._total_reused += 1
+        else:
+            self._total_opened += 1
+            self._connections[key] = time.monotonic()
+
+        return [
+            *self._base_args(ssh_key_path, known_hosts_path, socket),
+            "-o",
             "ControlMaster=auto",
             "-o",
-            f"ControlPath={socket}",
-            "-o",
-            f"ControlPersist={self.control_persist}",
+            "ControlPersist=no",
             f"{ssh_user}@{host}",
             command,
         ]
@@ -94,23 +134,141 @@ class SSHConnectionPool:
         socket = self.get_socket_path(host, ssh_user)
         return os.path.exists(socket)
 
+    def _cancel_expiry(self, key: str) -> None:
+        task = self._expiry_tasks.pop(key, None)
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _stop_process(self, proc: asyncio.subprocess.Process) -> None:
+        """Boundedly stop and reap one explicit master/probe child."""
+        if proc.returncode is None:
+            try:
+                proc.terminate()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=3)
+            return
+        except TimeoutError:
+            pass
+        if proc.returncode is None:
+            try:
+                proc.kill()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=3)
+        except (TimeoutError, OSError, ProcessLookupError):
+            pass
+
+    async def _start_explicit_master(
+        self,
+        host: str,
+        ssh_key_path: str,
+        known_hosts_path: str,
+        ssh_user: str,
+    ) -> bool:
+        """Start a non-daemonizing ControlMaster and wait for its socket."""
+        key = self._key(host, ssh_user)
+        socket = self.get_socket_path(host, ssh_user)
+        proc = self._masters.get(key)
+        if proc is not None and proc.returncode is None and os.path.exists(socket):
+            return True
+        if proc is not None:
+            await self._stop_process(proc)
+            self._masters.pop(key, None)
+
+        # A socket without our direct live master may be a legacy master from
+        # the previous implementation. It remains usable and is handled by
+        # ensure_master_registered(); never start a competing master on it.
+        if os.path.exists(socket):
+            return True
+
+        proc = await asyncio.create_subprocess_exec(
+            *self._base_args(ssh_key_path, known_hosts_path, socket),
+            "-o",
+            "ControlMaster=yes",
+            "-o",
+            "ControlPersist=no",
+            "-N",
+            f"{ssh_user}@{host}",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        deadline = asyncio.get_running_loop().time() + 12.0
+        try:
+            while asyncio.get_running_loop().time() < deadline:
+                if proc.returncode is not None:
+                    await proc.wait()
+                    return False
+                if os.path.exists(socket):
+                    self._masters[key] = proc
+                    self._connections[key] = time.monotonic()
+                    return True
+                await asyncio.sleep(0.05)
+        except asyncio.CancelledError:
+            await self._stop_process(proc)
+            raise
+        await self._stop_process(proc)
+        return False
+
+    async def acquire(
+        self,
+        host: str,
+        ssh_key_path: str,
+        known_hosts_path: str,
+        ssh_user: str = "root",
+    ) -> bool:
+        """Acquire one active-use lease, establishing a direct master.
+
+        Returns False when the master could not be established. The caller
+        may still execute safely: command args use ``ControlPersist=no`` and
+        therefore cannot create the leaking daemonization shape.
+        """
+        key = self._key(host, ssh_user)
+        async with self._lock(key):
+            self._cancel_expiry(key)
+            ready = await self._start_explicit_master(
+                host, ssh_key_path, known_hosts_path, ssh_user
+            )
+            if ready:
+                self._active_leases[key] = self._active_leases.get(key, 0) + 1
+            return ready
+
+    def release(self, host: str, ssh_user: str = "root") -> None:
+        """Release an active-use lease and arm the configured idle expiry."""
+        key = self._key(host, ssh_user)
+        active = self._active_leases.get(key, 0)
+        if active <= 1:
+            self._active_leases.pop(key, None)
+            self._cancel_expiry(key)
+            self._expiry_tasks[key] = asyncio.create_task(
+                self._expire_after_idle(host, ssh_user),
+                name=f"ssh-master-expiry:{key}",
+            )
+        else:
+            self._active_leases[key] = active - 1
+
+    async def _expire_after_idle(self, host: str, ssh_user: str) -> None:
+        key = self._key(host, ssh_user)
+        try:
+            await asyncio.sleep(max(0, self.control_persist))
+            if self._active_leases.get(key, 0) == 0:
+                await self.close_host(host, ssh_user)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("Failed to expire SSH master %s", key)
+        finally:
+            if self._expiry_tasks.get(key) is asyncio.current_task():
+                self._expiry_tasks.pop(key, None)
+
     async def ensure_master_registered(self, host: str, ssh_user: str = "root") -> bool:
-        """Register the live ControlMaster's identity as ours-to-reap.
+        """Register a live legacy/detached ControlMaster as ours-to-reap.
 
-        A ControlPersist master daemonizes (double-fork + ``setsid``), so
-        child-subreaper containment adopts it and its eventual exit
-        status lands on THIS process — with nobody waiting, it lingers
-        as a zombie (PR #244 soak: three of the four found zombies were
-        exactly this). A zombie can no longer be attributed, so the
-        identity must be captured while the master is ALIVE: ``ssh -O
-        check`` names the pid, which is then corroborated against /proc
-        (comm must be ``ssh``) before the ``(pid, starttime)`` identity
-        enters the reap registry.
-
-        Never raises (cancellation excepted); returns True when a live
-        master is registered — including the fast path where the
-        recorded incarnation is still alive, which costs one /proc read
-        and no subprocess.
+        New masters are foreground asyncio children and need no registration.
+        This compatibility path covers a live socket inherited from the old
+        implementation during a rolling/in-place update.
         """
         from .process_manager import (
             _proc_live_starttime,
@@ -119,18 +277,15 @@ class SSHConnectionPool:
         )
 
         key = self._key(host, ssh_user)
+        direct = self._masters.get(key)
+        if direct is not None and direct.returncode is None:
+            return True
         recorded = self._registered_masters.get(key)
         if recorded is not None:
             pid, start = recorded
             if _proc_live_starttime(pid) == start:
-                # Refresh the registration's age so a long-lived,
-                # actively reused master never ages out of the registry.
                 register_reap_identity(pid, start, source=f"ssh-master:{key}")
                 return True
-            # Gone, reused — or a ZOMBIE: a corpse awaiting reap is not a
-            # live master, and treating it as one would let its
-            # replacement bypass registration entirely (round-16 #1).
-            # The zombie's own registration stays in the reap registry.
             self._registered_masters.pop(key, None)
         socket = self.get_socket_path(host, ssh_user)
         if not os.path.exists(socket):
@@ -168,10 +323,6 @@ class SSHConnectionPool:
         if match is None:
             return False
         pid = int(match.group(1))
-        # Corroborate against /proc while alive: the pid must still name
-        # an ssh process. A recycled or mis-reported pid must never enter
-        # the registry — registration is evidence, and evidence must not
-        # be guessed.
         try:
             comm = Path(f"/proc/{pid}/comm").read_bytes().strip()
         except OSError:
@@ -184,7 +335,7 @@ class SSHConnectionPool:
         register_reap_identity(pid, master_start, source=f"ssh-master:{key}")
         self._registered_masters[key] = (pid, master_start)
         log.debug(
-            "Registered ControlMaster %s (pid=%d) with the zombie reaper",
+            "Registered legacy ControlMaster %s (pid=%d) with the zombie reaper",
             key,
             pid,
         )
@@ -193,59 +344,69 @@ class SSHConnectionPool:
     def get_active_hosts(self) -> list[str]:
         """Return list of host keys with active sockets."""
         return [
-            key for key in self._connections if os.path.exists(os.path.join(self.socket_dir, key))
+            key for key in self._connections
+            if os.path.exists(os.path.join(self.socket_dir, key))
         ]
 
     async def close_host(self, host: str, ssh_user: str = "root") -> bool:
-        """Explicitly close a ControlMaster connection for a host."""
+        """Explicitly close and reap a ControlMaster connection."""
         socket = self.get_socket_path(host, ssh_user)
         key = self._key(host, ssh_user)
-
-        if not os.path.exists(socket):
-            self._connections.pop(key, None)
-            return False
-
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "ssh",
-                "-o",
-                f"ControlPath={socket}",
-                "-O",
-                "exit",
-                f"{ssh_user}@{host}",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await asyncio.wait_for(proc.communicate(), timeout=5)
-            self._connections.pop(key, None)
-            log.info("Closed SSH connection to %s@%s", ssh_user, host)
-            return True
-        except TimeoutError:
-            log.warning("Timeout closing SSH connection to %s@%s, killing process", ssh_user, host)
-            try:
-                proc.kill()
-                await proc.wait()
-            except (OSError, ProcessLookupError):
-                pass
+        async with self._lock(key):
+            self._cancel_expiry(key)
+            master = self._masters.pop(key, None)
+            had_connection = os.path.exists(socket) or master is not None
+            if os.path.exists(socket):
+                proc = None
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        "ssh",
+                        "-o",
+                        f"ControlPath={socket}",
+                        "-O",
+                        "exit",
+                        f"{ssh_user}@{host}",
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(proc.communicate(), timeout=5)
+                except asyncio.CancelledError:
+                    if proc is not None:
+                        await self._stop_process(proc)
+                    raise
+                except TimeoutError:
+                    if proc is not None:
+                        try:
+                            proc.kill()
+                        except (OSError, ProcessLookupError):
+                            pass
+                        try:
+                            await asyncio.wait_for(proc.wait(), timeout=3)
+                        except (TimeoutError, OSError, ProcessLookupError):
+                            pass
+                except Exception:
+                    if proc is not None:
+                        await self._stop_process(proc)
+            if master is not None:
+                try:
+                    await asyncio.wait_for(master.wait(), timeout=5)
+                except TimeoutError:
+                    await self._stop_process(master)
             try:
                 os.unlink(socket)
             except OSError:
                 pass
             self._connections.pop(key, None)
-            return False
-        except Exception as e:
-            log.warning("Failed to close SSH connection to %s@%s: %s", ssh_user, host, e)
-            try:
-                os.unlink(socket)
-            except OSError:
-                pass
-            self._connections.pop(key, None)
-            return False
+            self._active_leases.pop(key, None)
+            if had_connection:
+                log.info("Closed SSH connection to %s@%s", ssh_user, host)
+            return had_connection
 
     async def close_all(self) -> int:
         """Close all active ControlMaster connections. Returns count closed."""
         closed = 0
-        for key in list(self._connections):
+        keys = set(self._connections) | set(self._masters) | set(self._expiry_tasks)
+        for key in list(keys):
             parts = key.split("@", 1)
             if len(parts) == 2:
                 ssh_user, host = parts

--- a/src/tools/ssh_pool.py
+++ b/src/tools/ssh_pool.py
@@ -112,17 +112,25 @@ class SSHConnectionPool:
         recorded incarnation is still alive, which costs one /proc read
         and no subprocess.
         """
-        from .process_manager import _proc_starttime, register_reap_identity
+        from .process_manager import (
+            _proc_live_starttime,
+            _proc_starttime,
+            register_reap_identity,
+        )
 
         key = self._key(host, ssh_user)
         recorded = self._registered_masters.get(key)
         if recorded is not None:
             pid, start = recorded
-            if _proc_starttime(pid) == start:
+            if _proc_live_starttime(pid) == start:
                 # Refresh the registration's age so a long-lived,
                 # actively reused master never ages out of the registry.
                 register_reap_identity(pid, start, source=f"ssh-master:{key}")
                 return True
+            # Gone, reused — or a ZOMBIE: a corpse awaiting reap is not a
+            # live master, and treating it as one would let its
+            # replacement bypass registration entirely (round-16 #1).
+            # The zombie's own registration stays in the reap registry.
             self._registered_masters.pop(key, None)
         socket = self.get_socket_path(host, ssh_user)
         if not os.path.exists(socket):

--- a/src/tools/ssh_pool.py
+++ b/src/tools/ssh_pool.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import time
+from pathlib import Path
 
 from ..odin_log import get_logger
 
 log = get_logger("ssh_pool")
+
+_MASTER_PID_RE = re.compile(rb"pid=(\d+)")
 
 DEFAULT_CONTROL_PERSIST = 60
 DEFAULT_SOCKET_DIR = "/tmp/odin_ssh_sockets"
@@ -32,6 +36,9 @@ class SSHConnectionPool:
         self.control_persist = control_persist
         self.socket_dir = socket_dir
         self._connections: dict[str, float] = {}
+        # Masters whose (pid, starttime) identity is registered with the
+        # adopted-zombie reaper — see ensure_master_registered (PR #244).
+        self._registered_masters: dict[str, tuple[int, int]] = {}
         self._total_reused: int = 0
         self._total_opened: int = 0
         os.makedirs(self.socket_dir, mode=0o700, exist_ok=True)
@@ -86,6 +93,94 @@ class SSHConnectionPool:
         """Check if a ControlMaster socket exists for this host."""
         socket = self.get_socket_path(host, ssh_user)
         return os.path.exists(socket)
+
+    async def ensure_master_registered(self, host: str, ssh_user: str = "root") -> bool:
+        """Register the live ControlMaster's identity as ours-to-reap.
+
+        A ControlPersist master daemonizes (double-fork + ``setsid``), so
+        child-subreaper containment adopts it and its eventual exit
+        status lands on THIS process — with nobody waiting, it lingers
+        as a zombie (PR #244 soak: three of the four found zombies were
+        exactly this). A zombie can no longer be attributed, so the
+        identity must be captured while the master is ALIVE: ``ssh -O
+        check`` names the pid, which is then corroborated against /proc
+        (comm must be ``ssh``) before the ``(pid, starttime)`` identity
+        enters the reap registry.
+
+        Never raises (cancellation excepted); returns True when a live
+        master is registered — including the fast path where the
+        recorded incarnation is still alive, which costs one /proc read
+        and no subprocess.
+        """
+        from .process_manager import _proc_starttime, register_reap_identity
+
+        key = self._key(host, ssh_user)
+        recorded = self._registered_masters.get(key)
+        if recorded is not None:
+            pid, start = recorded
+            if _proc_starttime(pid) == start:
+                # Refresh the registration's age so a long-lived,
+                # actively reused master never ages out of the registry.
+                register_reap_identity(pid, start, source=f"ssh-master:{key}")
+                return True
+            self._registered_masters.pop(key, None)
+        socket = self.get_socket_path(host, ssh_user)
+        if not os.path.exists(socket):
+            return False
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ssh",
+                "-o",
+                f"ControlPath={socket}",
+                "-O",
+                "check",
+                f"{ssh_user}@{host}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except asyncio.CancelledError:
+            if proc is not None:
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except (OSError, ProcessLookupError):
+                    pass
+            raise
+        except Exception:
+            if proc is not None:
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except (OSError, ProcessLookupError):
+                    pass
+            return False
+        match = _MASTER_PID_RE.search(out)
+        if match is None:
+            return False
+        pid = int(match.group(1))
+        # Corroborate against /proc while alive: the pid must still name
+        # an ssh process. A recycled or mis-reported pid must never enter
+        # the registry — registration is evidence, and evidence must not
+        # be guessed.
+        try:
+            comm = Path(f"/proc/{pid}/comm").read_bytes().strip()
+        except OSError:
+            return False
+        if comm != b"ssh":
+            return False
+        master_start = _proc_starttime(pid)
+        if master_start is None:
+            return False
+        register_reap_identity(pid, master_start, source=f"ssh-master:{key}")
+        self._registered_masters[key] = (pid, master_start)
+        log.debug(
+            "Registered ControlMaster %s (pid=%d) with the zombie reaper",
+            key,
+            pid,
+        )
+        return True
 
     def get_active_hosts(self) -> list[str]:
         """Return list of host keys with active sockets."""

--- a/src/turn_state/codec.py
+++ b/src/turn_state/codec.py
@@ -29,7 +29,7 @@ from ..odin_log import get_logger
 
 log = get_logger("turn_state")
 
-CODEC_VERSION = 1
+CODEC_VERSION = 2
 
 # ── The classification (census-pinned) ───────────────────────────────
 
@@ -483,14 +483,14 @@ def validate_payload(payload: Any) -> None:
     fields = payload.get("fields")
     if not isinstance(fields, dict):
         raise CheckpointInvalidError("missing fields envelope")
-    # Legacy v1 normalization (PR #244 round-4 blocker #2): checkpoints
-    # written before wait_judgment_pending existed — same CODEC_VERSION —
-    # safely default it to False. This runs AFTER the store's digest
-    # verification (load_resumable_sync rejects tampered payloads before
-    # any caller sees them), so normalization can never launder an edit.
-    # The one and only field this is allowed for; everything else keeps
-    # the exact-set contract.
-    if "wait_judgment_pending" not in fields:
+    # Legacy normalization, VERSION-SCOPED (round-5 blocker #3): only a
+    # v1 payload — written before wait_judgment_pending existed — may
+    # default the field. New writers emit v2, so a v2 payload missing it
+    # is malformed and still rejected; the two cases are distinguishable.
+    # Runs AFTER the store's digest verification (load_resumable_sync
+    # rejects tampered payloads before any caller sees them), so
+    # normalization can never launder an edit.
+    if version == 1 and "wait_judgment_pending" not in fields:
         fields["wait_judgment_pending"] = False
     missing = PERSISTED_FIELDS - fields.keys()
     if missing:

--- a/src/turn_state/codec.py
+++ b/src/turn_state/codec.py
@@ -52,6 +52,7 @@ PERSISTED_FIELDS: frozenset[str] = frozenset({
     "hedging_retried",
     "code_hedging_retried",
     "premature_failure_retried",
+    "wait_judgment_pending",
     "pending_image_blocks",  # blob-externalized
     "_op_tool_details",
     "_pending_validations",
@@ -391,6 +392,7 @@ def snapshot_chat_turn(st, *, store_blob, generation_seq: int, extra: dict | Non
             "hedging_retried": st.hedging_retried,
             "code_hedging_retried": st.code_hedging_retried,
             "premature_failure_retried": st.premature_failure_retried,
+            "wait_judgment_pending": st.wait_judgment_pending,
             "pending_image_blocks": _externalize_blocks(
                 list(st.pending_image_blocks), store_blob
             ),
@@ -426,7 +428,7 @@ class CheckpointInvalidError(ValueError):
 _GUARD_FLAG_FIELDS = (
     "fabrication_retried", "promise_retried", "unavail_retried",
     "hedging_retried", "code_hedging_retried", "premature_failure_retried",
-    "_validation_required",
+    "_validation_required", "wait_judgment_pending",
 )
 _NON_NEGATIVE_INT_FIELDS = (
     "iteration", "continuation_count", "max_continuations",

--- a/src/turn_state/codec.py
+++ b/src/turn_state/codec.py
@@ -483,6 +483,15 @@ def validate_payload(payload: Any) -> None:
     fields = payload.get("fields")
     if not isinstance(fields, dict):
         raise CheckpointInvalidError("missing fields envelope")
+    # Legacy v1 normalization (PR #244 round-4 blocker #2): checkpoints
+    # written before wait_judgment_pending existed — same CODEC_VERSION —
+    # safely default it to False. This runs AFTER the store's digest
+    # verification (load_resumable_sync rejects tampered payloads before
+    # any caller sees them), so normalization can never launder an edit.
+    # The one and only field this is allowed for; everything else keeps
+    # the exact-set contract.
+    if "wait_judgment_pending" not in fields:
+        fields["wait_judgment_pending"] = False
     missing = PERSISTED_FIELDS - fields.keys()
     if missing:
         raise CheckpointInvalidError(f"missing persisted fields: {sorted(missing)}")

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -101,7 +101,9 @@ EXPECTED_TOOL_HASHES = {
     "read_channel": "22d87d43b1ac97e2",
     "add_reaction": "f466eef6573b0166",
     "create_poll": "6fb64482c930284b",
-    "manage_process": "13de19d29edd55ba",
+    # Updated 2026-07-31: wait_seconds param + monitoring guidance added to
+    # manage_process (deliberate schema change, PR fix/wait-polling).
+    "manage_process": "ecb65fc2b99e0d10",
     "manage_list": "1fe50a2ac7a59952",
     "analyze_image": "8680a337769f8d09",
     "start_loop": "67faa086c9b0987f",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,8 +242,12 @@ def _process_containment():
     correctly refuses to claim success and every shutdown path raises —
     tests would be exercising a mode production never runs in.
     """
-    from src.tools.process_manager import set_child_subreaper
+    import os
+    import secrets
+
+    from src.tools.process_manager import PROC_TOKEN_ENV, set_child_subreaper
 
     previous = set_child_subreaper(True)
+    os.environ.setdefault(PROC_TOKEN_ENV, secrets.token_hex(8))
     yield
     set_child_subreaper(previous)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,3 +232,19 @@ def _test_local_workspace(tmp_path_factory):
     yield workspace
     field.default = original
     ToolsConfig.model_rebuild(force=True)
+
+@pytest.fixture(scope="session", autouse=True)
+def _process_containment():
+    """Run the suite as a child subreaper, exactly like production.
+
+    ``src/__main__`` enables this at startup so escaped background
+    descendants stay attributable (PR #244). Without it here, cleanup
+    correctly refuses to claim success and every shutdown path raises —
+    tests would be exercising a mode production never runs in.
+    """
+    from src.tools.process_manager import reap_adopted_zombies, set_child_subreaper
+
+    previous = set_child_subreaper(True)
+    yield
+    reap_adopted_zombies()
+    set_child_subreaper(previous)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,9 +245,15 @@ def _process_containment():
     import os
     import secrets
 
-    from src.tools.process_manager import PROC_TOKEN_ENV, set_child_subreaper
+    from src.tools.process_manager import (
+        DEFAULT_JOB_TOKEN,
+        JOB_TOKEN_ENV,
+        PROC_TOKEN_ENV,
+        set_child_subreaper,
+    )
 
     previous = set_child_subreaper(True)
     os.environ.setdefault(PROC_TOKEN_ENV, secrets.token_hex(8))
+    os.environ.setdefault(JOB_TOKEN_ENV, DEFAULT_JOB_TOKEN)
     yield
     set_child_subreaper(previous)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,9 +242,8 @@ def _process_containment():
     correctly refuses to claim success and every shutdown path raises —
     tests would be exercising a mode production never runs in.
     """
-    from src.tools.process_manager import reap_adopted_zombies, set_child_subreaper
+    from src.tools.process_manager import set_child_subreaper
 
     previous = set_child_subreaper(True)
     yield
-    reap_adopted_zombies()
     set_child_subreaper(previous)

--- a/tests/test_connection_pools.py
+++ b/tests/test_connection_pools.py
@@ -748,3 +748,290 @@ class TestPoolBulkheadCoexistence:
             assert code == 0
             _, kwargs = mock_ssh.call_args
             assert kwargs["pool"] is executor.ssh_pool
+
+
+# ---------------------------------------------------------------------------
+# ensure_master_registered (PR #244): ControlPersist master identity capture
+# ---------------------------------------------------------------------------
+
+class TestEnsureMasterRegistered:
+    """A daemonized ControlPersist master is adopted by containment, so its
+    exit status lands on Odin — the pool captures the master's identity
+    while it is ALIVE so the zombie reaper may later consume it. The full
+    lifecycle pin (register → die → pidfd reap) lives in
+    test_process_manager.py; these cover the pool-side contract."""
+
+    async def test_no_socket_registers_nothing_and_spawns_nothing(self):
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec"
+            ) as mock_exec:
+                assert await pool.ensure_master_registered("h1", "root") is False
+                mock_exec.assert_not_called()
+        assert pm.registered_reap_identities() == frozenset()
+
+    async def test_check_failure_never_raises_and_never_registers(self):
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            open(pool.get_socket_path("h1", "root"), "w").close()
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                side_effect=OSError("no ssh binary"),
+            ):
+                assert await pool.ensure_master_registered("h1", "root") is False
+        assert pm.registered_reap_identities() == frozenset()
+
+    async def test_unparseable_check_output_is_false(self):
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            open(pool.get_socket_path("h1", "root"), "w").close()
+            proc = AsyncMock()
+            proc.communicate.return_value = (b"Master running (pid=unknown)\n", b"")
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ):
+                assert await pool.ensure_master_registered("h1", "root") is False
+        assert pm.registered_reap_identities() == frozenset()
+
+    async def test_comm_mismatch_is_never_registered(self):
+        """The -O check answer is corroborated against /proc: a pid that
+        does not name an ssh process (recycled, or a lying master) must
+        never enter the registry — evidence is read, not guessed."""
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        bystander = subprocess.Popen(["sleep", "30"])
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                pool = SSHConnectionPool(socket_dir=td)
+                open(pool.get_socket_path("h1", "root"), "w").close()
+                proc = AsyncMock()
+                proc.communicate.return_value = (
+                    b"Master running (pid=%d)\n" % bystander.pid,
+                    b"",
+                )
+                with patch(
+                    "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                    return_value=proc,
+                ):
+                    assert (
+                        await pool.ensure_master_registered("h1", "root") is False
+                    )
+            assert pm.registered_reap_identities() == frozenset()
+        finally:
+            bystander.terminate()
+            bystander.wait()
+
+    async def test_check_exception_after_spawn_kills_the_probe(self):
+        """communicate() failing after a successful spawn must kill the
+        probe process and report False — never raise, never leak. A
+        probe that is already gone when killed is equally fine."""
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            open(pool.get_socket_path("h1", "root"), "w").close()
+            proc = AsyncMock()
+            proc.communicate.side_effect = RuntimeError("probe died")
+            proc.kill = MagicMock()
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ):
+                assert await pool.ensure_master_registered("h1", "root") is False
+            proc.kill.assert_called_once()
+            # Round 2: the reap itself fails (probe already gone).
+            gone = AsyncMock()
+            gone.communicate.side_effect = RuntimeError("probe died")
+            gone.wait.side_effect = ProcessLookupError()
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                return_value=gone,
+            ):
+                assert await pool.ensure_master_registered("h1", "root") is False
+
+    async def test_cancellation_kills_the_probe_and_propagates(self):
+        """Shutdown-time cancellation must not swallow — and must not
+        leak the probe subprocess either, even when the reap fails."""
+        import pytest
+
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            open(pool.get_socket_path("h1", "root"), "w").close()
+            proc = AsyncMock()
+            proc.communicate.side_effect = asyncio.CancelledError()
+            proc.kill = MagicMock()
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await pool.ensure_master_registered("h1", "root")
+            proc.kill.assert_called_once()
+            # Round 2: the reap itself fails — cancellation still wins.
+            gone = AsyncMock()
+            gone.communicate.side_effect = asyncio.CancelledError()
+            gone.wait.side_effect = OSError("gone")
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                return_value=gone,
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await pool.ensure_master_registered("h1", "root")
+
+    async def test_gone_pid_from_check_is_not_registered(self):
+        """-O check names a pid that no longer exists: comm is unreadable,
+        registration refused."""
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        free_pid = next(
+            p
+            for p in range(4194000, 4194304)
+            if not os.path.exists(f"/proc/{p}")
+        )
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            open(pool.get_socket_path("h1", "root"), "w").close()
+            proc = AsyncMock()
+            proc.communicate.return_value = (
+                b"Master running (pid=%d)\n" % free_pid,
+                b"",
+            )
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ):
+                assert await pool.ensure_master_registered("h1", "root") is False
+        assert pm.registered_reap_identities() == frozenset()
+
+    async def test_master_dying_before_identity_read_is_not_registered(
+        self, monkeypatch, tmp_path
+    ):
+        """comm said ssh, then the process died before the starttime
+        read: no identity, no registration — never a guess."""
+        import shutil
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        sleep_bin = shutil.which("sleep")
+        assert sleep_bin is not None
+        fake_ssh = tmp_path / "ssh"
+        shutil.copy(sleep_bin, fake_ssh)
+        fake_ssh.chmod(0o755)
+        master = subprocess.Popen([str(fake_ssh), "30"])
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                pool = SSHConnectionPool(socket_dir=td)
+                open(pool.get_socket_path("h1", "root"), "w").close()
+                proc = AsyncMock()
+                proc.communicate.return_value = (
+                    b"Master running (pid=%d)\n" % master.pid,
+                    b"",
+                )
+                monkeypatch.setattr(pm, "_proc_starttime", lambda _p: None)
+                with patch(
+                    "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                    return_value=proc,
+                ):
+                    assert (
+                        await pool.ensure_master_registered("h1", "root") is False
+                    )
+            assert pm.registered_reap_identities() == frozenset()
+        finally:
+            master.terminate()
+            master.wait()
+
+    async def test_stale_recorded_identity_reprobes(self):
+        """A recorded master that died (or whose pid was recycled) is
+        discarded and the socket re-probed, never trusted."""
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            open(pool.get_socket_path("h1", "root"), "w").close()
+            # pid 2 (kthreadd) exists but can never match this starttime.
+            pool._registered_masters["root@h1"] = (2, 12345)
+            probes: list = []
+
+            async def fake_exec(*argv, **_kw):
+                probes.append(argv)
+                proc = AsyncMock()
+                proc.communicate.return_value = (b"no master\n", b"")
+                return proc
+
+            with patch(
+                "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+                side_effect=fake_exec,
+            ):
+                assert await pool.ensure_master_registered("h1", "root") is False
+            assert probes  # the stale record did not satisfy the fast path
+            assert "root@h1" not in pool._registered_masters
+
+
+class TestRunSSHCommandMasterRegistration:
+    """run_ssh_command must attempt master registration after every pooled
+    attempt — success, failure, or timeout — because the FIRST pooled
+    command is what forks the master (PR #244)."""
+
+    async def test_pooled_command_attempts_registration(self):
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            seen: list = []
+
+            async def record(host, ssh_user="root"):
+                seen.append((host, ssh_user))
+                return False
+
+            pool.ensure_master_registered = record  # type: ignore[method-assign]
+            with patch("src.tools.ssh.asyncio.create_subprocess_exec") as mock_exec:
+                proc = AsyncMock()
+                proc.communicate.return_value = (b"ok", None)
+                proc.returncode = 0
+                mock_exec.return_value = proc
+                await run_ssh_command("h1", "ls", "/k", "/kh", pool=pool)
+            assert seen == [("h1", "root")]
+
+    async def test_unpooled_command_has_no_pool_to_register(self):
+        with patch("src.tools.ssh.asyncio.create_subprocess_exec") as mock_exec:
+            proc = AsyncMock()
+            proc.communicate.return_value = (b"ok", None)
+            proc.returncode = 0
+            mock_exec.return_value = proc
+            code, _ = await run_ssh_command("h1", "ls", "/k", "/kh", pool=None)
+            assert code == 0
+
+    async def test_timeout_arm_still_attempts_registration(self):
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            seen: list = []
+
+            async def record(host, ssh_user="root"):
+                seen.append((host, ssh_user))
+                return False
+
+            pool.ensure_master_registered = record  # type: ignore[method-assign]
+            with patch(
+                "src.tools.ssh.asyncio.create_subprocess_exec"
+            ) as mock_exec, patch(
+                "src.tools.ssh.terminate_process_tree", new_callable=AsyncMock
+            ):
+                proc = AsyncMock()
+                proc.communicate.side_effect = TimeoutError()
+                mock_exec.return_value = proc
+                code, out = await run_ssh_command(
+                    "h1", "ls", "/k", "/kh", timeout=1, pool=pool, max_retries=1
+                )
+            assert code == 1 and "timed out" in out
+            assert seen == [("h1", "root")]

--- a/tests/test_connection_pools.py
+++ b/tests/test_connection_pools.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1209,57 +1208,70 @@ class TestForegroundMasterLifecycle:
         assert pool._total_opened == 1
         assert pool._total_reused == 0
 
-    async def test_real_controlmaster_is_foreground_and_reaped_without_orphan(
-        self, tmp_path
+    async def test_process_level_master_stays_direct_and_is_reaped(
+        self, tmp_path, monkeypatch
     ):
-        """Load-bearing process pin for the soak's exact structural defect.
+        """Process-level pin for the soak's fast-double-fork class.
 
-        A real OpenSSH client substitutes for the remote handshake endpoint:
-        the test does not need network access to prove lifecycle topology.
-        The master pid returned by create_subprocess_exec remains the direct,
-        waitable child until close_host() terminates and reaps it; no adopted
-        zombie can be created because neither argv contains daemonizing
-        ControlPersist.
+        The fake ssh deliberately models the relevant OpenSSH boundary: a
+        master with ``ControlPersist=no`` remains the direct process and can
+        be signalled through ``-O exit``; any other value exits before making
+        a usable socket. Thus changing either master or command argv back to
+        daemonizing persistence fails this pin instead of blessing the leak.
         """
-        import shutil
-
-        ssh = shutil.which("ssh")
-        assert ssh is not None
-        pool = SSHConnectionPool(control_persist=60, socket_dir=str(tmp_path))
-        socket = pool.get_socket_path("h1", "root")
-        process = await asyncio.create_subprocess_exec(
-            ssh,
-            "-o",
-            f"ControlPath={socket}",
-            "-o",
-            "ControlMaster=yes",
-            "-o",
-            "ControlPersist=no",
-            "-N",
-            "-F",
-            "/dev/null",
-            "-o",
-            "ProxyCommand=sleep 300",
-            "root@invalid",
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
+        fake_ssh = tmp_path / "ssh"
+        fake_ssh.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os, signal, sys, time\n"
+            "args = sys.argv[1:]\n"
+            "path = next(a.split('=', 1)[1] for a in args "
+            "if a.startswith('ControlPath='))\n"
+            "if '-O' in args:\n"
+            "    try:\n"
+            "        pid = int(open(path + '.pid').read())\n"
+            "        os.kill(pid, signal.SIGTERM)\n"
+            "    except (OSError, ValueError):\n"
+            "        pass\n"
+            "    raise SystemExit(0)\n"
+            "persist = next(a.split('=', 1)[1] for a in args "
+            "if a.startswith('ControlPersist='))\n"
+            "if persist != 'no':\n"
+            "    raise SystemExit(42)\n"
+            "open(path, 'w').close()\n"
+            "with open(path + '.pid', 'w') as fh:\n"
+            "    fh.write(str(os.getpid()))\n"
+            "signal.signal(signal.SIGTERM, lambda *_: raise_exit())\n"
+            "def never_called():\n"
+            "    return None\n"
+            "time.sleep(300)\n"
         )
-        key = "root@h1"
-        pool._masters[key] = process
-        pool._connections[key] = time.monotonic()
-        try:
-            await asyncio.sleep(0.1)
-            assert process.returncode is None
-            raw = open(f"/proc/{process.pid}/stat", "rb").read()
-            rest = raw.rsplit(b")", 1)[1].split()
-            assert int(rest[1]) == os.getpid()  # direct child, never adopted
-            assert await pool.close_host("h1", "root") is True
-            assert process.returncode is not None
-            assert not os.path.exists(f"/proc/{process.pid}")
-        finally:
-            if process.returncode is None:
-                process.kill()
-                await process.wait()
+        # Replace the forward-referenced signal handler with a definition
+        # before installation while keeping the generated script readable.
+        text = fake_ssh.read_text().replace(
+            "signal.signal(signal.SIGTERM, lambda *_: raise_exit())\n"
+            "def never_called():\n"
+            "    return None\n",
+            "def raise_exit():\n"
+            "    raise SystemExit(0)\n"
+            "signal.signal(signal.SIGTERM, lambda *_: raise_exit())\n",
+        )
+        fake_ssh.write_text(text)
+        fake_ssh.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+
+        pool = SSHConnectionPool(control_persist=0, socket_dir=str(tmp_path / "s"))
+        assert await pool.acquire("h1", "/k", "/kh") is True
+        master = pool._masters["root@h1"]
+        assert master.returncode is None
+        raw = open(f"/proc/{master.pid}/stat", "rb").read()
+        rest = raw.rsplit(b")", 1)[1].split()
+        assert int(rest[1]) == os.getpid()
+
+        pool.release("h1")
+        await asyncio.wait_for(pool._expiry_tasks["root@h1"], timeout=2)
+        assert master.returncode == 0
+        assert not os.path.exists(f"/proc/{master.pid}")
+
 
 class TestRunSSHCommandMasterRegistration:
     """run_ssh_command must attempt master registration after every pooled

--- a/tests/test_connection_pools.py
+++ b/tests/test_connection_pools.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from src.config.schema import (
     Config,
@@ -179,7 +182,10 @@ class TestSSHPoolGetArgs:
             args = pool.get_ssh_args("host1", "ls", "/key", "/known", "root")
             assert "-o" in args
             assert "ControlMaster=auto" in args
-            assert "ControlPersist=90" in args
+            # Idle persistence is owned by the pool; command-side OpenSSH
+            # must never daemonize a master under subreaper containment.
+            assert "ControlPersist=no" in args
+            assert "ControlPersist=90" not in args
             assert f"ControlPath={td}/root@host1" in args
 
     def test_includes_standard_ssh_options(self):
@@ -226,6 +232,17 @@ class TestSSHPoolGetArgs:
 # ---------------------------------------------------------------------------
 
 class TestSSHPoolClose:
+    async def test_close_all_reaps_foreground_master_without_socket(self):
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            master = AsyncMock(returncode=None)
+            master.wait.side_effect = lambda: setattr(master, "returncode", 0) or 0
+            pool._masters["root@host1"] = master
+            pool._connections["root@host1"] = 1.0
+            assert await pool.close_all() == 1
+            master.wait.assert_awaited()
+            assert pool._masters == {}
+
     async def test_close_host_no_socket(self):
         with tempfile.TemporaryDirectory() as td:
             pool = SSHConnectionPool(socket_dir=td)
@@ -274,7 +291,7 @@ class TestSSHPoolClose:
 
             with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
                 result = await pool.close_host("host1", "root")
-            assert result is False
+            assert result is True
             mock_proc.kill.assert_called_once()
             assert "root@host1" not in pool._connections
 
@@ -360,7 +377,8 @@ class TestSSHCommandWithPool:
                 call_args = mock_exec.call_args[0]
                 # Should include ControlMaster options
                 assert "ControlMaster=auto" in call_args
-                assert "ControlPersist=120" in call_args
+                assert "ControlPersist=no" in call_args
+                assert "ControlPersist=120" not in call_args
 
     async def test_no_pool_no_control_master(self):
         with patch("src.tools.ssh.asyncio.create_subprocess_exec") as mock_exec:
@@ -980,6 +998,269 @@ class TestEnsureMasterRegistered:
             assert "root@h1" not in pool._registered_masters
 
 
+class TestForegroundMasterLifecycle:
+    """The fast-double-fork leak is prevented by construction.
+
+    A pooled master remains an asyncio-owned foreground child. Command-side
+    OpenSSH has ControlPersist disabled, so neither process can daemonize and
+    produce the already-adopted intermediate that runtime evidence cannot
+    identify safely.
+    """
+
+    async def test_acquire_starts_direct_master_and_idle_expiry_reaps_it(
+        self, tmp_path, monkeypatch
+    ):
+        pool = SSHConnectionPool(control_persist=0, socket_dir=str(tmp_path))
+        socket = pool.get_socket_path("h1", "root")
+        spawned: list[tuple[tuple, AsyncMock]] = []
+
+        async def fake_exec(*argv, **_kwargs):
+            proc = AsyncMock()
+            proc.returncode = None
+            proc.wait.side_effect = lambda: setattr(proc, "returncode", 0) or 0
+            spawned.append((argv, proc))
+            open(socket, "w").close()
+            return proc
+
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.create_subprocess_exec", fake_exec
+        )
+        assert await pool.acquire("h1", "/key", "/known", "root") is True
+        argv, master = spawned[0]
+        assert "ControlMaster=yes" in argv
+        assert "ControlPersist=no" in argv
+        assert "-N" in argv
+        assert pool._masters["root@h1"] is master
+
+        pool.release("h1", "root")
+        await asyncio.wait_for(pool._expiry_tasks["root@h1"], timeout=1)
+        assert "root@h1" not in pool._masters
+        master.wait.assert_awaited()
+
+    async def test_acquire_reuses_live_direct_master(self, tmp_path):
+        pool = SSHConnectionPool(socket_dir=str(tmp_path))
+        socket = pool.get_socket_path("h1", "root")
+        open(socket, "w").close()
+        master = AsyncMock(returncode=None)
+        master.wait.side_effect = lambda: setattr(master, "returncode", 0) or 0
+        pool._masters["root@h1"] = master
+        assert await pool.acquire("h1", "/k", "/kh") is True
+        assert pool._active_leases["root@h1"] == 1
+        pool.release("h1")
+        await pool.close_all()
+
+    async def test_failed_master_exits_without_lease(self, tmp_path, monkeypatch):
+        pool = SSHConnectionPool(socket_dir=str(tmp_path))
+        proc = AsyncMock(returncode=255)
+        proc.wait.return_value = 255
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        )
+        assert await pool.acquire("h1", "/k", "/kh") is False
+        assert pool._active_leases == {}
+        proc.wait.assert_awaited()
+
+    async def test_master_start_cancellation_reaps_child(
+        self, tmp_path, monkeypatch
+    ):
+        pool = SSHConnectionPool(socket_dir=str(tmp_path))
+        proc = AsyncMock(returncode=None)
+        proc.wait.return_value = 0
+        proc.terminate = MagicMock()
+        proc.kill = MagicMock()
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        )
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.sleep",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await pool.acquire("h1", "/k", "/kh")
+        proc.terminate.assert_called_once()
+        proc.wait.assert_awaited()
+
+    async def test_stop_process_tolerates_signal_and_final_wait_failures(self):
+        pool = SSHConnectionPool()
+        proc = MagicMock(returncode=None)
+        proc.terminate.side_effect = ProcessLookupError()
+        proc.kill.side_effect = OSError("gone")
+        proc.wait = AsyncMock(side_effect=[TimeoutError(), OSError("gone")])
+        await pool._stop_process(proc)
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+
+    async def test_stale_direct_master_is_reaped_before_replacement(
+        self, tmp_path, monkeypatch
+    ):
+        pool = SSHConnectionPool(socket_dir=str(tmp_path))
+        stale = AsyncMock(returncode=0)
+        pool._masters["root@h1"] = stale
+        fresh = AsyncMock(returncode=None)
+        fresh.wait.return_value = 0
+        fresh.terminate = MagicMock()
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=fresh),
+        )
+        socket = pool.get_socket_path("h1", "root")
+
+        async def create_socket(_delay):
+            open(socket, "w").close()
+
+        monkeypatch.setattr("src.tools.ssh_pool.asyncio.sleep", create_socket)
+        assert await pool.acquire("h1", "/k", "/kh") is True
+        stale.wait.assert_awaited()
+        assert pool._masters["root@h1"] is fresh
+        pool.release("h1")
+        await pool.close_all()
+
+    async def test_master_socket_deadline_returns_false(self, tmp_path, monkeypatch):
+        pool = SSHConnectionPool(socket_dir=str(tmp_path))
+        proc = AsyncMock(returncode=None)
+        proc.wait.return_value = 0
+        proc.terminate = MagicMock()
+        proc.kill = MagicMock()
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        )
+        clock = iter((0.0, 13.0))
+        loop = MagicMock()
+        loop.time.side_effect = lambda: next(clock)
+        monkeypatch.setattr(
+            "src.tools.ssh_pool.asyncio.get_running_loop", lambda: loop
+        )
+        assert await pool.acquire("h1", "/k", "/kh") is False
+        proc.terminate.assert_called_once()
+        proc.wait.assert_awaited()
+
+    async def test_stop_process_escalates_after_wait_timeout(self):
+        pool = SSHConnectionPool()
+        proc = MagicMock(returncode=None)
+        proc.wait = AsyncMock(side_effect=[TimeoutError(), 0])
+        await pool._stop_process(proc)
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.await_count == 2
+
+    async def test_two_leases_expire_only_after_last_release(
+        self, tmp_path, monkeypatch
+    ):
+        pool = SSHConnectionPool(control_persist=0, socket_dir=str(tmp_path))
+        socket = pool.get_socket_path("h1", "root")
+        open(socket, "w").close()
+        master = AsyncMock(returncode=None)
+        master.wait.side_effect = lambda: setattr(master, "returncode", 0) or 0
+        pool._masters["root@h1"] = master
+        assert await pool.acquire("h1", "/k", "/kh") is True
+        assert await pool.acquire("h1", "/k", "/kh") is True
+        pool.release("h1")
+        assert pool._active_leases["root@h1"] == 1
+        assert pool._expiry_tasks == {}
+        pool.release("h1")
+        await asyncio.wait_for(pool._expiry_tasks["root@h1"], timeout=1)
+        assert "root@h1" not in pool._masters
+
+    async def test_expiry_cancellation_propagates_and_clears_record(
+        self, tmp_path
+    ):
+        pool = SSHConnectionPool(control_persist=60, socket_dir=str(tmp_path))
+        task = asyncio.create_task(pool._expire_after_idle("h1", "root"))
+        pool._expiry_tasks["root@h1"] = task
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert "root@h1" not in pool._expiry_tasks
+
+    async def test_expiry_failure_is_contained_and_task_record_cleared(
+        self, tmp_path, monkeypatch
+    ):
+        pool = SSHConnectionPool(control_persist=0, socket_dir=str(tmp_path))
+        pool._active_leases["root@h1"] = 1
+        pool.release("h1")
+        monkeypatch.setattr(
+            pool, "close_host", AsyncMock(side_effect=RuntimeError("boom"))
+        )
+        await asyncio.wait_for(pool._expiry_tasks["root@h1"], timeout=1)
+        assert "root@h1" not in pool._expiry_tasks
+
+    async def test_command_never_enables_openssh_daemonization(self):
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(control_persist=60, socket_dir=td)
+            args = pool.get_ssh_args("h1", "true", "/k", "/kh")
+            assert "ControlMaster=auto" in args
+            assert "ControlPersist=no" in args
+            assert not any(
+                str(arg).startswith("ControlPersist=")
+                and arg != "ControlPersist=no"
+                for arg in args
+            )
+
+    def test_pre_acquire_state_preserves_opened_metric(self, tmp_path):
+        pool = SSHConnectionPool(socket_dir=str(tmp_path))
+        open(pool.get_socket_path("h1", "root"), "w").close()
+        pool.get_ssh_args(
+            "h1", "true", "/k", "/kh", was_connected=False
+        )
+        assert pool._total_opened == 1
+        assert pool._total_reused == 0
+
+    async def test_real_controlmaster_is_foreground_and_reaped_without_orphan(
+        self, tmp_path
+    ):
+        """Load-bearing process pin for the soak's exact structural defect.
+
+        A real OpenSSH client substitutes for the remote handshake endpoint:
+        the test does not need network access to prove lifecycle topology.
+        The master pid returned by create_subprocess_exec remains the direct,
+        waitable child until close_host() terminates and reaps it; no adopted
+        zombie can be created because neither argv contains daemonizing
+        ControlPersist.
+        """
+        import shutil
+
+        ssh = shutil.which("ssh")
+        assert ssh is not None
+        pool = SSHConnectionPool(control_persist=60, socket_dir=str(tmp_path))
+        socket = pool.get_socket_path("h1", "root")
+        process = await asyncio.create_subprocess_exec(
+            ssh,
+            "-o",
+            f"ControlPath={socket}",
+            "-o",
+            "ControlMaster=yes",
+            "-o",
+            "ControlPersist=no",
+            "-N",
+            "-F",
+            "/dev/null",
+            "-o",
+            "ProxyCommand=sleep 300",
+            "root@invalid",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        key = "root@h1"
+        pool._masters[key] = process
+        pool._connections[key] = time.monotonic()
+        try:
+            await asyncio.sleep(0.1)
+            assert process.returncode is None
+            raw = open(f"/proc/{process.pid}/stat", "rb").read()
+            rest = raw.rsplit(b")", 1)[1].split()
+            assert int(rest[1]) == os.getpid()  # direct child, never adopted
+            assert await pool.close_host("h1", "root") is True
+            assert process.returncode is not None
+            assert not os.path.exists(f"/proc/{process.pid}")
+        finally:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+
 class TestRunSSHCommandMasterRegistration:
     """run_ssh_command must attempt master registration after every pooled
     attempt — success, failure, or timeout — because the FIRST pooled
@@ -1002,6 +1283,16 @@ class TestRunSSHCommandMasterRegistration:
                 mock_exec.return_value = proc
                 await run_ssh_command("h1", "ls", "/k", "/kh", pool=pool)
             assert seen == [("h1", "root")]
+
+    async def test_acquire_exception_becomes_bounded_ssh_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            pool = SSHConnectionPool(socket_dir=td)
+            pool.acquire = AsyncMock(side_effect=OSError("cannot spawn"))  # type: ignore[method-assign]
+            code, out = await run_ssh_command(
+                "h1", "ls", "/k", "/kh", pool=pool
+            )
+            assert code == 1
+            assert out == "SSH error: cannot spawn"
 
     async def test_unpooled_command_has_no_pool_to_register(self):
         with patch("src.tools.ssh.asyncio.create_subprocess_exec") as mock_exec:

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -331,3 +331,30 @@ class TestProcessRegistryShutdown:
         registry._processes[4] = info
 
         await registry.shutdown()  # must not propagate
+
+
+class TestUnprovenCleanupEscalation:
+    """PR #244 round-7 #3: unprovable cleanup must reach the caller — the
+    re-exec decision belongs there, not to a swallowed log line."""
+
+    @pytest.mark.asyncio
+    async def test_wiring_reports_cleanup_error_without_raising(self, caplog):
+        from types import SimpleNamespace
+
+        from src.discord.wiring import shutdown_services
+        from src.tools.process_manager import ProcessCleanupError
+
+        registry = SimpleNamespace(
+            shutdown=AsyncMock(side_effect=ProcessCleanupError("PID [4242] unproven"))
+        )
+        bot = SimpleNamespace(
+            tool_executor=SimpleNamespace(_process_registry=registry)
+        )
+        with caplog.at_level("ERROR"):
+            await shutdown_services(bot)  # teardown continues
+        registry.shutdown.assert_awaited_once()
+        assert any(
+            "cleanup could not be verified" in r.message.lower()
+            or "cleanup could not be verified" in r.getMessage().lower()
+            for r in caplog.records
+        )

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -431,7 +431,10 @@ class TestFinalizeLoop:
         assert restart.reexec_blocked() is None  # verified drain ⇒ no veto
         assert not os.path.exists(f"/proc/{orphan}")  # consumed at teardown
 
-    def test_unverified_drain_blocks_reexec(self):
+    def test_unverified_drain_is_a_failure_verdict(self):
+        """Round-20 #1: a drain that cannot verify is a failure verdict
+        like any other — returned with ZERO I/O (no veto record, no
+        logging, loop untouched); the emergency scribe says it."""
         import logging
 
         import src.tools.process_manager as pm
@@ -441,12 +444,13 @@ class TestFinalizeLoop:
         loop = asyncio.new_event_loop()
         reaper = pm.AdoptedZombieReaper()
         reaper.drain_at_teardown = lambda: (0, False)  # type: ignore[method-assign]
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
-        veto = restart.reexec_blocked()
-        assert veto is not None and "verify" in veto
-        assert loop.is_closed()
+        failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert failure is not None and "could not verify" in failure
+        assert restart.reexec_blocked() is None
+        assert not loop.is_closed()
+        loop.close()
 
-    def test_drain_exception_blocks_reexec(self):
+    def test_raising_drain_is_a_failure_verdict(self):
         import logging
 
         import src.tools.process_manager as pm
@@ -460,10 +464,12 @@ class TestFinalizeLoop:
             raise RuntimeError("drain exploded")
 
         reaper.drain_at_teardown = explode  # type: ignore[method-assign]
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
-        veto = restart.reexec_blocked()
-        assert veto is not None and "failed" in veto
-        assert loop.is_closed()
+        failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert failure is not None
+        assert "drain failed" in failure and "drain exploded" in failure
+        assert restart.reexec_blocked() is None
+        assert not loop.is_closed()
+        loop.close()
 
     def test_cancellation_resistant_task_cannot_hold_teardown(self):
         """Round-16 #2: a task that swallows CancelledError must not make
@@ -688,6 +694,55 @@ class TestUncleanBarrierExit:
         assert b"UNREACHABLE" not in proc.stderr  # os._exit, not a return
         assert b"default-executor shutdown did not finish" in proc.stderr
 
+    def test_failing_drain_with_blocking_logger_exits_promptly(self, tmp_path):
+        """Round-20 #1, process level (Odin's repro shape): owners are
+        PROVEN, the drain fails, and the root logger blocks — the old
+        code hung in block_reexec/log.exception before selecting the
+        emergency path. Now the process still exits nonzero fast."""
+        import subprocess
+        import time
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        script = tmp_path / "blocked_drain_logger.py"
+        script.write_text(
+            "import asyncio\n"
+            "import logging\n"
+            "import sys\n"
+            "import threading\n"
+            "\n"
+            "logging.basicConfig(level=logging.INFO)\n"
+            "from src.__main__ import _finalize_and_exit\n"
+            "from src.tools.process_manager import AdoptedZombieReaper\n"
+            "\n"
+            "loop = asyncio.new_event_loop()\n"
+            "reaper = AdoptedZombieReaper()\n"
+            "reaper.drain_at_teardown = lambda: (0, False)\n"
+            "print('FINALIZE_ENTER', file=sys.stderr, flush=True)\n"
+            "class BlockingHandler(logging.Handler):\n"
+            "    def emit(self, record):\n"
+            "        print('BLOCKING_LOG_EMIT', file=sys.__stderr__, flush=True)\n"
+            "        threading.Event().wait()\n"
+            "logging.getLogger().addHandler(BlockingHandler())\n"
+            "_finalize_and_exit(\n"
+            "    loop, reaper, logging.getLogger('repro'), 0\n"
+            ")\n"
+            "print('UNREACHABLE', file=sys.stderr, flush=True)\n"
+        )
+        start = time.monotonic()
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=repo_root,
+            capture_output=True,
+            timeout=15,
+        )
+        elapsed = time.monotonic() - start
+        assert proc.returncode == 1
+        assert elapsed < 10.0
+        assert b"FINALIZE_ENTER" in proc.stderr
+        assert b"UNREACHABLE" not in proc.stderr
+        assert b"could not verify" in proc.stderr  # said by the scribe
+
     def test_unclean_barrier_uses_immediate_exit(self, monkeypatch):
         """In-process arm coverage: unproven owners → os._exit with a
         promoted nonzero code; a clean barrier returns normally."""
@@ -707,7 +762,8 @@ class TestUncleanBarrierExit:
         assert calls == [1]
         # The veto is recorded by the emergency scribe, reason included.
         veto = restart.reexec_blocked()
-        assert veto is not None and "boom reason" in veto and "owners" in veto
+        assert veto is not None and "boom reason" in veto
+        assert "could not prove" in veto
         entry._finalize_and_exit(
             loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 7
         )
@@ -760,6 +816,108 @@ class TestUncleanBarrierExit:
             loop.close()
         finally:
             poisoned.handlers.clear()
+
+    def test_drain_failure_path_never_logs(self):
+        """Round-20 #1 core: between a drain-failure verdict and the
+        return there is NO synchronous I/O either — a blocking handler
+        must not hang the main thread before the emergency exit."""
+        import logging
+        import threading
+        import time
+
+        import src.tools.process_manager as pm
+        from src.__main__ import _finalize_loop
+
+        class BlockingHandler(logging.Handler):
+            def emit(self, record):
+                threading.Event().wait()
+
+        poisoned = logging.getLogger("test-poisoned-drain")
+        poisoned.propagate = False
+        poisoned.addHandler(BlockingHandler())
+        try:
+            loop = asyncio.new_event_loop()
+            reaper = pm.AdoptedZombieReaper()
+            reaper.drain_at_teardown = lambda: (0, False)  # type: ignore[method-assign]
+            start = time.monotonic()
+            failure = _finalize_loop(loop, reaper, poisoned)
+            assert time.monotonic() - start < 5.0  # never touched the logger
+            assert failure is not None and "could not verify" in failure
+            loop.close()
+        finally:
+            poisoned.handlers.clear()
+
+    def test_broken_repr_cannot_escape_the_crash_guard(self, monkeypatch):
+        """Round-20 #2: a hostile __repr__ raising inside the crash
+        guard must not keep os._exit from running."""
+        import logging
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+        from src import restart
+
+        class EvilReprError(RuntimeError):
+            def __repr__(self):
+                raise ValueError("repr broke")
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        def crash(*_a):
+            raise EvilReprError("boom")
+
+        monkeypatch.setattr(entry, "_finalize_loop", crash)
+        loop = asyncio.new_event_loop()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert calls == [1]
+        veto = restart.reexec_blocked()
+        assert veto is not None and "finalize crashed" in veto
+        assert "EvilReprError" in veto  # safe-repr fallback names the type
+        loop.close()
+
+    def test_broken_repr_in_barrier_exception_arm(self):
+        """The barrier's own except arm builds a reason from the caught
+        exception — that construction must not raise either."""
+        import logging
+
+        import src.tools.process_manager as pm
+        from src.__main__ import _finalize_loop
+
+        class EvilReprError(RuntimeError):
+            def __repr__(self):
+                raise ValueError("repr broke")
+
+        loop = asyncio.new_event_loop()
+
+        def explode(_coro):
+            raise EvilReprError("barrier blew up")
+
+        loop.run_until_complete = explode  # type: ignore[method-assign]
+        failure = _finalize_loop(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t")
+        )
+        assert failure is not None and "EvilReprError" in failure
+        loop.close()
+
+    def test_thread_guard_catches_base_exceptions(self, monkeypatch):
+        """os._exit is unconditional: even a BaseException out of the
+        scribe machinery (a signal mid-join) must not stop it."""
+        import logging
+        import threading
+
+        import src.__main__ as entry
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        def interrupted(*_a, **_k):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(threading, "Thread", interrupted)
+        entry._emergency_exit(logging.getLogger("t"), 4, "test reason")
+        assert calls == [4]
 
     def test_finalize_crash_still_exits_immediately(self, monkeypatch):
         """Nothing may escape _finalize_and_exit into ordinary

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -590,15 +590,41 @@ class TestUncleanBarrierExit:
     interpreter shutdown then joins that thread forever — the exit must
     not rely on Python shutdown."""
 
-    def test_blocked_executor_worker_cannot_hold_process_exit(self, tmp_path):
+    _SINKS = {
+        "healthy": "",
+        "raising": (
+            "class BrokenOut:\n"
+            "    def write(self, *_a):\n"
+            "        return 0\n"
+            "    def flush(self):\n"
+            "        raise OSError('forced stdout flush failure')\n"
+            "sys.stdout = BrokenOut()\n"
+        ),
+        "blocking": (
+            "class BlockedOut:\n"
+            "    def write(self, *_a):\n"
+            "        return 0\n"
+            "    def flush(self):\n"
+            "        threading.Event().wait()\n"
+            "sys.stdout = BlockedOut()\n"
+        ),
+    }
+
+    @pytest.mark.parametrize("sink", ["healthy", "raising", "blocking"])
+    def test_blocked_executor_worker_cannot_hold_process_exit(
+        self, tmp_path, sink
+    ):
         """Process-level, real blocked worker (Odin's round-17 repro
-        shape): the process must actually EXIT nonzero, promptly."""
+        shape): the process must actually EXIT nonzero, promptly — even
+        when the output sink itself RAISES or BLOCKS (round-18: a
+        raising stdout.flush unwound into ordinary interpreter shutdown
+        and hung; a blocking sink never returned at all)."""
         import subprocess
         import time
         from pathlib import Path
 
         repo_root = Path(__file__).resolve().parents[1]
-        script = tmp_path / "blocked_worker.py"
+        script = tmp_path / f"blocked_worker_{sink}.py"
         script.write_text(
             "import asyncio\n"
             "import logging\n"
@@ -619,11 +645,12 @@ class TestUncleanBarrierExit:
             "    await asyncio.sleep(0.2)  # let the worker actually start\n"
             "\n"
             "loop.run_until_complete(arm())\n"
-            "print('FINALIZE_ENTER', flush=True)\n"
-            "_finalize_and_exit(\n"
+            "print('FINALIZE_ENTER', file=sys.stderr, flush=True)\n"
+            + self._SINKS[sink]
+            + "_finalize_and_exit(\n"
             "    loop, AdoptedZombieReaper(), logging.getLogger('repro'), 0\n"
             ")\n"
-            "print('UNREACHABLE', flush=True)\n"
+            "print('UNREACHABLE', file=sys.stderr, flush=True)\n"
         )
         start = time.monotonic()
         proc = subprocess.run(
@@ -634,9 +661,9 @@ class TestUncleanBarrierExit:
         )
         elapsed = time.monotonic() - start
         assert proc.returncode == 1  # exit_code 0 promoted: unclean = failure
-        assert elapsed < 10.0  # bounded barrier + immediate exit
-        assert b"FINALIZE_ENTER" in proc.stdout
-        assert b"UNREACHABLE" not in proc.stdout  # os._exit, not a return
+        assert elapsed < 10.0  # bounded barrier + bounded last words
+        assert b"FINALIZE_ENTER" in proc.stderr
+        assert b"UNREACHABLE" not in proc.stderr  # os._exit, not a return
         assert b"default-executor shutdown did not finish" in proc.stderr
 
     def test_unclean_barrier_uses_immediate_exit(self, monkeypatch):
@@ -666,6 +693,45 @@ class TestUncleanBarrierExit:
         )
         assert calls == [1, 7]  # clean barrier: no immediate exit
         loop.close()
+
+    def test_emergency_exit_survives_raising_and_blocked_sinks(
+        self, monkeypatch
+    ):
+        """The exit depends on NOTHING: a raising stdout is swallowed by
+        the scribe thread; a blocking one is abandoned at the bounded
+        join. os._exit runs either way."""
+        import logging
+        import threading
+        import time
+
+        import src.__main__ as entry
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        class Raising:
+            def write(self, *_a):
+                return 0
+
+            def flush(self):
+                raise OSError("flush refused")
+
+        monkeypatch.setattr(entry.sys, "stdout", Raising())
+        entry._emergency_exit(logging.getLogger("t"), 0)
+        assert calls == [1]
+
+        class Blocking:
+            def write(self, *_a):
+                return 0
+
+            def flush(self):
+                threading.Event().wait()
+
+        monkeypatch.setattr(entry.sys, "stdout", Blocking())
+        start = time.monotonic()
+        entry._emergency_exit(logging.getLogger("t"), 5)
+        assert calls == [1, 5]
+        assert time.monotonic() - start < 3.0  # bounded by the scribe join
 
 
 class TestVetoedReexec:

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -346,3 +346,164 @@ class TestShutdownBarrierAndInPlaceRestart:
         with patch("os.execve") as execve:
             assert signal_entry_point() is None
         execve.assert_not_called()
+
+
+class TestFinalizeLoop:
+    """PR #244 round-15 §3.3 steps 2–6: the owner barrier (loop tasks,
+    async generators, default executor) must complete BEFORE the final
+    zombie drain, and any unproven step VETOES the in-place re-exec."""
+
+    @staticmethod
+    def _spawn_orphan_zombie(loop, tmp_path) -> int:
+        """A real, unobserved adopted zombie of THIS process (containment
+        is enabled suite-wide in conftest)."""
+        import os
+        import time
+
+        pidfile = tmp_path / "orphan.pid"
+        script = tmp_path / "orphan.py"
+        script.write_text(
+            "import os, sys\n"
+            "if os.fork() == 0:\n"
+            f"    with open({str(pidfile)!r}, 'w') as fh:\n"
+            "        fh.write(str(os.getpid()))\n"
+            "    os._exit(0)\n"
+            "sys.exit(0)\n"
+        )
+
+        async def spawn():
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, str(script),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+            for _ in range(200):
+                text = pidfile.read_text().strip() if pidfile.exists() else ""
+                if text:
+                    return int(text)
+                await asyncio.sleep(0.02)
+            raise AssertionError("orphan never reported its pid")
+
+        orphan = loop.run_until_complete(spawn())
+        for _ in range(200):
+            try:
+                raw = open(f"/proc/{orphan}/stat", "rb").read()
+                rest = raw.rsplit(b")", 1)[1].split()
+                if rest[0] == b"Z" and int(rest[1]) == os.getpid():
+                    return orphan
+            except (OSError, IndexError, ValueError):
+                pass
+            time.sleep(0.02)
+        raise AssertionError("orphan never became our zombie")
+
+    def test_drain_runs_after_executor_and_consumes_unobserved_zombie(
+        self, tmp_path
+    ):
+        import logging
+        import os
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+        orphan = self._spawn_orphan_zombie(loop, tmp_path)
+        reaper = pm.AdoptedZombieReaper()
+        order: list = []
+        real_exec_shutdown = loop.shutdown_default_executor
+
+        async def traced_executor():
+            order.append("executor")
+            await real_exec_shutdown()
+
+        loop.shutdown_default_executor = traced_executor  # type: ignore[method-assign]
+        real_drain = reaper.drain_at_teardown
+
+        def traced_drain():
+            order.append("drain")
+            return real_drain()
+
+        reaper.drain_at_teardown = traced_drain  # type: ignore[method-assign]
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert order == ["executor", "drain"]  # owners stop, THEN drain
+        assert loop.is_closed()
+        assert restart.reexec_blocked() is None  # verified drain ⇒ no veto
+        assert not os.path.exists(f"/proc/{orphan}")  # consumed at teardown
+
+    def test_unverified_drain_blocks_reexec(self):
+        import logging
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+        reaper = pm.AdoptedZombieReaper()
+        reaper.drain_at_teardown = lambda: (0, False)  # type: ignore[method-assign]
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        veto = restart.reexec_blocked()
+        assert veto is not None and "verify" in veto
+        assert loop.is_closed()
+
+    def test_drain_exception_blocks_reexec(self):
+        import logging
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+        reaper = pm.AdoptedZombieReaper()
+
+        def explode():
+            raise RuntimeError("drain exploded")
+
+        reaper.drain_at_teardown = explode  # type: ignore[method-assign]
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        veto = restart.reexec_blocked()
+        assert veto is not None and "failed" in veto
+        assert loop.is_closed()
+
+    def test_failed_owner_barrier_skips_drain_and_blocks(self):
+        """If subprocess owners cannot be proven stopped, running the
+        drain could steal a status a live owner still awaits — it must
+        be SKIPPED, and the re-exec vetoed."""
+        import logging
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+        reaper = pm.AdoptedZombieReaper()
+
+        async def broken():
+            raise RuntimeError("executor wedged")
+
+        loop.shutdown_default_executor = broken  # type: ignore[method-assign]
+        drained: list = []
+        reaper.drain_at_teardown = (  # type: ignore[method-assign]
+            lambda: drained.append(True) or (0, True)
+        )
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert drained == []  # never ran on unproven owners
+        veto = restart.reexec_blocked()
+        assert veto is not None and "owners" in veto
+        assert loop.is_closed()
+
+
+class TestVetoedReexec:
+    def test_vetoed_reexec_exits_nonzero_instead_of_exec(self, signal_entry_point):
+        """§3.6 pin: a failed final proof blocks execve — the process
+        exits nonzero so the supervisor starts a clean image and PID 1
+        inherits whatever survived."""
+        from src import restart
+
+        restart.request_restart()
+        restart.block_reexec("unproven teardown (test)")
+        with patch("os.execve") as execve:
+            with pytest.raises(SystemExit) as excinfo:
+                signal_entry_point()
+        execve.assert_not_called()
+        assert excinfo.value.code == 1

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -425,7 +425,7 @@ class TestFinalizeLoop:
             return real_drain()
 
         reaper.drain_at_teardown = traced_drain  # type: ignore[method-assign]
-        assert _finalize_loop(loop, reaper, logging.getLogger("test")) is True
+        assert _finalize_loop(loop, reaper, logging.getLogger("test")) is None
         assert order == ["executor", "drain"]  # owners stop, THEN drain
         assert loop.is_closed()
         assert restart.reexec_blocked() is None  # verified drain ⇒ no veto
@@ -495,12 +495,16 @@ class TestFinalizeLoop:
             lambda: drained.append(True) or (0, True)
         )
         start = time.monotonic()
-        assert _finalize_loop(loop, reaper, logging.getLogger("test")) is False
+        failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
         assert time.monotonic() - start < 5.0  # Odin's probe bound
+        assert failure is not None and "survived cancellation" in failure
         assert drained == []  # owners unproven ⇒ drain skipped
-        veto = restart.reexec_blocked()
-        assert veto is not None and "survived cancellation" in veto
-        assert loop.is_closed()
+        # The unproven path has NO side effects: the veto travels with
+        # the emergency scribe, and the loop is left alone (round-19 —
+        # close() warnings go through logging).
+        assert restart.reexec_blocked() is None
+        assert not loop.is_closed()
+        loop.close()
 
     def test_hung_asyncgen_shutdown_is_bounded_and_vetoes(self):
         import logging
@@ -522,12 +526,13 @@ class TestFinalizeLoop:
             lambda: drained.append(True) or (0, True)
         )
         start = time.monotonic()
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
         assert time.monotonic() - start < 5.0
+        assert failure is not None and "async-generator" in failure
         assert drained == []
-        veto = restart.reexec_blocked()
-        assert veto is not None and "async-generator" in veto
-        assert loop.is_closed()
+        assert restart.reexec_blocked() is None
+        assert not loop.is_closed()
+        loop.close()
 
     def test_hung_executor_shutdown_is_bounded_and_vetoes(self):
         import logging
@@ -549,12 +554,13 @@ class TestFinalizeLoop:
             lambda: drained.append(True) or (0, True)
         )
         start = time.monotonic()
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
         assert time.monotonic() - start < 5.0
+        assert failure is not None and "default-executor" in failure
         assert drained == []
-        veto = restart.reexec_blocked()
-        assert veto is not None and "default-executor" in veto
-        assert loop.is_closed()
+        assert restart.reexec_blocked() is None
+        assert not loop.is_closed()
+        loop.close()
 
     def test_failed_owner_barrier_skips_drain_and_blocks(self):
         """If subprocess owners cannot be proven stopped, running the
@@ -577,11 +583,12 @@ class TestFinalizeLoop:
         reaper.drain_at_teardown = (  # type: ignore[method-assign]
             lambda: drained.append(True) or (0, True)
         )
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert failure is not None and "default-executor" in failure
         assert drained == []  # never ran on unproven owners
-        veto = restart.reexec_blocked()
-        assert veto is not None and "owners" in veto
-        assert loop.is_closed()
+        assert restart.reexec_blocked() is None
+        assert not loop.is_closed()
+        loop.close()
 
 
 class TestUncleanBarrierExit:
@@ -592,6 +599,19 @@ class TestUncleanBarrierExit:
 
     _SINKS = {
         "healthy": "",
+        "raising_log": (
+            "class RaisingHandler(logging.Handler):\n"
+            "    def emit(self, record):\n"
+            "        raise OSError('forced handler failure')\n"
+            "logging.getLogger().addHandler(RaisingHandler())\n"
+        ),
+        "blocking_log": (
+            "class BlockingHandler(logging.Handler):\n"
+            "    def emit(self, record):\n"
+            "        print('BLOCKING_LOG_EMIT', file=sys.__stderr__, flush=True)\n"
+            "        threading.Event().wait()\n"
+            "logging.getLogger().addHandler(BlockingHandler())\n"
+        ),
         "raising": (
             "class BrokenOut:\n"
             "    def write(self, *_a):\n"
@@ -610,7 +630,9 @@ class TestUncleanBarrierExit:
         ),
     }
 
-    @pytest.mark.parametrize("sink", ["healthy", "raising", "blocking"])
+    @pytest.mark.parametrize(
+        "sink", ["healthy", "raising", "blocking", "raising_log", "blocking_log"]
+    )
     def test_blocked_executor_worker_cannot_hold_process_exit(
         self, tmp_path, sink
     ):
@@ -673,25 +695,96 @@ class TestUncleanBarrierExit:
 
         import src.__main__ as entry
         import src.tools.process_manager as pm
+        from src import restart
 
         calls: list = []
         monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
-        monkeypatch.setattr(entry, "_finalize_loop", lambda *_a: False)
+        monkeypatch.setattr(entry, "_finalize_loop", lambda *_a: "boom reason")
         loop = asyncio.new_event_loop()
         entry._finalize_and_exit(
             loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
         )
         assert calls == [1]
+        # The veto is recorded by the emergency scribe, reason included.
+        veto = restart.reexec_blocked()
+        assert veto is not None and "boom reason" in veto and "owners" in veto
         entry._finalize_and_exit(
             loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 7
         )
         assert calls == [1, 7]
 
-        monkeypatch.setattr(entry, "_finalize_loop", lambda *_a: True)
+        monkeypatch.setattr(entry, "_finalize_loop", lambda *_a: None)
         entry._finalize_and_exit(
             loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
         )
         assert calls == [1, 7]  # clean barrier: no immediate exit
+        loop.close()
+
+    def test_unproven_verdict_path_never_logs(self):
+        """Round-19 core: between the unproven verdict and the return
+        there is NO synchronous I/O — a blocking logging handler must
+        not be able to hang the main thread before the emergency exit
+        is reachable."""
+        import logging
+        import threading
+        import time
+
+        import src.tools.process_manager as pm
+        from src.__main__ import _finalize_loop
+
+        class BlockingHandler(logging.Handler):
+            def emit(self, record):
+                threading.Event().wait()
+
+        poisoned = logging.getLogger("test-poisoned-finalize")
+        poisoned.propagate = False
+        poisoned.addHandler(BlockingHandler())
+        try:
+            loop = asyncio.new_event_loop()
+
+            async def stubborn():
+                while True:
+                    try:
+                        await asyncio.sleep(3600)
+                    except asyncio.CancelledError:
+                        continue
+
+            async def arm():
+                loop.create_task(stubborn())
+
+            loop.run_until_complete(arm())
+            start = time.monotonic()
+            failure = _finalize_loop(loop, pm.AdoptedZombieReaper(), poisoned)
+            assert time.monotonic() - start < 5.0  # never touched the logger
+            assert failure is not None and "survived cancellation" in failure
+            loop.close()
+        finally:
+            poisoned.handlers.clear()
+
+    def test_finalize_crash_still_exits_immediately(self, monkeypatch):
+        """Nothing may escape _finalize_and_exit into ordinary
+        interpreter shutdown — even finalize itself crashing becomes an
+        unproven verdict and an immediate exit."""
+        import logging
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+        from src import restart
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        def crash(*_a):
+            raise RuntimeError("finalize blew up")
+
+        monkeypatch.setattr(entry, "_finalize_loop", crash)
+        loop = asyncio.new_event_loop()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert calls == [1]
+        veto = restart.reexec_blocked()
+        assert veto is not None and "finalize crashed" in veto
         loop.close()
 
     def test_emergency_exit_survives_raising_and_blocked_sinks(
@@ -717,7 +810,7 @@ class TestUncleanBarrierExit:
                 raise OSError("flush refused")
 
         monkeypatch.setattr(entry.sys, "stdout", Raising())
-        entry._emergency_exit(logging.getLogger("t"), 0)
+        entry._emergency_exit(logging.getLogger("t"), 0, "test reason")
         assert calls == [1]
 
         class Blocking:
@@ -729,7 +822,7 @@ class TestUncleanBarrierExit:
 
         monkeypatch.setattr(entry.sys, "stdout", Blocking())
         start = time.monotonic()
-        entry._emergency_exit(logging.getLogger("t"), 5)
+        entry._emergency_exit(logging.getLogger("t"), 5, "test reason")
         assert calls == [1, 5]
         assert time.monotonic() - start < 3.0  # bounded by the scribe join
 

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -466,7 +466,10 @@ class TestFinalizeLoop:
         reaper.drain_at_teardown = explode  # type: ignore[method-assign]
         failure = _finalize_loop(loop, reaper, logging.getLogger("test"))
         assert failure is not None
-        assert "drain failed" in failure and "drain exploded" in failure
+        # The reason names the exception TYPE; the message is dropped on
+        # purpose — it is user-controlled data of user-controlled type
+        # (round-21).
+        assert "drain failed" in failure and "RuntimeError" in failure
         assert restart.reexec_blocked() is None
         assert not loop.is_closed()
         loop.close()
@@ -900,6 +903,137 @@ class TestUncleanBarrierExit:
         )
         assert failure is not None and "EvilReprError" in failure
         loop.close()
+
+    def test_blocking_repr_cannot_hang_the_emergency_path(self, monkeypatch):
+        """Round-21: reason construction must execute NO exception code
+        — a blocking __repr__ used to hang the main thread inside
+        _safe_repr itself, before os._exit was reachable."""
+        import logging
+        import threading
+        import time
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+        from src import restart
+
+        executed: list = []
+
+        class BlockingReprError(RuntimeError):
+            def __repr__(self):
+                executed.append(True)
+                threading.Event().wait()
+                return "never"
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        def crash(*_a):
+            raise BlockingReprError("boom")
+
+        monkeypatch.setattr(entry, "_finalize_loop", crash)
+        loop = asyncio.new_event_loop()
+        start = time.monotonic()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert time.monotonic() - start < 3.0
+        assert calls == [1]
+        assert executed == []  # the hostile __repr__ never ran at all
+        veto = restart.reexec_blocked()
+        assert veto is not None and "BlockingReprError" in veto
+        loop.close()
+
+    def test_hostile_format_cannot_escape_reason_construction(self, monkeypatch):
+        """Round-21: a __repr__ returning a str SUBCLASS with a hostile
+        __format__ escaped through the f-string that consumed the
+        reason. Reason construction now never touches exception code."""
+        import logging
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+        from src import restart
+
+        class Sneaky(str):
+            def __format__(self, _spec):
+                raise RuntimeError("format boom")
+
+        executed: list = []
+
+        class EvilFormatError(RuntimeError):
+            def __repr__(self):
+                executed.append(True)
+                return Sneaky("innocent")
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        def crash(*_a):
+            raise EvilFormatError("boom")
+
+        monkeypatch.setattr(entry, "_finalize_loop", crash)
+        loop = asyncio.new_event_loop()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert calls == [1]  # never escaped, exit reached
+        assert executed == []  # the hostile __repr__ never ran
+        veto = restart.reexec_blocked()
+        assert veto is not None and "EvilFormatError" in veto
+        loop.close()
+
+    def test_blocking_repr_process_level(self, tmp_path):
+        """Odin's round-21 repro shape: the hostile exception comes out
+        of the barrier machinery in a REAL process. The marker inside
+        __repr__ must never print — the code is not executed — and the
+        process exits promptly."""
+        import subprocess
+        import time
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        script = tmp_path / "blocking_repr.py"
+        script.write_text(
+            "import asyncio\n"
+            "import logging\n"
+            "import sys\n"
+            "import threading\n"
+            "\n"
+            "logging.basicConfig(level=logging.INFO)\n"
+            "from src.__main__ import _finalize_and_exit\n"
+            "from src.tools.process_manager import AdoptedZombieReaper\n"
+            "\n"
+            "class BlockingReprError(RuntimeError):\n"
+            "    def __repr__(self):\n"
+            "        print('BLOCKING_REPR_ENTER', file=sys.stderr, flush=True)\n"
+            "        threading.Event().wait()\n"
+            "        return 'never'\n"
+            "\n"
+            "loop = asyncio.new_event_loop()\n"
+            "\n"
+            "def explode(_coro):\n"
+            "    raise BlockingReprError('barrier blew up')\n"
+            "\n"
+            "loop.run_until_complete = explode\n"
+            "print('FINALIZE_ENTER', file=sys.stderr, flush=True)\n"
+            "_finalize_and_exit(\n"
+            "    loop, AdoptedZombieReaper(), logging.getLogger('repro'), 0\n"
+            ")\n"
+            "print('UNREACHABLE', file=sys.stderr, flush=True)\n"
+        )
+        start = time.monotonic()
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=repo_root,
+            capture_output=True,
+            timeout=15,
+        )
+        elapsed = time.monotonic() - start
+        assert proc.returncode == 1
+        assert elapsed < 10.0
+        assert b"FINALIZE_ENTER" in proc.stderr
+        assert b"BLOCKING_REPR_ENTER" not in proc.stderr  # never executed
+        assert b"UNREACHABLE" not in proc.stderr
+        assert b"BlockingReprError" in proc.stderr  # named by object.__repr__
 
     def test_thread_guard_catches_base_exceptions(self, monkeypatch):
         """os._exit is unconditional: even a BaseException out of the

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -658,6 +658,7 @@ class TestUncleanBarrierExit:
         script = tmp_path / f"blocked_worker_{sink}.py"
         script.write_text(
             "import asyncio\n"
+            "import ctypes\n"
             "import logging\n"
             "import sys\n"
             "import threading\n"
@@ -1263,6 +1264,190 @@ class TestUncleanBarrierExit:
         entry._emergency_exit(logging.getLogger("t"), 5, "test reason")
         assert calls == [1, 5]
         assert time.monotonic() - start < 3.0  # bounded by the scribe join
+
+
+class TestFinalizeHardDeadline:
+    """Round-23: finalization needs a non-cooperative wall-clock bound.
+
+    Asyncio timeouts cannot fire while synchronous code owns the event-loop
+    thread. These process-level pins put hostile code in each of the three
+    reproduced locations and prove the pre-armed watchdog still reaches
+    os._exit. The marker proves the adversarial path executed; prompt nonzero
+    process exit proves it could not hold teardown.
+    """
+
+    @staticmethod
+    def _run_repro(tmp_path, name: str, body: str, marker: bytes):
+        import subprocess
+        import time
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        script = tmp_path / (name + ".py")
+        script.write_text(
+            "import asyncio\n"
+            "import ctypes\n"
+            "import logging\n"
+            "import sys\n"
+            "import threading\n"
+            "import src.__main__ as entry\n"
+            "from src.tools.process_manager import AdoptedZombieReaper\n"
+            "entry._FINALIZE_WATCHDOG_TIMEOUT = 1.0\n"
+            "loop = asyncio.new_event_loop()\n"
+            + body
+            + "\nprint('FINALIZE_ENTER', file=sys.stderr, flush=True)\n"
+            "entry._finalize_and_exit(\n"
+            "    loop, reaper, logging.getLogger('repro'), 0\n"
+            ")\n"
+            "print('UNREACHABLE', file=sys.stderr, flush=True)\n"
+        )
+        started = time.monotonic()
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=repo_root,
+            capture_output=True,
+            timeout=8,
+        )
+        import signal
+
+        elapsed = time.monotonic() - started
+        assert proc.returncode == -signal.SIGKILL
+        assert elapsed < 5.0
+        assert b"FINALIZE_ENTER" in proc.stderr
+        assert marker in proc.stderr  # proves the adversarial path executed
+        assert b"UNREACHABLE" not in proc.stderr  # watchdog used os._exit
+
+    def test_failed_drain_cannot_drop_completed_task_frame(self, tmp_path):
+        """Dropping successful-barrier task frames before emergency exit
+        used to run a frame-local __del__ and wedge the main thread."""
+        body = (
+            "class BlockingFrameLocal:\n"
+            "    def __del__(self):\n"
+            "        print('BLOCKING_FRAME_LOCAL_DEL_ENTER', "
+            "file=sys.__stderr__, flush=True)\n"
+            "        threading.Event().wait()\n"
+            "async def owner():\n"
+            "    local = BlockingFrameLocal()\n"
+            "    try:\n"
+            "        await asyncio.Event().wait()\n"
+            "    except asyncio.CancelledError:\n"
+            "        return local\n"
+            "loop.create_task(owner())\n"
+            "loop.run_until_complete(asyncio.sleep(0))\n"
+            "reaper = AdoptedZombieReaper()\n"
+            "reaper.drain_at_teardown = lambda: (0, False)\n"
+        )
+        self._run_repro(
+            tmp_path,
+            "blocked_frame_local",
+            body,
+            b"BLOCKING_FRAME_LOCAL_DEL_ENTER",
+        )
+
+    def test_cancellation_finally_cannot_defeat_wall_clock(self, tmp_path):
+        """A synchronous cancellation finally blocks the event loop itself,
+        so asyncio.wait(timeout=...) never gets a chance to return."""
+        body = (
+            "async def owner():\n"
+            "    try:\n"
+            "        await asyncio.Event().wait()\n"
+            "    finally:\n"
+            "        print('CANCEL_FINALLY_ENTER', "
+            "file=sys.__stderr__, flush=True)\n"
+            "        entry.os._exit = lambda code: None\n"
+            "        ctypes.PyDLL(None).sleep(10)\n"
+            "loop.create_task(owner())\n"
+            "loop.run_until_complete(asyncio.sleep(0))\n"
+            "reaper = AdoptedZombieReaper()\n"
+        )
+        self._run_repro(
+            tmp_path,
+            "blocked_cancel_finally",
+            body,
+            b"CANCEL_FINALLY_ENTER",
+        )
+
+    def test_loop_close_finalizer_cannot_defeat_wall_clock(self, tmp_path):
+        """loop.close() clears delayed handles synchronously; hostile handle
+        arguments must not be able to strand an otherwise-clean shutdown."""
+        body = (
+            "class BlockingHandleArg:\n"
+            "    def __del__(self):\n"
+            "        print('HANDLE_ARG_DEL_ENTER', "
+            "file=sys.__stderr__, flush=True)\n"
+            "        threading.Event().wait()\n"
+            "arg = BlockingHandleArg()\n"
+            "loop.call_later(3600, lambda value: None, arg)\n"
+            "del arg\n"
+            "reaper = AdoptedZombieReaper()\n"
+        )
+        self._run_repro(
+            tmp_path,
+            "blocked_loop_close",
+            body,
+            b"HANDLE_ARG_DEL_ENTER",
+        )
+
+    def test_armed_deadline_is_captured_immutably(self, tmp_path):
+        """Changing the module setting after READY cannot postpone an armed
+        helper. A late global read made the deadline user-mutable."""
+        body = (
+            "async def owner():\n"
+            "    try:\n"
+            "        await asyncio.Event().wait()\n"
+            "    finally:\n"
+            "        print('CAPTURED_DEADLINE_ENTER', "
+            "file=sys.__stderr__, flush=True)\n"
+            "        entry._FINALIZE_WATCHDOG_TIMEOUT = 3600\n"
+            "        ctypes.PyDLL(None).sleep(10)\n"
+            "loop.create_task(owner())\n"
+            "loop.run_until_complete(asyncio.sleep(0))\n"
+            "reaper = AdoptedZombieReaper()\n"
+        )
+        self._run_repro(
+            tmp_path,
+            "captured_deadline",
+            body,
+            b"CAPTURED_DEADLINE_ENTER",
+        )
+
+    def test_watchdog_helper_is_not_attributed_as_an_adopted_orphan(self):
+        import os
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+
+        watchdog = entry._arm_finalize_watchdog(0)
+        reaper = pm.AdoptedZombieReaper()
+        reaper.drain_at_teardown()
+        waited, _ = watchdog.waitpid(watchdog.pid, os.WNOHANG)
+        assert waited == 0  # final drain did not consume/kill the live helper
+        entry._disarm_finalize_watchdog(watchdog, 0)
+
+    def test_clean_finalize_disarms_watchdog(self, monkeypatch):
+        import logging
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(entry, "_FINALIZE_WATCHDOG_TIMEOUT", 5.0)
+        calls: list[int] = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+        real_disarm = entry._disarm_finalize_watchdog
+        disarmed: list[int] = []
+
+        def capture(watchdog, code):
+            real_disarm(watchdog, code)
+            disarmed.append(watchdog.pid)
+
+        monkeypatch.setattr(entry, "_disarm_finalize_watchdog", capture)
+        loop = asyncio.new_event_loop()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("test"), 0
+        )
+        assert len(disarmed) == 1
+        assert calls == []
+        assert loop.is_closed()
 
 
 class TestVetoedReexec:

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -465,6 +465,97 @@ class TestFinalizeLoop:
         assert veto is not None and "failed" in veto
         assert loop.is_closed()
 
+    def test_cancellation_resistant_task_cannot_hold_teardown(self):
+        """Round-16 #2: a task that swallows CancelledError must not make
+        the final drain and the re-exec veto UNREACHABLE. The barrier is
+        bounded; the unproven owners veto re-exec instead."""
+        import logging
+        import time
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+
+        async def stubborn():
+            while True:
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    continue  # refuses to die
+
+        async def arm():
+            loop.create_task(stubborn())
+
+        loop.run_until_complete(arm())
+        reaper = pm.AdoptedZombieReaper()
+        drained: list = []
+        reaper.drain_at_teardown = (  # type: ignore[method-assign]
+            lambda: drained.append(True) or (0, True)
+        )
+        start = time.monotonic()
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert time.monotonic() - start < 5.0  # Odin's probe bound
+        assert drained == []  # owners unproven ⇒ drain skipped
+        veto = restart.reexec_blocked()
+        assert veto is not None and "survived cancellation" in veto
+        assert loop.is_closed()
+
+    def test_hung_asyncgen_shutdown_is_bounded_and_vetoes(self):
+        import logging
+        import time
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+
+        async def never():
+            await asyncio.Event().wait()
+
+        loop.shutdown_asyncgens = never  # type: ignore[method-assign]
+        reaper = pm.AdoptedZombieReaper()
+        drained: list = []
+        reaper.drain_at_teardown = (  # type: ignore[method-assign]
+            lambda: drained.append(True) or (0, True)
+        )
+        start = time.monotonic()
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert time.monotonic() - start < 5.0
+        assert drained == []
+        veto = restart.reexec_blocked()
+        assert veto is not None and "async-generator" in veto
+        assert loop.is_closed()
+
+    def test_hung_executor_shutdown_is_bounded_and_vetoes(self):
+        import logging
+        import time
+
+        import src.tools.process_manager as pm
+        from src import restart
+        from src.__main__ import _finalize_loop
+
+        loop = asyncio.new_event_loop()
+
+        async def never():
+            await asyncio.Event().wait()
+
+        loop.shutdown_default_executor = never  # type: ignore[method-assign]
+        reaper = pm.AdoptedZombieReaper()
+        drained: list = []
+        reaper.drain_at_teardown = (  # type: ignore[method-assign]
+            lambda: drained.append(True) or (0, True)
+        )
+        start = time.monotonic()
+        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert time.monotonic() - start < 5.0
+        assert drained == []
+        veto = restart.reexec_blocked()
+        assert veto is not None and "default-executor" in veto
+        assert loop.is_closed()
+
     def test_failed_owner_barrier_skips_drain_and_blocks(self):
         """If subprocess owners cannot be proven stopped, running the
         drain could steal a status a live owner still awaits — it must

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -1035,6 +1035,152 @@ class TestUncleanBarrierExit:
         assert b"UNREACHABLE" not in proc.stderr
         assert b"BlockingReprError" in proc.stderr  # named by object.__repr__
 
+    @staticmethod
+    def _hostile_del_error():
+        """An exception whose __del__ blocks forever — armed via a flag
+        so the parked instance can be disarmed before interpreter
+        shutdown (the parking lot is never cleared, by design)."""
+        import threading
+
+        executed: list = []
+        armed = {"on": True}
+
+        class BlockingDelError(RuntimeError):
+            def __del__(self):
+                if armed["on"]:
+                    executed.append(True)
+                    threading.Event().wait()
+
+        return BlockingDelError, executed, armed
+
+    def test_hostile_del_cannot_hang_the_crash_guard(self, monkeypatch):
+        """Round-22: clearing the `except ... as exc` binding could drop
+        the final reference and run a user __del__ on the main thread
+        before os._exit. Parking the exception makes the finalizer
+        unreachable — it must never execute."""
+        import logging
+        import time
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+
+        blocking_del_error, executed, armed = self._hostile_del_error()
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+
+        def crash(*_a):
+            raise blocking_del_error("boom")
+
+        monkeypatch.setattr(entry, "_finalize_loop", crash)
+        loop = asyncio.new_event_loop()
+        start = time.monotonic()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert time.monotonic() - start < 3.0
+        assert calls == [1]
+        assert executed == []  # the __del__ never ran: the ref is parked
+        loop.close()
+        armed["on"] = False  # disarm before interpreter shutdown
+
+    def test_hostile_del_cannot_hang_the_barrier_arm(self):
+        import logging
+        import time
+
+        import src.tools.process_manager as pm
+        from src.__main__ import _finalize_loop
+
+        blocking_del_error, executed, armed = self._hostile_del_error()
+        loop = asyncio.new_event_loop()
+
+        def explode(_coro):
+            raise blocking_del_error("barrier blew up")
+
+        loop.run_until_complete = explode  # type: ignore[method-assign]
+        start = time.monotonic()
+        failure = _finalize_loop(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t")
+        )
+        assert time.monotonic() - start < 3.0
+        assert failure is not None and "BlockingDelError" in failure
+        assert executed == []
+        loop.close()
+        armed["on"] = False
+
+    def test_hostile_del_cannot_hang_the_drain_arm(self):
+        import logging
+        import time
+
+        import src.tools.process_manager as pm
+        from src.__main__ import _finalize_loop
+
+        blocking_del_error, executed, armed = self._hostile_del_error()
+        loop = asyncio.new_event_loop()
+        reaper = pm.AdoptedZombieReaper()
+
+        def explode():
+            raise blocking_del_error("drain blew up")
+
+        reaper.drain_at_teardown = explode  # type: ignore[method-assign]
+        start = time.monotonic()
+        failure = _finalize_loop(loop, reaper, logging.getLogger("t"))
+        assert time.monotonic() - start < 3.0
+        assert failure is not None and "drain failed" in failure
+        assert "BlockingDelError" in failure
+        assert executed == []
+        loop.close()
+        armed["on"] = False
+
+    def test_hostile_del_process_level(self, tmp_path):
+        """Odin's round-22 repro shape in a real process: the marker
+        inside __del__ must never print, and the child exits fast."""
+        import subprocess
+        import time
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        script = tmp_path / "blocking_del.py"
+        script.write_text(
+            "import asyncio\n"
+            "import logging\n"
+            "import sys\n"
+            "import threading\n"
+            "\n"
+            "logging.basicConfig(level=logging.INFO)\n"
+            "from src.__main__ import _finalize_and_exit\n"
+            "from src.tools.process_manager import AdoptedZombieReaper\n"
+            "\n"
+            "class BlockingDelError(RuntimeError):\n"
+            "    def __del__(self):\n"
+            "        print('BLOCKING_DEL_ENTER', file=sys.__stderr__, flush=True)\n"
+            "        threading.Event().wait()\n"
+            "\n"
+            "loop = asyncio.new_event_loop()\n"
+            "\n"
+            "def explode(_coro):\n"
+            "    raise BlockingDelError('barrier blew up')\n"
+            "\n"
+            "loop.run_until_complete = explode\n"
+            "print('FINALIZE_ENTER', file=sys.stderr, flush=True)\n"
+            "_finalize_and_exit(\n"
+            "    loop, AdoptedZombieReaper(), logging.getLogger('repro'), 0\n"
+            ")\n"
+            "print('UNREACHABLE', file=sys.stderr, flush=True)\n"
+        )
+        start = time.monotonic()
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=repo_root,
+            capture_output=True,
+            timeout=15,
+        )
+        elapsed = time.monotonic() - start
+        assert proc.returncode == 1
+        assert elapsed < 10.0
+        assert b"FINALIZE_ENTER" in proc.stderr
+        assert b"BLOCKING_DEL_ENTER" not in proc.stderr  # never finalized
+        assert b"UNREACHABLE" not in proc.stderr
+
     def test_thread_guard_catches_base_exceptions(self, monkeypatch):
         """os._exit is unconditional: even a BaseException out of the
         scribe machinery (a signal mid-join) must not stop it."""

--- a/tests/test_main_exit_codes.py
+++ b/tests/test_main_exit_codes.py
@@ -425,7 +425,7 @@ class TestFinalizeLoop:
             return real_drain()
 
         reaper.drain_at_teardown = traced_drain  # type: ignore[method-assign]
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert _finalize_loop(loop, reaper, logging.getLogger("test")) is True
         assert order == ["executor", "drain"]  # owners stop, THEN drain
         assert loop.is_closed()
         assert restart.reexec_blocked() is None  # verified drain ⇒ no veto
@@ -495,7 +495,7 @@ class TestFinalizeLoop:
             lambda: drained.append(True) or (0, True)
         )
         start = time.monotonic()
-        _finalize_loop(loop, reaper, logging.getLogger("test"))
+        assert _finalize_loop(loop, reaper, logging.getLogger("test")) is False
         assert time.monotonic() - start < 5.0  # Odin's probe bound
         assert drained == []  # owners unproven ⇒ drain skipped
         veto = restart.reexec_blocked()
@@ -582,6 +582,90 @@ class TestFinalizeLoop:
         veto = restart.reexec_blocked()
         assert veto is not None and "owners" in veto
         assert loop.is_closed()
+
+
+class TestUncleanBarrierExit:
+    """Round-17: a blocked default-executor worker is a NON-DAEMON
+    thread. The bounded barrier returns and vetoes, but ordinary
+    interpreter shutdown then joins that thread forever — the exit must
+    not rely on Python shutdown."""
+
+    def test_blocked_executor_worker_cannot_hold_process_exit(self, tmp_path):
+        """Process-level, real blocked worker (Odin's round-17 repro
+        shape): the process must actually EXIT nonzero, promptly."""
+        import subprocess
+        import time
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        script = tmp_path / "blocked_worker.py"
+        script.write_text(
+            "import asyncio\n"
+            "import logging\n"
+            "import sys\n"
+            "import threading\n"
+            "\n"
+            "logging.basicConfig(level=logging.INFO)\n"
+            "from src.__main__ import _finalize_and_exit\n"
+            "from src.tools.process_manager import AdoptedZombieReaper\n"
+            "\n"
+            "loop = asyncio.new_event_loop()\n"
+            "\n"
+            "def blocked():\n"
+            "    threading.Event().wait()  # a worker that never returns\n"
+            "\n"
+            "async def arm():\n"
+            "    loop.run_in_executor(None, blocked)\n"
+            "    await asyncio.sleep(0.2)  # let the worker actually start\n"
+            "\n"
+            "loop.run_until_complete(arm())\n"
+            "print('FINALIZE_ENTER', flush=True)\n"
+            "_finalize_and_exit(\n"
+            "    loop, AdoptedZombieReaper(), logging.getLogger('repro'), 0\n"
+            ")\n"
+            "print('UNREACHABLE', flush=True)\n"
+        )
+        start = time.monotonic()
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=repo_root,
+            capture_output=True,
+            timeout=15,  # a regression hangs here and fails loudly
+        )
+        elapsed = time.monotonic() - start
+        assert proc.returncode == 1  # exit_code 0 promoted: unclean = failure
+        assert elapsed < 10.0  # bounded barrier + immediate exit
+        assert b"FINALIZE_ENTER" in proc.stdout
+        assert b"UNREACHABLE" not in proc.stdout  # os._exit, not a return
+        assert b"default-executor shutdown did not finish" in proc.stderr
+
+    def test_unclean_barrier_uses_immediate_exit(self, monkeypatch):
+        """In-process arm coverage: unproven owners → os._exit with a
+        promoted nonzero code; a clean barrier returns normally."""
+        import logging
+
+        import src.__main__ as entry
+        import src.tools.process_manager as pm
+
+        calls: list = []
+        monkeypatch.setattr(entry.os, "_exit", lambda code: calls.append(code))
+        monkeypatch.setattr(entry, "_finalize_loop", lambda *_a: False)
+        loop = asyncio.new_event_loop()
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert calls == [1]
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 7
+        )
+        assert calls == [1, 7]
+
+        monkeypatch.setattr(entry, "_finalize_loop", lambda *_a: True)
+        entry._finalize_and_exit(
+            loop, pm.AdoptedZombieReaper(), logging.getLogger("t"), 0
+        )
+        assert calls == [1, 7]  # clean barrier: no immediate exit
+        loop.close()
 
 
 class TestVetoedReexec:

--- a/tests/test_native_agents_tasks.py
+++ b/tests/test_native_agents_tasks.py
@@ -767,6 +767,26 @@ class TestAgentHandlers:
         out = await t._handle_wait_for_agents({"agent_ids": ["a1"], "timeout": 10})
         assert "`a1`" in out and "..." in out  # long content truncated at 800
 
+    async def test_wait_render_carries_iteration_count_not_runtime(self):
+        """PR #244 round-1 blocker #4: iteration_count is the stable
+        progress marker for the wait-class stuck signature — a silently
+        progressing agent must not render identically to a hung one.
+        Runtime stays excluded (it would make a hung agent immortal)."""
+        t = _tools()
+        t._agent_manager.wait_for_agents = AsyncMock(return_value={
+            "a1": {"status": "running", "label": "w", "iteration_count": 7,
+                   "runtime_seconds": 123.4, "result": ""}})
+        out = await t._handle_wait_for_agents({"agent_ids": ["a1"], "timeout": 10})
+        assert "[iterations=7]" in out
+        assert "123" not in out  # runtime never rendered
+        # Progressing iterations change the render (and therefore the
+        # wait signature); a frozen count repeats identically.
+        t._agent_manager.wait_for_agents = AsyncMock(return_value={
+            "a1": {"status": "running", "label": "w", "iteration_count": 8,
+                   "runtime_seconds": 200.0, "result": ""}})
+        out2 = await t._handle_wait_for_agents({"agent_ids": ["a1"], "timeout": 10})
+        assert out2 != out and "[iterations=8]" in out2
+
     async def test_collect_agent_result_helper(self):
         t = _tools()
         t._agent_manager.wait_for_agents = AsyncMock(return_value={

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -600,3 +600,108 @@ class TestConstants:
 
     def test_output_buffer_lines(self):
         assert OUTPUT_BUFFER_LINES == 500
+
+
+class TestRound2Blockers:
+    async def test_cleanup_never_cancels_inflight_reap(self):
+        """PR #244 round-2 blocker #1: cleanup() must never cancel a
+        lifecycle task — cancellation propagates through the group reap
+        and strands TERM-immune descendants (the v3.59.1 class). A record
+        with running tasks is deferred, not cancelled."""
+        reg = ProcessRegistry()
+        gate = asyncio.Event()
+
+        async def slow_reap():
+            await gate.wait()
+
+        task = asyncio.create_task(slow_reap())
+        await asyncio.sleep(0)
+        info = ProcessInfo(
+            pid=1, command="test", host="local",
+            start_time=time.time() - 7200,  # old enough to be eligible
+            status="completed", exit_code=0,
+        )
+        info._exit_task = task
+        reg._processes[1] = info
+
+        removed = reg.cleanup()
+        assert removed == 0  # deferred, present, NOT cancelled
+        assert 1 in reg._processes
+        assert not task.cancelled()
+
+        gate.set()
+        await task
+        assert reg.cleanup() == 1  # next cycle removes it
+        assert 1 not in reg._processes
+
+    async def test_terminal_poll_waits_for_drain_completion(self):
+        """PR #244 round-2 blocker #3: a poll landing between terminal
+        status publication and drain completion must still report the
+        final output, not a torn tail."""
+        reg = ProcessRegistry()
+        info = ProcessInfo(
+            pid=1, command="test", host="local", start_time=time.time(),
+            status="completed", exit_code=0,
+        )
+
+        async def late_drain():
+            await asyncio.sleep(0.3)
+            info.output_buffer.append("the final tail\n")
+
+        info._reader_task = asyncio.create_task(late_drain())
+        reg._processes[1] = info
+        result = await reg.poll(1)  # wait_seconds=0 — still settles drain
+        assert "the final tail" in result
+
+    async def test_forced_flush_never_splits_multibyte_utf8(self):
+        """PR #244 round-2 blocker #4: >4096 bytes of unterminated
+        multibyte output crosses the forced-flush boundary — the split
+        must land on a UTF-8 boundary, never mid-sequence."""
+        reg = ProcessRegistry()
+        # 3000 × 'я' (2 bytes) = 6000 bytes, no newline: guarantees a
+        # forced flush with an odd chance of landing mid-character.
+        started = await reg.start(
+            "localhost",
+            'python3 -c "import sys; sys.stdout.write(\'\\u044f\'*3000); '
+            'sys.stdout.flush()"',
+        )
+        pid = int(started.split("PID ")[1].split(")")[0])
+        result = await reg.poll(pid, wait_seconds=15)
+        assert "status=completed" in result
+        info = reg._processes[pid]
+        assert info.total_output_bytes == 6000
+        joined = "".join(info.output_buffer)
+        assert "\ufffd" not in joined
+        assert joined.count("я") == 3000
+
+
+class TestUtf8BoundarySplit:
+    def test_ascii_passthrough(self):
+        from src.tools.process_manager import _utf8_boundary_split
+
+        head, tail = _utf8_boundary_split(b"hello world")
+        assert head == b"hello world" and tail == b""
+
+    def test_carries_partial_sequences(self):
+        from src.tools.process_manager import _utf8_boundary_split
+
+        euro = "€".encode()  # 3 bytes
+        for cut in (1, 2):
+            head, tail = _utf8_boundary_split(b"abc" + euro[:cut])
+            assert head == b"abc" and tail == euro[:cut]
+        # Complete sequence at the end flushes whole.
+        head, tail = _utf8_boundary_split(b"abc" + euro)
+        assert head == b"abc" + euro and tail == b""
+        # 4-byte lead with only 2 bytes present.
+        clef = "\U0001d11e".encode()  # 4 bytes
+        head, tail = _utf8_boundary_split(b"x" + clef[:2])
+        assert head == b"x" and tail == clef[:2]
+
+    def test_binary_garbage_bounded_carry(self):
+        from src.tools.process_manager import _utf8_boundary_split
+
+        # Pure continuation bytes: at most 3 carried, rest flushes.
+        buf = b"data" + b"\x80\x80\x80\x80"
+        head, tail = _utf8_boundary_split(buf)
+        assert head + tail == buf
+        assert len(tail) <= 3

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -782,12 +782,13 @@ class TestRound3Blockers:
 
 
 class TestRaceFreeGroupTermination:
-    """Round-5 blocker #2: every signal to a post-leader-exit group goes
-    through a pidfd pinned BEFORE membership verification, so pid reuse
-    between check and signal cannot misdirect it."""
+    """Round-5 #2 / round-6 #1-#2: every signal goes to a pidfd pinned
+    BEFORE membership verification (no pid-reuse window), every pass
+    RE-ENUMERATES (fork-on-TERM cannot escape), and a scan that could not
+    complete is never mistaken for an empty group."""
 
     async def test_pins_only_true_group_members(self):
-        from src.tools.process_manager import _close_pinned, _pinned_group_members
+        from src.tools.process_manager import _close_pinned, _scan_group_members
 
         proc = await asyncio.create_subprocess_shell(
             "sleep 5 & sleep 5", stdout=asyncio.subprocess.PIPE,
@@ -795,23 +796,63 @@ class TestRaceFreeGroupTermination:
         )
         try:
             await asyncio.sleep(0.4)
-            pinned = _pinned_group_members(proc.pid)
+            pinned, complete = _scan_group_members(proc.pid)
             try:
                 pids = {pid for pid, _fd in pinned}
-                assert proc.pid in pids  # the leader
-                assert len(pids) >= 2  # plus descendants
-                # NOTHING outside the group: our own process is never pinned.
-                assert os.getpid() not in pids
+                assert complete is True
+                assert proc.pid in pids and len(pids) >= 2
+                assert os.getpid() not in pids  # nothing outside the group
             finally:
                 _close_pinned(pinned)
         finally:
             proc.kill()
             await proc.wait()
 
-    async def test_reap_racefree_kills_term_immune_descendant(self):
-        from src.tools.process_manager import _reap_group_racefree
+    async def test_fork_on_term_descendant_cannot_escape(self):
+        """Round-6 blocker #1 (Odin's repro): a TERM handler that forks a
+        fresh same-session TERM-immune child is caught by the NEXT
+        enumeration pass — a one-shot pinned set would miss it."""
+        from src.tools.process_manager import (
+            _scan_group_members,
+            _terminate_group_until_empty,
+        )
 
-        # A descendant that ignores SIGTERM: only the KILL escalation ends it.
+        script = (
+            "import os, signal, sys, time\n"
+            "def handler(sig, frm):\n"
+            "    if os.fork() == 0:\n"
+            "        signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "        time.sleep(60)\n"
+            "        os._exit(0)\n"
+            "    os._exit(0)\n"
+            "signal.signal(signal.SIGTERM, handler)\n"
+            "time.sleep(60)\n"
+        )
+        proc = await asyncio.create_subprocess_exec(
+            "python3", "-c", script,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        pgid = proc.pid
+        try:
+            await asyncio.sleep(0.5)
+            gone = await _terminate_group_until_empty(pgid, grace=0.5, timeout=10.0)
+            assert gone is True  # affirmative empty observation
+            pinned, complete = _scan_group_members(pgid)
+            try:
+                assert complete and not pinned  # the forked child died too
+            finally:
+                from src.tools.process_manager import _close_pinned
+
+                _close_pinned(pinned)
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+    async def test_term_immune_descendant_is_killed(self):
+        from src.tools.process_manager import _terminate_group_until_empty
+
         proc = await asyncio.create_subprocess_shell(
             "python3 -c \"import signal,time;"
             "signal.signal(signal.SIGTERM, signal.SIG_IGN);time.sleep(30)\" & "
@@ -819,35 +860,75 @@ class TestRaceFreeGroupTermination:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT, start_new_session=True,
         )
-        pgid = proc.pid
         try:
             await asyncio.sleep(0.5)
-            await _reap_group_racefree(pgid, grace=0.5)
-            from src.tools.process_manager import _pinned_group_members
-
-            for _ in range(30):
-                pinned = _pinned_group_members(pgid)
-                alive = len(pinned)
-                _close_pinned_local(pinned)
-                if alive == 0:
-                    break
-                await asyncio.sleep(0.2)
-            assert alive == 0  # TERM-immune descendant did NOT survive
+            assert await _terminate_group_until_empty(
+                proc.pid, grace=0.5, timeout=10.0
+            ) is True
         finally:
             if proc.returncode is None:
                 proc.kill()
                 await proc.wait()
 
-    async def test_empty_group_is_a_noop(self):
-        from src.tools.process_manager import _kill_group_racefree_sync
+    async def test_empty_group_is_immediately_complete(self):
+        from src.tools.process_manager import _terminate_group_until_empty
 
-        assert _kill_group_racefree_sync(4_000_000) == 0
+        assert await _terminate_group_until_empty(4_000_000, timeout=1.0) is True
 
 
-def _close_pinned_local(pinned):
-    from src.tools.process_manager import _close_pinned
+class TestScanCompleteness:
+    """Round-6 blocker #2: inspection failure is NOT absence."""
 
-    _close_pinned(pinned)
+    def test_unreadable_proc_is_incomplete(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(
+            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
+        )
+        pinned, complete = pm._scan_group_members(1234)
+        assert pinned == [] and complete is False
+
+    def test_pidfd_exhaustion_is_incomplete_not_empty(self, monkeypatch):
+        """Odin's EMFILE repro: pidfd_open failing for LIVE processes must
+        not render the group empty."""
+        import src.tools.process_manager as pm
+
+        def emfile(_pid):
+            raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(pm.os, "pidfd_open", emfile)
+        pinned, complete = pm._scan_group_members(1234)
+        assert pinned == [] and complete is False
+
+    def test_vanished_candidate_does_not_spoil_the_scan(self, monkeypatch):
+        """A process that exits mid-scan is genuinely gone — ESRCH from
+        pidfd_open keeps the scan COMPLETE."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(
+            pm.os, "pidfd_open",
+            lambda _pid: (_ for _ in ()).throw(ProcessLookupError()),
+        )
+        pinned, complete = pm._scan_group_members(1234)
+        assert pinned == [] and complete is True
+
+    def test_stat_read_error_is_unknown_not_gone(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        class FakePath:
+            def __init__(self, _p):
+                pass
+
+            def read_text(self):
+                raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        assert pm._stat_fields(1) == "unknown"
+
+    def test_stat_missing_is_gone(self):
+        import src.tools.process_manager as pm
+
+        assert pm._stat_fields(4_000_000) is None
 
 
 class TestShutdownBarrier:
@@ -881,14 +962,13 @@ class TestShutdownBarrier:
         reg._processes[proc.pid] = info
         try:
             start = time.monotonic()
-            await asyncio.wait_for(reg.shutdown(), timeout=SHUTDOWN_REAP_TIMEOUT + 15)
-            assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 15
-            # Barrier held: leader reaped and the group provably gone
-            # BEFORE shutdown returned, despite the immortal task.
-            assert proc.returncode is not None
-            from src.tools.process_manager import _kill_group_racefree_sync
+            await asyncio.wait_for(reg.shutdown(), timeout=SHUTDOWN_REAP_TIMEOUT + 20)
+            assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 20
+            assert proc.returncode is not None  # leader reaped
+            from src.tools.process_manager import _scan_group_members
 
-            assert _kill_group_racefree_sync(proc.pid) == 0
+            pinned, complete = _scan_group_members(proc.pid)
+            assert complete and not pinned  # group provably empty
         finally:
             resist = False
             task.cancel()
@@ -900,18 +980,22 @@ class TestShutdownBarrier:
                 proc.kill()
                 await proc.wait()
 
-    async def test_kill_group_until_gone_reports_failure_loudly(self, monkeypatch):
-        """An unkillable survivor makes the barrier return False (the
-        caller's loud report), never a silent success."""
+    async def test_barrier_reports_failure_when_scan_cannot_complete(
+        self, monkeypatch
+    ):
+        """Round-6 #2 end-to-end: a scan that cannot complete makes the
+        barrier return False — never a false success with a live group."""
         import src.tools.process_manager as pm
 
         reg = ProcessRegistry()
-        monkeypatch.setattr(pm, "_kill_group_racefree_sync", lambda pgid: 1)
+        monkeypatch.setattr(
+            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
+        )
         stub = type("P", (), {"pid": 4242, "returncode": 0})()
         info = ProcessInfo(
             pid=4242, command="x", host="local", start_time=0.0, process=stub,
         )
-        assert await reg._kill_group_until_gone(info, timeout=0.3) is False
+        assert await reg._kill_group_until_gone(info, timeout=0.5) is False
 
     async def test_kill_group_until_gone_no_process_is_true(self):
         reg = ProcessRegistry()
@@ -920,15 +1004,23 @@ class TestShutdownBarrier:
 
 
 class TestRaceFreeHelperArms:
-    """Defensive arms of the pidfd machinery — every one is a fail-safe
-    path (skip the candidate / treat as exited), never a signal."""
+    def test_close_pinned_tolerates_bad_fd(self):
+        from src.tools.process_manager import _close_pinned
 
-    def test_stat_fields_missing_process(self):
-        from src.tools.process_manager import _stat_fields
+        _close_pinned([(1, 999_999)])  # already-closed fd → swallowed
 
-        assert _stat_fields(4_000_000) is None
+    def test_pidfd_exited_on_bad_fd_reports_exited(self, monkeypatch):
+        import select as _select
 
-    def test_stat_fields_malformed_stat(self, tmp_path, monkeypatch):
+        from src.tools.process_manager import _pidfd_exited
+
+        monkeypatch.setattr(
+            _select, "select",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("bad fd")),
+        )
+        assert _pidfd_exited(999_999) is True
+
+    def test_malformed_stat_is_gone(self, monkeypatch):
         import src.tools.process_manager as pm
 
         class FakePath:
@@ -941,34 +1033,45 @@ class TestRaceFreeHelperArms:
         monkeypatch.setattr(pm, "Path", FakePath)
         assert pm._stat_fields(1) is None
 
-    def test_pinned_members_survives_unreadable_proc(self, monkeypatch):
+    def test_pinned_member_with_unreadable_stat_is_incomplete(self, monkeypatch):
+        """A candidate we pinned but cannot classify (stat unreadable)
+        leaves the scan INCOMPLETE — never silently skipped as absent."""
         import src.tools.process_manager as pm
 
-        def boom(_path):
-            raise OSError("proc unavailable")
+        real_stat = pm._stat_fields
+        target = os.getpid()
 
-        monkeypatch.setattr(pm.os, "listdir", boom)
-        assert pm._pinned_group_members(1234) == []
+        def flaky(pid):
+            return "unknown" if pid == target else real_stat(pid)
 
-    def test_close_pinned_tolerates_bad_fd(self):
-        from src.tools.process_manager import _close_pinned
+        monkeypatch.setattr(pm, "_stat_fields", flaky)
+        pinned, complete = pm._scan_group_members(4_000_001)
+        assert complete is False
+        pm._close_pinned(pinned)
 
-        _close_pinned([(1, 999_999)])  # already-closed fd → swallowed
+    def test_signal_to_dead_pidfd_is_swallowed(self):
+        """Signalling a pidfd whose process already exited must not raise
+        out of a termination pass."""
+        import src.tools.process_manager as pm
 
-    def test_pidfd_exited_on_bad_fd_reports_exited(self, monkeypatch):
-        """An unusable fd must read as EXITED (fail-safe): the caller then
-        stops waiting on it rather than looping forever."""
-        import select as _select
+        assert pm._signal_pinned([(1, 999_999)], 15) is None  # bad fd → debug log
 
-        from src.tools.process_manager import _pidfd_exited
+    async def test_pidfd_exited_true_after_exit(self):
+        """The positive arm: a pidfd polls readable once its process is
+        gone (the loop's completion signal)."""
+        import src.tools.process_manager as pm
 
-        def boom(*_a, **_k):
-            raise OSError("bad file descriptor")
-
-        monkeypatch.setattr(_select, "select", boom)
-        assert _pidfd_exited(999_999) is True
-
-    async def test_reap_racefree_returns_when_nothing_pinned(self):
-        from src.tools.process_manager import _reap_group_racefree
-
-        await _reap_group_racefree(4_000_000, grace=0.1)  # returns immediately
+        proc = await asyncio.create_subprocess_shell(
+            "true", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        fd = os.pidfd_open(proc.pid)
+        try:
+            await proc.wait()
+            for _ in range(30):
+                if pm._pidfd_exited(fd):
+                    break
+                await asyncio.sleep(0.1)
+            assert pm._pidfd_exited(fd) is True
+        finally:
+            os.close(fd)

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -2536,6 +2536,81 @@ class TestAdoptedZombieReaper:
         assert reaper.sweep_once() == 1
         assert master not in self._our_zombie_map()
 
+    async def test_dead_master_record_does_not_mask_its_replacement(
+        self, tmp_path, monkeypatch
+    ):
+        """Round-16 #1: a cached master record whose process is now a
+        ZOMBIE is not alive — the fast path must fall through and
+        re-probe, so the REPLACEMENT master gets registered. The
+        corpse's own registration survives for the reaper."""
+        import shutil
+
+        import src.tools.process_manager as pm
+        import src.tools.ssh_pool as sp
+
+        sleep_bin = shutil.which("sleep")
+        assert sleep_bin is not None
+        fake_ssh = tmp_path / "ssh"
+        shutil.copy(sleep_bin, fake_ssh)
+        fake_ssh.chmod(0o755)
+        master_a = await self._spawn_adopted(
+            tmp_path, lifetime="300", exec_path=str(fake_ssh)
+        )
+        await self._wait_adopted_alive(master_a)
+        master_b = await self._spawn_adopted(
+            tmp_path, lifetime="300", exec_path=str(fake_ssh)
+        )
+        await self._wait_adopted_alive(master_b)
+
+        pool = sp.SSHConnectionPool(socket_dir=str(tmp_path / "sockets"))
+        open(pool.get_socket_path("h1", "root"), "w").close()
+        current = {"pid": master_a}
+        calls: list = []
+
+        class FakeCheck:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"Master running (pid=%d)\r\n" % current["pid"], b"")
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return 0
+
+        async def fake_exec(*argv, **_kw):
+            calls.append(argv)
+            return FakeCheck()
+
+        monkeypatch.setattr(sp.asyncio, "create_subprocess_exec", fake_exec)
+        assert await pool.ensure_master_registered("h1", "root") is True
+        table, _c = pm._scan_process_table()
+        identity_a = (master_a, table[master_a][1])
+        assert identity_a in pm.registered_reap_identities()
+
+        # A dies (ControlPersist expiry) and is now OUR ZOMBIE, unreaped;
+        # its replacement B is already serving the socket.
+        os.kill(master_a, 9)
+        await self._wait_zombie(master_a)
+        current["pid"] = master_b
+        probes = len(calls)
+        assert await pool.ensure_master_registered("h1", "root") is True
+        assert len(calls) == probes + 1  # re-probed — no stale fast path
+        table, _c = pm._scan_process_table()
+        identity_b = (master_b, table[master_b][1])
+        assert identity_b in pm.registered_reap_identities()
+        assert identity_a in pm.registered_reap_identities()  # corpse kept
+
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        assert reaper.sweep_once() == 1  # A reaped…
+        assert master_a not in self._our_zombie_map()
+        table, _c = pm._scan_process_table()
+        assert table[master_b][2] != b"Z"  # …B alive and untouched
+        os.kill(master_b, 9)
+        await self._wait_zombie(master_b)
+        assert reaper.sweep_once() == 1  # B's own zombie is covered too
+
     # -- exclusions and fail-closed inspection ------------------------------
 
     async def test_pidfd_owned_child_is_never_reaped(self, monkeypatch):
@@ -2906,6 +2981,29 @@ class TestAdoptedZombieReaper:
         finally:
             live.terminate()
             live.wait()
+
+    def test_proc_live_starttime_states(self):
+        """Alive → its starttime; gone → None (the zombie arm is proven
+        by the replacement-master pin: a corpse is never 'live')."""
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        live = subprocess.Popen(["sleep", "30"])
+        try:
+            assert (
+                pm._proc_live_starttime(live.pid)
+                == pm._proc_starttime(live.pid)
+            )
+        finally:
+            live.terminate()
+            live.wait()
+        free_pid = next(
+            p
+            for p in range(4194000, 4194304)
+            if not os.path.exists(f"/proc/{p}")
+        )
+        assert pm._proc_live_starttime(free_pid) is None
 
     def test_scan_marks_unreadable_stat_incomplete(self, monkeypatch):
         """A pid listed in /proc whose stat cannot be read (EACCES shape)

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -233,6 +233,34 @@ class TestPollWaitSeconds:
             )
             assert code == 0, ok
 
+    async def test_wedged_reader_never_wedges_the_poll(self):
+        """Process exits during the wait but the reader task hangs: the
+        bounded (shielded) drain gives up and the poll still reports —
+        a stuck reader must not turn a bounded wait into an unbounded one,
+        and the shield must not cancel the reader."""
+
+        class _ExitedProc:
+            async def wait(self):
+                return 0
+
+        reg = ProcessRegistry()
+        wedge = asyncio.Event()  # never set
+        reader = asyncio.create_task(wedge.wait())
+        info = ProcessInfo(
+            pid=1, command="test", host="local", start_time=time.time(),
+            process=_ExitedProc(),  # type: ignore[arg-type]
+        )
+        info._reader_task = reader
+        reg._processes[1] = info
+        try:
+            start = time.monotonic()
+            result = await reg.poll(1, wait_seconds=30)
+            assert time.monotonic() - start < 12.0  # drain bound, not 30s
+            assert "[PID 1]" in result
+            assert not reader.cancelled()  # shield held
+        finally:
+            reader.cancel()
+
     async def test_cancellation_aborts_wait_not_process(self):
         reg = ProcessRegistry()
         proc = await asyncio.create_subprocess_shell(

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -735,16 +735,14 @@ class TestRound3Blockers:
         try:
             start = time.monotonic()
             await reg.shutdown()
-            assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 5
-            # The group died by the synchronous hard kill, not the reap.
-            for _ in range(20):
-                try:
-                    os.killpg(proc.pid, 0)
-                except ProcessLookupError:
-                    break
-                await asyncio.sleep(0.25)
+            assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 10
+            # COMPLETION BARRIER (round-4 blocker #1): shutdown returns only
+            # after the cancellation landed, the leader was reaped, and the
+            # group provably dissolved.
+            assert info._exit_task.done()
+            assert proc.returncode is not None  # leader reaped, no zombie
             with pytest.raises(ProcessLookupError):
-                os.killpg(proc.pid, 0)
+                os.killpg(proc.pid, 0)  # group gone BEFORE shutdown returned
         finally:
             gate.set()
             if proc.returncode is None:
@@ -811,3 +809,116 @@ class TestHardKillGroup:
             process=type("P", (), {"pid": 4242})(),
         )
         ProcessRegistry._hard_kill_group(info)  # Exception arm → debug log
+
+
+class TestPgidRecycleGuard:
+    async def test_unreaped_leader_pins_the_pgid(self):
+        proc = await asyncio.create_subprocess_shell(
+            "sleep 5", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        info = ProcessInfo(
+            pid=proc.pid, command="sleep 5", host="local",
+            start_time=time.time(), process=proc,
+        )
+        try:
+            assert ProcessRegistry._pgid_safe_to_signal(info) is True
+        finally:
+            proc.kill()
+            await proc.wait()
+
+    async def test_reaped_leader_with_proc_entry_is_recycled(self):
+        """After reap, a PRESENT /proc/<pgid> can only be an unrelated
+        process that recycled the pid — never signalled (round-4)."""
+        import os as _os
+
+        stub = type("P", (), {"pid": _os.getpid(), "returncode": 0})()
+        info = ProcessInfo(
+            pid=stub.pid, command="x", host="local",
+            start_time=0.0, process=stub,
+        )
+        assert ProcessRegistry._pgid_safe_to_signal(info) is False
+
+    async def test_reaped_and_gone_is_safe(self):
+        proc = await asyncio.create_subprocess_shell(
+            "true", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        await proc.wait()
+        info = ProcessInfo(
+            pid=proc.pid, command="true", host="local",
+            start_time=time.time(), status="completed", process=proc,
+        )
+        # /proc entry gone after reap: killpg reaches our surviving members
+        # or raises ESRCH — both safe.
+        assert ProcessRegistry._pgid_safe_to_signal(info) is True
+
+    def test_no_process_is_never_safe(self):
+        info = ProcessInfo(pid=1, command="x", host="local", start_time=0.0)
+        assert ProcessRegistry._pgid_safe_to_signal(info) is False
+
+
+class TestShutdownBarrierArms:
+    async def test_abandoned_reaper_error_is_swallowed(self):
+        """A reaper that dies with a non-cancel error when cancelled must
+        not break the shutdown barrier."""
+        reg = ProcessRegistry()
+        gate = asyncio.Event()
+
+        async def bad_reaper():
+            try:
+                await gate.wait()
+            except asyncio.CancelledError:
+                raise ValueError("reaper corrupted on cancel") from None
+
+        proc = await asyncio.create_subprocess_shell(
+            "true", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        await proc.wait()
+        info = ProcessInfo(
+            pid=proc.pid, command="true", host="local",
+            start_time=time.time(), status="completed", exit_code=0,
+            process=proc,
+        )
+        info._exit_task = asyncio.create_task(bad_reaper())
+        reg._processes[proc.pid] = info
+        await reg.shutdown()  # must not raise
+        assert info._exit_task.done()
+
+    async def test_confirm_group_gone_warns_on_survivor(self):
+        """A group that outlives the confirmation window is logged loudly,
+        never silently abandoned."""
+        reg = ProcessRegistry()
+        proc = await asyncio.create_subprocess_shell(
+            "sleep 5", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        info = ProcessInfo(
+            pid=proc.pid, command="sleep 5", host="local",
+            start_time=time.time(), process=proc,
+        )
+        try:
+            await reg._confirm_group_gone(info, timeout=0.3)  # exhausts window
+        finally:
+            proc.kill()
+            await proc.wait()
+
+    async def test_confirm_group_gone_tolerates_probe_errors(self, monkeypatch):
+        """A probe error (e.g. EPERM against a group we cannot signal)
+        ends the confirmation quietly — never raises out of shutdown."""
+        import os as _os
+
+        reg = ProcessRegistry()
+
+        def eperm(pgid, sig):
+            raise PermissionError("operation not permitted")
+
+        monkeypatch.setattr(_os, "killpg", eperm)
+        stub = type("P", (), {"pid": 4242, "returncode": None})()
+        info = ProcessInfo(
+            pid=4242, command="x", host="local", start_time=0.0, process=stub,
+        )
+        start = time.monotonic()
+        await reg._confirm_group_gone(info, timeout=5.0)
+        assert time.monotonic() - start < 1.0  # returned on first probe error

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -2023,54 +2023,136 @@ class TestSelectiveProvenanceErasure:
         assert pinned == []  # never killed on a guess
         assert complete is False  # and emptiness is NOT affirmed
 
-    async def test_selective_erasure_escapee_blocks_affirmative_cleanup(self):
-        """Odin's exact repro through the real start() path: an escapee
-        that keeps ODIN_PROC but deletes ODIN_BG_JOB must prevent
-        confirmed-empty while it is alive."""
+    async def test_forged_or_erased_token_cannot_survive_teardown(self):
+        """Round-13 (Odin's token-REPLACEMENT repro): environment markers
+        are child-controlled, so they can be deleted OR forged and can
+        never prove a process foreign. At teardown, adoption alone is
+        sufficient — a descendant that forges its provenance, double-forks
+        and setsid()s is still ended, and cleanup's verdict is honest.
+
+        Unconditional: the escapee is located deterministically (it writes
+        its pid to a file) rather than by a search that could pass
+        vacuously — the flaw Odin found in the previous pin.
+        """
         import src.tools.process_manager as pm
 
         previously = pm.child_subreaper_active()
         pm.set_child_subreaper(True)
         reg = ProcessRegistry()
-        escaped_pid = None
+        pidfile = None
+        escaped = None
         try:
-            escape = (
-                "import os,signal,sys,time\n"
-                "if os.fork()==0:\n"
-                " os.setsid()\n"
-                " os.environ.pop('ODIN_BG_JOB', None)\n"
-                " os.execve(sys.executable, [sys.executable, '-c',"
-                " 'import signal,time;"
-                " signal.signal(signal.SIGTERM, signal.SIG_IGN);"
-                " time.sleep(45)'], os.environ)\n"
-                "sys.exit(0)\n"
-            )
-            started = await reg.start("localhost", f'python3 -c "exec({escape!r})"')
+            import tempfile
+
+            fd, pidfile = tempfile.mkstemp(prefix="escapee-", suffix=".pid")
+            os.close(fd)
+            # Script goes to a FILE: quoting a python source string through
+            # the shell is how earlier attempts silently produced a dead
+            # escapee (repr picks double quotes when the body contains
+            # single ones, and the shell then breaks on the parens).
+            script = f"""
+import os, signal, sys, time
+if os.fork() == 0:
+    os.setsid()
+    os.environ['ODIN_BG_JOB'] = 'forged-not-a-real-job'
+    with open({pidfile!r}, 'w') as fh:
+        fh.write(str(os.getpid()))
+    os.execve(
+        sys.executable,
+        [sys.executable, '-c',
+         'import signal,time\\n'
+         'signal.signal(signal.SIGTERM, signal.SIG_IGN)\\n'
+         'time.sleep(45)\\n'],
+        os.environ,
+    )
+sys.exit(0)
+"""
+            script_path = pidfile + ".py"
+            with open(script_path, "w") as fh:
+                fh.write(script)
+            started = await reg.start("localhost", f"python3 {script_path}")
             pid = int(started.split("PID ")[1].split(")")[0])
-            await asyncio.sleep(1.2)
-            info = reg._processes[pid]
-            gone = await reg._kill_group_until_gone(info, timeout=6.0)
-            # The escapee is alive with erased job provenance: cleanup must
-            # NOT claim success.
-            for entry in os.listdir("/proc"):
-                if not entry.isdigit():
-                    continue
-                ids = pm._proc_ids(int(entry))
-                if (
-                    isinstance(ids, tuple)
-                    and ids[0] == os.getpid()
-                    and int(entry) not in reg._own_children
-                    and pm._read_job_token(int(entry)) is None
-                ):
-                    escaped_pid = int(entry)
+
+            for _ in range(60):
+                text = open(pidfile).read().strip()
+                if text:
+                    escaped = int(text)
                     break
-            if escaped_pid is not None:
-                assert gone is False  # ambiguity ⇒ no affirmative emptiness
+                await asyncio.sleep(0.1)
+            assert escaped is not None, "escapee never reported its pid"
+            assert pm._read_job_token(escaped) == "forged-not-a-real-job"
+            assert pm._proc_starttime(escaped) is not None  # alive
+
+            info = reg._processes[pid]
+            gone = await reg._kill_group_until_gone(info, timeout=15.0)
+
+            assert gone is True  # teardown resolves adoption as ours…
+            # …and the forged escapee is actually DEAD, not just claimed.
+            for _ in range(40):
+                ids = pm._proc_ids(escaped)
+                if ids is None:
+                    break
+                await asyncio.sleep(0.25)
+            assert pm._proc_ids(escaped) is None, "forged escapee survived teardown"
         finally:
-            if escaped_pid is not None:
+            if escaped is not None:
                 try:
-                    os.kill(escaped_pid, 9)
+                    os.kill(escaped, 9)
                 except ProcessLookupError:
                     pass
+            if pidfile is not None:
+                for path in (pidfile, pidfile + ".py"):
+                    try:
+                        os.unlink(path)
+                    except OSError:
+                        pass
             await reg.shutdown()
             pm.set_child_subreaper(previously)
+
+    def test_live_cleanup_still_refuses_to_guess(self, monkeypatch):
+        """Outside teardown the rule is unchanged: a forged/absent token
+        is ambiguous — untouched, and emptiness is not affirmed."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        monkeypatch.setattr(
+            pm, "_read_env_tokens", lambda _pid: {pm.PROC_TOKEN_ENV: "P"}
+        )
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok", proc_token="P"
+        )
+        pm._close_pinned(pinned)
+        assert pinned == [] and complete is False
+
+    def test_unavailable_own_session_never_sweeps(self, monkeypatch):
+        """If our own session id cannot be read, the teardown arm must not
+        fire — an unknown 'own session' would make every adopted child
+        look like an escapee."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(
+            pm.os, "getsid", lambda _p: (_ for _ in ()).throw(OSError("no sid"))
+        )
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        # A direct child in session -1 would "differ" from an unreadable
+        # own-session sentinel; provenance must still decide it.
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, -1))
+        monkeypatch.setattr(
+            pm, "_read_env_tokens", lambda _pid: {pm.PROC_TOKEN_ENV: "P"}
+        )
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok",
+            proc_token="P", teardown=True,
+        )
+        pm._close_pinned(pinned)
+        assert pinned == []  # not swept on an unknown own-session
+        assert complete is False  # and emptiness is not affirmed

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -16,6 +16,7 @@ from src.tools.process_manager import (
     MAX_CONCURRENT,
     MAX_LIFETIME_SECONDS,
     OUTPUT_BUFFER_LINES,
+    SHUTDOWN_REAP_TIMEOUT,
     ProcessInfo,
     ProcessRegistry,
 )
@@ -705,3 +706,108 @@ class TestUtf8BoundarySplit:
         head, tail = _utf8_boundary_split(buf)
         assert head + tail == buf
         assert len(tail) <= 3
+
+
+class TestRound3Blockers:
+    async def test_shutdown_hard_kills_group_before_abandoning_wedged_reap(self):
+        """PR #244 round-3 blocker #2: a wedged async reap must not strand
+        the owned group across re-exec — shutdown hard-KILLs the group
+        synchronously before cancelling the task."""
+        import os
+
+        reg = ProcessRegistry()
+        proc = await asyncio.create_subprocess_shell(
+            "sleep 30", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        gate = asyncio.Event()  # never set — the wedged "reaper"
+
+        async def wedged():
+            await gate.wait()
+
+        info = ProcessInfo(
+            pid=proc.pid, command="sleep 30", host="local",
+            start_time=time.time(), status="completed", exit_code=0,
+            process=proc,
+        )
+        info._exit_task = asyncio.create_task(wedged())
+        reg._processes[proc.pid] = info
+        try:
+            start = time.monotonic()
+            await reg.shutdown()
+            assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 5
+            # The group died by the synchronous hard kill, not the reap.
+            for _ in range(20):
+                try:
+                    os.killpg(proc.pid, 0)
+                except ProcessLookupError:
+                    break
+                await asyncio.sleep(0.25)
+            with pytest.raises(ProcessLookupError):
+                os.killpg(proc.pid, 0)
+        finally:
+            gate.set()
+            if proc.returncode is None:
+                proc.kill()
+            await proc.wait()
+
+    async def test_zero_wait_poll_settles_when_returncode_beats_publication(self):
+        """PR #244 round-3 blocker #3: returncode set but status not yet
+        published — a zero-wait poll must settle via the watcher instead
+        of reporting stale running status with a torn tail."""
+        reg = ProcessRegistry()
+        proc = await asyncio.create_subprocess_shell(
+            "echo tail-marker; exit 0",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        # Let the child exit (returncode set at SIGCHLD reap) WITHOUT any
+        # watcher having run yet — status still says running.
+        for _ in range(40):
+            if proc.returncode is not None:
+                break
+            await asyncio.sleep(0.1)
+        assert proc.returncode is not None
+        info = ProcessInfo(
+            pid=proc.pid, command="echo", host="local",
+            start_time=time.time(), process=proc,  # status="running"
+        )
+        info._reader_task = asyncio.create_task(reg._read_output(info))
+        info._exit_task = asyncio.create_task(reg._watch_exit(info))
+        reg._processes[proc.pid] = info
+
+        result = await reg.poll(proc.pid)  # wait_seconds=0
+        assert "status=completed" in result
+        assert "exit_code=0" in result
+        assert "tail-marker" in result
+
+
+class TestHardKillGroup:
+    async def test_already_dead_group_is_the_goal_state(self):
+        proc = await asyncio.create_subprocess_shell(
+            "true", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        await proc.wait()
+        info = ProcessInfo(
+            pid=proc.pid, command="true", host="local",
+            start_time=time.time(), status="completed", process=proc,
+        )
+        ProcessRegistry._hard_kill_group(info)  # ProcessLookupError → pass
+
+    def test_no_process_is_a_noop(self):
+        info = ProcessInfo(pid=1, command="x", host="local", start_time=0.0)
+        ProcessRegistry._hard_kill_group(info)  # process=None → return
+
+    def test_unexpected_error_is_swallowed(self, monkeypatch):
+        import os as _os
+
+        def boom(pgid, sig):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(_os, "killpg", boom)
+        info = ProcessInfo(
+            pid=1, command="x", host="local", start_time=0.0,
+            process=type("P", (), {"pid": 4242})(),
+        )
+        ProcessRegistry._hard_kill_group(info)  # Exception arm → debug log

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -93,45 +93,167 @@ class TestProcessRegistryStart:
 # ---------------------------------------------------------------------------
 
 class TestProcessRegistryPoll:
-    def test_poll_nonexistent(self):
+    async def test_poll_nonexistent(self):
         reg = ProcessRegistry()
-        result = reg.poll(99999)
+        result = await reg.poll(99999)
         assert "No process" in result
 
-    def test_poll_running_no_output(self):
+    async def test_poll_running_no_output(self):
         reg = ProcessRegistry()
         info = ProcessInfo(pid=1, command="test", host="local", start_time=time.time())
         reg._processes[1] = info
-        result = reg.poll(1)
+        result = await reg.poll(1)
         assert "status=running" in result
         assert "no output yet" in result
 
-    def test_poll_with_output(self):
+    async def test_poll_with_output(self):
         reg = ProcessRegistry()
         info = ProcessInfo(pid=1, command="test", host="local", start_time=time.time())
         info.output_buffer.append("hello world\n")
         info.output_buffer.append("second line\n")
         reg._processes[1] = info
-        result = reg.poll(1)
+        result = await reg.poll(1)
         assert "hello world" in result
         assert "second line" in result
 
-    def test_poll_shows_exit_code(self):
+    async def test_poll_shows_exit_code(self):
         reg = ProcessRegistry()
         info = ProcessInfo(
             pid=1, command="test", host="local",
             start_time=time.time(), status="completed", exit_code=0,
         )
         reg._processes[1] = info
-        result = reg.poll(1)
+        result = await reg.poll(1)
         assert "exit_code=0" in result
 
-    def test_poll_shows_uptime(self):
+    async def test_poll_shows_uptime(self):
         reg = ProcessRegistry()
         info = ProcessInfo(pid=1, command="test", host="local", start_time=time.time() - 30)
         reg._processes[1] = info
-        result = reg.poll(1)
+        result = await reg.poll(1)
         assert "uptime=" in result
+
+    async def test_poll_reports_total_output_bytes(self):
+        reg = ProcessRegistry()
+        info = ProcessInfo(
+            pid=1, command="test", host="local", start_time=time.time(),
+            total_output_bytes=4096,
+        )
+        reg._processes[1] = info
+        result = await reg.poll(1)
+        assert "output_bytes=4096" in result
+
+
+class TestPollWaitSeconds:
+    """wait_seconds semantics (design settled with Odin, 2026-07-31):
+    terminal → immediate; running → wait until EXIT or deadline (never an
+    early-output wakeup); cancellation aborts only the wait."""
+
+    async def test_terminal_process_returns_immediately(self):
+        reg = ProcessRegistry()
+        info = ProcessInfo(
+            pid=1, command="test", host="local",
+            start_time=time.time(), status="completed", exit_code=0,
+        )
+        reg._processes[1] = info
+        start = time.monotonic()
+        result = await reg.poll(1, wait_seconds=60)
+        assert time.monotonic() - start < 1.0
+        assert "exit_code=0" in result
+
+    async def test_running_process_waits_until_deadline(self):
+        reg = ProcessRegistry()
+        proc = await asyncio.create_subprocess_shell(
+            "sleep 30", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        info = ProcessInfo(
+            pid=proc.pid, command="sleep 30", host="local",
+            start_time=time.time(), process=proc,
+        )
+        reg._processes[proc.pid] = info
+        try:
+            start = time.monotonic()
+            result = await reg.poll(proc.pid, wait_seconds=1.0)
+            elapsed = time.monotonic() - start
+            assert 0.9 <= elapsed < 5.0  # waited the deadline, not longer
+            assert "status=running" in result
+            assert proc.returncode is None  # wait never touched the process
+        finally:
+            proc.kill()
+            await proc.wait()
+
+    async def test_exit_during_wait_returns_early_with_terminal_state(self):
+        reg = ProcessRegistry()
+        result_start = await reg.start("localhost", "echo done-marker; exit 0")
+        pid = int(result_start.split("PID ")[1].split(")")[0])
+        start = time.monotonic()
+        result = await reg.poll(pid, wait_seconds=30)
+        elapsed = time.monotonic() - start
+        assert elapsed < 10.0  # exited long before the 30s deadline
+        assert "status=completed" in result
+        assert "exit_code=0" in result
+        assert "done-marker" in result  # reader drained before the report
+
+    async def test_handler_rejects_invalid_wait_seconds(self):
+        """Invalid wait_seconds is REJECTED, never clamped (the
+        reasoning-effort validation rule). bool is an int subtype and
+        must not slip through."""
+        from src.tools.handlers.system import SystemTools
+
+        reg = ProcessRegistry()
+        info = ProcessInfo(pid=1, command="test", host="local", start_time=time.time())
+        reg._processes[1] = info
+        h = SystemTools.__new__(SystemTools)
+        h._process_registry = lambda: reg
+
+        for bad in (-1, 121, float("nan"), float("inf"), "60", True, None):
+            result = await h._handle_manage_process(
+                {"action": "poll", "pid": 1, "wait_seconds": bad}
+            )
+            assert isinstance(result, tuple) and result[1] == 1, bad
+            assert "wait_seconds must be" in result[0], bad
+
+    async def test_handler_accepts_valid_wait_and_defaults_to_zero(self):
+        from src.tools.handlers.system import SystemTools
+
+        reg = ProcessRegistry()
+        info = ProcessInfo(pid=1, command="test", host="local", start_time=time.time())
+        reg._processes[1] = info
+        h = SystemTools.__new__(SystemTools)
+        h._process_registry = lambda: reg
+
+        # Omitted → default 0 → immediate report, exit 0.
+        out, code = await h._handle_manage_process({"action": "poll", "pid": 1})
+        assert code == 0 and "status=running" in out
+        # Boundary values accepted.
+        for ok in (0, 0.5, 120):
+            out, code = await h._handle_manage_process(
+                {"action": "poll", "pid": 1, "wait_seconds": ok}
+            )
+            assert code == 0, ok
+
+    async def test_cancellation_aborts_wait_not_process(self):
+        reg = ProcessRegistry()
+        proc = await asyncio.create_subprocess_shell(
+            "sleep 30", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        info = ProcessInfo(
+            pid=proc.pid, command="sleep 30", host="local",
+            start_time=time.time(), process=proc,
+        )
+        reg._processes[proc.pid] = info
+        try:
+            task = asyncio.create_task(reg.poll(proc.pid, wait_seconds=60))
+            await asyncio.sleep(0.2)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert proc.returncode is None  # detached process untouched
+        finally:
+            proc.kill()
+            await proc.wait()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -1443,6 +1443,7 @@ class TestSubreaperContainment:
                 pid, leader_pid=pid,
                 adopted_by=os.getpid(),
                 known_own_children=frozenset(reg._own_children),
+                job_token=reg._processes[pid].job_token,
             )
             adopted = len(pinned)
             _close_pinned(pinned)
@@ -1456,13 +1457,14 @@ class TestSubreaperContainment:
                 pid, leader_pid=pid,
                 adopted_by=os.getpid(),
                 known_own_children=frozenset(reg._own_children),
+                job_token=reg._processes[pid].job_token,
             )
             left = len(pinned)
             _close_pinned(pinned)
             assert complete and left == 0
         finally:
             await reg.shutdown()
-            reap_adopted_zombies(frozenset(reg._own_children))
+            reap_adopted_zombies(frozenset(reg._adopted_pids))
             set_child_subreaper(previously)
 
     def test_registry_does_not_flip_process_state(self):
@@ -1561,59 +1563,84 @@ class TestContainmentHelpers:
         assert pm.child_subreaper_active() is False
         assert pm.set_child_subreaper(True) is False
 
-    async def test_sweeper_reaps_adopted_zombie_only(self):
-        from src.tools.process_manager import (
-            child_subreaper_active,
-            reap_adopted_zombies,
-            set_child_subreaper,
-        )
+    async def test_sweeper_reaps_recorded_adopted_zombie(self):
+        """Attribution happens while the process is ALIVE (a zombie's
+        environ is unreadable), so the sweeper works from recorded pids —
+        and only reaps zombies that are actually parented to us."""
+        import src.tools.process_manager as pm
 
-        before = child_subreaper_active()
-        set_child_subreaper(True)
+        before = pm.child_subreaper_active()
+        pm.set_child_subreaper(True)
         try:
-            # A double-forked orphan: reparents to US, dies immediately,
-            # and lingers as a zombie nobody else will wait on.
             src = (
-                "import os,sys\n"
+                "import os,sys,time\n"
                 "if os.fork()==0:\n"
+                " time.sleep(0.6)\n"
                 " os._exit(0)\n"
                 "sys.exit(0)\n"
             )
+            env = dict(os.environ)
+            env[pm.JOB_TOKEN_ENV] = "sweeper-test-token"
             proc = await asyncio.create_subprocess_shell(
                 f'python3 -c "exec({src!r})"',
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
+                env=env,
             )
             await proc.wait()
+            # Identify the orphan WHILE ALIVE, by provenance.
+            grandchild = None
             for _ in range(40):
-                if reap_adopted_zombies(frozenset({proc.pid})) >= 1:
+                for entry in os.listdir("/proc"):
+                    if not entry.isdigit():
+                        continue
+                    pid = int(entry)
+                    ids = pm._proc_ids(pid)
+                    if (
+                        isinstance(ids, tuple)
+                        and ids[0] == os.getpid()
+                        and pid != proc.pid
+                        and pm._read_job_token(pid) == "sweeper-test-token"
+                    ):
+                        grandchild = pid
+                        break
+                if grandchild is not None:
+                    break
+                await asyncio.sleep(0.05)
+            assert grandchild is not None, "orphan never reparented to us"
+            # Once it dies it is a zombie; the recorded pid still reaps it.
+            for _ in range(60):
+                if pm.reap_adopted_zombies(frozenset({grandchild})) >= 1:
                     break
                 await asyncio.sleep(0.1)
             else:
                 pytest.fail("adopted zombie was never reaped")
         finally:
-            set_child_subreaper(before)
+            pm.set_child_subreaper(before)
 
-    def test_sweeper_never_touches_own_children(self, monkeypatch):
-        """Our deliberate children belong to asyncio's watcher — stealing
-        a status would break it, so they are skipped by pid."""
+    def test_sweeper_is_a_noop_without_tokens(self, monkeypatch):
+        """No job tokens ⇒ nothing is provably ours ⇒ nothing is reaped."""
         import src.tools.process_manager as pm
 
         waited: list[int] = []
-        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
         monkeypatch.setattr(
             pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
         )
-        assert pm.reap_adopted_zombies(frozenset({4242})) == 0
+        assert pm.reap_adopted_zombies() == 0  # no recorded pids → no-op
         assert waited == []
 
     def test_sweeper_survives_unreadable_proc(self, monkeypatch):
         import src.tools.process_manager as pm
 
-        monkeypatch.setattr(
-            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
-        )
-        assert pm.reap_adopted_zombies() == 0
+        class FakePath:
+            def __init__(self, _p):
+                pass
+
+            def read_bytes(self):
+                raise OSError("unreadable")
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        assert pm.reap_adopted_zombies(frozenset({4242})) == 0
 
     def test_prctl_nonzero_return_reads_state(self, monkeypatch):
         """A failing prctl must not be reported as success — the value is
@@ -1629,11 +1656,11 @@ class TestContainmentHelpers:
         assert pm.set_child_subreaper(True) is False
 
     def test_sweeper_skips_unreadable_and_unwaitable_entries(self, monkeypatch):
+        """Unreadable /proc entries and non-children are skipped, never
+        raised."""
         """A vanished/unreadable /proc entry and a pid that is not our
         child are both skipped, never raised."""
         import src.tools.process_manager as pm
-
-        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["111", "222"])
 
         class FakePath:
             def __init__(self, path):
@@ -1650,7 +1677,7 @@ class TestContainmentHelpers:
             raise ChildProcessError("not ours")
 
         monkeypatch.setattr(pm.os, "waitpid", not_our_child)
-        assert pm.reap_adopted_zombies() == 0  # neither raised, neither counted
+        assert pm.reap_adopted_zombies(frozenset({111, 222})) == 0
 
     def test_inline_reap_skips_own_children(self, monkeypatch):
         """The in-loop reap after KILL uses the same asyncio-safety rule:
@@ -1661,5 +1688,198 @@ class TestContainmentHelpers:
         monkeypatch.setattr(
             pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
         )
-        pm._reap_adopted([100, 200], frozenset({100}))
+        pm._reap_adopted({100, 200}, frozenset({100}))
         assert waited == [200]  # 100 is ours → left to asyncio's watcher
+
+
+class TestNoCollateralDamage:
+    """Round-10: adoption is containment, NOT attribution. Cleanup of one
+    managed job must never touch another subsystem's direct child."""
+
+    async def test_unrelated_asyncio_child_is_never_signalled(self):
+        from src.tools.process_manager import (
+            child_subreaper_active,
+            set_child_subreaper,
+        )
+
+        previously = child_subreaper_active()
+        set_child_subreaper(True)
+        reg = ProcessRegistry()
+        # A direct child of THIS process created outside the registry —
+        # exactly what another Odin subsystem (ssh, run_command) has.
+        unrelated = await asyncio.create_subprocess_shell(
+            "sleep 30", stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            started = await reg.start("localhost", "true")
+            pid = int(started.split("PID ")[1].split(")")[0])
+            info = reg._processes[pid]
+            assert info.job_token  # provenance minted at spawn
+            gone = await reg._kill_group_until_gone(info, timeout=10.0)
+            assert gone is True  # managed job cleaned up…
+            await asyncio.sleep(0.3)
+            # …and the unrelated child is untouched: not signalled, alive.
+            assert unrelated.returncode is None
+        finally:
+            unrelated.kill()
+            await unrelated.wait()
+            await reg.shutdown()
+            set_child_subreaper(previously)
+
+    async def test_escapee_of_another_job_is_not_ours(self):
+        """Two managed jobs: job A's cleanup must not claim job B's
+        adopted escapee — tokens differ."""
+        import src.tools.process_manager as pm
+
+        previously = pm.child_subreaper_active()
+        pm.set_child_subreaper(True)
+        reg = ProcessRegistry()
+        try:
+            a = await reg.start("localhost", "sleep 20")
+            b = await reg.start("localhost", "sleep 20")
+            pid_a = int(a.split("PID ")[1].split(")")[0])
+            pid_b = int(b.split("PID ")[1].split(")")[0])
+            info_a, info_b = reg._processes[pid_a], reg._processes[pid_b]
+            assert info_a.job_token != info_b.job_token
+            # Job B's leader, seen from job A's scan with A's token, is
+            # NOT owned by A (different provenance, different session).
+            pinned, complete = pm._scan_owned_members(
+                pid_a, leader_pid=pid_a,
+                adopted_by=os.getpid(),
+                known_own_children=frozenset(reg._own_children),
+                job_token=info_a.job_token,
+            )
+            owned = {p for p, _fd in pinned}
+            pm._close_pinned(pinned)
+            assert pid_b not in owned
+        finally:
+            await reg.shutdown()
+            pm.set_child_subreaper(previously)
+
+    def test_ambiguous_direct_child_is_untouched_and_incomplete(self, monkeypatch):
+        """A direct child whose provenance cannot be READ is left alone
+        AND makes the scan incomplete — ambiguity never authorizes a kill
+        nor permits affirmative emptiness."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        monkeypatch.setattr(pm, "_read_job_token", lambda _pid: pm._UNKNOWN)
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok"
+        )
+        pm._close_pinned(pinned)
+        assert pinned == []  # untouched
+        assert complete is False  # emptiness cannot be affirmed
+
+    def test_foreign_token_is_explicitly_not_ours(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        monkeypatch.setattr(pm, "_read_job_token", lambda _pid: "someone-elses")
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok"
+        )
+        pm._close_pinned(pinned)
+        assert pinned == [] and complete is True  # decided: not ours
+
+    def test_reap_never_touches_foreign_provenance(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        monkeypatch.setattr(pm, "_read_job_token", lambda pid: "ours" if pid == 1 else "theirs")
+        # Only pids VERIFIED as ours (recorded at scan time) are reaped.
+        pm._reap_adopted({1}, frozenset())
+        assert waited == [1]
+        waited.clear()
+        pm._reap_adopted(set(), frozenset())  # nothing verified → no reaping
+        assert waited == []
+
+
+class TestProvenanceArms:
+    """Defensive arms of the per-job provenance reader."""
+
+    def test_no_token_means_adoption_cannot_attribute(self, monkeypatch):
+        """Without a job token there is no way to attribute an adopted
+        child, so it is ambiguous: untouched, and the scan is incomplete."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token=None
+        )
+        pm._close_pinned(pinned)
+        assert pinned == [] and complete is False
+
+    def test_token_reader_states(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        # Gone → None (absence is provable).
+        assert pm._read_job_token(4_000_000) is None
+
+        class GonePath:
+            def __init__(self, _p):
+                pass
+
+            def read_bytes(self):
+                raise FileNotFoundError()
+
+        monkeypatch.setattr(pm, "Path", GonePath)
+        assert pm._read_job_token(1) is None
+
+        class UnreadablePath:
+            def __init__(self, _p):
+                pass
+
+            def read_bytes(self):
+                raise PermissionError("denied")
+
+        monkeypatch.setattr(pm, "Path", UnreadablePath)
+        assert pm._read_job_token(1) is pm._UNKNOWN  # ambiguity, not absence
+
+        class TokenPath:
+            def __init__(self, _p):
+                pass
+
+            def read_bytes(self):
+                return b"PATH=/usr/bin\x00ODIN_BG_JOB=abc123\x00HOME=/root\x00"
+
+        monkeypatch.setattr(pm, "Path", TokenPath)
+        assert pm._read_job_token(1) == "abc123"
+
+        class NoTokenPath:
+            def __init__(self, _p):
+                pass
+
+            def read_bytes(self):
+                return b"PATH=/usr/bin\x00HOME=/root\x00"
+
+        monkeypatch.setattr(pm, "Path", NoTokenPath)
+        assert pm._read_job_token(1) is None  # carries no token
+
+    def test_reap_swallows_unwaitable(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        def boom(_pid, _flags):
+            raise ChildProcessError("not our child")
+
+        monkeypatch.setattr(pm.os, "waitpid", boom)
+        pm._reap_adopted({4242}, frozenset())  # must not raise

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -6,6 +6,7 @@ shutdown, cleanup, concurrency limits, and lifetime enforcement.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections import deque
 from unittest.mock import AsyncMock, MagicMock
@@ -780,145 +781,194 @@ class TestRound3Blockers:
         assert "tail-marker" in result
 
 
-class TestHardKillGroup:
-    async def test_already_dead_group_is_the_goal_state(self):
+class TestRaceFreeGroupTermination:
+    """Round-5 blocker #2: every signal to a post-leader-exit group goes
+    through a pidfd pinned BEFORE membership verification, so pid reuse
+    between check and signal cannot misdirect it."""
+
+    async def test_pins_only_true_group_members(self):
+        from src.tools.process_manager import _close_pinned, _pinned_group_members
+
         proc = await asyncio.create_subprocess_shell(
-            "true", stdout=asyncio.subprocess.PIPE,
+            "sleep 5 & sleep 5", stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT, start_new_session=True,
-        )
-        await proc.wait()
-        info = ProcessInfo(
-            pid=proc.pid, command="true", host="local",
-            start_time=time.time(), status="completed", process=proc,
-        )
-        ProcessRegistry._hard_kill_group(info)  # ProcessLookupError → pass
-
-    def test_no_process_is_a_noop(self):
-        info = ProcessInfo(pid=1, command="x", host="local", start_time=0.0)
-        ProcessRegistry._hard_kill_group(info)  # process=None → return
-
-    def test_unexpected_error_is_swallowed(self, monkeypatch):
-        import os as _os
-
-        def boom(pgid, sig):
-            raise PermissionError("nope")
-
-        monkeypatch.setattr(_os, "killpg", boom)
-        info = ProcessInfo(
-            pid=1, command="x", host="local", start_time=0.0,
-            process=type("P", (), {"pid": 4242})(),
-        )
-        ProcessRegistry._hard_kill_group(info)  # Exception arm → debug log
-
-
-class TestPgidRecycleGuard:
-    async def test_unreaped_leader_pins_the_pgid(self):
-        proc = await asyncio.create_subprocess_shell(
-            "sleep 5", stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
-        )
-        info = ProcessInfo(
-            pid=proc.pid, command="sleep 5", host="local",
-            start_time=time.time(), process=proc,
         )
         try:
-            assert ProcessRegistry._pgid_safe_to_signal(info) is True
+            await asyncio.sleep(0.4)
+            pinned = _pinned_group_members(proc.pid)
+            try:
+                pids = {pid for pid, _fd in pinned}
+                assert proc.pid in pids  # the leader
+                assert len(pids) >= 2  # plus descendants
+                # NOTHING outside the group: our own process is never pinned.
+                assert os.getpid() not in pids
+            finally:
+                _close_pinned(pinned)
         finally:
             proc.kill()
             await proc.wait()
 
-    async def test_reaped_leader_with_proc_entry_is_recycled(self):
-        """After reap, a PRESENT /proc/<pgid> can only be an unrelated
-        process that recycled the pid — never signalled (round-4)."""
-        import os as _os
+    async def test_reap_racefree_kills_term_immune_descendant(self):
+        from src.tools.process_manager import _reap_group_racefree
 
-        stub = type("P", (), {"pid": _os.getpid(), "returncode": 0})()
-        info = ProcessInfo(
-            pid=stub.pid, command="x", host="local",
-            start_time=0.0, process=stub,
-        )
-        assert ProcessRegistry._pgid_safe_to_signal(info) is False
-
-    async def test_reaped_and_gone_is_safe(self):
+        # A descendant that ignores SIGTERM: only the KILL escalation ends it.
         proc = await asyncio.create_subprocess_shell(
-            "true", stdout=asyncio.subprocess.PIPE,
+            "python3 -c \"import signal,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);time.sleep(30)\" & "
+            "exit 0",
+            stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT, start_new_session=True,
         )
-        await proc.wait()
-        info = ProcessInfo(
-            pid=proc.pid, command="true", host="local",
-            start_time=time.time(), status="completed", process=proc,
-        )
-        # /proc entry gone after reap: killpg reaches our surviving members
-        # or raises ESRCH — both safe.
-        assert ProcessRegistry._pgid_safe_to_signal(info) is True
+        pgid = proc.pid
+        try:
+            await asyncio.sleep(0.5)
+            await _reap_group_racefree(pgid, grace=0.5)
+            from src.tools.process_manager import _pinned_group_members
 
-    def test_no_process_is_never_safe(self):
-        info = ProcessInfo(pid=1, command="x", host="local", start_time=0.0)
-        assert ProcessRegistry._pgid_safe_to_signal(info) is False
+            for _ in range(30):
+                pinned = _pinned_group_members(pgid)
+                alive = len(pinned)
+                _close_pinned_local(pinned)
+                if alive == 0:
+                    break
+                await asyncio.sleep(0.2)
+            assert alive == 0  # TERM-immune descendant did NOT survive
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+    async def test_empty_group_is_a_noop(self):
+        from src.tools.process_manager import _kill_group_racefree_sync
+
+        assert _kill_group_racefree_sync(4_000_000) == 0
 
 
-class TestShutdownBarrierArms:
-    async def test_abandoned_reaper_error_is_swallowed(self):
-        """A reaper that dies with a non-cancel error when cancelled must
-        not break the shutdown barrier."""
+def _close_pinned_local(pinned):
+    from src.tools.process_manager import _close_pinned
+
+    _close_pinned(pinned)
+
+
+class TestShutdownBarrier:
+    async def test_cancellation_resistant_task_cannot_hang_shutdown(self):
+        """Round-5 blocker #1 (Odin's repro): a lifecycle task that
+        SWALLOWS cancellation must not hold shutdown — the barrier is
+        bounded by process state, never by awaiting the task."""
         reg = ProcessRegistry()
-        gate = asyncio.Event()
+        resist = True  # cleared at teardown so the loop can close
 
-        async def bad_reaper():
-            try:
-                await gate.wait()
-            except asyncio.CancelledError:
-                raise ValueError("reaper corrupted on cancel") from None
+        async def immortal():
+            while True:
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    if not resist:
+                        raise
+                    continue  # refuses to die while under test
 
         proc = await asyncio.create_subprocess_shell(
-            "true", stdout=asyncio.subprocess.PIPE,
+            "sleep 30", stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT, start_new_session=True,
         )
-        await proc.wait()
         info = ProcessInfo(
-            pid=proc.pid, command="true", host="local",
+            pid=proc.pid, command="sleep 30", host="local",
             start_time=time.time(), status="completed", exit_code=0,
             process=proc,
         )
-        info._exit_task = asyncio.create_task(bad_reaper())
+        task = asyncio.create_task(immortal())
+        info._exit_task = task
         reg._processes[proc.pid] = info
-        await reg.shutdown()  # must not raise
-        assert info._exit_task.done()
-
-    async def test_confirm_group_gone_warns_on_survivor(self):
-        """A group that outlives the confirmation window is logged loudly,
-        never silently abandoned."""
-        reg = ProcessRegistry()
-        proc = await asyncio.create_subprocess_shell(
-            "sleep 5", stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
-        )
-        info = ProcessInfo(
-            pid=proc.pid, command="sleep 5", host="local",
-            start_time=time.time(), process=proc,
-        )
         try:
-            await reg._confirm_group_gone(info, timeout=0.3)  # exhausts window
-        finally:
-            proc.kill()
-            await proc.wait()
+            start = time.monotonic()
+            await asyncio.wait_for(reg.shutdown(), timeout=SHUTDOWN_REAP_TIMEOUT + 15)
+            assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 15
+            # Barrier held: leader reaped and the group provably gone
+            # BEFORE shutdown returned, despite the immortal task.
+            assert proc.returncode is not None
+            from src.tools.process_manager import _kill_group_racefree_sync
 
-    async def test_confirm_group_gone_tolerates_probe_errors(self, monkeypatch):
-        """A probe error (e.g. EPERM against a group we cannot signal)
-        ends the confirmation quietly — never raises out of shutdown."""
-        import os as _os
+            assert _kill_group_racefree_sync(proc.pid) == 0
+        finally:
+            resist = False
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+    async def test_kill_group_until_gone_reports_failure_loudly(self, monkeypatch):
+        """An unkillable survivor makes the barrier return False (the
+        caller's loud report), never a silent success."""
+        import src.tools.process_manager as pm
 
         reg = ProcessRegistry()
-
-        def eperm(pgid, sig):
-            raise PermissionError("operation not permitted")
-
-        monkeypatch.setattr(_os, "killpg", eperm)
-        stub = type("P", (), {"pid": 4242, "returncode": None})()
+        monkeypatch.setattr(pm, "_kill_group_racefree_sync", lambda pgid: 1)
+        stub = type("P", (), {"pid": 4242, "returncode": 0})()
         info = ProcessInfo(
             pid=4242, command="x", host="local", start_time=0.0, process=stub,
         )
-        start = time.monotonic()
-        await reg._confirm_group_gone(info, timeout=5.0)
-        assert time.monotonic() - start < 1.0  # returned on first probe error
+        assert await reg._kill_group_until_gone(info, timeout=0.3) is False
+
+    async def test_kill_group_until_gone_no_process_is_true(self):
+        reg = ProcessRegistry()
+        info = ProcessInfo(pid=1, command="x", host="local", start_time=0.0)
+        assert await reg._kill_group_until_gone(info) is True
+
+
+class TestRaceFreeHelperArms:
+    """Defensive arms of the pidfd machinery — every one is a fail-safe
+    path (skip the candidate / treat as exited), never a signal."""
+
+    def test_stat_fields_missing_process(self):
+        from src.tools.process_manager import _stat_fields
+
+        assert _stat_fields(4_000_000) is None
+
+    def test_stat_fields_malformed_stat(self, tmp_path, monkeypatch):
+        import src.tools.process_manager as pm
+
+        class FakePath:
+            def __init__(self, _p):
+                pass
+
+            def read_text(self):
+                return "1 (comm) S"  # too few fields after the parens
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        assert pm._stat_fields(1) is None
+
+    def test_pinned_members_survives_unreadable_proc(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        def boom(_path):
+            raise OSError("proc unavailable")
+
+        monkeypatch.setattr(pm.os, "listdir", boom)
+        assert pm._pinned_group_members(1234) == []
+
+    def test_close_pinned_tolerates_bad_fd(self):
+        from src.tools.process_manager import _close_pinned
+
+        _close_pinned([(1, 999_999)])  # already-closed fd → swallowed
+
+    def test_pidfd_exited_on_bad_fd_reports_exited(self, monkeypatch):
+        """An unusable fd must read as EXITED (fail-safe): the caller then
+        stops waiting on it rather than looping forever."""
+        import select as _select
+
+        from src.tools.process_manager import _pidfd_exited
+
+        def boom(*_a, **_k):
+            raise OSError("bad file descriptor")
+
+        monkeypatch.setattr(_select, "select", boom)
+        assert _pidfd_exited(999_999) is True
+
+    async def test_reap_racefree_returns_when_nothing_pinned(self):
+        from src.tools.process_manager import _reap_group_racefree
+
+        await _reap_group_racefree(4_000_000, grace=0.1)  # returns immediately

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -275,7 +275,6 @@ class TestPollWaitSeconds:
         leader exits immediately while the descendant holds stdout open.
         Terminal state must publish at LEADER exit, and the group reap
         (which is what closes the pipe) must not stall behind EOF."""
-        import os
 
         reg = ProcessRegistry()
         started = await reg.start("localhost", "sleep 20 & exit 0")
@@ -286,17 +285,20 @@ class TestPollWaitSeconds:
         assert elapsed < 10.0  # never waited on EOF or the full deadline
         assert "status=completed" in result
         assert "exit_code=0" in result
-        # The v3.59.1 contract: descendants are reaped at leader exit. Give
-        # the reap a moment, then probe group existence with signal 0 (a
-        # pure existence check, delivers nothing).
+        # The v3.59.1 contract: descendants are reaped at leader exit.
+        # Asserted through the ownership scan rather than killpg: an
+        # adopted orphan lingers as a ZOMBIE until reaped, which killpg
+        # still sees but which is dead by every meaningful measure.
+        from src.tools.process_manager import _close_pinned, _scan_owned_members
+
         for _ in range(40):
-            try:
-                os.killpg(pid, 0)
-            except ProcessLookupError:
+            pinned, complete = _scan_owned_members(pid, leader_pid=pid)
+            alive = len(pinned)
+            _close_pinned(pinned)
+            if complete and alive == 0:
                 break
             await asyncio.sleep(0.25)
-        with pytest.raises(ProcessLookupError):
-            os.killpg(pid, 0)
+        assert alive == 0
 
     async def test_wedged_reader_never_wedges_the_poll(self):
         """Process exits during the wait but the reader task hangs: the
@@ -714,7 +716,6 @@ class TestRound3Blockers:
         """PR #244 round-3 blocker #2: a wedged async reap must not strand
         the owned group across re-exec — shutdown hard-KILLs the group
         synchronously before cancelling the task."""
-        import os
 
         reg = ProcessRegistry()
         proc = await asyncio.create_subprocess_shell(
@@ -742,8 +743,15 @@ class TestRound3Blockers:
             # group provably dissolved.
             assert info._exit_task.done()
             assert proc.returncode is not None  # leader reaped, no zombie
-            with pytest.raises(ProcessLookupError):
-                os.killpg(proc.pid, 0)  # group gone BEFORE shutdown returned
+            # Ownership scan, not killpg: an adopted orphan lingers as a
+            # ZOMBIE until reaped, which killpg still reports as present
+            # though it is dead by every meaningful measure.
+            from src.tools.process_manager import _close_pinned, _scan_owned_members
+
+            pinned, complete = _scan_owned_members(proc.pid, leader_pid=proc.pid)
+            alive = len(pinned)
+            _close_pinned(pinned)
+            assert complete and alive == 0  # gone BEFORE shutdown returned
         finally:
             gate.set()
             if proc.returncode is None:
@@ -1294,7 +1302,7 @@ class TestSetsidEscapeAndSettleWindow:
 
         scans = {"n": 0}
 
-        def scan(_sid, leader_pid=None):
+        def scan(_sid, leader_pid=None, **_kw):
             scans["n"] += 1
             if scans["n"] == 1:
                 return [], True  # first snapshot looks empty…
@@ -1317,7 +1325,7 @@ class TestSetsidEscapeAndSettleWindow:
         seq = [([], True), ([(1, -1)], True), ([], True), ([], True)]
         calls = {"n": 0}
 
-        def scan(_sid, leader_pid=None):
+        def scan(_sid, leader_pid=None, **_kw):
             i = min(calls["n"], len(seq) - 1)
             calls["n"] += 1
             return seq[i]
@@ -1385,3 +1393,273 @@ class TestReexecVeto:
         pinned, complete = pm._scan_owned_members(7, leader_pid=7)
         assert pinned == []  # nothing claimed
         assert complete is True
+
+
+class TestSubreaperContainment:
+    """Round-9 #1: kernel-backed containment. A descendant that BOTH
+    double-forks and calls setsid() leaves session AND ancestry, but as a
+    child subreaper we ADOPT it — so it stays attributable and cleanup can
+    never report success while it lives."""
+
+    async def test_double_fork_setsid_escapee_is_adopted_and_killed(self):
+        from src.tools.process_manager import (
+            _close_pinned,
+            _scan_owned_members,
+            child_subreaper_active,
+            reap_adopted_zombies,
+            set_child_subreaper,
+        )
+
+        # Containment is PROCESS state set once at the app boundary; a
+        # library constructor must never flip it. Enable it explicitly
+        # here and restore it, so no other test inherits adoption.
+        previously = child_subreaper_active()
+        assert set_child_subreaper(True) is True
+        reg = ProcessRegistry()
+        assert reg._containment is True
+
+        # Double-fork + setsid: the grandchild orphans itself past our
+        # ancestry AND leaves our session, then ignores TERM.
+        # exec() so PYTHON interprets the newlines: passing them through
+        # the shell as literals is a SyntaxError, and the escapee would
+        # never start.
+        escape = (
+            "import os,signal,sys,time\n"
+            "if os.fork()==0:\n"
+            " os.setsid()\n"
+            " signal.signal(signal.SIGTERM,signal.SIG_IGN)\n"
+            " time.sleep(60)\n"
+            " os._exit(0)\n"
+            "sys.exit(0)\n"
+        )
+        started = await reg.start(
+            "localhost", f'python3 -c "exec({escape!r})"'
+        )
+        pid = int(started.split("PID ")[1].split(")")[0])
+        try:
+            await asyncio.sleep(1.0)
+            # The escapee reparented to US (subreaper), so it is owned.
+            pinned, complete = _scan_owned_members(
+                pid, leader_pid=pid,
+                adopted_by=os.getpid(),
+                known_own_children=frozenset(reg._own_children),
+            )
+            adopted = len(pinned)
+            _close_pinned(pinned)
+            assert complete and adopted >= 1  # escapee visible
+
+            # Cleanup must actually remove it before claiming success.
+            assert await reg._kill_group_until_gone(
+                reg._processes[pid], timeout=12.0
+            ) is True
+            pinned, complete = _scan_owned_members(
+                pid, leader_pid=pid,
+                adopted_by=os.getpid(),
+                known_own_children=frozenset(reg._own_children),
+            )
+            left = len(pinned)
+            _close_pinned(pinned)
+            assert complete and left == 0
+        finally:
+            await reg.shutdown()
+            reap_adopted_zombies(frozenset(reg._own_children))
+            set_child_subreaper(previously)
+
+    def test_registry_does_not_flip_process_state(self):
+        """Constructing a registry must not enable containment as a side
+        effect — it reads what the application set."""
+        from src.tools.process_manager import child_subreaper_active
+
+        before = child_subreaper_active()
+        ProcessRegistry()
+        assert child_subreaper_active() is before
+
+    async def test_without_containment_emptiness_is_never_claimed(self):
+        """No subreaper ⇒ an escape would be undetectable ⇒ the terminator
+        refuses to claim emptiness at all (honest failure, not false
+        success)."""
+        from src.tools.process_manager import _terminate_session_until_empty
+
+        assert await _terminate_session_until_empty(
+            4_000_000, timeout=0.5, term_first=False, containment=False
+        ) is False
+
+
+class TestAncestryBoundIsUncertainty:
+    """Round-9 #3: walk exhaustion is UNKNOWN, never 'not ours'."""
+
+    def test_deep_chain_makes_the_scan_incomplete(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        # A 70-deep chain: pid N's parent is N-1, root pid 2 is unrelated.
+        depth = 70
+        pids = list(range(2, 2 + depth))
+        table = {p: (p - 1, 999) for p in pids}
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: [str(p) for p in pids])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda pid: table.get(pid, "unknown"))
+        # Leader pid deliberately OUTSIDE the chain, so no walk short-
+        # circuits on it: the deepest members exhaust the bound.
+        pinned, complete = pm._scan_owned_members(500_000, leader_pid=500_000)
+        pm._close_pinned(pinned)
+        # Bound exhaustion → uncertainty → incomplete, so emptiness can
+        # never be affirmed from this scan.
+        assert complete is False
+
+
+class TestAnyTeardownFailureVetoesReexec:
+    """Round-9 #2: an unexpected verifier error is as unproven as an
+    explicit ProcessCleanupError."""
+
+    async def test_generic_registry_error_blocks_reexec(self):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from src import restart
+        from src.discord.wiring import shutdown_services
+
+        restart.reset()
+        registry = SimpleNamespace(
+            shutdown=AsyncMock(side_effect=RuntimeError("verifier exploded"))
+        )
+        bot = SimpleNamespace(
+            tool_executor=SimpleNamespace(_process_registry=registry)
+        )
+        try:
+            await shutdown_services(bot)
+            veto = restart.reexec_blocked()
+            assert veto is not None
+            assert "RuntimeError" in veto and "verifier exploded" in veto
+        finally:
+            restart.reset()
+
+
+class TestContainmentHelpers:
+    """The prctl wrappers and the adopted-zombie sweeper."""
+
+    def test_set_and_read_back(self):
+        from src.tools.process_manager import child_subreaper_active, set_child_subreaper
+
+        before = child_subreaper_active()
+        try:
+            assert set_child_subreaper(True) is True
+            assert child_subreaper_active() is True
+            assert set_child_subreaper(False) is False
+            assert child_subreaper_active() is False
+        finally:
+            set_child_subreaper(before)
+
+    def test_libc_failure_reads_as_inactive(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        def boom(*_a, **_k):
+            raise OSError("no libc")
+
+        monkeypatch.setattr(pm.ctypes, "CDLL", boom)
+        assert pm.child_subreaper_active() is False
+        assert pm.set_child_subreaper(True) is False
+
+    async def test_sweeper_reaps_adopted_zombie_only(self):
+        from src.tools.process_manager import (
+            child_subreaper_active,
+            reap_adopted_zombies,
+            set_child_subreaper,
+        )
+
+        before = child_subreaper_active()
+        set_child_subreaper(True)
+        try:
+            # A double-forked orphan: reparents to US, dies immediately,
+            # and lingers as a zombie nobody else will wait on.
+            src = (
+                "import os,sys\n"
+                "if os.fork()==0:\n"
+                " os._exit(0)\n"
+                "sys.exit(0)\n"
+            )
+            proc = await asyncio.create_subprocess_shell(
+                f'python3 -c "exec({src!r})"',
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+            for _ in range(40):
+                if reap_adopted_zombies(frozenset({proc.pid})) >= 1:
+                    break
+                await asyncio.sleep(0.1)
+            else:
+                pytest.fail("adopted zombie was never reaped")
+        finally:
+            set_child_subreaper(before)
+
+    def test_sweeper_never_touches_own_children(self, monkeypatch):
+        """Our deliberate children belong to asyncio's watcher — stealing
+        a status would break it, so they are skipped by pid."""
+        import src.tools.process_manager as pm
+
+        waited: list[int] = []
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        assert pm.reap_adopted_zombies(frozenset({4242})) == 0
+        assert waited == []
+
+    def test_sweeper_survives_unreadable_proc(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(
+            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
+        )
+        assert pm.reap_adopted_zombies() == 0
+
+    def test_prctl_nonzero_return_reads_state(self, monkeypatch):
+        """A failing prctl must not be reported as success — the value is
+        always read back from the kernel."""
+        import src.tools.process_manager as pm
+
+        class FakeLibc:
+            def prctl(self, op, *_a):
+                return -1  # every prctl fails
+
+        monkeypatch.setattr(pm.ctypes, "CDLL", lambda *_a, **_k: FakeLibc())
+        assert pm.child_subreaper_active() is False
+        assert pm.set_child_subreaper(True) is False
+
+    def test_sweeper_skips_unreadable_and_unwaitable_entries(self, monkeypatch):
+        """A vanished/unreadable /proc entry and a pid that is not our
+        child are both skipped, never raised."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["111", "222"])
+
+        class FakePath:
+            def __init__(self, path):
+                self.path = str(path)
+
+            def read_bytes(self):
+                if "111" in self.path:
+                    raise OSError("vanished")  # unreadable → skipped
+                return b"222 (x) Z " + str(os.getpid()).encode() + b" 0 0 " + b"0 " * 40
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+
+        def not_our_child(_pid, _flags):
+            raise ChildProcessError("not ours")
+
+        monkeypatch.setattr(pm.os, "waitpid", not_our_child)
+        assert pm.reap_adopted_zombies() == 0  # neither raised, neither counted
+
+    def test_inline_reap_skips_own_children(self, monkeypatch):
+        """The in-loop reap after KILL uses the same asyncio-safety rule:
+        deliberate children are never waited on here."""
+        import src.tools.process_manager as pm
+
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        pm._reap_adopted([100, 200], frozenset({100}))
+        assert waited == [200]  # 100 is ours → left to asyncio's watcher

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -2156,3 +2156,342 @@ sys.exit(0)
         pm._close_pinned(pinned)
         assert pinned == []  # not swept on an unknown own-session
         assert complete is False  # and emptiness is not affirmed
+
+
+class TestAdoptedZombieReaper:
+    """PR #244 soak finding: containment reparents escaped descendants to
+    us, so nothing else will ever wait on them — without a reaper they
+    accumulate as zombies for the process lifetime. Ownership is decided
+    by evidence (open pidfd, registered identity), never by age alone."""
+
+    @staticmethod
+    async def _make_real_orphan_zombie() -> int:
+        """A REAL double-forked orphan that dies immediately: reparented to
+        us by containment, and owned by nobody (Odin's amendment: test the
+        real behavior, not a mocked zombie)."""
+        import tempfile
+
+        fd, pidfile = tempfile.mkstemp(prefix="orphan-", suffix=".pid")
+        os.close(fd)
+        script_path = pidfile + ".py"
+        with open(script_path, "w") as fh:
+            fh.write(
+                "import os, sys, time\n"
+                "if os.fork() == 0:\n"
+                f"    with open({pidfile!r}, 'w') as fh:\n"
+                "        fh.write(str(os.getpid()))\n"
+                "    time.sleep(0.2)\n"
+                "    os._exit(0)\n"
+                "sys.exit(0)\n"
+            )
+        proc = await asyncio.create_subprocess_exec(
+            "python3", script_path,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+        orphan = None
+        for _ in range(60):
+            text = open(pidfile).read().strip()
+            if text:
+                orphan = int(text)
+                break
+            await asyncio.sleep(0.05)
+        for path in (pidfile, script_path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        assert orphan is not None, "orphan never reported its pid"
+        return orphan
+
+    async def test_real_orphan_zombie_is_reaped_after_grace(self):
+        import src.tools.process_manager as pm
+
+        previously = pm.child_subreaper_active()
+        pm.set_child_subreaper(True)
+        try:
+            orphan = await self._make_real_orphan_zombie()
+            # Wait for it to actually become OUR zombie.
+            for _ in range(60):
+                if (orphan, ) and any(
+                    pid == orphan for pid, _st in pm._zombie_children(os.getpid())
+                ):
+                    break
+                await asyncio.sleep(0.1)
+            zombies = pm._zombie_children(os.getpid())
+            assert any(pid == orphan for pid, _st in zombies), "never became our zombie"
+
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            assert reaper.sweep_once() >= 1
+            assert reaper.reaped_total >= 1
+            # Gone for good.
+            assert not any(
+                pid == orphan for pid, _st in pm._zombie_children(os.getpid())
+            )
+        finally:
+            pm.set_child_subreaper(previously)
+
+    async def test_grace_period_holds_a_fresh_zombie(self):
+        """A zombie younger than the grace is left alone — it may still be
+        settling in a watcher."""
+        import src.tools.process_manager as pm
+
+        previously = pm.child_subreaper_active()
+        pm.set_child_subreaper(True)
+        try:
+            orphan = await self._make_real_orphan_zombie()
+            for _ in range(60):
+                if any(pid == orphan for pid, _st in pm._zombie_children(os.getpid())):
+                    break
+                await asyncio.sleep(0.1)
+            reaper = pm.AdoptedZombieReaper(grace=3600.0)  # effectively never
+            assert reaper.sweep_once() == 0
+            assert reaper.pending_zombies >= 1  # tracked, not reaped
+            assert any(pid == orphan for pid, _st in pm._zombie_children(os.getpid()))
+            # Teardown drain ignores the grace and takes it.
+            assert reaper.drain_at_teardown() >= 1
+        finally:
+            pm.set_child_subreaper(previously)
+
+    async def test_pidfd_owned_child_is_never_reaped(self, monkeypatch):
+        """The decisive exclusion: an open pidfd means asyncio still owns
+        that exit status, so the reaper must not take it — even when the
+        process IS a zombie and past the grace."""
+        import src.tools.process_manager as pm
+
+        proc = await asyncio.create_subprocess_exec(
+            "true", stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+        )
+        held = os.pidfd_open(proc.pid)  # stand in for the watcher's pidfd
+        try:
+            owned = pm._pidfd_owned_pids()
+            assert owned is not None and proc.pid in owned
+            # Present it as a settled zombie of ours, past any grace.
+            monkeypatch.setattr(
+                pm, "_zombie_children", lambda _p: {(proc.pid, 12345): None}
+            )
+            waited: list[int] = []
+            monkeypatch.setattr(
+                pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+            )
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            assert reaper.sweep_once() == 0
+            assert waited == []  # its status was never consumed by us
+            assert reaper.reaped_total == 0
+        finally:
+            os.close(held)
+            await proc.wait()
+
+    def test_unreadable_fd_table_reaps_nothing(self, monkeypatch):
+        """If we cannot enumerate our own fds we cannot prove abandonment,
+        so the pass must reap nothing — even with an eligible zombie
+        present and the grace elapsed."""
+        import src.tools.process_manager as pm
+
+        real_listdir = pm.os.listdir
+
+        def selective(path):
+            if str(path).startswith("/proc/self/fd"):
+                raise OSError("fd table unreadable")
+            return real_listdir(path)
+
+        monkeypatch.setattr(pm.os, "listdir", selective)
+        assert pm._pidfd_owned_pids() is None
+        # An eligible zombie IS present and past the grace…
+        monkeypatch.setattr(
+            pm, "_zombie_children", lambda _p: {(4242, 111): None}
+        )
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        assert reaper.sweep_once() == 0  # …and is still not reaped
+        assert waited == []
+
+    def test_registered_identity_is_skipped(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        identity = (4242, 111)
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        monkeypatch.setattr(pm, "_zombie_children", lambda _p: {identity: None})
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        reaper = pm.AdoptedZombieReaper(
+            grace=0.0, registered=lambda: frozenset({identity})
+        )
+        assert reaper.sweep_once() == 0
+        assert waited == []
+
+    def test_identity_change_between_observations_is_dropped(self, monkeypatch):
+        """A pid whose incarnation changed between passes is not the
+        process we saw — it is dropped, never waited on."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        seq = [{(4242, 111): None}, {(4242, 999): None}]
+        monkeypatch.setattr(pm, "_zombie_children", lambda _p: seq[0])
+        reaper = pm.AdoptedZombieReaper(grace=3600.0)
+        reaper.sweep_once()
+        assert reaper.pending_zombies == 1
+        seq[0] = seq[1]  # pid reused by a different incarnation
+        reaper.sweep_once()
+        assert (4242, 111) not in reaper._first_seen  # old identity forgotten
+
+    async def test_sweep_failure_does_not_kill_the_task(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        reaper = pm.AdoptedZombieReaper(scan_interval=0.05, grace=0.0)
+        calls = {"n": 0}
+
+        def boom():
+            calls["n"] += 1
+            raise RuntimeError("sweep exploded")
+
+        monkeypatch.setattr(reaper, "sweep_once", boom)
+        pm.set_child_subreaper(True)
+        reaper.start()
+        try:
+            for _ in range(40):
+                if calls["n"] >= 2:
+                    break
+                await asyncio.sleep(0.05)
+            assert calls["n"] >= 2  # survived the first failure
+            assert reaper._task is not None and not reaper._task.done()
+        finally:
+            await reaper.stop()
+
+    async def test_start_requires_containment_and_stop_is_clean(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm, "child_subreaper_active", lambda: False)
+        reaper = pm.AdoptedZombieReaper()
+        reaper.start()
+        assert reaper._task is None  # no containment ⇒ nothing to reap
+
+        monkeypatch.setattr(pm, "child_subreaper_active", lambda: True)
+        reaper.start()
+        assert reaper._task is not None
+        await reaper.stop()
+        assert reaper._task is None
+
+    def test_stats_surface(self):
+        import src.tools.process_manager as pm
+
+        reaper = pm.AdoptedZombieReaper()
+        assert reaper.stats == {"pending_zombies": 0, "reaped_total": 0}
+
+    def test_pidfd_scan_tolerates_malformed_fdinfo(self, monkeypatch, tmp_path):
+        """A malformed or racing fdinfo entry is skipped, never raised."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["3", "4"])
+
+        class FakePath:
+            def __init__(self, path):
+                self.path = str(path)
+
+            def read_text(self):
+                if self.path.endswith("/3"):
+                    return "pos:\t0\nPid:\tnot-a-number\n"  # malformed
+                raise OSError("fd closed under us")  # racing close
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        assert pm._pidfd_owned_pids() == set()  # neither raised
+
+    def test_zombie_scan_tolerates_unreadable_proc(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(
+            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("gone"))
+        )
+        assert pm._zombie_children(os.getpid()) == {}
+
+    async def test_stop_is_idempotent_without_a_task(self):
+        import src.tools.process_manager as pm
+
+        reaper = pm.AdoptedZombieReaper()
+        await reaper.stop()  # never started — must be a clean no-op
+        await reaper.stop()
+
+    async def test_cancellation_propagates_out_of_the_loop(self, monkeypatch):
+        """CancelledError must end the task, not be swallowed as a
+        per-pass failure."""
+        import src.tools.process_manager as pm
+
+        reaper = pm.AdoptedZombieReaper(scan_interval=0.01, grace=0.0)
+        monkeypatch.setattr(pm, "child_subreaper_active", lambda: True)
+
+        def cancel_now():
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(reaper, "sweep_once", cancel_now)
+        reaper.start()
+        task = reaper._task
+        assert task is not None
+        for _ in range(60):
+            if task.done():
+                break
+            await asyncio.sleep(0.02)
+        assert task.done() and task.cancelled()
+        await reaper.stop()
+
+    def test_vanished_between_verify_and_reap_is_dropped(self, monkeypatch):
+        """The re-verification immediately before waitpid: an identity that
+        stopped being our zombie is dropped, never waited on."""
+        import src.tools.process_manager as pm
+
+        identity = (4242, 111)
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        calls = {"n": 0}
+
+        def zombies(_p):
+            calls["n"] += 1
+            return {identity: None} if calls["n"] == 1 else {}
+
+        monkeypatch.setattr(pm, "_zombie_children", zombies)
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        assert reaper.sweep_once() == 0
+        assert waited == []  # re-verify said it was gone
+        assert reaper.pending_zombies == 0
+
+    def test_waitpid_error_is_swallowed(self, monkeypatch):
+        """Losing the race to another owner is not an error."""
+        import src.tools.process_manager as pm
+
+        identity = (4242, 111)
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        monkeypatch.setattr(pm, "_zombie_children", lambda _p: {identity: None})
+
+        def not_ours(_pid, _flags):
+            raise ChildProcessError("someone else took it")
+
+        monkeypatch.setattr(pm.os, "waitpid", not_ours)
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        assert reaper.sweep_once() == 0
+        assert reaper.reaped_total == 0
+
+    def test_zombie_scan_skips_vanished_and_malformed_entries(self, monkeypatch):
+        """A process that exits mid-scan, or a truncated stat line, is
+        skipped rather than raising out of the sweep."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["111", "222", "notapid"])
+
+        class FakePath:
+            def __init__(self, path):
+                self.path = str(path)
+
+            def read_bytes(self):
+                if "/111/" in self.path:
+                    raise FileNotFoundError()  # vanished mid-scan
+                return b"222 (x) Z"  # truncated — no fields after comm
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        assert pm._zombie_children(os.getpid()) == {}

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -788,7 +788,7 @@ class TestRaceFreeGroupTermination:
     complete is never mistaken for an empty group."""
 
     async def test_pins_only_true_group_members(self):
-        from src.tools.process_manager import _close_pinned, _scan_group_members
+        from src.tools.process_manager import _close_pinned, _scan_session_members
 
         proc = await asyncio.create_subprocess_shell(
             "sleep 5 & sleep 5", stdout=asyncio.subprocess.PIPE,
@@ -796,7 +796,7 @@ class TestRaceFreeGroupTermination:
         )
         try:
             await asyncio.sleep(0.4)
-            pinned, complete = _scan_group_members(proc.pid)
+            pinned, complete = _scan_session_members(proc.pid)
             try:
                 pids = {pid for pid, _fd in pinned}
                 assert complete is True
@@ -813,8 +813,8 @@ class TestRaceFreeGroupTermination:
         fresh same-session TERM-immune child is caught by the NEXT
         enumeration pass — a one-shot pinned set would miss it."""
         from src.tools.process_manager import (
-            _scan_group_members,
-            _terminate_group_until_empty,
+            _scan_session_members,
+            _terminate_session_until_empty,
         )
 
         script = (
@@ -836,9 +836,9 @@ class TestRaceFreeGroupTermination:
         pgid = proc.pid
         try:
             await asyncio.sleep(0.5)
-            gone = await _terminate_group_until_empty(pgid, grace=0.5, timeout=10.0)
+            gone = await _terminate_session_until_empty(pgid, grace=0.5, timeout=10.0)
             assert gone is True  # affirmative empty observation
-            pinned, complete = _scan_group_members(pgid)
+            pinned, complete = _scan_session_members(pgid)
             try:
                 assert complete and not pinned  # the forked child died too
             finally:
@@ -851,7 +851,7 @@ class TestRaceFreeGroupTermination:
                 await proc.wait()
 
     async def test_term_immune_descendant_is_killed(self):
-        from src.tools.process_manager import _terminate_group_until_empty
+        from src.tools.process_manager import _terminate_session_until_empty
 
         proc = await asyncio.create_subprocess_shell(
             "python3 -c \"import signal,time;"
@@ -862,7 +862,7 @@ class TestRaceFreeGroupTermination:
         )
         try:
             await asyncio.sleep(0.5)
-            assert await _terminate_group_until_empty(
+            assert await _terminate_session_until_empty(
                 proc.pid, grace=0.5, timeout=10.0
             ) is True
         finally:
@@ -871,9 +871,9 @@ class TestRaceFreeGroupTermination:
                 await proc.wait()
 
     async def test_empty_group_is_immediately_complete(self):
-        from src.tools.process_manager import _terminate_group_until_empty
+        from src.tools.process_manager import _terminate_session_until_empty
 
-        assert await _terminate_group_until_empty(4_000_000, timeout=1.0) is True
+        assert await _terminate_session_until_empty(4_000_000, timeout=1.0) is True
 
 
 class TestScanCompleteness:
@@ -885,7 +885,7 @@ class TestScanCompleteness:
         monkeypatch.setattr(
             pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
         )
-        pinned, complete = pm._scan_group_members(1234)
+        pinned, complete = pm._scan_session_members(1234)
         assert pinned == [] and complete is False
 
     def test_pidfd_exhaustion_is_incomplete_not_empty(self, monkeypatch):
@@ -897,7 +897,7 @@ class TestScanCompleteness:
             raise OSError(24, "Too many open files")
 
         monkeypatch.setattr(pm.os, "pidfd_open", emfile)
-        pinned, complete = pm._scan_group_members(1234)
+        pinned, complete = pm._scan_session_members(1234)
         assert pinned == [] and complete is False
 
     def test_vanished_candidate_does_not_spoil_the_scan(self, monkeypatch):
@@ -909,7 +909,7 @@ class TestScanCompleteness:
             pm.os, "pidfd_open",
             lambda _pid: (_ for _ in ()).throw(ProcessLookupError()),
         )
-        pinned, complete = pm._scan_group_members(1234)
+        pinned, complete = pm._scan_session_members(1234)
         assert pinned == [] and complete is True
 
     def test_stat_read_error_is_unknown_not_gone(self, monkeypatch):
@@ -919,16 +919,16 @@ class TestScanCompleteness:
             def __init__(self, _p):
                 pass
 
-            def read_text(self):
+            def read_bytes(self):
                 raise OSError(24, "Too many open files")
 
         monkeypatch.setattr(pm, "Path", FakePath)
-        assert pm._stat_fields(1) == "unknown"
+        assert pm._proc_session(1) == "unknown"
 
     def test_stat_missing_is_gone(self):
         import src.tools.process_manager as pm
 
-        assert pm._stat_fields(4_000_000) is None
+        assert pm._proc_session(4_000_000) is None
 
 
 class TestShutdownBarrier:
@@ -965,9 +965,9 @@ class TestShutdownBarrier:
             await asyncio.wait_for(reg.shutdown(), timeout=SHUTDOWN_REAP_TIMEOUT + 20)
             assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 20
             assert proc.returncode is not None  # leader reaped
-            from src.tools.process_manager import _scan_group_members
+            from src.tools.process_manager import _scan_session_members
 
-            pinned, complete = _scan_group_members(proc.pid)
+            pinned, complete = _scan_session_members(proc.pid)
             assert complete and not pinned  # group provably empty
         finally:
             resist = False
@@ -1020,32 +1020,48 @@ class TestRaceFreeHelperArms:
         )
         assert _pidfd_exited(999_999) is True
 
-    def test_malformed_stat_is_gone(self, monkeypatch):
+    def test_malformed_stat_is_unknown_not_gone(self, monkeypatch):
+        """Round-7 #2: only provable disappearance may read as GONE."""
         import src.tools.process_manager as pm
 
         class FakePath:
             def __init__(self, _p):
                 pass
 
-            def read_text(self):
-                return "1 (comm) S"  # too few fields after the parens
+            def read_bytes(self):
+                return b"1 (comm) S"  # too few fields after the parens
 
         monkeypatch.setattr(pm, "Path", FakePath)
-        assert pm._stat_fields(1) is None
+        assert pm._proc_session(1) == "unknown"
+
+    def test_non_utf8_comm_is_parsed_not_raised(self, monkeypatch):
+        """Round-7 #2: comm may hold arbitrary bytes — parsing on BYTES
+        means a non-UTF-8 name neither raises nor reads as absence."""
+        import src.tools.process_manager as pm
+
+        class FakePath:
+            def __init__(self, _p):
+                pass
+
+            def read_bytes(self):
+                return b"7 (od\xffin) S 1 42 4242 " + b"0 " * 40
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        assert pm._proc_session(7) == 4242
 
     def test_pinned_member_with_unreadable_stat_is_incomplete(self, monkeypatch):
         """A candidate we pinned but cannot classify (stat unreadable)
         leaves the scan INCOMPLETE — never silently skipped as absent."""
         import src.tools.process_manager as pm
 
-        real_stat = pm._stat_fields
+        real_stat = pm._proc_session
         target = os.getpid()
 
         def flaky(pid):
             return "unknown" if pid == target else real_stat(pid)
 
-        monkeypatch.setattr(pm, "_stat_fields", flaky)
-        pinned, complete = pm._scan_group_members(4_000_001)
+        monkeypatch.setattr(pm, "_proc_session", flaky)
+        pinned, complete = pm._scan_session_members(4_000_001)
         assert complete is False
         pm._close_pinned(pinned)
 
@@ -1075,3 +1091,156 @@ class TestRaceFreeHelperArms:
             assert pm._pidfd_exited(fd) is True
         finally:
             os.close(fd)
+
+
+class TestSessionFenceEscapes:
+    """Round-7 #1: leaving the process GROUP does not leave the session."""
+
+    async def test_setpgid_escapee_is_still_terminated(self):
+        """Odin's repro: a TERM-immune descendant calls setpgid(0, 0) to
+        leave the original group while staying in our session. Group-based
+        membership made it invisible; session-based membership does not."""
+        from src.tools.process_manager import (
+            _close_pinned,
+            _scan_session_members,
+            _terminate_session_until_empty,
+        )
+
+        # setpgid(0, 0) → new GROUP, SAME session; TERM ignored.
+        escapee = (
+            "import os,signal,time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "os.setpgid(0,0); time.sleep(60)"
+        )
+        proc = await asyncio.create_subprocess_shell(
+            f'python3 -c "{escapee}" & exit 0',
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        sid = proc.pid
+        try:
+            await asyncio.sleep(0.6)
+            pinned, complete = _scan_session_members(sid)
+            try:
+                # The escapee is VISIBLE: it left the group, not the session.
+                assert complete and len(pinned) >= 1
+            finally:
+                _close_pinned(pinned)
+            assert await _terminate_session_until_empty(
+                sid, grace=0.5, timeout=12.0
+            ) is True
+            pinned, complete = _scan_session_members(sid)
+            try:
+                assert complete and not pinned  # escapee is gone
+            finally:
+                _close_pinned(pinned)
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+
+class TestShutdownAffirmativeProof:
+    """Round-7 #3: a completed watcher is not proof; shutdown re-verifies
+    and escalates anything it cannot prove."""
+
+    async def test_failed_watcher_reap_is_reverified_and_escalated(
+        self, monkeypatch
+    ):
+        import src.tools.process_manager as pm
+
+        reg = ProcessRegistry()
+        stub = type("P", (), {"pid": 4242, "returncode": 0})()
+        info = ProcessInfo(
+            pid=4242, command="x", host="local", start_time=0.0,
+            status="completed", exit_code=0, process=stub,
+        )
+        info.session_confirmed_empty = False  # the watcher's reap FAILED
+        info._exit_task = None
+        reg._processes[4242] = info
+
+        # Verification cannot complete either → shutdown must escalate.
+        monkeypatch.setattr(
+            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
+        )
+        with pytest.raises(pm.ProcessCleanupError) as exc:
+            await reg.shutdown()
+        assert "4242" in str(exc.value)
+
+    async def test_confirmed_record_needs_no_reverification(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        reg = ProcessRegistry()
+        stub = type("P", (), {"pid": 4242, "returncode": 0})()
+        info = ProcessInfo(
+            pid=4242, command="x", host="local", start_time=0.0,
+            status="completed", exit_code=0, process=stub,
+        )
+        info.session_confirmed_empty = True  # the watcher PROVED it
+        reg._processes[4242] = info
+        called = False
+
+        def boom(_p):
+            nonlocal called
+            called = True
+            raise OSError("must not be re-scanned")
+
+        monkeypatch.setattr(pm.os, "listdir", boom)
+        assert await reg.shutdown() == 0
+        assert called is False
+
+    async def test_watcher_records_its_verdict(self):
+        """The verdict reaches ProcessInfo instead of being discarded."""
+        reg = ProcessRegistry()
+        started = await reg.start("localhost", "echo hi; exit 0")
+        pid = int(started.split("PID ")[1].split(")")[0])
+        await reg.poll(pid, wait_seconds=15)
+        for _ in range(40):
+            if reg._processes[pid].session_confirmed_empty:
+                break
+            await asyncio.sleep(0.25)
+        assert reg._processes[pid].session_confirmed_empty is True
+        assert await reg.shutdown() == 0  # no escalation
+
+    async def test_final_verification_exception_is_escalated(self, monkeypatch):
+        """A verification that RAISES is as unproven as one returning
+        False — both escalate rather than passing teardown."""
+        import src.tools.process_manager as pm
+
+        reg = ProcessRegistry()
+        stub = type("P", (), {"pid": 4242, "returncode": 0})()
+        info = ProcessInfo(
+            pid=4242, command="x", host="local", start_time=0.0,
+            status="completed", exit_code=0, process=stub,
+        )
+        reg._processes[4242] = info
+
+        async def boom(_info, timeout=8.0):
+            raise RuntimeError("verification exploded")
+
+        monkeypatch.setattr(reg, "_kill_group_until_gone", boom)
+        with pytest.raises(pm.ProcessCleanupError):
+            await reg.shutdown()
+
+    async def test_watcher_records_failure_when_reap_raises(self, monkeypatch):
+        """A reap that raises inside the watcher leaves the record
+        UNCONFIRMED (never silently 'clean')."""
+        import src.tools.process_manager as pm
+
+        reg = ProcessRegistry()
+
+        async def boom(*_a, **_k):
+            raise RuntimeError("reap exploded")
+
+        monkeypatch.setattr(pm, "_terminate_session_until_empty", boom)
+        proc = await asyncio.create_subprocess_shell(
+            "true", stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        info = ProcessInfo(
+            pid=proc.pid, command="true", host="local",
+            start_time=time.time(), process=proc,
+        )
+        reg._processes[proc.pid] = info
+        await reg._watch_exit(info)
+        assert info.session_confirmed_empty is False

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -1997,3 +1997,80 @@ class TestPidReuseSafety:
         recorded = {(4242, 111)}
         assert pm.reap_adopted_zombies(recorded) == 0
         assert recorded == set()
+
+
+class TestSelectiveProvenanceErasure:
+    """Round-12: deleting only the JOB token (keeping the process marker)
+    must not read as 'another subsystem's child'."""
+
+    def test_absent_job_token_is_ambiguous(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        # Process marker kept, job token deleted — selective erasure.
+        monkeypatch.setattr(
+            pm, "_read_env_tokens", lambda _pid: {pm.PROC_TOKEN_ENV: "P"}
+        )
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok", proc_token="P"
+        )
+        pm._close_pinned(pinned)
+        assert pinned == []  # never killed on a guess
+        assert complete is False  # and emptiness is NOT affirmed
+
+    async def test_selective_erasure_escapee_blocks_affirmative_cleanup(self):
+        """Odin's exact repro through the real start() path: an escapee
+        that keeps ODIN_PROC but deletes ODIN_BG_JOB must prevent
+        confirmed-empty while it is alive."""
+        import src.tools.process_manager as pm
+
+        previously = pm.child_subreaper_active()
+        pm.set_child_subreaper(True)
+        reg = ProcessRegistry()
+        escaped_pid = None
+        try:
+            escape = (
+                "import os,signal,sys,time\n"
+                "if os.fork()==0:\n"
+                " os.setsid()\n"
+                " os.environ.pop('ODIN_BG_JOB', None)\n"
+                " os.execve(sys.executable, [sys.executable, '-c',"
+                " 'import signal,time;"
+                " signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+                " time.sleep(45)'], os.environ)\n"
+                "sys.exit(0)\n"
+            )
+            started = await reg.start("localhost", f'python3 -c "exec({escape!r})"')
+            pid = int(started.split("PID ")[1].split(")")[0])
+            await asyncio.sleep(1.2)
+            info = reg._processes[pid]
+            gone = await reg._kill_group_until_gone(info, timeout=6.0)
+            # The escapee is alive with erased job provenance: cleanup must
+            # NOT claim success.
+            for entry in os.listdir("/proc"):
+                if not entry.isdigit():
+                    continue
+                ids = pm._proc_ids(int(entry))
+                if (
+                    isinstance(ids, tuple)
+                    and ids[0] == os.getpid()
+                    and int(entry) not in reg._own_children
+                    and pm._read_job_token(int(entry)) is None
+                ):
+                    escaped_pid = int(entry)
+                    break
+            if escaped_pid is not None:
+                assert gone is False  # ambiguity ⇒ no affirmative emptiness
+        finally:
+            if escaped_pid is not None:
+                try:
+                    os.kill(escaped_pid, 9)
+                except ProcessLookupError:
+                    pass
+            await reg.shutdown()
+            pm.set_child_subreaper(previously)

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -1608,9 +1608,11 @@ class TestContainmentHelpers:
                     break
                 await asyncio.sleep(0.05)
             assert grandchild is not None, "orphan never reparented to us"
-            # Once it dies it is a zombie; the recorded pid still reaps it.
+            identity = (grandchild, pm._proc_starttime(grandchild))
+            assert identity[1] is not None
+            # Once it dies it is a zombie; the recorded IDENTITY reaps it.
             for _ in range(60):
-                if pm.reap_adopted_zombies(frozenset({grandchild})) >= 1:
+                if pm.reap_adopted_zombies({identity}) >= 1:
                     break
                 await asyncio.sleep(0.1)
             else:
@@ -1632,6 +1634,8 @@ class TestContainmentHelpers:
     def test_sweeper_survives_unreadable_proc(self, monkeypatch):
         import src.tools.process_manager as pm
 
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 111)
+
         class FakePath:
             def __init__(self, _p):
                 pass
@@ -1640,7 +1644,7 @@ class TestContainmentHelpers:
                 raise OSError("unreadable")
 
         monkeypatch.setattr(pm, "Path", FakePath)
-        assert pm.reap_adopted_zombies(frozenset({4242})) == 0
+        assert pm.reap_adopted_zombies({(4242, 111)}) == 0
 
     def test_prctl_nonzero_return_reads_state(self, monkeypatch):
         """A failing prctl must not be reported as success — the value is
@@ -1677,7 +1681,8 @@ class TestContainmentHelpers:
             raise ChildProcessError("not ours")
 
         monkeypatch.setattr(pm.os, "waitpid", not_our_child)
-        assert pm.reap_adopted_zombies(frozenset({111, 222})) == 0
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 5)
+        assert pm.reap_adopted_zombies({(111, 5), (222, 5)}) == 0
 
     def test_inline_reap_skips_own_children(self, monkeypatch):
         """The in-loop reap after KILL uses the same asyncio-safety rule:
@@ -1688,7 +1693,8 @@ class TestContainmentHelpers:
         monkeypatch.setattr(
             pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
         )
-        pm._reap_adopted({100, 200}, frozenset({100}))
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 42)
+        pm._reap_adopted({(100, 42), (200, 42)}, frozenset({100}))
         assert waited == [200]  # 100 is ours → left to asyncio's watcher
 
 
@@ -1769,12 +1775,34 @@ class TestNoCollateralDamage:
             pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
         )
         monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
-        monkeypatch.setattr(pm, "_read_job_token", lambda _pid: pm._UNKNOWN)
+        monkeypatch.setattr(pm, "_read_env_tokens", lambda _pid: pm._UNKNOWN)
         pinned, complete = pm._scan_owned_members(
-            7, leader_pid=7, adopted_by=mypid, job_token="tok"
+            7, leader_pid=7, adopted_by=mypid, job_token="tok", proc_token="P"
         )
         pm._close_pinned(pinned)
         assert pinned == []  # untouched
+        assert complete is False  # emptiness cannot be affirmed
+
+    def test_stripped_provenance_fails_closed(self, monkeypatch):
+        """Round-11 #1: the environment is CHILD-CONTROLLED (`env -i`),
+        so a MISSING token can never mean 'not ours' — an escapee could
+        erase its own provenance and be certified gone while alive. It is
+        ambiguous: untouched, and the scan is incomplete."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        # No Odin process marker at all: the environment was discarded.
+        monkeypatch.setattr(pm, "_read_env_tokens", lambda _pid: {})
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok", proc_token="P"
+        )
+        pm._close_pinned(pinned)
+        assert pinned == []  # never killed on a guess
         assert complete is False  # emptiness cannot be affirmed
 
     def test_foreign_token_is_explicitly_not_ours(self, monkeypatch):
@@ -1786,12 +1814,18 @@ class TestNoCollateralDamage:
             pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
         )
         monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
-        monkeypatch.setattr(pm, "_read_job_token", lambda _pid: "someone-elses")
+        # Carries our PROCESS marker but a different job token.
+        monkeypatch.setattr(
+            pm, "_read_env_tokens",
+            lambda _pid: {pm.PROC_TOKEN_ENV: "P", pm.JOB_TOKEN_ENV: "someone-elses"},
+        )
         pinned, complete = pm._scan_owned_members(
-            7, leader_pid=7, adopted_by=mypid, job_token="tok"
+            7, leader_pid=7, adopted_by=mypid, job_token="tok", proc_token="P"
         )
         pm._close_pinned(pinned)
-        assert pinned == [] and complete is True  # decided: not ours
+        # A DIFFERENT job's token is positive evidence, so this one is
+        # decided (not ours) and the scan stays complete.
+        assert pinned == [] and complete is True
 
     def test_reap_never_touches_foreign_provenance(self, monkeypatch):
         import src.tools.process_manager as pm
@@ -1801,8 +1835,10 @@ class TestNoCollateralDamage:
             pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
         )
         monkeypatch.setattr(pm, "_read_job_token", lambda pid: "ours" if pid == 1 else "theirs")
-        # Only pids VERIFIED as ours (recorded at scan time) are reaped.
-        pm._reap_adopted({1}, frozenset())
+        # Only identities VERIFIED as ours (recorded at scan time) are
+        # reaped, and the incarnation must still match.
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 111)
+        pm._reap_adopted({(1, 111)}, frozenset())
         assert waited == [1]
         waited.clear()
         pm._reap_adopted(set(), frozenset())  # nothing verified → no reaping
@@ -1882,4 +1918,82 @@ class TestProvenanceArms:
             raise ChildProcessError("not our child")
 
         monkeypatch.setattr(pm.os, "waitpid", boom)
-        pm._reap_adopted({4242}, frozenset())  # must not raise
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 111)
+        pm._reap_adopted({(4242, 111)}, frozenset())  # must not raise
+
+
+class TestPidReuseSafety:
+    """Round-11 #2: a bare pid is not an identity. Records carry the
+    process's starttime so a reused pid can never redirect a waitpid."""
+
+    def test_reap_skips_reused_pid_and_prunes_it(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 999)  # different
+        recorded = {(4242, 111)}
+        pm._reap_adopted(recorded, frozenset())
+        assert waited == []  # the incarnation differs → never waited on
+        assert recorded == set()  # stale record pruned
+
+    def test_reap_prunes_vanished_identity(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: None)
+        recorded = {(4242, 111)}
+        pm._reap_adopted(recorded, frozenset())
+        assert recorded == set()  # provably gone → pruned
+
+    def test_sweeper_skips_reused_pid(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        waited: list[int] = []
+        monkeypatch.setattr(
+            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+        )
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 999)
+        recorded = {(4242, 111)}
+        assert pm.reap_adopted_zombies(recorded) == 0
+        assert waited == [] and recorded == set()
+
+    def test_recorded_identity_carries_starttime(self, monkeypatch):
+        """The scan records (pid, starttime), not a bare pid."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["4242"])
+        monkeypatch.setattr(
+            pm.os, "pidfd_open", lambda _pid: os.open("/dev/null", os.O_RDONLY)
+        )
+        monkeypatch.setattr(pm, "_proc_ids", lambda _pid: (mypid, 999))
+        monkeypatch.setattr(
+            pm, "_read_env_tokens",
+            lambda _pid: {pm.PROC_TOKEN_ENV: "P", pm.JOB_TOKEN_ENV: "tok"},
+        )
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: 777)
+        sink: set[tuple[int, int]] = set()
+        pinned, complete = pm._scan_owned_members(
+            7, leader_pid=7, adopted_by=mypid, job_token="tok",
+            proc_token="P", adopted_sink=sink,
+        )
+        pm._close_pinned(pinned)
+        assert sink == {(4242, 777)}
+
+    def test_starttime_reader_states(self):
+        import src.tools.process_manager as pm
+
+        assert pm._proc_starttime(4_000_000) is None  # gone
+        assert isinstance(pm._proc_starttime(os.getpid()), int)  # live
+
+    def test_sweeper_prunes_vanished_identity(self, monkeypatch):
+        """A recorded escapee that is provably gone is pruned from the
+        record rather than retained forever."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm, "_proc_starttime", lambda _pid: None)
+        recorded = {(4242, 111)}
+        assert pm.reap_adopted_zombies(recorded) == 0
+        assert recorded == set()

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -2157,188 +2157,986 @@ sys.exit(0)
         assert pinned == []  # not swept on an unknown own-session
         assert complete is False  # and emptiness is not affirmed
 
+class TestProcessTableScan:
+    """The one scanner every reaping decision reads: pid → (ppid,
+    starttime, state), with HONEST completeness."""
+
+    def test_unreadable_proc_is_incomplete(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(
+            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("gone"))
+        )
+        table, complete = pm._scan_process_table()
+        assert table == {} and complete is False
+
+    def test_vanished_entry_is_skipped_and_still_complete(self, monkeypatch):
+        """A process that exits mid-scan is provably gone — skipping it
+        does not blind the scan."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["111", "notapid"])
+
+        class FakePath:
+            def __init__(self, path):
+                self.path = str(path)
+
+            def read_bytes(self):
+                raise FileNotFoundError()
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        table, complete = pm._scan_process_table()
+        assert table == {} and complete is True
+
+    def test_malformed_stat_makes_the_scan_incomplete(self, monkeypatch):
+        """A truncated stat is a process whose state is UNKNOWN: the scan
+        must say so, or absence would be inferred from a blind spot."""
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["222"])
+
+        class FakePath:
+            def __init__(self, path):
+                self.path = str(path)
+
+            def read_bytes(self):
+                return b"222 (x) Z"  # no fields after the state
+
+        monkeypatch.setattr(pm, "Path", FakePath)
+        table, complete = pm._scan_process_table()
+        assert table == {} and complete is False
+
+    def test_descendants_follow_chains_and_adoption(self):
+        import src.tools.process_manager as pm
+
+        table = {
+            10: (1, 5, b"S"),  # unrelated
+            20: (100, 6, b"S"),  # direct child
+            21: (20, 7, b"S"),  # grandchild
+            22: (21, 8, b"Z"),  # great-grandchild, zombie
+            30: (100, 9, b"Z"),  # adopted straight under us
+        }
+        assert pm._descendants_of(table, 100) == {20, 21, 22, 30}
+
+
+class TestPidfdInspection:
+    """Round-15 blocker #2 groundwork: the owned-pidfd inspection must be
+    complete evidence or no evidence."""
+
+    async def test_held_pidfd_is_found_and_ordinary_fds_never_poison(self):
+        import src.tools.process_manager as pm
+
+        proc = await asyncio.create_subprocess_exec(
+            "sleep", "5",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        held = os.pidfd_open(proc.pid)
+        extra = os.open("/dev/null", os.O_RDONLY)  # an ordinary fd
+        try:
+            owned = pm._pidfd_owned_pids()
+            assert owned is not None  # ordinary fds are classifiable
+            assert proc.pid in owned
+        finally:
+            os.close(extra)
+            os.close(held)
+            proc.terminate()
+            await proc.wait()
+
+    def test_closed_between_enumeration_and_inspection_is_gone(self, monkeypatch):
+        """An entry that PROVABLY closed under us is gone, not ambiguous —
+        it must not poison the pass."""
+        import src.tools.process_manager as pm
+
+        real_listdir = os.listdir
+
+        def with_ghost(path):
+            entries = list(real_listdir(path))
+            if str(path) == "/proc/self/fd":
+                entries.append("999999")  # closed before inspection
+            return entries
+
+        monkeypatch.setattr(pm.os, "listdir", with_ghost)
+        assert pm._pidfd_owned_pids() is not None
+
+    def test_unreadable_fd_listing_proves_nothing(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        real_listdir = os.listdir
+
+        def refuse(path):
+            if str(path) == "/proc/self/fd":
+                raise OSError("fd table unreadable")
+            return real_listdir(path)
+
+        monkeypatch.setattr(pm.os, "listdir", refuse)
+        assert pm._pidfd_owned_pids() is None
+
 
 class TestAdoptedZombieReaper:
     """PR #244 soak finding: containment reparents escaped descendants to
     us, so nothing else will ever wait on them — without a reaper they
-    accumulate as zombies for the process lifetime. Ownership is decided
-    by evidence (open pidfd, registered identity), never by age alone."""
+    accumulate as zombies for the process lifetime.
+
+    Round-15 rework: eligibility is a union of POSITIVE evidence only
+    (observed same-incarnation reparenting, explicit registration by the
+    spawning subsystem, or final teardown) — never age, never adoption
+    alone. Lifecycle pins run against REAL processes (Odin's amendment)."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_registry(self):
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        yield
+        pm._reset_reap_registry()
+
+    # -- real-process helpers ------------------------------------------------
 
     @staticmethod
-    async def _make_real_orphan_zombie() -> int:
-        """A REAL double-forked orphan that dies immediately: reparented to
-        us by containment, and owned by nobody (Odin's amendment: test the
-        real behavior, not a mocked zombie)."""
-        import tempfile
+    async def _spawn_adopted(
+        tmp_path,
+        *,
+        lifetime: str = "0.2",
+        exec_path: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> int:
+        """A REAL double-forked orphan, reparented to us by containment.
 
-        fd, pidfile = tempfile.mkstemp(prefix="orphan-", suffix=".pid")
-        os.close(fd)
-        script_path = pidfile + ".py"
-        with open(script_path, "w") as fh:
-            fh.write(
-                "import os, sys, time\n"
-                "if os.fork() == 0:\n"
-                f"    with open({pidfile!r}, 'w') as fh:\n"
-                "        fh.write(str(os.getpid()))\n"
-                "    time.sleep(0.2)\n"
-                "    os._exit(0)\n"
-                "sys.exit(0)\n"
+        The default short lifetime dies promptly — an unobserved adopted
+        zombie. A long lifetime keeps it alive for the test to kill.
+        ``exec_path`` replaces the child image (comm follows the binary,
+        which is how a ControlPersist master looks). Returns the orphan
+        pid once reported.
+        """
+        import sys
+
+        pidfile = tmp_path / f"orphan-{os.urandom(4).hex()}.pid"
+        script = pidfile.with_suffix(".py")
+        if exec_path is not None:
+            tail = (
+                f"    os.execv({str(exec_path)!r}, "
+                f"[{str(exec_path)!r}, {lifetime!r}])\n"
             )
+        else:
+            tail = f"    time.sleep({lifetime})\n    os._exit(0)\n"
+        script.write_text(
+            "import os, sys, time\n"
+            "if os.fork() == 0:\n"
+            f"    with open({str(pidfile)!r}, 'w') as fh:\n"
+            "        fh.write(str(os.getpid()))\n"
+            + tail
+            + "sys.exit(0)\n"
+        )
         proc = await asyncio.create_subprocess_exec(
-            "python3", script_path,
-            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+            sys.executable, str(script),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            env={**os.environ, **(env or {})},
         )
         await proc.wait()
-        orphan = None
-        for _ in range(60):
-            text = open(pidfile).read().strip()
+        for _ in range(100):
+            text = pidfile.read_text().strip() if pidfile.exists() else ""
             if text:
-                orphan = int(text)
-                break
+                return int(text)
             await asyncio.sleep(0.05)
-        for path in (pidfile, script_path):
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
-        assert orphan is not None, "orphan never reported its pid"
-        return orphan
+        raise AssertionError("orphan never reported its pid")
 
-    async def test_real_orphan_zombie_is_reaped_after_grace(self):
+    @staticmethod
+    def _our_zombie_map() -> dict[int, int]:
+        """pid → starttime of every zombie currently parented to us."""
         import src.tools.process_manager as pm
 
-        previously = pm.child_subreaper_active()
-        pm.set_child_subreaper(True)
-        try:
-            orphan = await self._make_real_orphan_zombie()
-            # Wait for it to actually become OUR zombie.
-            for _ in range(60):
-                if (orphan, ) and any(
-                    pid == orphan for pid, _st in pm._zombie_children(os.getpid())
-                ):
-                    break
-                await asyncio.sleep(0.1)
-            zombies = pm._zombie_children(os.getpid())
-            assert any(pid == orphan for pid, _st in zombies), "never became our zombie"
+        table, _complete = pm._scan_process_table()
+        return {
+            pid: entry[1]
+            for pid, entry in table.items()
+            if entry[2] == b"Z" and entry[0] == os.getpid()
+        }
 
-            reaper = pm.AdoptedZombieReaper(grace=0.0)
-            assert reaper.sweep_once() >= 1
-            assert reaper.reaped_total >= 1
-            # Gone for good.
-            assert not any(
-                pid == orphan for pid, _st in pm._zombie_children(os.getpid())
-            )
-        finally:
-            pm.set_child_subreaper(previously)
+    @classmethod
+    async def _wait_zombie(cls, pid: int) -> int:
+        """Wait until ``pid`` is our zombie; returns its starttime."""
+        for _ in range(200):
+            zombies = cls._our_zombie_map()
+            if pid in zombies:
+                return zombies[pid]
+            await asyncio.sleep(0.05)
+        raise AssertionError(f"{pid} never became our zombie")
 
-    async def test_grace_period_holds_a_fresh_zombie(self):
-        """A zombie younger than the grace is left alone — it may still be
-        settling in a watcher."""
+    @staticmethod
+    async def _wait_adopted_alive(pid: int) -> None:
         import src.tools.process_manager as pm
 
-        previously = pm.child_subreaper_active()
-        pm.set_child_subreaper(True)
-        try:
-            orphan = await self._make_real_orphan_zombie()
-            for _ in range(60):
-                if any(pid == orphan for pid, _st in pm._zombie_children(os.getpid())):
-                    break
-                await asyncio.sleep(0.1)
-            reaper = pm.AdoptedZombieReaper(grace=3600.0)  # effectively never
+        for _ in range(200):
+            table, _complete = pm._scan_process_table()
+            entry = table.get(pid)
+            if entry is not None and entry[0] == os.getpid() and entry[2] != b"Z":
+                return
+            await asyncio.sleep(0.05)
+        raise AssertionError(f"{pid} never adopted alive")
+
+    # -- eligibility: the positive-evidence union ---------------------------
+
+    async def test_fast_double_fork_is_not_claimed_without_registration(
+        self, tmp_path
+    ):
+        """§3.6 pin 1: an orphan whose intermediate parent died between
+        scans is FIRST seen already parented to us — transition history
+        must not claim it. Registration is exactly what unlocks it."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        for _ in range(3):
             assert reaper.sweep_once() == 0
-            assert reaper.pending_zombies >= 1  # tracked, not reaped
-            assert any(pid == orphan for pid, _st in pm._zombie_children(os.getpid()))
-            # Teardown drain ignores the grace and takes it.
-            assert reaper.drain_at_teardown() >= 1
+        assert orphan in self._our_zombie_map()  # untouched without evidence
+        assert reaper.pending_zombies >= 1  # tracked, not claimed
+        pm.register_reap_identity(orphan, start, source="test")
+        assert reaper.sweep_once() == 1
+        assert orphan not in self._our_zombie_map()
+        assert reaper.reaped_total == 1
+
+    async def test_direct_popen_child_retains_status(self):
+        """Round-15 blocker #1: a synchronous ``Popen`` child has no
+        pidfd, but it has a legitimate owner. Positive evidence can never
+        exist for it, so its status survives every sweep (Odin's repro:
+        exit 23 was read as 0 after the old reaper stole it)."""
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        child = subprocess.Popen(["sh", "-c", "exit 23"])
+        try:
+            for _ in range(200):
+                if child.pid in self._our_zombie_map():
+                    break
+                time.sleep(0.02)
+            assert child.pid in self._our_zombie_map()
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            for _ in range(3):
+                assert reaper.sweep_once() == 0
+            assert child.pid in self._our_zombie_map()  # still waitable
         finally:
-            pm.set_child_subreaper(previously)
+            assert child.wait() == 23
+
+    async def test_observed_reparenting_grants_eligibility(self, tmp_path):
+        """The transition rule end-to-end on real processes: seen under
+        its intermediate parent, then seen adopted (same incarnation) —
+        that history alone authorizes the reap once it dies."""
+        import sys
+
+        import src.tools.process_manager as pm
+
+        pidfile = tmp_path / "gc.pid"
+        flag = tmp_path / "release"
+        script = tmp_path / "linger.py"
+        script.write_text(
+            "import os, sys, time\n"
+            "if os.fork() == 0:\n"
+            f"    with open({str(pidfile)!r}, 'w') as fh:\n"
+            "        fh.write(str(os.getpid()))\n"
+            "    time.sleep(300)\n"
+            "    os._exit(0)\n"
+            "for _ in range(1200):\n"
+            f"    if os.path.exists({str(flag)!r}):\n"
+            "        break\n"
+            "    time.sleep(0.05)\n"
+            "sys.exit(0)\n"
+        )
+        inter = await asyncio.create_subprocess_exec(
+            sys.executable, str(script),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            for _ in range(200):
+                if pidfile.exists() and pidfile.read_text().strip():
+                    break
+                await asyncio.sleep(0.05)
+            gpid = int(pidfile.read_text())
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            reaper.sweep_once()  # observed under the intermediate parent
+            identity = next(i for i in reaper._candidates if i[0] == gpid)
+            assert reaper._candidates[identity].adoption_observed is False
+            flag.write_text("go")  # release the intermediate parent
+            await inter.wait()
+            await self._wait_adopted_alive(gpid)
+            reaper.sweep_once()  # same incarnation, now parented to us
+            assert reaper._candidates[identity].adoption_observed is True
+            os.kill(gpid, 9)
+            start = await self._wait_zombie(gpid)
+            assert (gpid, start) == identity
+            assert reaper.sweep_once() == 1  # transition history alone
+            assert gpid not in self._our_zombie_map()
+        finally:
+            if inter.returncode is None:
+                inter.kill()
+                await inter.wait()
+
+    async def test_ssh_master_registration_reaches_pidfd_reap(
+        self, tmp_path, monkeypatch
+    ):
+        """§3.6 pin: the ControlPersist shape end-to-end — daemonized in
+        milliseconds (no observable transition), identified via ``-O
+        check`` while alive, registered, and reaped through the §3.5
+        sequence after it dies."""
+        import shutil
+
+        import src.tools.process_manager as pm
+        import src.tools.ssh_pool as sp
+
+        sleep_bin = shutil.which("sleep")
+        assert sleep_bin is not None
+        fake_ssh = tmp_path / "ssh"
+        shutil.copy(sleep_bin, fake_ssh)
+        fake_ssh.chmod(0o755)
+        master = await self._spawn_adopted(
+            tmp_path, lifetime="300", exec_path=str(fake_ssh)
+        )
+        await self._wait_adopted_alive(master)
+
+        pool = sp.SSHConnectionPool(socket_dir=str(tmp_path / "sockets"))
+        socket_path = pool.get_socket_path("h1", "root")
+        open(socket_path, "w").close()
+
+        calls: list[tuple] = []
+
+        class FakeCheck:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"Master running (pid=%d)\r\n" % master, b"")
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return 0
+
+        async def fake_exec(*argv, **_kw):
+            calls.append(argv)
+            return FakeCheck()
+
+        monkeypatch.setattr(sp.asyncio, "create_subprocess_exec", fake_exec)
+        assert await pool.ensure_master_registered("h1", "root") is True
+        table, _complete = pm._scan_process_table()
+        identity = (master, table[master][1])
+        assert identity in pm.registered_reap_identities()
+        # Fast path: same live incarnation → no second -O check subprocess.
+        before = len(calls)
+        assert await pool.ensure_master_registered("h1", "root") is True
+        assert len(calls) == before
+
+        os.kill(master, 9)  # ControlPersist expiry stand-in
+        start = await self._wait_zombie(master)
+        assert (master, start) == identity
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        assert reaper.sweep_once() == 1
+        assert master not in self._our_zombie_map()
+
+    # -- exclusions and fail-closed inspection ------------------------------
 
     async def test_pidfd_owned_child_is_never_reaped(self, monkeypatch):
         """The decisive exclusion: an open pidfd means asyncio still owns
-        that exit status, so the reaper must not take it — even when the
-        process IS a zombie and past the grace."""
+        that exit status — even a REGISTERED, grace-expired zombie must
+        not be taken."""
         import src.tools.process_manager as pm
 
         proc = await asyncio.create_subprocess_exec(
-            "true", stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+            "true",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
         )
-        held = os.pidfd_open(proc.pid)  # stand in for the watcher's pidfd
+        held = os.pidfd_open(proc.pid)
         try:
             owned = pm._pidfd_owned_pids()
             assert owned is not None and proc.pid in owned
-            # Present it as a settled zombie of ours, past any grace.
+            fake_table = {proc.pid: (os.getpid(), 12345, b"Z")}
             monkeypatch.setattr(
-                pm, "_zombie_children", lambda _p: {(proc.pid, 12345): None}
+                pm, "_scan_process_table", lambda: (dict(fake_table), True)
             )
-            waited: list[int] = []
+            pm.register_reap_identity(proc.pid, 12345, source="test")
+            touched: list = []
             monkeypatch.setattr(
-                pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+                pm, "_reap_identity", lambda *a: touched.append(a) or True
             )
             reaper = pm.AdoptedZombieReaper(grace=0.0)
             assert reaper.sweep_once() == 0
-            assert waited == []  # its status was never consumed by us
-            assert reaper.reaped_total == 0
+            assert touched == []  # its status was never approached
         finally:
             os.close(held)
             await proc.wait()
 
-    def test_unreadable_fd_table_reaps_nothing(self, monkeypatch):
-        """If we cannot enumerate our own fds we cannot prove abandonment,
-        so the pass must reap nothing — even with an eligible zombie
-        present and the grace elapsed."""
+    async def test_malformed_pidfd_entry_blocks_the_pass(
+        self, tmp_path, monkeypatch
+    ):
+        """Round-15 blocker #2 (replaces the pin that BLESSED the unsafe
+        skip): ONE pidfd whose fdinfo cannot be attributed makes the whole
+        inspection incomplete, and an otherwise-eligible zombie is NOT
+        reaped. Clearing the fault reaps it — proof the pin is
+        load-bearing."""
+        from pathlib import Path as RealPath
+
         import src.tools.process_manager as pm
 
-        real_listdir = pm.os.listdir
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+        pm.register_reap_identity(orphan, start, source="test")
 
-        def selective(path):
-            if str(path).startswith("/proc/self/fd"):
+        holder = await asyncio.create_subprocess_exec(
+            "sleep", "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        held = os.pidfd_open(holder.pid)
+        target = f"/proc/self/fdinfo/{held}"
+        try:
+
+            class Fake:
+                def __init__(self, path):
+                    self._p = RealPath(path)
+
+                def read_text(self):
+                    if str(self._p) == target:
+                        return "pos:\t0\nPid:\tnot-a-number\n"
+                    return self._p.read_text()
+
+                def read_bytes(self):
+                    return self._p.read_bytes()
+
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            with monkeypatch.context() as m:
+                m.setattr(pm, "Path", Fake)
+                assert reaper.sweep_once() == 0  # the pass proved nothing
+                assert orphan in self._our_zombie_map()
+            assert reaper.sweep_once() == 1  # fault cleared → it WAS eligible
+            assert orphan not in self._our_zombie_map()
+        finally:
+            os.close(held)
+            holder.terminate()
+            await holder.wait()
+
+    async def test_unreadable_pidfd_entry_blocks_the_pass(
+        self, tmp_path, monkeypatch
+    ):
+        """The unreadable half of blocker #2: an fdinfo read failing with
+        anything but ENOENT could be hiding a pidfd — prove nothing."""
+        from pathlib import Path as RealPath
+
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+        pm.register_reap_identity(orphan, start, source="test")
+
+        holder = await asyncio.create_subprocess_exec(
+            "sleep", "30",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        held = os.pidfd_open(holder.pid)
+        target = f"/proc/self/fdinfo/{held}"
+        try:
+
+            class Fake:
+                def __init__(self, path):
+                    self._p = RealPath(path)
+
+                def read_text(self):
+                    if str(self._p) == target:
+                        raise OSError("EIO reading fdinfo")
+                    return self._p.read_text()
+
+                def read_bytes(self):
+                    return self._p.read_bytes()
+
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            with monkeypatch.context() as m:
+                m.setattr(pm, "Path", Fake)
+                assert reaper.sweep_once() == 0
+                assert orphan in self._our_zombie_map()
+            assert reaper.sweep_once() == 1
+        finally:
+            os.close(held)
+            holder.terminate()
+            await holder.wait()
+
+    async def test_unreadable_fd_table_reaps_nothing(self, tmp_path, monkeypatch):
+        """If we cannot enumerate our own fds we cannot prove abandonment
+        — even a registered, grace-expired REAL zombie stays."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+        pm.register_reap_identity(orphan, start, source="test")
+        real_listdir = os.listdir
+
+        def refuse(path):
+            if str(path) == "/proc/self/fd":
                 raise OSError("fd table unreadable")
             return real_listdir(path)
 
-        monkeypatch.setattr(pm.os, "listdir", selective)
-        assert pm._pidfd_owned_pids() is None
-        # An eligible zombie IS present and past the grace…
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        with monkeypatch.context() as m:
+            m.setattr(pm.os, "listdir", refuse)
+            assert reaper.sweep_once() == 0
+            assert orphan in self._our_zombie_map()
+        assert reaper.sweep_once() == 1  # load-bearing: it WAS eligible
+
+    def test_incomplete_scan_never_prunes_or_reaps(self, monkeypatch):
+        """§3.4 both ways: an incomplete table neither authorizes a reap
+        nor infers absence; the same state on a COMPLETE table does
+        both."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        zombie_entry = {4242: (mypid, 11, b"Z")}
+        pm.register_reap_identity(4242, 11, source="test")
+        reap_calls: list = []
         monkeypatch.setattr(
-            pm, "_zombie_children", lambda _p: {(4242, 111): None}
+            pm, "_reap_identity", lambda *a: reap_calls.append(a) or True
         )
-        waited: list[int] = []
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
         monkeypatch.setattr(
-            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+            pm, "_scan_process_table", lambda: (dict(zombie_entry), False)
         )
         reaper = pm.AdoptedZombieReaper(grace=0.0)
-        assert reaper.sweep_once() == 0  # …and is still not reaped
-        assert waited == []
-
-    def test_registered_identity_is_skipped(self, monkeypatch):
-        import src.tools.process_manager as pm
-
-        identity = (4242, 111)
-        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
-        monkeypatch.setattr(pm, "_zombie_children", lambda _p: {identity: None})
-        waited: list[int] = []
-        monkeypatch.setattr(
-            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
-        )
-        reaper = pm.AdoptedZombieReaper(
-            grace=0.0, registered=lambda: frozenset({identity})
-        )
         assert reaper.sweep_once() == 0
-        assert waited == []
+        assert reap_calls == []  # not authorized
+        assert (4242, 11) in reaper._candidates  # observed and kept
+        # An identity ABSENT from an incomplete table is not pruned…
+        monkeypatch.setattr(pm, "_scan_process_table", lambda: ({}, False))
+        assert reaper.sweep_once() == 0
+        assert (4242, 11) in reaper._candidates
+        assert (4242, 11) in pm.registered_reap_identities()
+        # …and a COMPLETE table acts: present → reaped.
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: (dict(zombie_entry), True)
+        )
+        assert reaper.sweep_once() == 1
+        assert reap_calls and reap_calls[0][0] == 4242
+        assert (4242, 11) not in reaper._candidates
+        assert (4242, 11) not in pm.registered_reap_identities()
 
-    def test_identity_change_between_observations_is_dropped(self, monkeypatch):
-        """A pid whose incarnation changed between passes is not the
-        process we saw — it is dropped, never waited on."""
+    def test_complete_scan_prunes_vanished_and_reincarnated(self, monkeypatch):
+        """Identity change between observations is a DIFFERENT process:
+        the old identity is forgotten, never waited on."""
         import src.tools.process_manager as pm
 
+        mypid = os.getpid()
         monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
-        seq = [{(4242, 111): None}, {(4242, 999): None}]
-        monkeypatch.setattr(pm, "_zombie_children", lambda _p: seq[0])
+        seq = {"table": {4242: (mypid, 111, b"S")}}
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: (dict(seq["table"]), True)
+        )
         reaper = pm.AdoptedZombieReaper(grace=3600.0)
         reaper.sweep_once()
-        assert reaper.pending_zombies == 1
-        seq[0] = seq[1]  # pid reused by a different incarnation
+        assert (4242, 111) in reaper._candidates
+        seq["table"] = {4242: (mypid, 999, b"S")}  # pid reused
         reaper.sweep_once()
-        assert (4242, 111) not in reaper._first_seen  # old identity forgotten
+        assert (4242, 111) not in reaper._candidates
+        assert (4242, 999) in reaper._candidates
+
+    # -- grace semantics -----------------------------------------------------
+
+    async def test_grace_runs_from_zombie_observation_not_adoption(
+        self, tmp_path, monkeypatch
+    ):
+        """§3.2: time spent adopted-but-ALIVE must not pre-spend the
+        grace — otherwise a long-lived ControlPersist master would be
+        reaped the instant it died."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path, lifetime="300")
+        await self._wait_adopted_alive(orphan)
+        table, _complete = pm._scan_process_table()
+        start = table[orphan][1]
+        pm.register_reap_identity(orphan, start, source="test")
+
+        reaper = pm.AdoptedZombieReaper()  # real GRACE (30s)
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(pm.time, "monotonic", lambda: clock["now"])
+        reaper.sweep_once()  # tracked ALIVE at t=1000
+        clock["now"] = 1500.0
+        reaper.sweep_once()  # adopted-alive for 500 fake seconds
+        os.kill(orphan, 9)
+        for _ in range(200):
+            if orphan in self._our_zombie_map():
+                break
+            time.sleep(0.02)
+        assert reaper.sweep_once() == 0  # first seen AS ZOMBIE at t=1500
+        assert orphan in self._our_zombie_map()
+        clock["now"] = 1529.0
+        assert reaper.sweep_once() == 0  # 29s < GRACE
+        clock["now"] = 1531.0
+        assert reaper.sweep_once() == 1  # grace from the ZOMBIE sighting
+        assert orphan not in self._our_zombie_map()
+
+    # -- §3.5 identity-stable reaping ---------------------------------------
+
+    def test_pid_reuse_cannot_redirect_the_reap(self, monkeypatch):
+        """§3.6 pin: the identity is re-verified AFTER ``pidfd_open`` —
+        a stale snapshot naming a pid now occupied by a DIFFERENT
+        incarnation aborts before any waitid, and the live occupant is
+        untouched."""
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        occupant = subprocess.Popen(["sleep", "30"])
+        try:
+            table, _complete = pm._scan_process_table()
+            real_start = table[occupant.pid][1]
+            stale = real_start - 7  # the recorded incarnation is long gone
+            fake_table = {occupant.pid: (os.getpid(), stale, b"Z")}
+            monkeypatch.setattr(
+                pm, "_scan_process_table", lambda: (dict(fake_table), True)
+            )
+            monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+            pm.register_reap_identity(occupant.pid, stale, source="test")
+            waited: list = []
+            monkeypatch.setattr(pm.os, "waitid", lambda *a: waited.append(a))
+            reaper = pm.AdoptedZombieReaper(grace=0.0)
+            assert reaper.sweep_once() == 0
+            assert waited == []  # nothing was ever consumed
+            assert (occupant.pid, stale) not in reaper._candidates  # pruned
+            assert occupant.poll() is None  # the occupant lives on
+        finally:
+            occupant.terminate()
+            assert occupant.wait() == -15  # its status reached its owner
+
+    async def test_reap_identity_verifies_incarnation_after_open(self, tmp_path):
+        """§3.5 step 3 in isolation: with a REAL zombie present, a
+        mismatched starttime aborts (the recorded incarnation is not the
+        current occupant) and consumes nothing; the true identity then
+        consumes it."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+        assert pm._reap_identity(orphan, start - 1, os.getpid()) is None
+        assert orphan in self._our_zombie_map()  # nothing was consumed
+        assert pm._reap_identity(orphan, start, os.getpid()) is True
+        assert orphan not in self._our_zombie_map()
+
+    def test_identity_gone_at_reap_time_is_pruned_without_waitid(
+        self, monkeypatch
+    ):
+        import src.tools.process_manager as pm
+
+        free_pid = next(
+            p
+            for p in range(4194000, 4194304)
+            if not os.path.exists(f"/proc/{p}")
+        )
+        mypid = os.getpid()
+        stale = {free_pid: (mypid, 11, b"Z")}
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: (dict(stale), True)
+        )
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        pm.register_reap_identity(free_pid, 11, source="test")
+        waited: list = []
+        monkeypatch.setattr(pm.os, "waitid", lambda *a: waited.append(a))
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        assert reaper.sweep_once() == 0
+        assert waited == []
+        assert (free_pid, 11) not in reaper._candidates  # provably gone
+
+    async def test_reap_identity_failure_arms(self, tmp_path, monkeypatch):
+        """§3.5 fault arms: every failure to PROVE aborts without
+        consuming — a failed pidfd_open, an unreadable, malformed or
+        vanished stat — and a LIVE process is never state-eligible."""
+        import subprocess
+        from pathlib import Path as RealPath
+
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+
+        with monkeypatch.context() as m:
+
+            def no_fd(_pid):
+                raise OSError("EMFILE")
+
+            m.setattr(pm.os, "pidfd_open", no_fd)
+            assert pm._reap_identity(orphan, start, os.getpid()) is False
+
+        def selective(effect):
+            class Fake:
+                def __init__(self, path):
+                    self._p = RealPath(path)
+
+                def read_text(self):
+                    return self._p.read_text()
+
+                def read_bytes(self):
+                    if str(self._p) == f"/proc/{orphan}/stat":
+                        return effect()
+                    return self._p.read_bytes()
+
+            return Fake
+
+        with monkeypatch.context() as m:
+            m.setattr(pm, "Path", selective(lambda: (_ for _ in ()).throw(OSError("EIO"))))
+            assert pm._reap_identity(orphan, start, os.getpid()) is False
+        with monkeypatch.context() as m:
+            m.setattr(pm, "Path", selective(lambda: b"1 (x) Z"))
+            assert pm._reap_identity(orphan, start, os.getpid()) is False
+        with monkeypatch.context() as m:
+            m.setattr(
+                pm,
+                "Path",
+                selective(lambda: (_ for _ in ()).throw(FileNotFoundError())),
+            )
+            assert pm._reap_identity(orphan, start, os.getpid()) is None
+        # None of the faults consumed it — the true identity still does.
+        assert pm._reap_identity(orphan, start, os.getpid()) is True
+        assert orphan not in self._our_zombie_map()
+
+        live = subprocess.Popen(["sleep", "30"])
+        try:
+            table, _c = pm._scan_process_table()
+            live_start = table[live.pid][1]
+            assert pm._reap_identity(live.pid, live_start, os.getpid()) is False
+            assert live.poll() is None  # untouched
+        finally:
+            live.terminate()
+            live.wait()
+
+    def test_scan_marks_unreadable_stat_incomplete(self, monkeypatch):
+        """A pid listed in /proc whose stat cannot be read (EACCES shape)
+        is a live process in an UNKNOWN state — the scan must admit it."""
+        from pathlib import Path as RealPath
+
+        import src.tools.process_manager as pm
+
+        victim = os.getpid()
+
+        class Refuse:
+            def __init__(self, path):
+                self._p = RealPath(path)
+
+            def read_text(self):
+                return self._p.read_text()
+
+            def read_bytes(self):
+                if str(self._p) == f"/proc/{victim}/stat":
+                    raise PermissionError("hidepid")
+                return self._p.read_bytes()
+
+        with monkeypatch.context() as m:
+            m.setattr(pm, "Path", Refuse)
+            table, complete = pm._scan_process_table()
+        assert victim not in table
+        assert complete is False
+
+    def test_drain_exhausts_attempts_on_a_replenishing_table(self, monkeypatch):
+        """A table that presents zombies faster than they settle bounds
+        the drain at four attempts, then reports honestly unverified."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: ({4242: (mypid, 11, b"Z")}, True)
+        )
+        monkeypatch.setattr(pm, "_reap_identity", lambda *a: True)
+        reaper = pm.AdoptedZombieReaper()
+        drained, verified = reaper.drain_at_teardown()
+        assert drained == 4  # one per bounded attempt
+        assert verified is False  # the table never came clean
+
+    async def test_waitid_echild_is_not_counted(self, tmp_path, monkeypatch):
+        """Losing the race to another owner is not a reap."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        start = await self._wait_zombie(orphan)
+        pm.register_reap_identity(orphan, start, source="test")
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        with monkeypatch.context() as m:
+
+            def echild(*_a):
+                raise ChildProcessError("not ours")
+
+            m.setattr(pm.os, "waitid", echild)
+            assert reaper.sweep_once() == 0
+            assert reaper.reaped_total == 0
+        pm.register_reap_identity(orphan, start, source="test")
+        assert reaper.sweep_once() == 1  # cleanly consumed once ours again
+
+    # -- bounded history -----------------------------------------------------
+
+    def test_candidate_cap_evicts_and_counts(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        table = {
+            101: (mypid, 11, b"S"),
+            102: (mypid, 12, b"S"),
+            103: (mypid, 13, b"S"),
+        }
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: (dict(table), True)
+        )
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        reaper = pm.AdoptedZombieReaper(grace=0.0)
+        reaper.MAX_TRACKED = 2
+        reaper.sweep_once()
+        assert len(reaper._candidates) == 2
+        assert reaper.evicted_total == 1
+        assert reaper.stats["evicted_total"] == 1
+
+    def test_age_bound_is_the_backstop_for_dead_proc(self, monkeypatch):
+        """When /proc goes dark the completeness-gated pruning never
+        runs; the age bound keeps history from growing forever. Eviction
+        only loses evidence."""
+        import src.tools.process_manager as pm
+
+        mypid = os.getpid()
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(pm.time, "monotonic", lambda: clock["now"])
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: ({4242: (mypid, 11, b"S")}, True)
+        )
+        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
+        reaper = pm.AdoptedZombieReaper()
+        reaper.sweep_once()
+        assert (4242, 11) in reaper._candidates
+        monkeypatch.setattr(pm, "_scan_process_table", lambda: ({}, False))
+        clock["now"] = 1000.0 + reaper.MAX_AGE + 1
+        reaper.sweep_once()
+        assert (4242, 11) not in reaper._candidates
+        assert reaper.evicted_total == 1
+
+    def test_registry_cap_evicts_oldest_registration(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(pm, "_REAP_REGISTRY_CAP", 2)
+        pm.register_reap_identity(1, 1, source="a")
+        pm.register_reap_identity(2, 2, source="b")
+        pm.register_reap_identity(3, 3, source="c")
+        assert pm.registered_reap_identities() == frozenset({(2, 2), (3, 3)})
+        reaper = pm.AdoptedZombieReaper()
+        assert reaper.stats["registered_candidates"] == 2
+        assert reaper.stats["evicted_total"] == 1
+
+    # -- registration API ----------------------------------------------------
+
+    def test_register_candidate_verifies_against_proc(self):
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        live = subprocess.Popen(["sleep", "30"])
+        try:
+            start = pm.register_reap_candidate(live.pid, source="test")
+            assert start is not None
+            assert (live.pid, start) in pm.registered_reap_identities()
+        finally:
+            live.terminate()
+            live.wait()
+
+    def test_register_candidate_refuses_unidentifiable_pids(self):
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        gone = subprocess.Popen(["true"])
+        gone.wait()  # reaped — the pid names nothing now
+        assert pm.register_reap_candidate(gone.pid, source="test") is None
+        assert pm.registered_reap_identities() == frozenset()
+
+    def test_registration_prunes_when_identity_is_gone(self):
+        import subprocess
+
+        import src.tools.process_manager as pm
+
+        child = subprocess.Popen(["sleep", "30"])
+        reaper = pm.AdoptedZombieReaper()
+        try:
+            start = pm.register_reap_candidate(child.pid, source="test")
+            assert start is not None
+            reaper.sweep_once()  # complete scan, identity alive → retained
+            assert (child.pid, start) in pm.registered_reap_identities()
+        finally:
+            child.terminate()
+            child.wait()
+        reaper.sweep_once()  # complete scan, identity gone → pruned
+        assert (child.pid, start) not in pm.registered_reap_identities()
+
+    # -- teardown drain ------------------------------------------------------
+
+    async def test_drain_at_teardown_consumes_unobserved_zombies(self, tmp_path):
+        """Teardown rule: after every subprocess owner has stopped, every
+        remaining zombie child is ours — no history, no registration, no
+        grace required."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        await self._wait_zombie(orphan)
+        reaper = pm.AdoptedZombieReaper()  # never swept before
+        drained, verified = reaper.drain_at_teardown()
+        assert drained >= 1
+        assert verified is True
+        assert orphan not in self._our_zombie_map()
+
+    async def test_drain_ignores_pidfd_ownership(self, tmp_path):
+        """At teardown asyncio will never run its callbacks again: an
+        open pidfd is no longer a live status interest, and the zombie
+        must not survive into the exec'd image."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        await self._wait_zombie(orphan)
+        held = os.pidfd_open(orphan)
+        try:
+            reaper = pm.AdoptedZombieReaper()
+            drained, verified = reaper.drain_at_teardown()
+            assert drained >= 1
+            assert verified is True
+            assert orphan not in self._our_zombie_map()
+        finally:
+            os.close(held)
+
+    async def test_drain_unverified_when_a_zombie_cannot_be_consumed(
+        self, tmp_path, monkeypatch
+    ):
+        """§3.6 pin half 1: a failed final proof is LOUD — (…, False),
+        which the caller must treat as a re-exec veto."""
+        import src.tools.process_manager as pm
+
+        orphan = await self._spawn_adopted(tmp_path)
+        await self._wait_zombie(orphan)
+        reaper = pm.AdoptedZombieReaper()
+        with monkeypatch.context() as m:
+
+            def refuse(*_a):
+                raise OSError("waitid refused")
+
+            m.setattr(pm.os, "waitid", refuse)
+            drained, verified = reaper.drain_at_teardown()
+            assert drained == 0
+            assert verified is False
+        drained, verified = reaper.drain_at_teardown()
+        assert drained >= 1  # the zombie was real — fault, not phantom
+        assert verified is True
+
+    def test_drain_incomplete_scan_is_unverified(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        monkeypatch.setattr(
+            pm, "_scan_process_table", lambda: ({}, False)
+        )
+        reaper = pm.AdoptedZombieReaper()
+        drained, verified = reaper.drain_at_teardown()
+        assert drained == 0
+        assert verified is False
+
+    # -- task machinery ------------------------------------------------------
 
     async def test_sweep_failure_does_not_kill_the_task(self, monkeypatch):
         import src.tools.process_manager as pm
@@ -2377,38 +3175,6 @@ class TestAdoptedZombieReaper:
         await reaper.stop()
         assert reaper._task is None
 
-    def test_stats_surface(self):
-        import src.tools.process_manager as pm
-
-        reaper = pm.AdoptedZombieReaper()
-        assert reaper.stats == {"pending_zombies": 0, "reaped_total": 0}
-
-    def test_pidfd_scan_tolerates_malformed_fdinfo(self, monkeypatch, tmp_path):
-        """A malformed or racing fdinfo entry is skipped, never raised."""
-        import src.tools.process_manager as pm
-
-        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["3", "4"])
-
-        class FakePath:
-            def __init__(self, path):
-                self.path = str(path)
-
-            def read_text(self):
-                if self.path.endswith("/3"):
-                    return "pos:\t0\nPid:\tnot-a-number\n"  # malformed
-                raise OSError("fd closed under us")  # racing close
-
-        monkeypatch.setattr(pm, "Path", FakePath)
-        assert pm._pidfd_owned_pids() == set()  # neither raised
-
-    def test_zombie_scan_tolerates_unreadable_proc(self, monkeypatch):
-        import src.tools.process_manager as pm
-
-        monkeypatch.setattr(
-            pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("gone"))
-        )
-        assert pm._zombie_children(os.getpid()) == {}
-
     async def test_stop_is_idempotent_without_a_task(self):
         import src.tools.process_manager as pm
 
@@ -2438,60 +3204,136 @@ class TestAdoptedZombieReaper:
         assert task.done() and task.cancelled()
         await reaper.stop()
 
-    def test_vanished_between_verify_and_reap_is_dropped(self, monkeypatch):
-        """The re-verification immediately before waitpid: an identity that
-        stopped being our zombie is dropped, never waited on."""
+    def test_stats_surface(self):
         import src.tools.process_manager as pm
 
-        identity = (4242, 111)
-        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
-        calls = {"n": 0}
+        reaper = pm.AdoptedZombieReaper()
+        assert reaper.stats == {
+            "pending_zombies": 0,
+            "reaped_total": 0,
+            "tracked_candidates": 0,
+            "registered_candidates": 0,
+            "evicted_total": 0,
+        }
 
-        def zombies(_p):
-            calls["n"] += 1
-            return {identity: None} if calls["n"] == 1 else {}
 
-        monkeypatch.setattr(pm, "_zombie_children", zombies)
-        waited: list[int] = []
-        monkeypatch.setattr(
-            pm.os, "waitpid", lambda pid, _f: waited.append(pid) or (pid, 0)
+class TestReapRegistrationBridge:
+    """§3.1.2, ProcessRegistry side: an adopted descendant that the
+    ownership scan positively attributes is registered while alive, and
+    registration alone carries the reap after it dies."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_registry(self):
+        import src.tools.process_manager as pm
+
+        pm._reset_reap_registry()
+        yield
+        pm._reset_reap_registry()
+
+    async def test_job_descendant_registration_reaches_pidfd_reap(self, tmp_path):
+        import src.tools.process_manager as pm
+
+        job_token = "job-" + os.urandom(4).hex()
+        orphan = await TestAdoptedZombieReaper._spawn_adopted(
+            tmp_path,
+            lifetime="300",
+            env={pm.JOB_TOKEN_ENV: job_token},
         )
+        await TestAdoptedZombieReaper._wait_adopted_alive(orphan)
+        sink: set[tuple[int, int]] = set()
+        pinned, _complete = pm._scan_owned_members(
+            -12345,  # a session nothing belongs to
+            adopted_by=os.getpid(),
+            known_own_children=frozenset(),
+            job_token=job_token,
+            proc_token=os.environ.get(pm.PROC_TOKEN_ENV),
+            adopted_sink=sink,
+        )
+        pm._close_pinned(pinned)  # release our pins so no pidfd exclusion
+        table, _complete2 = pm._scan_process_table()
+        identity = (orphan, table[orphan][1])
+        assert identity in sink  # provenance proven while alive
+        assert identity in pm.registered_reap_identities()  # and REGISTERED
+        os.kill(orphan, 9)
+        start = await TestAdoptedZombieReaper._wait_zombie(orphan)
+        assert (orphan, start) == identity
         reaper = pm.AdoptedZombieReaper(grace=0.0)
-        assert reaper.sweep_once() == 0
-        assert waited == []  # re-verify said it was gone
-        assert reaper.pending_zombies == 0
+        assert reaper.sweep_once() >= 1
+        assert orphan not in TestAdoptedZombieReaper._our_zombie_map()
 
-    def test_waitpid_error_is_swallowed(self, monkeypatch):
-        """Losing the race to another owner is not an error."""
+    async def test_adopted_session_member_is_registered(self):
+        """The soak's job-shell ``sleep`` exactly: a session member whose
+        shell died is our direct child now — the ownership scan must
+        record it while ALIVE (session proof + adoption), because killed
+        or not, its zombie lands on us and only the recorded identity can
+        carry the reap."""
         import src.tools.process_manager as pm
 
-        identity = (4242, 111)
-        monkeypatch.setattr(pm, "_pidfd_owned_pids", lambda: set())
-        monkeypatch.setattr(pm, "_zombie_children", lambda _p: {identity: None})
-
-        def not_ours(_pid, _flags):
-            raise ChildProcessError("someone else took it")
-
-        monkeypatch.setattr(pm.os, "waitpid", not_ours)
+        # The sleeper's output must be detached from the pipe: a
+        # `&`-descendant holding stdout keeps communicate() from EOF —
+        # the PR #244 round-1 bug shape, live in this very test.
+        leader = await asyncio.create_subprocess_shell(
+            "sleep 300 >/dev/null 2>&1 & echo $!; exit 0",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        out, _err = await leader.communicate()
+        sleeper = int(out.strip())
+        try:
+            await TestAdoptedZombieReaper._wait_adopted_alive(sleeper)
+            sink: set[tuple[int, int]] = set()
+            pinned, _complete = pm._scan_owned_members(
+                leader.pid,  # the job session
+                leader_pid=leader.pid,
+                adopted_by=os.getpid(),
+                known_own_children=frozenset({leader.pid}),
+                job_token="job-x",
+                proc_token=os.environ.get(pm.PROC_TOKEN_ENV),
+                adopted_sink=sink,
+            )
+            pm._close_pinned(pinned)
+            table, _c = pm._scan_process_table()
+            identity = (sleeper, table[sleeper][1])
+            assert identity in sink
+            assert identity in pm.registered_reap_identities()
+        finally:
+            os.kill(sleeper, 9)
+        start = await TestAdoptedZombieReaper._wait_zombie(sleeper)
+        assert (sleeper, start) == identity
         reaper = pm.AdoptedZombieReaper(grace=0.0)
-        assert reaper.sweep_once() == 0
-        assert reaper.reaped_total == 0
+        assert reaper.sweep_once() >= 1
+        assert sleeper not in TestAdoptedZombieReaper._our_zombie_map()
 
-    def test_zombie_scan_skips_vanished_and_malformed_entries(self, monkeypatch):
-        """A process that exits mid-scan, or a truncated stat line, is
-        skipped rather than raising out of the sweep."""
+    async def test_teardown_scan_does_not_register(self, tmp_path):
+        """The teardown arm attributes by adoption alone — that evidence
+        must stay OUT of the runtime registry (the process is being
+        killed now, and adoption-alone is not the runtime bar)."""
         import src.tools.process_manager as pm
 
-        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["111", "222", "notapid"])
-
-        class FakePath:
-            def __init__(self, path):
-                self.path = str(path)
-
-            def read_bytes(self):
-                if "/111/" in self.path:
-                    raise FileNotFoundError()  # vanished mid-scan
-                return b"222 (x) Z"  # truncated — no fields after comm
-
-        monkeypatch.setattr(pm, "Path", FakePath)
-        assert pm._zombie_children(os.getpid()) == {}
+        job_token = "job-" + os.urandom(4).hex()
+        orphan = await TestAdoptedZombieReaper._spawn_adopted(
+            tmp_path,
+            lifetime="300",
+            env={pm.JOB_TOKEN_ENV: job_token},
+        )
+        await TestAdoptedZombieReaper._wait_adopted_alive(orphan)
+        try:
+            sink: set[tuple[int, int]] = set()
+            pinned, _complete = pm._scan_owned_members(
+                -12345,
+                adopted_by=os.getpid(),
+                known_own_children=frozenset(),
+                job_token=job_token,
+                proc_token=os.environ.get(pm.PROC_TOKEN_ENV),
+                adopted_sink=sink,
+                teardown=True,
+            )
+            pm._close_pinned(pinned)
+            assert any(pid == orphan for pid, _s in sink)
+            assert pm.registered_reap_identities() == frozenset()
+        finally:
+            os.kill(orphan, 9)
+            await TestAdoptedZombieReaper._wait_zombie(orphan)
+            reaper = pm.AdoptedZombieReaper()
+            reaper.drain_at_teardown()

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -788,7 +788,7 @@ class TestRaceFreeGroupTermination:
     complete is never mistaken for an empty group."""
 
     async def test_pins_only_true_group_members(self):
-        from src.tools.process_manager import _close_pinned, _scan_session_members
+        from src.tools.process_manager import _close_pinned, _scan_owned_members
 
         proc = await asyncio.create_subprocess_shell(
             "sleep 5 & sleep 5", stdout=asyncio.subprocess.PIPE,
@@ -796,7 +796,7 @@ class TestRaceFreeGroupTermination:
         )
         try:
             await asyncio.sleep(0.4)
-            pinned, complete = _scan_session_members(proc.pid)
+            pinned, complete = _scan_owned_members(proc.pid)
             try:
                 pids = {pid for pid, _fd in pinned}
                 assert complete is True
@@ -813,7 +813,7 @@ class TestRaceFreeGroupTermination:
         fresh same-session TERM-immune child is caught by the NEXT
         enumeration pass — a one-shot pinned set would miss it."""
         from src.tools.process_manager import (
-            _scan_session_members,
+            _scan_owned_members,
             _terminate_session_until_empty,
         )
 
@@ -838,7 +838,7 @@ class TestRaceFreeGroupTermination:
             await asyncio.sleep(0.5)
             gone = await _terminate_session_until_empty(pgid, grace=0.5, timeout=10.0)
             assert gone is True  # affirmative empty observation
-            pinned, complete = _scan_session_members(pgid)
+            pinned, complete = _scan_owned_members(pgid)
             try:
                 assert complete and not pinned  # the forked child died too
             finally:
@@ -885,7 +885,7 @@ class TestScanCompleteness:
         monkeypatch.setattr(
             pm.os, "listdir", lambda _p: (_ for _ in ()).throw(OSError("nope"))
         )
-        pinned, complete = pm._scan_session_members(1234)
+        pinned, complete = pm._scan_owned_members(1234)
         assert pinned == [] and complete is False
 
     def test_pidfd_exhaustion_is_incomplete_not_empty(self, monkeypatch):
@@ -897,7 +897,7 @@ class TestScanCompleteness:
             raise OSError(24, "Too many open files")
 
         monkeypatch.setattr(pm.os, "pidfd_open", emfile)
-        pinned, complete = pm._scan_session_members(1234)
+        pinned, complete = pm._scan_owned_members(1234)
         assert pinned == [] and complete is False
 
     def test_vanished_candidate_does_not_spoil_the_scan(self, monkeypatch):
@@ -909,7 +909,7 @@ class TestScanCompleteness:
             pm.os, "pidfd_open",
             lambda _pid: (_ for _ in ()).throw(ProcessLookupError()),
         )
-        pinned, complete = pm._scan_session_members(1234)
+        pinned, complete = pm._scan_owned_members(1234)
         assert pinned == [] and complete is True
 
     def test_stat_read_error_is_unknown_not_gone(self, monkeypatch):
@@ -965,9 +965,9 @@ class TestShutdownBarrier:
             await asyncio.wait_for(reg.shutdown(), timeout=SHUTDOWN_REAP_TIMEOUT + 20)
             assert time.monotonic() - start < SHUTDOWN_REAP_TIMEOUT + 20
             assert proc.returncode is not None  # leader reaped
-            from src.tools.process_manager import _scan_session_members
+            from src.tools.process_manager import _scan_owned_members
 
-            pinned, complete = _scan_session_members(proc.pid)
+            pinned, complete = _scan_owned_members(proc.pid)
             assert complete and not pinned  # group provably empty
         finally:
             resist = False
@@ -1054,14 +1054,14 @@ class TestRaceFreeHelperArms:
         leaves the scan INCOMPLETE — never silently skipped as absent."""
         import src.tools.process_manager as pm
 
-        real_stat = pm._proc_session
+        real_ids = pm._proc_ids
         target = os.getpid()
 
         def flaky(pid):
-            return "unknown" if pid == target else real_stat(pid)
+            return "unknown" if pid == target else real_ids(pid)
 
-        monkeypatch.setattr(pm, "_proc_session", flaky)
-        pinned, complete = pm._scan_session_members(4_000_001)
+        monkeypatch.setattr(pm, "_proc_ids", flaky)
+        pinned, complete = pm._scan_owned_members(4_000_001)
         assert complete is False
         pm._close_pinned(pinned)
 
@@ -1102,7 +1102,7 @@ class TestSessionFenceEscapes:
         membership made it invisible; session-based membership does not."""
         from src.tools.process_manager import (
             _close_pinned,
-            _scan_session_members,
+            _scan_owned_members,
             _terminate_session_until_empty,
         )
 
@@ -1120,7 +1120,7 @@ class TestSessionFenceEscapes:
         sid = proc.pid
         try:
             await asyncio.sleep(0.6)
-            pinned, complete = _scan_session_members(sid)
+            pinned, complete = _scan_owned_members(sid)
             try:
                 # The escapee is VISIBLE: it left the group, not the session.
                 assert complete and len(pinned) >= 1
@@ -1129,7 +1129,7 @@ class TestSessionFenceEscapes:
             assert await _terminate_session_until_empty(
                 sid, grace=0.5, timeout=12.0
             ) is True
-            pinned, complete = _scan_session_members(sid)
+            pinned, complete = _scan_owned_members(sid)
             try:
                 assert complete and not pinned  # escapee is gone
             finally:
@@ -1244,3 +1244,144 @@ class TestShutdownAffirmativeProof:
         reg._processes[proc.pid] = info
         await reg._watch_exit(info)
         assert info.session_confirmed_empty is False
+
+
+class TestSetsidEscapeAndSettleWindow:
+    """Round-8 #1/#2: ancestry catches a setsid escapee whose parent chain
+    still reaches our leader; emptiness needs consecutive clean scans."""
+
+    async def test_setsid_child_is_still_owned_via_ancestry(self):
+        from src.tools.process_manager import (
+            _close_pinned,
+            _scan_owned_members,
+            _terminate_session_until_empty,
+        )
+
+        # Child calls setsid() → leaves our SESSION entirely, but its
+        # parent (the managed shell) stays alive, so ancestry still owns it.
+        escapee = (
+            "import os,signal,time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "os.setsid(); time.sleep(60)"
+        )
+        proc = await asyncio.create_subprocess_shell(
+            f'python3 -c "{escapee}" & sleep 60',
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+        )
+        sid = proc.pid
+        try:
+            await asyncio.sleep(0.7)
+            pinned, complete = _scan_owned_members(sid, leader_pid=sid)
+            try:
+                assert complete
+                # The setsid escapee is OWNED through the ancestry relation.
+                assert len(pinned) >= 3  # shell + sleep + escapee
+            finally:
+                _close_pinned(pinned)
+            assert await _terminate_session_until_empty(
+                sid, grace=0.5, timeout=15.0
+            ) is True
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+    async def test_single_clean_scan_is_not_enough(self, monkeypatch):
+        """Round-8 #2: one complete-and-empty snapshot must NOT prove
+        emptiness — a member can fork after enumeration and exit."""
+        import src.tools.process_manager as pm
+
+        scans = {"n": 0}
+
+        def scan(_sid, leader_pid=None):
+            scans["n"] += 1
+            if scans["n"] == 1:
+                return [], True  # first snapshot looks empty…
+            if scans["n"] == 2:
+                return [(4242, -1)], True  # …but a forked child appears
+            return [], True
+
+        monkeypatch.setattr(pm, "_scan_owned_members", scan)
+        monkeypatch.setattr(pm, "_signal_pinned", lambda *_a: None)
+        monkeypatch.setattr(pm, "_close_pinned", lambda *_a: None)
+        assert await pm._terminate_session_until_empty(
+            1234, timeout=5.0, term_first=False
+        ) is True
+        # It kept scanning past the first clean look and caught the child.
+        assert scans["n"] >= 4
+
+    async def test_settle_window_counts_consecutive_only(self, monkeypatch):
+        import src.tools.process_manager as pm
+
+        seq = [([], True), ([(1, -1)], True), ([], True), ([], True)]
+        calls = {"n": 0}
+
+        def scan(_sid, leader_pid=None):
+            i = min(calls["n"], len(seq) - 1)
+            calls["n"] += 1
+            return seq[i]
+
+        monkeypatch.setattr(pm, "_scan_owned_members", scan)
+        monkeypatch.setattr(pm, "_signal_pinned", lambda *_a: None)
+        monkeypatch.setattr(pm, "_close_pinned", lambda *_a: None)
+        assert await pm._terminate_session_until_empty(
+            1, timeout=5.0, term_first=False
+        ) is True
+        assert calls["n"] == 4  # the non-empty scan RESET the counter
+
+
+class TestReexecVeto:
+    """Round-8 #3: unprovable cleanup must PREVENT the in-place re-exec."""
+
+    def test_block_and_read_veto(self):
+        from src import restart
+
+        restart.reset()
+        assert restart.reexec_blocked() is None
+        restart.block_reexec("cleanup unverified: PID [42]")
+        assert "PID [42]" in (restart.reexec_blocked() or "")
+        restart.reset()
+        assert restart.reexec_blocked() is None
+
+    async def test_wiring_vetoes_on_cleanup_error(self):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from src import restart
+        from src.discord.wiring import shutdown_services
+        from src.tools.process_manager import ProcessCleanupError
+
+        restart.reset()
+        registry = SimpleNamespace(
+            shutdown=AsyncMock(side_effect=ProcessCleanupError("PID [4242] unproven"))
+        )
+        bot = SimpleNamespace(
+            tool_executor=SimpleNamespace(_process_registry=registry)
+        )
+        try:
+            await shutdown_services(bot)
+            veto = restart.reexec_blocked()
+            assert veto is not None and "4242" in veto
+        finally:
+            restart.reset()
+
+    def test_ancestry_walk_is_bounded_and_cycle_safe(self, monkeypatch):
+        """The ppid walk must terminate on a chain that leaves our
+        snapshot, and on a (kernel-impossible but cheap to guard) cycle —
+        neither may loop or claim ownership."""
+        import src.tools.process_manager as pm
+
+        # /proc lists two pids; one's parent is OUTSIDE the snapshot, the
+        # other pair points at each other.
+        monkeypatch.setattr(pm.os, "listdir", lambda _p: ["100", "200", "300"])
+        monkeypatch.setattr(pm.os, "pidfd_open", lambda pid: os.open("/dev/null", os.O_RDONLY))
+        table = {
+            100: (999, 5),   # parent 999 not in the snapshot → unowned
+            200: (300, 5),   # 200 ↔ 300 cycle, neither in our session
+            300: (200, 5),
+        }
+        monkeypatch.setattr(pm, "_proc_ids", lambda pid: table.get(pid, "unknown"))
+        pinned, complete = pm._scan_owned_members(7, leader_pid=7)
+        assert pinned == []  # nothing claimed
+        assert complete is True

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -233,6 +233,69 @@ class TestPollWaitSeconds:
             )
             assert code == 0, ok
 
+    async def test_carriage_return_progress_advances_output_bytes(self):
+        """PR #244 round-1 blocker #2: \\r progress bars and newline-free
+        output must advance total_output_bytes — it is the wait-poll
+        progress signal, and readline() left it at zero."""
+        reg = ProcessRegistry()
+        started = await reg.start(
+            "localhost",
+            r"printf 'step 1\rstep 2\rstep 3\r'; printf 'no newline tail'; sleep 0.3",
+        )
+        pid = int(started.split("PID ")[1].split(")")[0])
+        result = await reg.poll(pid, wait_seconds=10)
+        assert "status=completed" in result
+        info = reg._processes[pid]
+        assert info.total_output_bytes >= len("step 1\rstep 2\rstep 3\r")
+        # \r segments render as display lines; the unterminated tail is
+        # flushed at EOF.
+        joined = "".join(info.output_buffer)
+        assert "step 2" in joined
+        assert "no newline tail" in joined
+
+    async def test_over_limit_line_does_not_kill_drainage(self):
+        """A single line beyond the asyncio stream limit (64KB) killed the
+        old readline() drainer; bounded raw reads cannot overrun."""
+        reg = ProcessRegistry()
+        size = 200_000
+        started = await reg.start(
+            "localhost",
+            f"python3 -c \"import sys; sys.stdout.write('x'*{size}); "
+            'sys.stdout.flush()"',
+        )
+        pid = int(started.split("PID ")[1].split(")")[0])
+        result = await reg.poll(pid, wait_seconds=15)
+        assert "status=completed" in result
+        assert reg._processes[pid].total_output_bytes == size
+
+    async def test_leader_exit_publishes_status_despite_pipe_holding_descendant(self):
+        """PR #244 round-1 blocker #3 (Odin's repro): `sleep 20 &` — the
+        leader exits immediately while the descendant holds stdout open.
+        Terminal state must publish at LEADER exit, and the group reap
+        (which is what closes the pipe) must not stall behind EOF."""
+        import os
+
+        reg = ProcessRegistry()
+        started = await reg.start("localhost", "sleep 20 & exit 0")
+        pid = int(started.split("PID ")[1].split(")")[0])
+        start = time.monotonic()
+        result = await reg.poll(pid, wait_seconds=15)
+        elapsed = time.monotonic() - start
+        assert elapsed < 10.0  # never waited on EOF or the full deadline
+        assert "status=completed" in result
+        assert "exit_code=0" in result
+        # The v3.59.1 contract: descendants are reaped at leader exit. Give
+        # the reap a moment, then probe group existence with signal 0 (a
+        # pure existence check, delivers nothing).
+        for _ in range(40):
+            try:
+                os.killpg(pid, 0)
+            except ProcessLookupError:
+                break
+            await asyncio.sleep(0.25)
+        with pytest.raises(ProcessLookupError):
+            os.killpg(pid, 0)
+
     async def test_wedged_reader_never_wedges_the_poll(self):
         """Process exits during the wait but the reader task hangs: the
         bounded (shielded) drain gives up and the poll still reports —
@@ -240,6 +303,8 @@ class TestPollWaitSeconds:
         and the shield must not cancel the reader."""
 
         class _ExitedProc:
+            returncode = 0  # leader already exited (SIGCHLD-reaped)
+
             async def wait(self):
                 return 0
 

--- a/tests/test_process_tree_reaping.py
+++ b/tests/test_process_tree_reaping.py
@@ -15,6 +15,7 @@ import asyncio
 import os
 import signal
 import time
+from pathlib import Path
 
 import pytest
 
@@ -22,12 +23,29 @@ from src.tools.process_manager import ProcessInfo, ProcessRegistry
 from src.tools.ssh import run_local_command, run_ssh_command, terminate_process_tree
 
 
+def _pid_dead(pid: int) -> bool:
+    """Dead means DEAD — including a zombie awaiting reap.
+
+    The process runs as a child subreaper (like production), so a killed
+    orphan reparents to us and lingers as a zombie until swept.
+    ``os.kill(pid, 0)`` still succeeds for it, so liveness is read from
+    /proc state instead.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_bytes()
+        return raw.rsplit(b")", 1)[1].split()[0] == b"Z"
+    except (OSError, IndexError):
+        return True
+
+
 async def _assert_pid_gone(pid: int, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
+        if _pid_dead(pid):
             return
         await asyncio.sleep(0.05)
     pytest.fail(f"PID {pid} is still alive")

--- a/tests/test_response_guards.py
+++ b/tests/test_response_guards.py
@@ -374,3 +374,161 @@ class TestScrubOutputSecrets:
         # Short strings starting with "eyJ" should NOT be scrubbed
         text = "The eyJump module is loaded."
         assert scrub_output_secrets(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Wait-class iterations (result-aware stuck detection)
+# ---------------------------------------------------------------------------
+
+from src.discord.response_guards import (  # noqa: E402
+    StuckLoopTracker,
+    _fingerprint_tool_calls,
+    is_wait_iteration,
+    wait_iteration_fingerprint,
+    wait_target_alive,
+)
+
+
+def _mp_render(pid=77, status="running", exit_code=None, uptime=3, out_bytes=100):
+    line = f"[PID {pid}] status={status}"
+    if exit_code is not None:
+        line += f" exit_code={exit_code}"
+    line += f" uptime={uptime}s output_bytes={out_bytes}"
+    return line + "\nsome build output\n"
+
+
+class TestIsWaitIteration:
+    def test_single_poll_is_wait(self):
+        calls = [{"name": "manage_process", "input": {"action": "poll", "pid": 1}}]
+        assert is_wait_iteration(calls) is True
+
+    def test_single_wait_for_agents_is_wait(self):
+        calls = [{"name": "wait_for_agents", "input": {"agent_ids": ["a"]}}]
+        assert is_wait_iteration(calls) is True
+
+    def test_manage_process_start_is_not_wait(self):
+        calls = [{"name": "manage_process", "input": {"action": "start", "command": "x"}}]
+        assert is_wait_iteration(calls) is False
+
+    def test_mixed_batch_is_never_wait(self):
+        """A changing poll result must never bless a repeated side-effecting
+        call riding beside it — two calls is a mixed batch, full stop."""
+        calls = [
+            {"name": "manage_process", "input": {"action": "poll", "pid": 1}},
+            {"name": "run_command", "input": {"command": "date"}},
+        ]
+        assert is_wait_iteration(calls) is False
+        assert is_wait_iteration([]) is False
+
+
+class TestWaitIterationFingerprint:
+    def test_uptime_is_excluded(self):
+        """Two polls differing ONLY in uptime are the SAME signature —
+        hashing elapsed time would make a hung process immortal."""
+        a = wait_iteration_fingerprint(
+            "manage_process", {"action": "poll", "pid": 77}, _mp_render(uptime=3)
+        )
+        b = wait_iteration_fingerprint(
+            "manage_process", {"action": "poll", "pid": 77}, _mp_render(uptime=120)
+        )
+        assert a == b
+
+    def test_output_bytes_growth_is_progress(self):
+        a = wait_iteration_fingerprint(
+            "manage_process", {}, _mp_render(out_bytes=100)
+        )
+        b = wait_iteration_fingerprint(
+            "manage_process", {}, _mp_render(out_bytes=200)
+        )
+        assert a != b
+
+    def test_status_transition_is_progress(self):
+        """running → completed with no new output is REAL progress."""
+        a = wait_iteration_fingerprint("manage_process", {}, _mp_render())
+        b = wait_iteration_fingerprint(
+            "manage_process", {}, _mp_render(status="completed", exit_code=0)
+        )
+        assert a != b
+
+    def test_different_pid_is_different_signature(self):
+        a = wait_iteration_fingerprint("manage_process", {}, _mp_render(pid=1))
+        b = wait_iteration_fingerprint("manage_process", {}, _mp_render(pid=2))
+        assert a != b
+
+    def test_non_report_results_are_stable(self):
+        """'No process with PID …' repeating identically must trip."""
+        a = wait_iteration_fingerprint("manage_process", {}, "No process with PID 5.")
+        b = wait_iteration_fingerprint("manage_process", {}, "No process with PID 5.")
+        assert a == b
+
+    def test_agents_signature_tracks_text_and_ids(self):
+        inp = {"agent_ids": ["a1", "a2"]}
+        r1 = "**x** (`a1`): running\n(no output)"
+        r2 = "**x** (`a1`): completed\nresult text"
+        assert wait_iteration_fingerprint("wait_for_agents", inp, r1) == \
+            wait_iteration_fingerprint("wait_for_agents", inp, r1)
+        assert wait_iteration_fingerprint("wait_for_agents", inp, r1) != \
+            wait_iteration_fingerprint("wait_for_agents", inp, r2)
+        assert wait_iteration_fingerprint(
+            "wait_for_agents", {"agent_ids": ["other"]}, r1
+        ) != wait_iteration_fingerprint("wait_for_agents", inp, r1)
+
+    def test_wait_prefix_disjoint_from_argument_fingerprints(self):
+        """A wait fingerprint can never equal an argument fingerprint —
+        the families share one window and must stay unambiguous."""
+        wf = wait_iteration_fingerprint("manage_process", {}, _mp_render())
+        assert wf.startswith("wait:")
+        af = _fingerprint_tool_calls(
+            [{"name": "manage_process", "input": {"action": "poll", "pid": 77}}]
+        )
+        assert not af.startswith("wait:")
+
+
+class TestWaitTargetAlive:
+    def test_running_process(self):
+        assert wait_target_alive("manage_process", _mp_render()) is True
+
+    def test_completed_process(self):
+        assert wait_target_alive(
+            "manage_process", _mp_render(status="completed", exit_code=0)
+        ) is False
+
+    def test_missing_process(self):
+        assert wait_target_alive("manage_process", "No process with PID 5.") is False
+
+    def test_running_agents(self):
+        assert wait_target_alive("wait_for_agents", "**x** (`a1`): running\n…") is True
+        assert wait_target_alive("wait_for_agents", "**x** (`a1`): completed\nok") is False
+
+
+class TestRecordFingerprintWindow:
+    def test_shared_window_and_order(self):
+        """record() and record_fingerprint() feed ONE window; three
+        identical wait fingerprints trip exactly like argument repeats."""
+        t = StuckLoopTracker()
+        fp = wait_iteration_fingerprint("manage_process", {}, _mp_render())
+        for _ in range(3):
+            t.record_fingerprint(fp)
+        assert t.check() is True
+
+    def test_progressing_wait_never_trips(self):
+        t = StuckLoopTracker()
+        for n in (100, 200, 300, 400, 500, 600):
+            t.record_fingerprint(
+                wait_iteration_fingerprint("manage_process", {}, _mp_render(out_bytes=n))
+            )
+        assert t.check() is False
+
+    def test_mixed_family_cycle_still_detected(self):
+        """A frozen poll interleaved with an identical spacer call is a
+        cycle-length-2 repeat — spacing polls does not hide a dead build."""
+        t = StuckLoopTracker()
+        wf = wait_iteration_fingerprint("manage_process", {}, _mp_render())
+        af = _fingerprint_tool_calls([{"name": "run_command", "input": {"command": "sleep 30"}}])
+        for _ in range(3):
+            t.record_fingerprint(wf)
+            t.record(
+                [{"name": "run_command", "input": {"command": "sleep 30"}}]
+            )
+        assert af  # sanity: spacer has a real fingerprint
+        assert t.check() is True

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -80,3 +80,56 @@ class TestReexec:
         with patch("os.execve", side_effect=OSError("bad interpreter")):
             with pytest.raises(OSError):
                 restart.reexec()
+
+
+class TestReexecVetoInMain:
+    """PR #244 round-8 #3: teardown that could not prove it terminated
+    everything it owned must PREVENT the in-place exec — the new image
+    would otherwise inherit survivors invisibly."""
+
+    def test_veto_state_round_trips(self):
+        restart.reset()
+        assert restart.reexec_blocked() is None
+        restart.block_reexec("process cleanup unverified: PID [4242]")
+        assert "4242" in (restart.reexec_blocked() or "")
+
+    def test_main_exits_instead_of_execing_when_vetoed(self, monkeypatch):
+        """The real tail of main(): restart requested AND vetoed → exit,
+        never execve."""
+        import src.__main__ as main_mod
+
+        restart.reset()
+        restart.request_restart()
+        restart.block_reexec("process cleanup unverified: PID [4242]")
+
+        # Drive only the post-loop tail by faking the run phase.
+        monkeypatch.setattr(main_mod.asyncio, "new_event_loop", lambda: _StubLoop())
+        monkeypatch.setattr(main_mod.asyncio, "set_event_loop", lambda _l: None)
+        monkeypatch.setattr(main_mod.asyncio, "all_tasks", lambda _l: [])
+        with patch("os.execve") as execve, patch.object(
+            main_mod.restart, "reexec", side_effect=AssertionError("must not exec")
+        ):
+            with pytest.raises(SystemExit) as exit_info:
+                main_mod.main()
+            assert exit_info.value.code != 0
+            execve.assert_not_called()
+        restart.reset()
+
+
+class _StubLoop:
+    """Minimal event loop stand-in: main() only needs run_until_complete,
+    close, and the drain hooks for the tail under test."""
+
+    def run_until_complete(self, coro):
+        if hasattr(coro, "close"):
+            coro.close()
+        return None
+
+    def close(self):
+        return None
+
+    def shutdown_asyncgens(self):
+        return None
+
+    def shutdown_default_executor(self):
+        return None

--- a/tests/test_resume_admission.py
+++ b/tests/test_resume_admission.py
@@ -455,18 +455,23 @@ class TestProductionPipelinePath:
         assert h2.row()[0] == TurnStatus.SUSPENDED
 
         heal_capacity(h2, text_response("Pipeline auto-finish."))
-        # Wait for a TERMINAL status — the row passes through ACTIVE while
-        # the auto-resume runs (breaking on first non-SUSPENDED raced the
-        # in-flight resume under coverage instrumentation).
+
+        def delivered() -> bool:
+            return any(
+                "Pipeline auto-finish." in (r["content"] or "")
+                for r in original.replies
+            )
+
+        # Wait for the USER-VISIBLE outcome, not just the row status: the
+        # turn settles TERMINAL a moment before delivery completes, and
+        # asserting on the status alone raced the reply under coverage
+        # instrumentation on CI.
         for _ in range(600):
             await asyncio.sleep(0.05)
-            if h2.row()[0] in TurnStatus.TERMINAL:
+            if h2.row()[0] in TurnStatus.TERMINAL and delivered():
                 break
         assert h2.row()[0] == TurnStatus.TERMINAL_COMPLETED
-        assert any(
-            "Pipeline auto-finish." in (r["content"] or "")
-            for r in original.replies
-        )
+        assert delivered()
         for task in list(h2.manager._waiters.values()):
             task.cancel()
 

--- a/tests/test_resume_admission.py
+++ b/tests/test_resume_admission.py
@@ -1094,3 +1094,23 @@ class TestRestoredTrackerJudgedBeforeGeneration:
         assert result is not None
         assert result[0] == "resumed and acted on the nudge"
         assert len(h.fake.calls) == calls_before + 1  # generation GRANTED
+
+
+class TestLegacyCheckpointCompatibility:
+    async def test_pre_pr244_checkpoint_resumes_with_default_pending(self, tmp_path):
+        """PR #244 round-4 blocker #2: suspended checkpoints written by
+        v3.67.0 (no wait_judgment_pending, same CODEC_VERSION) must resume
+        after upgrade — the field defaults to False during validation,
+        AFTER the store's digest verification."""
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("resumed a legacy checkpoint"))
+        make_breaker_probe_ready(h)
+        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
+        payload = json.loads(payload_text)
+        del payload["fields"]["wait_judgment_pending"]  # the v3.67.0 shape
+        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+        assert result is not None
+        assert result[0] == "resumed a legacy checkpoint"
+        assert h.row()[0] == TurnStatus.TERMINAL_COMPLETED

--- a/tests/test_resume_admission.py
+++ b/tests/test_resume_admission.py
@@ -981,3 +981,95 @@ class TestCheckpointIntegrityRejectsSameTypeTampering:
         assert "no longer resumable" in result[0]
         assert len(h.fake.calls) == calls_before
         assert h.row()[0] == TurnStatus.TERMINAL_REJECTED
+
+
+class TestRestoredTrackerJudgedBeforeGeneration:
+    """PR #244 round-2 blocker #2: the wait fingerprint survives WI-4, so
+    its pending judgment must survive too — a crash between checkpoint and
+    judgment must not buy the resumed turn a free generation-plus-poll."""
+
+    @staticmethod
+    def _trip_tracker(h, *, warned: bool):
+        (payload_text,) = h.store._conn.execute(
+            "SELECT payload FROM turns"
+        ).fetchone()
+        payload = json.loads(payload_text)
+        fp = "wait:mp:77:running::500"
+        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
+        payload["fields"]["stuck_tracker"]["warned"] = warned
+        rewrite_payload_with_valid_digest(
+            h.store, json.dumps(payload, sort_keys=True)
+        )
+
+    async def test_unconsumed_warning_nudges_before_first_generation(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("acted on the nudge"))
+        make_breaker_probe_ready(h)
+        self._trip_tracker(h, warned=False)
+        calls_before = len(h.fake.calls)
+
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+
+        assert result is not None and result[0] == "acted on the nudge"
+        assert len(h.fake.calls) == calls_before + 1  # exactly one generation
+        # The FIRST resumed generation already carried the wait nudge.
+        devs = h.fake.developer_messages_of_call(calls_before)
+        assert any("wait_seconds" in d for d in devs)
+
+    async def test_consumed_warning_terminates_with_zero_generations(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("must never generate"))
+        make_breaker_probe_ready(h)
+        self._trip_tracker(h, warned=True)
+        calls_before = len(h.fake.calls)
+
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+
+        assert result is not None
+        assert "already" in result[0] and "not touched" in result[0]
+        assert len(h.fake.calls) == calls_before  # ZERO generations
+
+    async def test_restored_agents_fp_gets_agents_nudge(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("adjusted the wait"))
+        make_breaker_probe_ready(h)
+        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
+        payload = json.loads(payload_text)
+        fp = "wait:agents:a1,a2:deadbeef"
+        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
+        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        calls_before = len(h.fake.calls)
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+        assert result is not None and result[0] == "adjusted the wait"
+        devs = h.fake.developer_messages_of_call(calls_before)
+        assert any("get_agent_results" in d for d in devs)
+
+    async def test_restored_terminal_target_fp_gets_ordinary_guidance(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("acted on it"))
+        make_breaker_probe_ready(h)
+        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
+        payload = json.loads(payload_text)
+        fp = "wait:mp:77:completed:0:500"
+        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
+        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        calls_before = len(h.fake.calls)
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+        assert result is not None
+        devs = h.fake.developer_messages_of_call(calls_before)
+        assert any("finished or missing target" in d for d in devs)
+
+    async def test_restored_argument_fp_gets_classic_nudge(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("changed approach"))
+        make_breaker_probe_ready(h)
+        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
+        payload = json.loads(payload_text)
+        fp = "parse_time({'text': 'now'})"
+        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
+        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        calls_before = len(h.fake.calls)
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+        assert result is not None
+        devs = h.fake.developer_messages_of_call(calls_before)
+        assert any("repeating the same tool-call sequence" in d for d in devs)

--- a/tests/test_resume_admission.py
+++ b/tests/test_resume_admission.py
@@ -1097,20 +1097,46 @@ class TestRestoredTrackerJudgedBeforeGeneration:
 
 
 class TestLegacyCheckpointCompatibility:
-    async def test_pre_pr244_checkpoint_resumes_with_default_pending(self, tmp_path):
+    async def test_pre_pr244_v1_checkpoint_resumes_with_default_pending(self, tmp_path):
         """PR #244 round-4 blocker #2: suspended checkpoints written by
-        v3.67.0 (no wait_judgment_pending, same CODEC_VERSION) must resume
-        after upgrade — the field defaults to False during validation,
-        AFTER the store's digest verification."""
+        v3.67.0 (codec v1, no wait_judgment_pending) must resume after
+        upgrade — the field defaults to False during validation, AFTER
+        the store's digest verification."""
         h, original = await suspend_turn(tmp_path)
         heal_capacity(h, text_response("resumed a legacy checkpoint"))
         make_breaker_probe_ready(h)
         (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
         payload = json.loads(payload_text)
         del payload["fields"]["wait_judgment_pending"]  # the v3.67.0 shape
+        payload["codec_version"] = 1  # written by the older codec
         rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
 
         result = await h.manager.try_explicit_resume(resume_msg(original))
         assert result is not None
         assert result[0] == "resumed a legacy checkpoint"
         assert h.row()[0] == TurnStatus.TERMINAL_COMPLETED
+
+    async def test_new_writers_emit_v2(self, tmp_path):
+        h, _original = await suspend_turn(tmp_path)
+        payload = json.loads(h.row()[1])
+        assert payload["codec_version"] == 2
+
+    async def test_v2_payload_missing_the_field_is_malformed(self, tmp_path):
+        """Round-5 blocker #3: version scoping makes the two cases
+        distinguishable — a CURRENT payload missing the field is corrupt
+        and must still be rejected, never silently defaulted."""
+        h, original = await suspend_turn(tmp_path)
+        heal_capacity(h, text_response("must never generate"))
+        make_breaker_probe_ready(h)
+        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
+        payload = json.loads(payload_text)
+        assert payload["codec_version"] == 2
+        del payload["fields"]["wait_judgment_pending"]
+        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        calls_before = len(h.fake.calls)
+
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+        assert result is not None
+        assert "could not be restored" in result[0]
+        assert len(h.fake.calls) == calls_before  # ZERO generation
+        assert h.row()[0] == TurnStatus.TERMINAL_REJECTED

--- a/tests/test_resume_admission.py
+++ b/tests/test_resume_admission.py
@@ -663,6 +663,96 @@ class TestMonotonicSessionFence:
         assert sess.mutation_revision("chX") == 3  # removal GROWS the watermark
 
 
+class _FakeBotUser:
+    def __init__(self, id: int) -> None:
+        self.id = id
+
+
+class TestMentionAnchoredResumeTrigger:
+    """Tag-mode channels force `@bot resume` — ONE leading anchored bot
+    mention is stripped before trigger matching. Anchored only; the exact
+    bare-command contract (trailing `!`/`.` tolerance included) is
+    otherwise unchanged."""
+
+    BOT_ID = 424242
+
+    def _arm(self, h):
+        h.manager._get_bot_user = lambda: _FakeBotUser(self.BOT_ID)
+
+    async def test_leading_mention_resume_triggers(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        self._arm(h)
+        heal_capacity(h, text_response("resumed output"))
+        make_breaker_probe_ready(h)
+        result = await h.manager.try_explicit_resume(
+            resume_msg(original, content=f"<@{self.BOT_ID}> resume")
+        )
+        assert result is not None  # recognized as the resume command
+        assert h.row()[0] != TurnStatus.SUSPENDED  # it acted on the turn
+
+    async def test_nickname_mention_form_triggers(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        self._arm(h)
+        heal_capacity(h, text_response("resumed output"))
+        make_breaker_probe_ready(h)
+        result = await h.manager.try_explicit_resume(
+            resume_msg(original, content=f"<@!{self.BOT_ID}> resume!")
+        )
+        assert result is not None  # <@!id> form + trailing-! contract intact
+
+    async def test_trailing_mention_is_not_a_command(self, tmp_path):
+        """`resume @bot` must run as a normal message — the strip is
+        anchored, never intake's strip-anywhere cleaning."""
+        h, original = await suspend_turn(tmp_path)
+        self._arm(h)
+        result = await h.manager.try_explicit_resume(
+            resume_msg(original, content=f"resume <@{self.BOT_ID}>")
+        )
+        assert result is None
+        assert h.row()[0] == TurnStatus.SUSPENDED  # untouched
+
+    async def test_mention_plus_sentence_is_not_a_command(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        self._arm(h)
+        result = await h.manager.try_explicit_resume(
+            resume_msg(
+                original,
+                content=f"<@{self.BOT_ID}> resume what you were doing",
+            )
+        )
+        assert result is None
+        assert h.row()[0] == TurnStatus.SUSPENDED
+
+    async def test_foreign_mention_is_not_stripped(self, tmp_path):
+        h, original = await suspend_turn(tmp_path)
+        self._arm(h)
+        result = await h.manager.try_explicit_resume(
+            resume_msg(original, content="<@777> resume")
+        )
+        assert result is None  # someone ELSE's mention is ordinary text
+
+    async def test_mention_recognized_trigger_still_fails_closed(self, tmp_path):
+        """The no-raise boundary anchors on CANDIDATE recognition: a store
+        read failure after a mention-form trigger refuses, never falls
+        through to a fresh turn."""
+        h, original = await suspend_turn(tmp_path)
+        self._arm(h)
+        heal_capacity(h, text_response("fresh turn that must never run"))
+        calls_before = len(h.fake.calls)
+
+        def boom(source=None):
+            raise OSError("forced read failure")
+
+        h.store.list_suspended_sync = boom
+        result = await h.manager.try_explicit_resume(
+            resume_msg(original, content=f"<@{self.BOT_ID}> resume")
+        )
+        assert result is not None
+        assert "Nothing was resumed or started fresh" in result[0]
+        assert len(h.fake.calls) == calls_before
+        assert h.row()[0] == TurnStatus.SUSPENDED
+
+
 class TestResumeLookupFailureFailClosed:
     async def test_first_store_read_failure_refuses_before_fresh_generation(
         self, tmp_path

--- a/tests/test_resume_admission.py
+++ b/tests/test_resume_admission.py
@@ -989,14 +989,18 @@ class TestRestoredTrackerJudgedBeforeGeneration:
     judgment must not buy the resumed turn a free generation-plus-poll."""
 
     @staticmethod
-    def _trip_tracker(h, *, warned: bool):
+    def _trip_tracker(h, *, warned: bool, fp: str = "wait:mp:77:running::500",
+                      pending: bool = True):
         (payload_text,) = h.store._conn.execute(
             "SELECT payload FROM turns"
         ).fetchone()
         payload = json.loads(payload_text)
-        fp = "wait:mp:77:running::500"
         payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
         payload["fields"]["stuck_tracker"]["warned"] = warned
+        # The crash window this class models: the fingerprint's WI-4 landed
+        # but its judgment never ran — the EXPLICIT persisted phase
+        # (round-3 blocker #1), never inferred from fingerprints.
+        payload["fields"]["wait_judgment_pending"] = pending
         rewrite_payload_with_valid_digest(
             h.store, json.dumps(payload, sort_keys=True)
         )
@@ -1033,11 +1037,7 @@ class TestRestoredTrackerJudgedBeforeGeneration:
         h, original = await suspend_turn(tmp_path)
         heal_capacity(h, text_response("adjusted the wait"))
         make_breaker_probe_ready(h)
-        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
-        payload = json.loads(payload_text)
-        fp = "wait:agents:a1,a2:deadbeef"
-        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
-        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        self._trip_tracker(h, warned=False, fp="wait:agents:a1,a2:deadbeef")
         calls_before = len(h.fake.calls)
         result = await h.manager.try_explicit_resume(resume_msg(original))
         assert result is not None and result[0] == "adjusted the wait"
@@ -1048,28 +1048,49 @@ class TestRestoredTrackerJudgedBeforeGeneration:
         h, original = await suspend_turn(tmp_path)
         heal_capacity(h, text_response("acted on it"))
         make_breaker_probe_ready(h)
-        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
-        payload = json.loads(payload_text)
-        fp = "wait:mp:77:completed:0:500"
-        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
-        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        self._trip_tracker(h, warned=False, fp="wait:mp:77:completed:0:500")
         calls_before = len(h.fake.calls)
         result = await h.manager.try_explicit_resume(resume_msg(original))
         assert result is not None
         devs = h.fake.developer_messages_of_call(calls_before)
         assert any("finished or missing target" in d for d in devs)
 
-    async def test_restored_argument_fp_gets_classic_nudge(self, tmp_path):
+    async def test_delivered_nudge_is_never_rejudged_on_resume(self, tmp_path):
+        """PR #244 round-3 blocker #1 (tampered form): a tripped tracker
+        with warned=True but NO pending judgment is a nudge that was
+        already delivered — the resumed turn gets its post-nudge
+        generation, never a zero-generation kill."""
         h, original = await suspend_turn(tmp_path)
-        heal_capacity(h, text_response("changed approach"))
+        heal_capacity(h, text_response("acted on the earlier nudge"))
         make_breaker_probe_ready(h)
-        (payload_text,) = h.store._conn.execute("SELECT payload FROM turns").fetchone()
-        payload = json.loads(payload_text)
-        fp = "parse_time({'text': 'now'})"
-        payload["fields"]["stuck_tracker"]["fingerprints"] = [fp, fp, fp]
-        rewrite_payload_with_valid_digest(h.store, json.dumps(payload, sort_keys=True))
+        self._trip_tracker(h, warned=True, pending=False)
+        calls_before = len(h.fake.calls)
+        result = await h.manager.try_explicit_resume(resume_msg(original))
+        assert result is not None and result[0] == "acted on the earlier nudge"
+        assert len(h.fake.calls) == calls_before + 1  # generation GRANTED
+
+    async def test_real_nudge_then_suspension_resumes_into_generation(self, tmp_path):
+        """PR #244 round-3 blocker #1 (Odin's exact repro, no tamper):
+        frozen polls → nudge delivered in-turn (WI-5) → capacity failure
+        suspends → resume must generate, not terminate."""
+        h, original = await suspend_turn(
+            tmp_path,
+            script=[
+                tool_call_response(("manage_process", {"action": "poll", "pid": 9})),
+                tool_call_response(("manage_process", {"action": "poll", "pid": 9})),
+                tool_call_response(("manage_process", {"action": "poll", "pid": 9})),
+                # 4th generation (post-nudge) hits capacity → suspends
+            ],
+        )
+        # Suspension happened AFTER the nudge: warned consumed, judgment
+        # NOT pending (it completed by delivering the nudge).
+        payload = json.loads(h.row()[1])
+        assert payload["fields"]["stuck_tracker"]["warned"] is True
+        assert payload["fields"]["wait_judgment_pending"] is False
+
+        heal_capacity(h, text_response("resumed and acted on the nudge"))
         calls_before = len(h.fake.calls)
         result = await h.manager.try_explicit_resume(resume_msg(original))
         assert result is not None
-        devs = h.fake.developer_messages_of_call(calls_before)
-        assert any("repeating the same tool-call sequence" in d for d in devs)
+        assert result[0] == "resumed and acted on the nudge"
+        assert len(h.fake.calls) == calls_before + 1  # generation GRANTED

--- a/tests/test_turn_durability_heartbeat.py
+++ b/tests/test_turn_durability_heartbeat.py
@@ -52,11 +52,39 @@ async def admit(store):
 async def test_beats_keep_the_lease_alive_past_the_ttl(tmp_path):
     store = make_store(tmp_path, ttl=0.3)
     handle = await admit(store)
-    await asyncio.sleep(0.8)  # ~2.5x TTL, several real beats
-    (expires,) = store._conn.execute(
-        "SELECT lease_expires_at FROM turns"
-    ).fetchone()
-    assert expires > time.time()  # still alive
+
+    def expiry() -> float:
+        (value,) = store._conn.execute(
+            "SELECT lease_expires_at FROM turns"
+        ).fetchone()
+        return float(value)
+
+    # Observe RENEWALS rather than sampling liveness at one instant: under
+    # coverage instrumentation a beat can land late, and an instantaneous
+    # "expires > now" check then fails for a lease that is being renewed
+    # perfectly well. The contract is that beats keep pushing the deadline
+    # out past the original TTL.
+    original = expiry()  # the deadline the turn would die on unaided
+    renewals = 0
+    renewed_past_original = False
+    last = original
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+        current = expiry()
+        if current > last:
+            renewals += 1
+            last = current
+            if time.time() > original:
+                # A renewal recorded AFTER the original deadline had
+                # already passed: the lease outlived it because beats
+                # kept pushing it out.
+                renewed_past_original = True
+        if renewals >= 2 and renewed_past_original:
+            break
+    assert renewals >= 2, "heartbeat never renewed the lease twice"
+    assert renewed_past_original, "lease was never renewed past its first deadline"
+
     await handle.settle_terminal(cancelled=False, is_error=False)
     assert handle._heartbeat_task is None  # stopped on settlement
     store.close()

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -241,11 +241,13 @@ def _make_runner(recorder_save=None):
 
 
 def _stub_state(channel=None):
+    from src.discord.response_guards import StuckLoopTracker
     from src.turn_state.durability import TurnDurability
 
     return SimpleNamespace(
         chat_cap=3,
         iteration=0,
+        stuck_tracker=StuckLoopTracker(),
         _cancel=asyncio.Event(),
         _trajectory=SimpleNamespace(),
         trace=None,

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -248,6 +248,7 @@ def _stub_state(channel=None):
         chat_cap=3,
         iteration=0,
         stuck_tracker=StuckLoopTracker(),
+        wait_judgment_pending=False,
         _cancel=asyncio.Event(),
         _trajectory=SimpleNamespace(),
         trace=None,

--- a/tests/test_wait_stuck_integration.py
+++ b/tests/test_wait_stuck_integration.py
@@ -241,3 +241,16 @@ class TestMixedBatchKeepsStrictDetector:
         # Pre-execution kill: the third (nudge) and fourth (kill) batches
         # never executed — 2 batches × 2 calls.
         assert bot.tool_executor.execute.await_count == 4
+
+
+class TestWaitResultTextPairing:
+    def test_unmatched_tool_use_id_yields_empty(self):
+        from types import SimpleNamespace
+
+        from src.discord.tool_loop import ToolLoopRunner
+
+        out = ToolLoopRunner._wait_result_text(
+            [SimpleNamespace(id="call-x")],
+            [{"tool_use_id": "call-y", "content": "other"}],
+        )
+        assert out == ""

--- a/tests/test_wait_stuck_integration.py
+++ b/tests/test_wait_stuck_integration.py
@@ -176,6 +176,50 @@ class TestFrozenWaitLadder:
         assert not any("wait_seconds" in d for d in devs)
 
 
+class TestFingerprintRidesTheCheckpoint:
+    async def test_wait_fingerprint_recorded_before_wi4_judged_after(self, monkeypatch):
+        """PR #244 round-1 blocker #1: the wait fingerprint must be IN the
+        tracker when WI-4 checkpoints the settled batch (a crash after the
+        checkpoint must not forget the stuck observation), while the nudge
+        appears only AFTER WI-4 — judgment is deferred until the
+        observation is durable."""
+        from src.turn_state.durability import TurnDurability
+
+        events: list[tuple[str, int, bool]] = []
+        orig = TurnDurability.on_batch_settled
+
+        async def spy(self, st):
+            fps = list(st.stuck_tracker._fingerprints)
+            nudged = any(
+                isinstance(m, dict)
+                and m.get("role") == "developer"
+                and "wait_seconds" in str(m.get("content", ""))
+                for m in st.messages
+            )
+            events.append(
+                ("wi4", sum(f.startswith("wait:") for f in fps), nudged)
+            )
+            return await orig(self, st)
+
+        monkeypatch.setattr(TurnDurability, "on_batch_settled", spy)
+
+        bot, fake = build([poll_call() for _ in range(5)])
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[poll_result(uptime=3 * (i + 1), out_bytes=500) for i in range(5)]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert is_error is True
+        # Every settled wait batch checkpointed WITH its own fingerprint
+        # already recorded: counts grow 1,2,3,4 across the four executed
+        # iterations.
+        assert [n for (_, n, _) in events] == [1, 2, 3, 4]
+        # And the nudge was NOT yet in the transcript at the third WI-4 —
+        # judgment ran after the checkpoint, never before.
+        assert events[2][2] is False
+        # By the fourth WI-4 (the post-nudge retry) it was.
+        assert events[3][2] is True
+
+
 class TestMixedBatchKeepsStrictDetector:
     async def test_poll_plus_side_effect_uses_pre_execution_detector(self):
         """Two-call batches never take the wait path: the argument-only

--- a/tests/test_wait_stuck_integration.py
+++ b/tests/test_wait_stuck_integration.py
@@ -1,0 +1,199 @@
+"""Wait-class stuck detection through the real chat tool loop.
+
+Pins the post-execution judgment path (design settled with Odin,
+2026-07-31): an iteration that is exactly one wait-class call is judged on
+a result-aware fingerprint AFTER execution — progressing waits never trip,
+frozen waits walk the same warn-once-then-terminate ladder, and mixed
+batches keep the pre-execution argument-only detector byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.tools.result_validator import ToolResult
+from tests.fakes import (
+    FakeLLM,
+    FakeMessage,
+    make_bot,
+    text_response,
+    tool_call_response,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def poll_call():
+    return tool_call_response(("manage_process", {"action": "poll", "pid": 77}))
+
+
+def poll_result(*, status="running", exit_code=None, uptime=3, out_bytes=100):
+    line = f"[PID 77] status={status}"
+    if exit_code is not None:
+        line += f" exit_code={exit_code}"
+    line += f" uptime={uptime}s output_bytes={out_bytes}"
+    return ToolResult(output=line + "\nbuild output\n", tool_name="manage_process")
+
+
+def build(script):
+    fake = FakeLLM(script)
+    bot = make_bot(fake_llm=fake)
+    return bot, fake
+
+
+async def run_loop(bot, msg):
+    return await bot.tool_loop.run(msg, history=[], system_prompt_override=None)
+
+
+def _developer_texts(fake):
+    return [
+        dev
+        for i in range(len(fake.calls))
+        for dev in fake.developer_messages_of_call(i)
+    ]
+
+
+class TestProgressingWaitNeverTrips:
+    async def test_advancing_output_bytes_poll_forever(self):
+        """Six identical-argument polls with growing output: no nudge, no
+        termination — the exact false positive that killed the 2026-07-30
+        animal-gif-catalog build turn."""
+        bot, fake = build([poll_call() for _ in range(6)] + [text_response("build finished")])
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                poll_result(uptime=3 * (i + 1), out_bytes=100 * (i + 1)) for i in range(6)
+            ]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch the build"))
+        assert text == "build finished"
+        assert is_error is False
+        assert bot.tool_executor.execute.await_count == 6
+        assert not any("no new output" in d for d in _developer_texts(fake))
+
+    async def test_status_transition_counts_as_progress(self):
+        """running → completed with identical bytes is progress, not a
+        repeat — the silent-finish transition must never be penalized."""
+        bot, fake = build(
+            [poll_call(), poll_call(), poll_call(), text_response("done")]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                poll_result(uptime=3),
+                poll_result(uptime=6),
+                poll_result(status="completed", exit_code=0, uptime=9),
+            ]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert text == "done"
+        assert is_error is False
+
+
+class TestFrozenWaitLadder:
+    async def test_frozen_poll_nudges_then_terminates_post_execution(self):
+        """Identical signatures (uptime advancing, bytes frozen) walk the
+        ladder — and unlike the argument detector, EVERY iteration
+        executed: the fourth poll's result was recorded before the kill
+        (Odin's ordering: terminate only after the latest result is
+        durable)."""
+        bot, fake = build([poll_call() for _ in range(5)])
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[poll_result(uptime=3 * (i + 1), out_bytes=500) for i in range(5)]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert is_error is True
+        assert "no observable progress" in text
+        assert "was not touched" in text  # the detached work is never killed
+        # Post-execution semantics: the tripping iterations all executed.
+        assert bot.tool_executor.execute.await_count == 4
+        # The wait-aware nudge (not the generic one) was injected once.
+        final_devs = fake.developer_messages_of_call(len(fake.calls) - 1)
+        assert sum("wait_seconds" in d for d in final_devs) == 1
+        assert not any(
+            "repeating the same tool-call sequence" in d for d in final_devs
+        )
+
+    async def test_nudge_respected_breaks_the_pattern(self):
+        """A different call after the nudge breaks the tail — no kill."""
+        bot, fake = build(
+            [
+                poll_call(),
+                poll_call(),
+                poll_call(),  # third frozen signature → nudge
+                tool_call_response(("parse_time", {"text": "now"})),
+                text_response("acted on it"),
+            ]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[poll_result(uptime=3 * (i + 1), out_bytes=500) for i in range(3)]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert text == "acted on it"
+        assert is_error is False
+
+    async def test_warned_is_one_shot_across_later_freeze(self):
+        """Progress after the nudge never re-arms the warning budget: a
+        later frozen trio terminates immediately, no second nudge."""
+        script = (
+            [poll_call(), poll_call(), poll_call()]  # freeze → nudge
+            + [tool_call_response(("parse_time", {"text": "now"}))]  # breaks tail
+            + [poll_call(), poll_call(), poll_call()]  # freezes again → kill
+        )
+        bot, fake = build(script)
+        results = [poll_result(uptime=3 * (i + 1), out_bytes=500) for i in range(3)] + [
+            poll_result(uptime=60 + 3 * (i + 1), out_bytes=500) for i in range(3)
+        ]
+        bot.tool_executor.execute = AsyncMock(side_effect=results)
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert is_error is True
+        assert "no observable progress" in text
+        # The transcript accumulates, so the FINAL call's developer messages
+        # hold every injection exactly once: one nudge total, ever.
+        final_devs = fake.developer_messages_of_call(len(fake.calls) - 1)
+        assert sum("wait_seconds" in d for d in final_devs) == 1
+
+    async def test_terminal_target_repetition_gets_ordinary_guidance(self):
+        """Re-polling a finished process is not 'still running' — the nudge
+        must not claim the target is alive."""
+        bot, fake = build(
+            [poll_call(), poll_call(), poll_call(), text_response("ok, it exited 0")]
+        )
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=[
+                poll_result(status="completed", exit_code=0, uptime=9 + i)
+                for i in range(3)
+            ]
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert text == "ok, it exited 0"
+        assert is_error is False
+        devs = _developer_texts(fake)
+        assert any("finished or missing target" in d for d in devs)
+        assert not any("wait_seconds" in d for d in devs)
+
+
+class TestMixedBatchKeepsStrictDetector:
+    async def test_poll_plus_side_effect_uses_pre_execution_detector(self):
+        """Two-call batches never take the wait path: the argument-only
+        detector fires BEFORE execution with the original messages."""
+        batch = tool_call_response(
+            ("manage_process", {"action": "poll", "pid": 77}),
+            ("run_command", {"command": "date"}),
+        )
+        bot, fake = build([batch, batch, batch, batch])
+        bot.tool_executor.execute = AsyncMock(
+            side_effect=lambda *a, **k: poll_result(out_bytes=999)
+        )
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("watch"))
+        assert is_error is True
+        assert "stuck tool-call cycle" in text  # the ORIGINAL terminal text
+        devs = _developer_texts(fake)
+        assert any("repeating the same tool-call sequence" in d for d in devs)
+        assert not any("wait_seconds" in d for d in devs)
+        # Pre-execution kill: the third (nudge) and fourth (kill) batches
+        # never executed — 2 batches × 2 calls.
+        assert bot.tool_executor.execute.await_count == 4


### PR DESCRIPTION
Two field-found fixes from the 2026-07-30 build-monitoring incident (design settled with Odin over the bridge; all his amendments adopted).

## 1. Resume trigger unreachable in mention-required channels
`try_explicit_resume` matched the trigger against raw `message.content`, so in tag mode `@bot resume` could never fire — the command only worked in DMs. Recognition now strips ONE leading anchored bot mention (`<@id>`/`<@!id>`) before matching. Deliberately anchored: `resume @bot` and mention-plus-sentence stay ordinary messages; foreign mentions are never stripped; the exact bare-command contract (trailing `!`/`.` tolerance) is unchanged; identity/admission checks keep the raw message. The recognized-never-falls-through boundary (PR #242) now anchors on candidate recognition — pinned including a forced store-read failure under mention-form recognition.

## 2. Stuck tracker killed a healthy build-monitoring turn
Four byte-identical `manage_process poll` iterations of a healthy streaming docker build walked the argument-only detector's ladder. Two complementary fixes:

**`wait_seconds` on `manage_process poll` (0–120, default 0 = byte-compatible):** one call now waits server-side until the process EXITS or the deadline elapses — never an early-output wakeup (a streaming build would return instantly and defeat the purpose). Terminal processes report immediately; exit during the wait returns early after a bounded shielded reader drain; cancellation aborts only the wait, never the detached process; invalid values are rejected, not clamped. The 120s ceiling stays under the executor's 300s per-tool wall; longer monitoring is chained polls. `ProcessInfo.total_output_bytes` (reader-incremented, unbounded by the ring) is reported by poll — the monotonic progress signal a full ring of repeated lines cannot provide.

**Result-aware stuck judgment for wait-class iterations:** an iteration that is exactly one wait-class call (`manage_process poll` / `wait_for_agents`) defers stuck judgment until AFTER execution and records a `wait:`-prefixed semantic fingerprint in the same tracker window — status transitions and output-byte growth are progress; volatile fields (uptime/runtimes) are excluded so a hung target cannot become immortal; a frozen signature walks the same warn-once-then-terminate ladder. Ordering per the settled design: the kill runs only after WI-4 checkpointed the result that proved the freeze; the nudge + consumed `warned` flag go durable via WI-5 before the retry generation; `warned` stays one-shot (later progress never re-arms it — pinned). Mixed batches keep the strict pre-execution detector byte-for-byte, and a frozen poll spaced by identical spacer calls still trips as a cycle-length-2 repeat (pinned). Nudges are wait-aware and status-aware; a terminal target gets ordinary guidance, never 'still running'.

## Fences
- Tracker stays chat-only (agents/loops benefit only via the cheaper tool itself — no new integration).
- Ledger contract untouched: a poll RUNNING at crash still settles OUTCOME_UNKNOWN.
- No checkpoint-schema change: fingerprints remain strings; the `wait:` prefix keeps the two families disjoint in one window.
- `wait_seconds=0` behavior byte-identical; manage_process parity hash updated deliberately.

## Flag for review judgment
The `wait_for_agents` signature hashes the rendered result (volatile-free by construction: label/status/content only) — it does NOT include agent iteration count, so an agent progressing silently across two full timeouts with no result draws the nudge. The nudge advice is followable (longer timeout / `get_agent_results`), and `wait_for_agents` already blocks up to its own timeout, so repetition there is rare. If you want manager-state (per-agent iteration count) in the signature instead, say so.

## Gates
Suite 7,969 passed / 5 skipped (+39 vs master); ruff clean; lint gate new=0; type gate new=0; coverage findings=0 @ 88.5%. 38 new pins across resume-trigger anchoring, wait semantics (incl. cancellation safety and the wedged-reader drain bound), fingerprint canonicalization, ladder integration, mixed-batch preservation, and one-shot warned.