### PR TITLE
feat: capability-filter the per-spawn effort catalogue for concrete agent models

### DIFF
--- a/src/tools/agent_tool_policy.py
+++ b/src/tools/agent_tool_policy.py
@@ -50,6 +50,16 @@ def _spawn_properties(tool: dict) -> dict:
     return schema["properties"]
 
 
+def _spawn_schema_object(tool: dict) -> dict:
+    """The object schema that owns the ``required`` list for the per-spawn
+    fields: the input schema itself for spawn_agent, ``tasks.items`` for
+    spawn_loop_agents."""
+    schema = tool["input_schema"]
+    if tool["name"] == "spawn_loop_agents":
+        return schema["properties"]["tasks"]["items"]
+    return schema
+
+
 # get_tool_definitions() appends an affordances annotation to every description
 # ("\n\n[affordances: ...]"); the catalog conditions the ALREADY-annotated defs,
 # so the suffix must be carried through when the content is rebuilt.
@@ -62,6 +72,7 @@ def _condition_spawn_tool(
     model_auto: bool,
     effort_auto: bool,
     allowed_efforts: list[str] | None = None,
+    effort_required: bool = False,
 ) -> None:
     """Mutate a CLONED spawn tool in place: keep each axis's field + clause only
     when that axis is auto. The affordances suffix (added by
@@ -71,7 +82,10 @@ def _condition_spawn_tool(
     exposed effort enum + clause to what the CONCRETE agent model can serve —
     None means unfiltered (the static catalogue). An empty list omits the
     field and clause entirely: an empty JSON-Schema enum is unsatisfiable and
-    worse than offering nothing.
+    worse than offering nothing. ``effort_required`` marks the field required
+    and swaps the clause tail: when the concrete model rejects the INHERITED
+    default, omission itself is an unservable spelling and must not remain a
+    schema-valid, advertised choice.
     """
     current = tool.get("description", "")
     marker_idx = current.find(_AFFORDANCES_MARKER)
@@ -82,19 +96,28 @@ def _condition_spawn_tool(
     if model_auto:
         desc += SPAWN_MODEL_CLAUSE
     if expose_effort:
-        desc += (
-            SPAWN_EFFORT_CLAUSE
-            if allowed_efforts is None
-            else spawn_effort_clause(allowed_efforts)
-        )
+        if allowed_efforts is None and not effort_required:
+            desc += SPAWN_EFFORT_CLAUSE
+        else:
+            desc += spawn_effort_clause(
+                SPAWN_EFFORT_OPTIONS if allowed_efforts is None else allowed_efforts,
+                required=effort_required,
+            )
     tool["description"] = desc + affordances
     props = _spawn_properties(tool)
     if not model_auto:
         props.pop("model", None)
     if not expose_effort:
         props.pop("reasoning_effort", None)
-    elif allowed_efforts is not None:
-        props["reasoning_effort"]["enum"] = list(allowed_efforts)
+    else:
+        if allowed_efforts is not None:
+            props["reasoning_effort"]["enum"] = list(allowed_efforts)
+        if effort_required:
+            schema_obj = _spawn_schema_object(tool)
+            required = list(schema_obj.get("required", []))
+            if "reasoning_effort" not in required:
+                required.append("reasoning_effort")
+            schema_obj["required"] = required
 
 
 def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:
@@ -118,6 +141,7 @@ def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:
     # the spawner picks the model, and the spawn boundary owns the pair.
     # Canonical option order, never a sorted set.
     allowed_efforts: list[str] | None = None
+    effort_required = False
     if effort_auto and not model_auto:
         codex = getattr(config, "openai_codex", None)
         raw = getattr(codex, "agent_model", None)
@@ -130,6 +154,14 @@ def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:
         ]
         if filtered != SPAWN_EFFORT_OPTIONS:
             allowed_efforts = filtered
+        # Omission inherits the MAIN effort at spawn time; when the concrete
+        # model rejects that inherited default, omission is itself an
+        # unservable spelling — the field must be REQUIRED so the schema stops
+        # advertising a guaranteed rejection. Runtime semantics unchanged: the
+        # spawn boundary still validates whatever arrives.
+        effort_required = model_rejects_effort(
+            resolved_model, getattr(codex, "reasoning_effort", None)
+        )
     out: list[dict] = []
     for tool in defs:
         if tool.get("name") not in _SPAWN_TOOLS:
@@ -141,6 +173,7 @@ def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:
             model_auto=model_auto,
             effort_auto=effort_auto,
             allowed_efforts=allowed_efforts,
+            effort_required=effort_required,
         )
         out.append(clone)
     return out

--- a/src/tools/agent_tool_policy.py
+++ b/src/tools/agent_tool_policy.py
@@ -27,6 +27,7 @@ from .defs.agents import (
     SPAWN_LOOP_BASE_DESC,
     SPAWN_MODEL_CLAUSE,
     spawn_effort_clause,
+    spawn_effort_property_desc,
 )
 
 _SPAWN_TOOLS = ("spawn_agent", "spawn_loop_agents")
@@ -118,6 +119,11 @@ def _condition_spawn_tool(
             if "reasoning_effort" not in required:
                 required.append("reasoning_effort")
             schema_obj["required"] = required
+            # The FIELD-level description must agree with the required list
+            # and the tool clause — the model reads all three while choosing.
+            props["reasoning_effort"]["description"] = spawn_effort_property_desc(
+                tool["name"], required=True
+            )
 
 
 def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:

--- a/src/tools/agent_tool_policy.py
+++ b/src/tools/agent_tool_policy.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 
 import copy
 
-from ..config.schema import agent_axis_mode
+from ..config.schema import agent_axis_mode, model_rejects_effort
 from .defs.agents import (
     SPAWN_AGENT_BASE_DESC,
     SPAWN_EFFORT_CLAUSE,
+    SPAWN_EFFORT_OPTIONS,
     SPAWN_LOOP_BASE_DESC,
     SPAWN_MODEL_CLAUSE,
+    spawn_effort_clause,
 )
 
 _SPAWN_TOOLS = ("spawn_agent", "spawn_loop_agents")
@@ -54,25 +56,45 @@ def _spawn_properties(tool: dict) -> dict:
 _AFFORDANCES_MARKER = "\n\n[affordances:"
 
 
-def _condition_spawn_tool(tool: dict, *, model_auto: bool, effort_auto: bool) -> None:
+def _condition_spawn_tool(
+    tool: dict,
+    *,
+    model_auto: bool,
+    effort_auto: bool,
+    allowed_efforts: list[str] | None = None,
+) -> None:
     """Mutate a CLONED spawn tool in place: keep each axis's field + clause only
     when that axis is auto. The affordances suffix (added by
-    ``get_tool_definitions``) is preserved."""
+    ``get_tool_definitions``) is preserved.
+
+    ``allowed_efforts`` (only meaningful with ``effort_auto``) narrows the
+    exposed effort enum + clause to what the CONCRETE agent model can serve —
+    None means unfiltered (the static catalogue). An empty list omits the
+    field and clause entirely: an empty JSON-Schema enum is unsatisfiable and
+    worse than offering nothing.
+    """
     current = tool.get("description", "")
     marker_idx = current.find(_AFFORDANCES_MARKER)
     affordances = current[marker_idx:] if marker_idx != -1 else ""
     base = SPAWN_AGENT_BASE_DESC if tool["name"] == "spawn_agent" else SPAWN_LOOP_BASE_DESC
+    expose_effort = effort_auto and allowed_efforts != []
     desc = base
     if model_auto:
         desc += SPAWN_MODEL_CLAUSE
-    if effort_auto:
-        desc += SPAWN_EFFORT_CLAUSE
+    if expose_effort:
+        desc += (
+            SPAWN_EFFORT_CLAUSE
+            if allowed_efforts is None
+            else spawn_effort_clause(allowed_efforts)
+        )
     tool["description"] = desc + affordances
     props = _spawn_properties(tool)
     if not model_auto:
         props.pop("model", None)
-    if not effort_auto:
+    if not expose_effort:
         props.pop("reasoning_effort", None)
+    elif allowed_efforts is not None:
+        props["reasoning_effort"]["enum"] = list(allowed_efforts)
 
 
 def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:
@@ -87,12 +109,38 @@ def apply_agent_axis_policy(defs: list[dict], config) -> list[dict]:
     effort_auto = effort_mode == "auto"
     if model_auto and effort_auto:
         return defs
+    # With the model axis NOT auto, the per-spawn model override is hard-
+    # rejected at the spawn boundary, so every spawn runs the ONE concrete
+    # model resolved from config (fixed agent_model, else the main model).
+    # The exposed effort catalogue must therefore only offer efforts that
+    # model can serve — a visible-but-unservable "max" costs the spawner a
+    # guaranteed rejection round-trip. Model axis auto keeps the full enum:
+    # the spawner picks the model, and the spawn boundary owns the pair.
+    # Canonical option order, never a sorted set.
+    allowed_efforts: list[str] | None = None
+    if effort_auto and not model_auto:
+        codex = getattr(config, "openai_codex", None)
+        raw = getattr(codex, "agent_model", None)
+        agent_model = (str(raw).strip() or None) if raw else None
+        resolved_model = agent_model or getattr(codex, "model", None)
+        filtered = [
+            effort
+            for effort in SPAWN_EFFORT_OPTIONS
+            if not model_rejects_effort(resolved_model, effort)
+        ]
+        if filtered != SPAWN_EFFORT_OPTIONS:
+            allowed_efforts = filtered
     out: list[dict] = []
     for tool in defs:
         if tool.get("name") not in _SPAWN_TOOLS:
             out.append(tool)
             continue
         clone = copy.deepcopy(tool)
-        _condition_spawn_tool(clone, model_auto=model_auto, effort_auto=effort_auto)
+        _condition_spawn_tool(
+            clone,
+            model_auto=model_auto,
+            effort_auto=effort_auto,
+            allowed_efforts=allowed_efforts,
+        )
         out.append(clone)
     return out

--- a/src/tools/defs/agents.py
+++ b/src/tools/defs/agents.py
@@ -34,10 +34,23 @@ SPAWN_MODEL_CLAUSE = (
 # the spawn boundary rejects known-incompatible model/effort pairs.
 SPAWN_EFFORT_OPTIONS: list[str] = ["none", "low", "medium", "high", "xhigh", "max"]
 
-SPAWN_EFFORT_CLAUSE = (
-    " Set 'reasoning_effort' (" + "/".join(SPAWN_EFFORT_OPTIONS) + ") for THIS agent — "
-    "higher is more thorough but slower/costlier. Omit to use the configured agent effort."
-)
+
+def spawn_effort_clause(options: list[str]) -> str:
+    """Render the effort clause for an ordered option list.
+
+    ONE wording template for both the static catalogue and the policy layer's
+    capability-filtered clones (a filtered enum with an unfiltered clause
+    would advertise efforts the schema no longer offers). Callers pass a
+    subsequence of ``SPAWN_EFFORT_OPTIONS`` — never a sorted set, which would
+    scramble the intentional escalation order.
+    """
+    return (
+        " Set 'reasoning_effort' (" + "/".join(options) + ") for THIS agent — "
+        "higher is more thorough but slower/costlier. Omit to use the configured agent effort."
+    )
+
+
+SPAWN_EFFORT_CLAUSE = spawn_effort_clause(SPAWN_EFFORT_OPTIONS)
 
 TOOLS_SECTION: list[dict] = [
     # --- Agent orchestration ---

--- a/src/tools/defs/agents.py
+++ b/src/tools/defs/agents.py
@@ -35,18 +35,27 @@ SPAWN_MODEL_CLAUSE = (
 SPAWN_EFFORT_OPTIONS: list[str] = ["none", "low", "medium", "high", "xhigh", "max"]
 
 
-def spawn_effort_clause(options: list[str]) -> str:
+def spawn_effort_clause(options: list[str], *, required: bool = False) -> str:
     """Render the effort clause for an ordered option list.
 
     ONE wording template for both the static catalogue and the policy layer's
     capability-filtered clones (a filtered enum with an unfiltered clause
     would advertise efforts the schema no longer offers). Callers pass a
     subsequence of ``SPAWN_EFFORT_OPTIONS`` — never a sorted set, which would
-    scramble the intentional escalation order.
+    scramble the intentional escalation order. ``required`` swaps the
+    omit-to-inherit tail for explicit-choice wording: when the configured
+    agent model cannot serve the inherited default, omission would be an
+    unservable spelling and must not be advertised.
     """
+    tail = (
+        "REQUIRED here: the configured default effort is not supported by the "
+        "configured agent model, so pick a compatible effort explicitly."
+        if required
+        else "Omit to use the configured agent effort."
+    )
     return (
         " Set 'reasoning_effort' (" + "/".join(options) + ") for THIS agent — "
-        "higher is more thorough but slower/costlier. Omit to use the configured agent effort."
+        "higher is more thorough but slower/costlier. " + tail
     )
 
 

--- a/src/tools/defs/agents.py
+++ b/src/tools/defs/agents.py
@@ -35,6 +35,15 @@ SPAWN_MODEL_CLAUSE = (
 SPAWN_EFFORT_OPTIONS: list[str] = ["none", "low", "medium", "high", "xhigh", "max"]
 
 
+# The ONE load-bearing required-wording tail, shared by the tool-level clause
+# AND the field-level property descriptions — a single source so no catalogue
+# surface can ever disagree about whether omission is a valid spelling.
+SPAWN_EFFORT_REQUIRED_TAIL = (
+    "REQUIRED here: the configured default effort is not supported by the "
+    "configured agent model, so pick a compatible effort explicitly."
+)
+
+
 def spawn_effort_clause(options: list[str], *, required: bool = False) -> str:
     """Render the effort clause for an ordered option list.
 
@@ -47,16 +56,35 @@ def spawn_effort_clause(options: list[str], *, required: bool = False) -> str:
     agent model cannot serve the inherited default, omission would be an
     unservable spelling and must not be advertised.
     """
-    tail = (
-        "REQUIRED here: the configured default effort is not supported by the "
-        "configured agent model, so pick a compatible effort explicitly."
-        if required
-        else "Omit to use the configured agent effort."
-    )
+    tail = SPAWN_EFFORT_REQUIRED_TAIL if required else "Omit to use the configured agent effort."
     return (
         " Set 'reasoning_effort' (" + "/".join(options) + ") for THIS agent — "
         "higher is more thorough but slower/costlier. " + tail
     )
+
+
+def spawn_effort_property_desc(tool_name: str, *, required: bool = False) -> str:
+    """Render the ``reasoning_effort`` PROPERTY description — the field-level
+    twin of ``spawn_effort_clause``. The static definitions below use the
+    optional form (byte-identical to the historical text); the policy layer
+    re-renders the required form onto clones, sharing
+    ``SPAWN_EFFORT_REQUIRED_TAIL`` so the property description, the tool
+    clause, and the required list can never contradict each other.
+    """
+    if tool_name == "spawn_loop_agents":
+        required_lead = "Reasoning effort (higher = more thorough, slower)."
+        optional_lead = "Optional reasoning effort (higher = more thorough, slower)."
+    else:
+        required_lead = (
+            "Reasoning effort for this agent — higher is more thorough but slower/costlier."
+        )
+        optional_lead = (
+            "Optional reasoning effort for this agent — higher is more thorough but "
+            "slower/costlier."
+        )
+    if required:
+        return required_lead + " " + SPAWN_EFFORT_REQUIRED_TAIL
+    return optional_lead + " Omit to inherit the configured agent effort."
 
 
 SPAWN_EFFORT_CLAUSE = spawn_effort_clause(SPAWN_EFFORT_OPTIONS)
@@ -84,10 +112,7 @@ TOOLS_SECTION: list[dict] = [
                 "reasoning_effort": {
                     "type": "string",
                     "enum": SPAWN_EFFORT_OPTIONS,
-                    "description": (
-                        "Optional reasoning effort for this agent — higher is more thorough but "
-                        "slower/costlier. Omit to inherit the configured agent effort."
-                    ),
+                    "description": spawn_effort_property_desc("spawn_agent"),
                 },
                 "parent_id": {
                     "type": "string",
@@ -199,10 +224,7 @@ TOOLS_SECTION: list[dict] = [
                             "reasoning_effort": {
                                 "type": "string",
                                 "enum": SPAWN_EFFORT_OPTIONS,
-                                "description": (
-                                    "Optional reasoning effort (higher = more thorough, "
-                                    "slower). Omit to inherit the configured agent effort."
-                                ),
+                                "description": spawn_effort_property_desc("spawn_loop_agents"),
                             },
                         },
                         "required": ["label", "goal"],

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -528,6 +528,11 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                 # iteration callbacks — persisting it must NOT trigger a codex
                 # client reload (auth-pool refresh) when nothing else changed.
                 needs_reload = False
+                # The spawn-tool effort catalogue depends on the MAIN model
+                # too (an inherit-model agent axis resolves through it), so a
+                # model change must refresh the cached catalog exactly like an
+                # axis change.
+                model_changed = False
                 if "enabled" in body:
                     cfg.enabled = bool(body["enabled"])
                     changed = True
@@ -536,6 +541,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     cfg.model = str(body["model"])
                     changed = True
                     needs_reload = True
+                    model_changed = True
                 if "max_tokens" in body:
                     cfg.max_tokens = _parse_int(body["max_tokens"], "max_tokens", 1, 128000)
                     changed = True
@@ -557,11 +563,13 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     cfg.agent_model = agent_model
                     changed = True
                     axis_changed = True
-                # An axis change mutates live cfg immediately, and the per-spawn
-                # tool schema depends on it — invalidate NOW (before reload /
-                # persist) so a later reload/persist failure can never leave the
-                # catalog cached against the old schema while cfg already moved.
-                if axis_changed and getattr(bot, "tool_catalog", None):
+                # An axis or model change mutates live cfg immediately, and the
+                # per-spawn tool schema depends on both — invalidate NOW
+                # (before reload / persist) so a later reload/persist failure
+                # can never leave the catalog cached against the old schema
+                # while cfg already moved.
+                catalog_changed = axis_changed or model_changed
+                if catalog_changed and getattr(bot, "tool_catalog", None):
                     bot.tool_catalog.invalidate()
                 if changed:
                     if needs_reload:

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -529,10 +529,12 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                 # client reload (auth-pool refresh) when nothing else changed.
                 needs_reload = False
                 # The spawn-tool effort catalogue depends on the MAIN model
-                # too (an inherit-model agent axis resolves through it), so a
-                # model change must refresh the cached catalog exactly like an
-                # axis change.
+                # (an inherit-model agent axis resolves through it) AND the
+                # main effort (the inherited default whose servability decides
+                # required-ness), so either change must refresh the cached
+                # catalog exactly like an axis change.
                 model_changed = False
+                effort_changed = False
                 if "enabled" in body:
                     cfg.enabled = bool(body["enabled"])
                     changed = True
@@ -550,6 +552,10 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     cfg.reasoning_effort = str(effort)
                     changed = True
                     needs_reload = True
+                    # The main effort is the INHERITED default an omitted
+                    # per-spawn effort resolves to — the catalogue's
+                    # required-ness depends on it (see agent_tool_policy).
+                    effort_changed = True
                 axis_changed = False
                 if agent_effort_present:
                     cfg.agent_reasoning_effort = (
@@ -568,7 +574,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                 # (before reload / persist) so a later reload/persist failure
                 # can never leave the catalog cached against the old schema
                 # while cfg already moved.
-                catalog_changed = axis_changed or model_changed
+                catalog_changed = axis_changed or model_changed or effort_changed
                 if catalog_changed and getattr(bot, "tool_catalog", None):
                     bot.tool_catalog.invalidate()
                 if changed:

--- a/tests/test_agent_auto_dynamic.py
+++ b/tests/test_agent_auto_dynamic.py
@@ -147,3 +147,88 @@ def test_policy_never_mutates_static_defs():
     ]:
         apply_agent_axis_policy(get_tool_definitions(), _cfg(m, e))
     assert get_tool_definitions() == before
+
+
+class TestEffortCatalogueFiltering:
+    """Capability-filtered effort catalogue: with the effort axis auto and the
+    model axis NOT auto, every spawn runs one concrete config-resolved model
+    (per-spawn model overrides are hard-rejected on a non-auto axis), so the
+    exposed enum + clause offer only efforts that model can serve. Model axis
+    auto keeps the full catalogue — the spawner picks the model and the spawn
+    boundary owns the pair."""
+
+    @staticmethod
+    def _effort_schema(cfg, name):
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        props, desc = _spawn_props(defs, name)
+        return props.get("reasoning_effort"), desc
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_fixed_excluded_model_drops_max(self, name):
+        from src.tools.defs.agents import spawn_effort_clause
+
+        field, desc = self._effort_schema(_cfg("gpt-5.5", "auto"), name)
+        assert field["enum"] == ["none", "low", "medium", "high", "xhigh"]
+        assert "max" not in desc
+        # clause text matches the filtered enum exactly (one renderer)
+        assert spawn_effort_clause(field["enum"]) in desc
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_inherited_excluded_main_model_drops_max(self, name):
+        field, desc = self._effort_schema(
+            _cfg(None, "auto", main_model="gpt-5.5"), name)
+        assert field["enum"] == ["none", "low", "medium", "high", "xhigh"]
+        assert "max" not in desc
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-luna", "brand-new-model"])
+    def test_capable_and_unknown_models_keep_full_ordered_enum(self, model):
+        field, desc = self._effort_schema(_cfg(model, "auto"), "spawn_agent")
+        assert field["enum"] == ["none", "low", "medium", "high", "xhigh", "max"]
+        assert "max" in desc
+
+    def test_inherited_capable_main_model_keeps_full_enum(self):
+        field, _ = self._effort_schema(
+            _cfg(None, "auto", main_model="gpt-5.6-sol"), "spawn_agent")
+        assert field["enum"] == ["none", "low", "medium", "high", "xhigh", "max"]
+
+    def test_model_axis_auto_never_filters(self):
+        # Even with an excluded MAIN model, auto model axis = spawner's choice.
+        field, desc = self._effort_schema(
+            _cfg("auto", "auto", main_model="gpt-5.5"), "spawn_agent")
+        assert field["enum"] == ["none", "low", "medium", "high", "xhigh", "max"]
+
+    def test_both_auto_returns_identity(self):
+        defs = get_tool_definitions()
+        assert apply_agent_axis_policy(defs, _cfg("auto", "auto")) is defs
+
+    def test_static_definitions_never_mutated(self):
+        # The filter works on deep clones — the shared static defs (and the
+        # canonical exposed form) must keep the full enum after policy calls.
+        apply_agent_axis_policy(get_tool_definitions(), _cfg("gpt-5.5", "auto"))
+        static_props, static_desc = _spawn_props(get_tool_definitions(), "spawn_agent")
+        assert static_props["reasoning_effort"]["enum"][-1] == "max"
+        assert "max" in static_desc
+
+    def test_empty_filter_omits_field_and_clause(self, monkeypatch):
+        # Defensive edge: capability data filtering EVERY effort must omit the
+        # property + clause, never emit an unsatisfiable empty enum.
+        from src.config import schema as schema_mod
+        from src.tools.defs.agents import SPAWN_EFFORT_OPTIONS
+
+        monkeypatch.setitem(
+            schema_mod.CODEX_MODEL_UNSUPPORTED_EFFORTS,
+            "gpt-5.5",
+            frozenset(SPAWN_EFFORT_OPTIONS),
+        )
+        field, desc = self._effort_schema(_cfg("gpt-5.5", "auto"), "spawn_agent")
+        assert field is None
+        assert "reasoning_effort" not in desc
+
+    def test_clause_renderer_is_the_static_source(self):
+        from src.tools.defs.agents import (
+            SPAWN_EFFORT_CLAUSE,
+            SPAWN_EFFORT_OPTIONS,
+            spawn_effort_clause,
+        )
+        # byte-identical static output — one wording template everywhere
+        assert spawn_effort_clause(SPAWN_EFFORT_OPTIONS) == SPAWN_EFFORT_CLAUSE

--- a/tests/test_agent_auto_dynamic.py
+++ b/tests/test_agent_auto_dynamic.py
@@ -307,3 +307,55 @@ class TestUnservableOmission:
         schema, desc = self._schema_obj(get_tool_definitions(), "spawn_agent")
         assert schema["required"] == ["label", "goal"]
         assert "Omit to use the configured agent effort" in desc
+
+
+class TestPropertyDescriptionTruthfulness:
+    """PR #246 round 2: the FIELD-level description must agree with the
+    required list and the tool clause — all three render from shared sources
+    (SPAWN_EFFORT_REQUIRED_TAIL / spawn_effort_property_desc), so no
+    catalogue surface can call the field optional while the schema requires
+    it, or advertise the guaranteed-failure omission inside the field."""
+
+    _CFG = None  # built per test via TestUnservableOmission's helper
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_required_state_rewrites_property_description(self, name):
+        from src.tools.defs.agents import SPAWN_EFFORT_REQUIRED_TAIL
+
+        cfg = TestUnservableOmission._cfg_main_effort(
+            "gpt-5.5", "auto", main_effort="max")
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        props, desc = _spawn_props(defs, name)
+        pd = props["reasoning_effort"]["description"]
+        assert SPAWN_EFFORT_REQUIRED_TAIL in pd
+        assert "Optional" not in pd
+        assert "Omit to inherit" not in pd
+        # the tool clause carries the SAME shared tail — one source
+        assert SPAWN_EFFORT_REQUIRED_TAIL in desc
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_optional_state_keeps_static_property_description(self, name):
+        cfg = TestUnservableOmission._cfg_main_effort(
+            "gpt-5.5", "auto", main_effort="xhigh")
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        props, _ = _spawn_props(defs, name)
+        static_props, _ = _spawn_props(get_tool_definitions(), name)
+        assert (props["reasoning_effort"]["description"]
+                == static_props["reasoning_effort"]["description"])
+        assert "Omit to inherit" in props["reasoning_effort"]["description"]
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_renderer_is_the_static_property_source(self, name):
+        from src.tools.defs.agents import spawn_effort_property_desc
+
+        static_props, _ = _spawn_props(get_tool_definitions(), name)
+        assert (spawn_effort_property_desc(name)
+                == static_props["reasoning_effort"]["description"])
+
+    def test_static_property_descriptions_untouched_after_required_render(self):
+        cfg = TestUnservableOmission._cfg_main_effort(
+            "gpt-5.5", "auto", main_effort="max")
+        apply_agent_axis_policy(get_tool_definitions(), cfg)
+        for name in ("spawn_agent", "spawn_loop_agents"):
+            static_props, _ = _spawn_props(get_tool_definitions(), name)
+            assert "Optional" in static_props["reasoning_effort"]["description"]

--- a/tests/test_agent_auto_dynamic.py
+++ b/tests/test_agent_auto_dynamic.py
@@ -232,3 +232,78 @@ class TestEffortCatalogueFiltering:
         )
         # byte-identical static output — one wording template everywhere
         assert spawn_effort_clause(SPAWN_EFFORT_OPTIONS) == SPAWN_EFFORT_CLAUSE
+
+
+class TestUnservableOmission:
+    """PR #246 round 1: filtering the enum is not enough — omission inherits
+    the MAIN effort at spawn, so when the concrete agent model rejects that
+    inherited default, omission itself is an unservable, advertised spelling.
+    The field becomes REQUIRED with explicit-choice clause wording; it stays
+    optional whenever the inherited default is servable. Runtime semantics
+    unchanged."""
+
+    @staticmethod
+    def _cfg_main_effort(model, effort, main_model="gpt-5.6-sol", main_effort="medium"):
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            openai_codex=SimpleNamespace(
+                agent_model=model, agent_reasoning_effort=effort,
+                model=main_model, reasoning_effort=main_effort,
+            )
+        )
+
+    @staticmethod
+    def _schema_obj(defs, name):
+        tool = next(x for x in defs if x["name"] == name)
+        if name == "spawn_loop_agents":
+            return tool["input_schema"]["properties"]["tasks"]["items"], tool["description"]
+        return tool["input_schema"], tool["description"]
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_unservable_inherited_default_makes_effort_required(self, name):
+        # Odin's exact repro: main sol@max, fixed agent gpt-5.5, effort auto.
+        cfg = self._cfg_main_effort("gpt-5.5", "auto", main_effort="max")
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        schema, desc = self._schema_obj(defs, name)
+        assert "reasoning_effort" in schema["required"]
+        assert "REQUIRED here" in desc
+        assert "Omit to use the configured agent effort" not in desc
+        # enum still filtered alongside
+        props, _ = _spawn_props(defs, name)
+        assert props["reasoning_effort"]["enum"] == [
+            "none", "low", "medium", "high", "xhigh"]
+
+    @pytest.mark.parametrize("name", ["spawn_agent", "spawn_loop_agents"])
+    def test_servable_inherited_default_stays_optional(self, name):
+        cfg = self._cfg_main_effort("gpt-5.5", "auto", main_effort="xhigh")
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        schema, desc = self._schema_obj(defs, name)
+        assert "reasoning_effort" not in schema.get("required", [])
+        assert "Omit to use the configured agent effort" in desc
+
+    def test_capable_model_never_required(self):
+        cfg = self._cfg_main_effort("gpt-5.6-luna", "auto", main_effort="max")
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        schema, desc = self._schema_obj(defs, "spawn_agent")
+        assert "reasoning_effort" not in schema.get("required", [])
+        # full enum, static clause
+        props, _ = _spawn_props(defs, "spawn_agent")
+        assert props["reasoning_effort"]["enum"][-1] == "max"
+
+    def test_inherited_main_model_unservable_default_required(self):
+        # model axis INHERIT resolving to gpt-5.5 with main effort max is
+        # load-rejected as a config (main pair 5.5+max is invalid), so the
+        # reachable inherit case is: main 5.5 + main effort xhigh = servable →
+        # optional. Pin that reachable shape.
+        cfg = self._cfg_main_effort(None, "auto", main_model="gpt-5.5",
+                                    main_effort="xhigh")
+        defs = apply_agent_axis_policy(get_tool_definitions(), cfg)
+        schema, _ = self._schema_obj(defs, "spawn_agent")
+        assert "reasoning_effort" not in schema.get("required", [])
+
+    def test_static_required_lists_untouched(self):
+        cfg = self._cfg_main_effort("gpt-5.5", "auto", main_effort="max")
+        apply_agent_axis_policy(get_tool_definitions(), cfg)
+        schema, desc = self._schema_obj(get_tool_definitions(), "spawn_agent")
+        assert schema["required"] == ["label", "goal"]
+        assert "Omit to use the configured agent effort" in desc

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -1325,3 +1325,57 @@ class TestCodexMaxEffortPairValidation:
                             json={"agent_model": "auto", "agent_reasoning_effort": "max"})
             assert r.status == 200
         assert bot.config.openai_codex.agent_reasoning_effort == "max"
+
+
+class TestCatalogInvalidationOnModelChange:
+    """The spawn-tool effort catalogue depends on the MAIN model (an
+    inherit-model agent axis resolves through it), so a model-only PUT must
+    refresh the cached catalog exactly like an axis change — and a rejected
+    PUT must refresh (and mutate) nothing."""
+
+    @pytest.mark.asyncio
+    async def test_model_only_change_invalidates(self):
+        app, bot = _app(register_provider_config)
+        _gw(bot)
+        bot.tool_catalog = MagicMock()
+        async with TestClient(TestServer(app)) as c:
+            r = await c.put("/api/llm/codex/config", json={"model": "gpt-5.6-terra"})
+            assert r.status == 200
+        bot.tool_catalog.invalidate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fixed_agent_model_swap_invalidates(self):
+        # fixed→fixed (5.6→5.5): the axis MODE doesn't change, but the value
+        # feeds the filtered enum — presence-based axis_changed covers it.
+        app, bot = _app(register_provider_config)
+        _gw(bot)
+        bot.config.openai_codex.agent_model = "gpt-5.6-sol"
+        bot.tool_catalog = MagicMock()
+        async with TestClient(TestServer(app)) as c:
+            r = await c.put("/api/llm/codex/config", json={"agent_model": "gpt-5.5"})
+            assert r.status == 200
+        bot.tool_catalog.invalidate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejected_put_invalidates_nothing(self):
+        app, bot = _app(register_provider_config)
+        gw = _gw(bot)
+        bot.config.openai_codex.model = "gpt-5.6-sol"
+        bot.config.openai_codex.reasoning_effort = "max"
+        bot.tool_catalog = MagicMock()
+        async with TestClient(TestServer(app)) as c:
+            r = await c.put("/api/llm/codex/config", json={"model": "gpt-5.5"})
+            assert r.status == 400
+        bot.tool_catalog.invalidate.assert_not_called()
+        gw.reload_codex_inner.assert_not_awaited()
+        assert bot.config.openai_codex.model == "gpt-5.6-sol"
+
+    @pytest.mark.asyncio
+    async def test_non_catalog_change_does_not_invalidate(self):
+        app, bot = _app(register_provider_config)
+        _gw(bot)
+        bot.tool_catalog = MagicMock()
+        async with TestClient(TestServer(app)) as c:
+            r = await c.put("/api/llm/codex/config", json={"max_tokens": 8192})
+            assert r.status == 200
+        bot.tool_catalog.invalidate.assert_not_called()

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -1379,3 +1379,20 @@ class TestCatalogInvalidationOnModelChange:
             r = await c.put("/api/llm/codex/config", json={"max_tokens": 8192})
             assert r.status == 200
         bot.tool_catalog.invalidate.assert_not_called()
+
+
+class TestCatalogInvalidationOnEffortChange:
+    """PR #246 round 1 follow-through: the required-ness of the exposed
+    effort field depends on the MAIN effort (the inherited default), so an
+    effort-only PUT must refresh the cached catalog too."""
+
+    @pytest.mark.asyncio
+    async def test_effort_only_change_invalidates(self):
+        app, bot = _app(register_provider_config)
+        _gw(bot)
+        bot.config.openai_codex.model = "gpt-5.6-sol"
+        bot.tool_catalog = MagicMock()
+        async with TestClient(TestServer(app)) as c:
+            r = await c.put("/api/llm/codex/config", json={"reasoning_effort": "max"})
+            assert r.status == 200
+        bot.tool_catalog.invalidate.assert_called_once()


### PR DESCRIPTION
With the effort axis auto and the model axis NOT auto, every spawn runs one concrete config-resolved model (per-spawn model overrides are hard-rejected on a non-auto axis) — yet the exposed `reasoning_effort` enum still offered `max` when that model was gpt-5.5, making every pick a guaranteed spawn-rejection round-trip. Follow-up to #245, design settled over the bridge.

## Changes

- `agent_tool_policy.apply_agent_axis_policy`: resolves the concrete agent model (fixed `agent_model`, else the main model) and filters the CLONED effort enum through `model_rejects_effort` in **canonical option order** (never a sorted set). Model axis auto keeps the full catalogue — the spawner picks the model, the spawn boundary owns the pair (settled #245 design). Both-axes-auto still returns the static definitions **by identity**.
- `defs/agents.py`: `spawn_effort_clause(options)` — ONE wording template renders both the static `SPAWN_EFFORT_CLAUSE` (byte-identical, parity hashes untouched) and the filtered clones, so description and enum can never disagree.
- Defensive edge: a filter that removes every effort omits the field + clause entirely rather than emit an unsatisfiable empty enum.
- `llm_admin` codex PUT: the catalogue now depends on model VALUES, not just axis modes → `catalog_changed = axis_changed or model_changed` invalidates the cached catalog on a main-model change too, same before-reload/persist placement; rejected PUTs invalidate nothing. (General `/api/config` already invalidates unconditionally; no other production path assigns `openai_codex.model`.)
- No UI, docs, or template changes — no deploy dance.

## Tests (all nine settled pins)

fixed-5.5 + inherit-main-5.5 drop max from BOTH tools with clause matching the enum exactly; capable/unknown/inherit-capable models keep the full ordered enum; model-axis-auto never filters; both-auto identity-pinned (`is`); static defs never mutated; empty-filter omits field+clause; renderer == static clause byte-pin; model-only PUT invalidates once; fixed→fixed agent_model swap invalidates; rejected PUT invalidates and mutates nothing; non-catalogue change doesn't invalidate.

## Gates

Full suite 8,236 passed / 5 skipped · ruff clean · lint gate new=0 · type gate new=0 · parity hashes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JEZMKAxTxfyyBdQhZhnmi