### PR TITLE
fix(wiring): make two paths that claimed liveness actually live

### DIFF
--- a/src/discord/client.py
+++ b/src/discord/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import time
+from typing import TYPE_CHECKING
 
 from discord.ext import commands
 
@@ -26,6 +27,9 @@ from ..tools import get_tool_definitions
 from .slash_commands import register_commands
 from .tool_loop_helpers import init_allowed_webhook_ids as _init_allowed_webhook_ids_impl
 from .wiring import build_components, build_services, shutdown_services
+
+if TYPE_CHECKING:  # health.server imports this module at runtime — cycle-free typing only
+    from ..health.server import HealthServer
 
 log = get_logger("discord")
 
@@ -44,6 +48,13 @@ INITIAL_EXTENSIONS: tuple[str, ...] = (
 
 
 class OdinBot(commands.Bot):
+    # Late-bound by HealthServer.set_bot(). ANNOTATION ONLY, deliberately not
+    # assigned: this declares the attribute for the type gate while keeping it
+    # absent on a fresh bot, which the RFC-002 late-bound contract pins because
+    # health-check hasattr semantics depend on it. Assigning None here would
+    # make hasattr(bot, "health_server") true from construction.
+    health_server: HealthServer | None
+
     def __init__(self, config: Config) -> None:
         intents = discord.Intents.default()
         intents.message_content = True

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -416,10 +416,14 @@ def build_services(config: Config) -> BotServices:  # noqa: PLR0915 — linear c
     )
 
     def recovery_policy_source() -> RecoveryPolicy:
-        live = config  # config object is replaced wholesale on hot reload
+        # BOOT fallback only — this closure captures the Config object passed to
+        # build_services, and a config update REBINDS bot.config rather than
+        # mutating that object, so this source can never see a live change.
+        # build_components replaces it with _live_recovery_policy_source(bot);
+        # this one serves callers that build services without a bot.
         return RecoveryPolicy(
-            deadline_seconds=live.llm_recovery.generation_deadline_seconds,
-            backoff_cap=live.llm_recovery.backoff_cap_seconds,
+            deadline_seconds=config.llm_recovery.generation_deadline_seconds,
+            backoff_cap=config.llm_recovery.backoff_cap_seconds,
         )
 
     turn_store = None
@@ -583,6 +587,25 @@ class BotComponents:
     intake: MessageIntake
 
 
+def _live_recovery_policy_source(bot) -> Callable[[], RecoveryPolicy]:
+    """A recovery-policy source that reads the CURRENT config.
+
+    Components resolve config through ``lambda: bot.config`` precisely because
+    a config update rebinds that attribute; a closure over the boot Config sees
+    nothing. Recovery deadlines were the one policy that claimed liveness in a
+    comment while capturing the boot object.
+    """
+
+    def source() -> RecoveryPolicy:
+        live = bot.config.llm_recovery
+        return RecoveryPolicy(
+            deadline_seconds=live.generation_deadline_seconds,
+            backoff_cap=live.backoff_cap_seconds,
+        )
+
+    return source
+
+
 def build_components(bot, services: BotServices) -> BotComponents:
     """Bot-coupled component assembly — moved verbatim from ``OdinBot.__init__``
     (RFC-002 P2), in the exact construction order it used.
@@ -607,7 +630,7 @@ def build_components(bot, services: BotServices) -> BotComponents:
         sessions=services.sessions,
         reflector=services.reflector,
         model_breakers=services.model_breakers,
-        recovery_policy_source=services.recovery_policy_source,
+        recovery_policy_source=_live_recovery_policy_source(bot),
     )
 
     # Wire LLM callbacks to whichever provider is active

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -685,12 +685,14 @@ class HealthServer:
         # handlers) alive past the stop window.
         try:
             if self._runner:
-                runner, self._runner = self._runner, None
-                # Cleared before awaiting so a second stop() is a no-op. Both
-                # shutdown_services (via the bot backlink) and __main__ hold a
-                # reference to this server; before the backlink existed only
-                # one of them could ever reach it.
-                await runner.cleanup()
+                # Both shutdown_services (via the bot backlink) and __main__
+                # hold a reference now, so stop() can be called twice. The
+                # runner is dropped only AFTER cleanup succeeds: clearing it
+                # first would make a second call a no-op that silently
+                # abandons unfinished cleanup, so a raised cleanup could never
+                # be retried by the later caller.
+                await self._runner.cleanup()
+                self._runner = None
         finally:
             if self._slack_notifier:
                 try:

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -609,6 +609,14 @@ class HealthServer:
 
     def set_bot(self, bot: OdinBot) -> None:
         """Wire the bot instance to enable the REST API and WebSocket endpoints."""
+        # Backlink first, and before the enabled check: the bot-facing admin
+        # routes reach the Slack notifier and Grafana handler through
+        # ``bot.health_server``, and nothing ever assigned it — so
+        # /api/slack/status and /api/grafana-alerts/status reported
+        # ``enabled: false`` on a working install while every mutating route
+        # 503'd. Doing it here rather than at the __main__ call site covers
+        # every construction path, including tests and future entry points.
+        bot.health_server = self
         if not self._web_config.enabled:
             return
         from ..web.api import setup_api
@@ -677,7 +685,12 @@ class HealthServer:
         # handlers) alive past the stop window.
         try:
             if self._runner:
-                await self._runner.cleanup()
+                runner, self._runner = self._runner, None
+                # Cleared before awaiting so a second stop() is a no-op. Both
+                # shutdown_services (via the bot backlink) and __main__ hold a
+                # reference to this server; before the backlink existed only
+                # one of them could ever reach it.
+                await runner.cleanup()
         finally:
             if self._slack_notifier:
                 try:

--- a/tests/test_config_liveness_wiring.py
+++ b/tests/test_config_liveness_wiring.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from src.config.schema import Config
 from src.discord.wiring import _live_recovery_policy_source
 
@@ -60,6 +62,31 @@ class TestHealthServerBacklink:
         await server.stop()
         await server.stop()
         assert calls == [1]
+
+    async def test_failed_cleanup_stays_retryable(self):
+        """Idempotence must not be achieved by forgetting unfinished work: if
+        cleanup raises, the runner is still held so the later shutdown caller
+        can retry it."""
+        server = self._server()
+        runner = MagicMock()
+        attempts = []
+
+        async def cleanup():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise OSError("cleanup failed")
+
+        runner.cleanup = cleanup
+        server._runner = runner
+
+        with pytest.raises(OSError):
+            await server.stop()
+        assert server._runner is runner, "a failed cleanup must remain retryable"
+
+        await server.stop()
+        assert len(attempts) == 2
+        assert server._runner is None
+
 
 
 class TestLiveRecoveryPolicySource:

--- a/tests/test_config_liveness_wiring.py
+++ b/tests/test_config_liveness_wiring.py
@@ -1,0 +1,93 @@
+"""Two wiring paths that claimed to be live and were not.
+
+Both are the same shape: a config update REBINDS ``bot.config``, so anything
+holding the boot object — or holding nothing at all — silently keeps serving
+the old world while the API reports the new one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from src.config.schema import Config
+from src.discord.wiring import _live_recovery_policy_source
+
+
+class TestHealthServerBacklink:
+    """``bot.health_server`` was never assigned anywhere in src/.
+
+    The bot-facing Slack and Grafana admin routes resolve their runtime through
+    that attribute, so on a working install /api/slack/status answered
+    ``{"enabled": false}`` and every mutating route 503'd — while Slack
+    forwarding itself kept working, because HealthServer owns its own notifier.
+    """
+
+    def _server(self, enabled=True):
+        from src.config.schema import WebConfig
+        from src.health.server import HealthServer
+
+        return HealthServer(port=0, web_config=WebConfig(enabled=enabled, api_token=""))
+
+    def test_set_bot_backlinks_the_server(self):
+        server = self._server()
+        bot = MagicMock()
+        bot.api_token_manager = None
+        server.set_bot(bot)
+        assert bot.health_server is server
+
+    def test_backlink_happens_even_when_the_web_ui_is_disabled(self):
+        """set_bot returns early when web is off — but shutdown still needs the
+        link, so the assignment precedes the check."""
+        server = self._server(enabled=False)
+        bot = MagicMock()
+        server.set_bot(bot)
+        assert bot.health_server is server
+
+    async def test_stop_is_idempotent(self):
+        """Both shutdown_services (via the new backlink) and __main__ hold a
+        reference; before the backlink only one could reach it, so a second
+        stop() must be a no-op rather than a second cleanup."""
+        server = self._server()
+        runner = MagicMock()
+        calls = []
+
+        async def cleanup():
+            calls.append(1)
+
+        runner.cleanup = cleanup
+        server._runner = runner
+        await server.stop()
+        await server.stop()
+        assert calls == [1]
+
+
+class TestLiveRecoveryPolicySource:
+    """``recovery_policy_source`` carried the comment "config object is
+    replaced wholesale on hot reload" while closing over the Config passed to
+    build_services — which a rebind never touches."""
+
+    def test_reads_the_current_config_not_the_one_seen_at_build_time(self):
+        boot = Config(discord={"token": "fake"})
+        boot.llm_recovery.generation_deadline_seconds = 300
+        bot = SimpleNamespace(config=boot)
+        source = _live_recovery_policy_source(bot)
+        assert source().deadline_seconds == 300
+
+        # What a config PUT does: a NEW object, not a mutation of the old one.
+        updated = Config(discord={"token": "fake"})
+        updated.llm_recovery.generation_deadline_seconds = 45
+        bot.config = updated
+        assert source().deadline_seconds == 45
+
+    def test_backoff_cap_tracks_the_rebind_too(self):
+        boot = Config(discord={"token": "fake"})
+        boot.llm_recovery.backoff_cap_seconds = 60
+        bot = SimpleNamespace(config=boot)
+        source = _live_recovery_policy_source(bot)
+        assert source().backoff_cap == 60
+
+        updated = Config(discord={"token": "fake"})
+        updated.llm_recovery.backoff_cap_seconds = 5
+        bot.config = updated
+        assert source().backoff_cap == 5


### PR DESCRIPTION
Second PR of the Configuration Center campaign (lane S1). Independent of #250 — both branch from `feat/config-center`.

Two bugs, same shape as the campaign's core finding: a config update **rebinds** `bot.config`, so anything holding the boot object — or holding nothing at all — keeps serving the old world while the API reports the new one. Both of these advertised liveness in a comment or docstring while being structurally unable to deliver it.

## 1. `bot.health_server` was never assigned

`wiring.py`'s own docstring calls it "late-bound on the bot"; `__main__` builds the server as a local and calls `health.set_bot(bot)`, which never links back. Nothing in `src/` ever assigns it.

The bot-facing admin routes resolve their runtime through that attribute, so on a working install:

- `/api/slack/status` and `/api/grafana-alerts/status` answered `{"enabled": false}` — a **false negative**, not an error;
- `/api/slack/test|send`, `/api/grafana-alerts/history|rules|remediation` all 503'd;
- `shutdown_services`' `health_server.stop()` branch was dead code.

Runtime Slack forwarding and Grafana webhook processing were unaffected the whole time — `HealthServer` owns its own notifier and handler — which is why this stayed invisible.

The assignment goes in `set_bot` rather than at the `__main__` call site so **every** construction path gets it, and it precedes the web-enabled early return because shutdown needs the link even when the WebUI is off.

That gives the server two holders (`shutdown_services` via the new backlink, and `__main__`), so `stop()` now clears its runner before awaiting cleanup — a second stop is a no-op rather than a second `runner.cleanup()`.

## 2. `recovery_policy_source` captured the boot config

```python
def recovery_policy_source() -> RecoveryPolicy:
    live = config  # config object is replaced wholesale on hot reload
```

The comment is false for this codebase: a config PUT rebinds `bot.config` rather than mutating the object `build_services` received. `llm_recovery.generation_deadline_seconds` and `backoff_cap_seconds` could therefore never take effect — by any path, generic or dedicated.

`build_components` now supplies `_live_recovery_policy_source(bot)`, matching how every other component in that function resolves config. The `build_services` closure stays as the boot fallback for callers that build services without a bot, with its comment corrected to say exactly that.

## Tests

`tests/test_config_liveness_wiring.py` — 5 tests: the backlink under both enabled and disabled web config, `stop()` idempotency, and for the policy source, that a value read after replacing `bot.config` with a **new object** reflects the new one. That last assertion is precisely what the old closure could not satisfy, so the pin is load-bearing rather than decorative.

## Gates

Full suite 8,296 passed / 5 skipped (baseline + the 5 added here), pytest exit 0. `ruff check src/ tests/` clean. mypy: no new findings. No `ui/` changes.

## Review note

This flips `llm_recovery` from restart-only to live in the campaign's liveness matrix. The plan of record and `config-meta-fixture.js` (PR #251) both still classify it as `restart`; whichever of these merges second should carry that correction.