### PR TITLE
feat(config): the server half of the Config Center refinement

### DIFF
--- a/scripts/ci/apply_registry_gate.py
+++ b/scripts/ci/apply_registry_gate.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.config.apply_registry import (  # noqa: E402
     FIELDS,
+    GROUP_DESCRIPTIONS,
     MIXED_SECTIONS,
     SECTIONS,
     element_model,
@@ -128,9 +129,29 @@ def main() -> int:
                 f"MIXED_SECTIONS names '{section}', which is not a config section"
             )
 
+    # Every two-segment subgroup renders as a card with its OWN heading copy.
+    # Without an entry the page would fall back to guessing — historically by
+    # stealing the first child's description.
+    subgroups = sorted({
+        ".".join(leaf.split(".")[:2]) for leaf in leaves if leaf.count(".") >= 2
+    })
+    for prefix in subgroups:
+        if prefix not in GROUP_DESCRIPTIONS:
+            findings.append(
+                f"subgroup '{prefix}' has no GROUP_DESCRIPTIONS entry — its "
+                f"card heading would be a guess"
+            )
+    for prefix in sorted(GROUP_DESCRIPTIONS):
+        if prefix not in subgroups:
+            findings.append(
+                f"GROUP_DESCRIPTIONS names '{prefix}', which the schema no "
+                f"longer produces"
+            )
+
     print(
         f"apply-registry-gate: sections={len(sections)} leaves={len(leaves)} "
         f"classified={len(FIELDS)} mixed={len(MIXED_SECTIONS)} "
+        f"groups={len(GROUP_DESCRIPTIONS)} "
         f"findings={len(findings)}"
     )
     if findings:

--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -168,8 +168,10 @@ class LoopAgentBridge:
                 if (
                     tool_name == "spawn_agent"
                     and _self_id["id"]
-                    and not tool_input.get("parent_id")
                 ):
+                    # Invocation ancestry is authoritative. A nested model may
+                    # not choose a sibling/root as parent and escape this
+                    # agent's depth, child, or lifetime-tree limits.
                     tool_input = {**tool_input, "parent_id": _self_id["id"]}
                 return await _shared_cb(tool_name, tool_input)
 

--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -151,6 +151,28 @@ class LoopAgentBridge:
                 else iteration_callback
             )
 
+            # Invocation-bound wrapper, mirroring the direct-agent path: a
+            # nested spawn_agent from THIS agent must carry its id as
+            # parent_id, or the child registers as a fresh ROOT and bypasses
+            # depth, child-limit, and tree-cap enforcement entirely. The
+            # shared callback used to be passed bare, which is exactly how
+            # loop-agent children escaped every tree limit.
+            _self_id: dict[str, str | None] = {"id": None}
+
+            async def _bound_tool_cb(
+                tool_name: str,
+                tool_input: dict,
+                _self_id: dict = _self_id,
+                _shared_cb=tool_executor_callback,
+            ) -> str:
+                if (
+                    tool_name == "spawn_agent"
+                    and _self_id["id"]
+                    and not tool_input.get("parent_id")
+                ):
+                    tool_input = {**tool_input, "parent_id": _self_id["id"]}
+                return await _shared_cb(tool_name, tool_input)
+
             agent_id = self._agent_manager.spawn(
                 label=label,
                 goal=enriched_goal,
@@ -158,7 +180,7 @@ class LoopAgentBridge:
                 requester_id=requester_id,
                 requester_name=requester_name,
                 iteration_callback=cb,
-                tool_executor_callback=tool_executor_callback,
+                tool_executor_callback=_bound_tool_cb,
                 announce_callback=announce_callback,
                 tools=tools,
                 system_prompt=system_prompt,
@@ -181,6 +203,9 @@ class LoopAgentBridge:
             )
 
             if not agent_id.startswith("Error"):
+                # The wrapper learns its own id only now — spawn() had to
+                # return first, same as the direct path's mutable-cell trick.
+                _self_id["id"] = agent_id
                 self._loop_agents[loop_id].append(
                     LoopAgentRecord(
                         agent_id=agent_id,

--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+from .manager import MAX_NESTING_DEPTH
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -91,6 +92,8 @@ class LoopAgentBridge:
         budget_warnings: list[int] | None = None,
         iteration_timeout: float | None = None,
         max_lifetime: float | None = None,
+        max_depth: int | None = None,
+        max_children: int | None = None,
         iteration_callback_factory: Callable[[str | None, str | None], IterationCallback]
         | None = None,
         context_compression_enabled: bool = False,
@@ -161,6 +164,11 @@ class LoopAgentBridge:
                 system_prompt=system_prompt,
                 tool_timeouts=tool_timeouts,
                 trajectory_saver=self._trajectory_saver,
+                # Loop-spawned agents used to ignore configured depth and
+                # child limits entirely — the built-in defaults applied no
+                # matter what config said. Same knobs, both paths now.
+                max_depth=max_depth if max_depth is not None else MAX_NESTING_DEPTH,
+                max_children=max_children,
                 max_iterations=max_iterations,
                 budget_warnings=budget_warnings,
                 iteration_timeout=iteration_timeout,

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -36,7 +36,10 @@ TOOL_EXEC_TIMEOUT = 300          # 5 min timeout per tool execution
 # callback via src/llm/recovery.py. AgentInfo.recovery_attempts remains for
 # API/trajectory shape compatibility and stays 0.)
 MAX_NESTING_DEPTH = 2            # default max sub-agent depth (root=0)
-MAX_CHILDREN_PER_AGENT = 3       # max direct children one agent can spawn
+MAX_CHILDREN_PER_AGENT = 3       # fallback direct-child limit (config overrides at spawn)
+TREE_MAX_AGENTS = 25             # hard ceiling on agents in one tree's lifetime —
+                                 # breadth x depth must never compound into a
+                                 # geometric invoice, whatever config says
 
 # Agent-management tools — allowed or blocked based on nesting depth
 AGENT_MANAGEMENT_TOOLS = frozenset({
@@ -286,6 +289,15 @@ class AgentInfo:
     # (chat/scheduled/hard limits differ) so progress can be computed honestly
     # instead of against a hardcoded guess.
     max_iterations: int = MAX_AGENT_ITERATIONS
+    # Lifetime direct-child limit for THIS agent, snapshotted from config when
+    # the ROOT of its tree was spawned; every descendant inherits the root's
+    # value, so a live config change never produces a tree whose members
+    # disagree about the rules. It counts children ever spawned, not merely
+    # concurrent ones. The agent's own prompt advertises this same number.
+    max_children: int = MAX_CHILDREN_PER_AGENT
+    # Root of this agent's tree (self for roots) — the unit the tree-lifetime
+    # agent cap is enforced against.
+    root_id: str = ""
     depth: int = 0
     parent_id: str | None = None
     children_ids: list[str] = field(default_factory=list)
@@ -350,6 +362,7 @@ class AgentManager:
         trajectory_saver: AgentTrajectorySaver | None = None,
         parent_id: str | None = None,
         max_depth: int = MAX_NESTING_DEPTH,
+        max_children: int | None = None,
         max_iterations: int | None = None,
         budget_warnings: builtins.list[int] | None = None,
         iteration_timeout: float | None = None,
@@ -385,10 +398,24 @@ class AgentManager:
                     f"Error: Maximum nesting depth ({max_depth}) exceeded. "
                     f"Parent '{parent_id}' is at depth {parent.depth}."
                 )
-            if len(parent.children_ids) >= MAX_CHILDREN_PER_AGENT:
+            # The PARENT's snapshot governs — taken from config when its
+            # tree's root spawned. A live config change applies to the next
+            # tree, never to one already running. Counts children ever
+            # spawned (lifetime), not merely concurrent.
+            if len(parent.children_ids) >= parent.max_children:
                 return (
                     f"Error: Parent agent '{parent_id}' has reached the "
-                    f"maximum of {MAX_CHILDREN_PER_AGENT} children."
+                    f"maximum of {parent.max_children} children."
+                )
+            tree_root = parent.root_id or parent.id
+            tree_size = sum(
+                1 for a in self._agents.values()
+                if (a.root_id or a.id) == tree_root
+            )
+            if tree_size >= TREE_MAX_AGENTS:
+                return (
+                    f"Error: This agent tree has reached the lifetime "
+                    f"maximum of {TREE_MAX_AGENTS} agents."
                 )
 
         agent_id = uuid.uuid4().hex[:8]
@@ -406,7 +433,19 @@ class AgentManager:
             model_override=model_override,
             reasoning_effort_override=reasoning_effort_override,
             max_iterations=max_iterations or MAX_AGENT_ITERATIONS,
+            max_children=(
+                self._agents[parent_id].max_children
+                if parent_id and parent_id in self._agents
+                else (max_children or MAX_CHILDREN_PER_AGENT)
+            ),
+            root_id=(
+                (self._agents[parent_id].root_id or parent_id)
+                if parent_id and parent_id in self._agents
+                else ""
+            ),
         )
+        if not agent.root_id:
+            agent.root_id = agent_id
 
         # Register as child of parent
         if parent_id and parent_id in self._agents:
@@ -424,7 +463,7 @@ class AgentManager:
             remaining = max_depth - depth
             agent_system += (
                 f"AGENT CONTEXT: You are agent '{label}' (depth {depth}). "
-                f"You may spawn up to {MAX_CHILDREN_PER_AGENT} sub-agents "
+                f"You may spawn up to {agent.max_children} sub-agents "
                 f"({remaining} nesting level{'s' if remaining != 1 else ''} remaining). "
                 f"When done, provide a clear summary of results."
             )

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -345,6 +345,12 @@ class AgentManager:
     def __init__(self) -> None:
         self._agents: dict[str, AgentInfo] = {}
         self._cleanup_tasks: dict[str, asyncio.Task] = {}
+        # Lifetime spawn count per tree, keyed by root id. Deliberately NOT
+        # derived from the registry: cleanup removes finished agents, and a
+        # registry count would let a tree spend its budget in waves forever.
+        # Entries are pruned only when the tree has no registered members
+        # left (nothing can spawn into it again — parents must exist).
+        self._tree_spawn_counts: dict[str, int] = {}
 
     def spawn(
         self,
@@ -408,11 +414,12 @@ class AgentManager:
                     f"maximum of {parent.max_children} children."
                 )
             tree_root = parent.root_id or parent.id
-            tree_size = sum(
-                1 for a in self._agents.values()
-                if (a.root_id or a.id) == tree_root
-            )
-            if tree_size >= TREE_MAX_AGENTS:
+            # Lifetime counter, never the registry: cleanup shrinks the
+            # registry, and counting it would let a tree respawn its whole
+            # budget every cleanup cycle — the exact geometric invoice the
+            # cap exists to prevent.
+            tree_spawned = self._tree_spawn_counts.get(tree_root, 0)
+            if tree_spawned >= TREE_MAX_AGENTS:
                 return (
                     f"Error: This agent tree has reached the lifetime "
                     f"maximum of {TREE_MAX_AGENTS} agents."
@@ -505,6 +512,9 @@ class AgentManager:
         # Schedule cleanup when the agent task finishes (any exit path)
         task.add_done_callback(lambda _t: self._schedule_cleanup(agent_id))
         self._agents[agent_id] = agent
+        self._tree_spawn_counts[agent.root_id] = (
+            self._tree_spawn_counts.get(agent.root_id, 0) + 1
+        )
 
         log.info(
             "Spawned agent %s (%s) depth=%d for channel %s by %s: %s",
@@ -797,6 +807,13 @@ class AgentManager:
         if ct and not ct.done():
             ct.cancel()
         if agent:
+            root = agent.root_id or agent_id
+            if not any(
+                (a.root_id or a.id) == root for a in self._agents.values()
+            ):
+                # Last member gone: nothing can ever spawn into this tree
+                # again (a parent must exist), so the lifetime counter can go.
+                self._tree_spawn_counts.pop(root, None)
             log.debug("Removed agent %s (%s) via %s", agent_id, agent.label, source or "cleanup")
             return True
         return False

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -289,12 +289,12 @@ class AgentInfo:
     # (chat/scheduled/hard limits differ) so progress can be computed honestly
     # instead of against a hardcoded guess.
     max_iterations: int = MAX_AGENT_ITERATIONS
-    # Lifetime direct-child limit for THIS agent, snapshotted from config when
-    # the ROOT of its tree was spawned; every descendant inherits the root's
-    # value, so a live config change never produces a tree whose members
-    # disagree about the rules. It counts children ever spawned, not merely
-    # concurrent ones. The agent's own prompt advertises this same number.
+    # Lifetime direct-child and depth limits, snapshotted from config when
+    # the ROOT of the tree was spawned. Every descendant inherits the root's
+    # values, so a live config change never changes the rules under a running
+    # tree. The agent's own prompt advertises these same effective limits.
     max_children: int = MAX_CHILDREN_PER_AGENT
+    max_depth: int = MAX_NESTING_DEPTH
     # Root of this agent's tree (self for roots) — the unit the tree-lifetime
     # agent cap is enforced against.
     root_id: str = ""
@@ -399,9 +399,13 @@ class AgentManager:
             if not parent:
                 return f"Error: Parent agent '{parent_id}' not found."
             depth = parent.depth + 1
-            if depth > max_depth:
+            # The root's depth snapshot governs every descendant. The
+            # caller-supplied max_depth is only meaningful when starting a
+            # new root; rereading live config here would split one tree across
+            # two different limits.
+            if depth > parent.max_depth:
                 return (
-                    f"Error: Maximum nesting depth ({max_depth}) exceeded. "
+                    f"Error: Maximum nesting depth ({parent.max_depth}) exceeded. "
                     f"Parent '{parent_id}' is at depth {parent.depth}."
                 )
             # The PARENT's snapshot governs — taken from config when its
@@ -445,6 +449,11 @@ class AgentManager:
                 if parent_id and parent_id in self._agents
                 else (max_children or MAX_CHILDREN_PER_AGENT)
             ),
+            max_depth=(
+                self._agents[parent_id].max_depth
+                if parent_id and parent_id in self._agents
+                else max_depth
+            ),
             root_id=(
                 (self._agents[parent_id].root_id or parent_id)
                 if parent_id and parent_id in self._agents
@@ -465,9 +474,9 @@ class AgentManager:
         else:
             agent_system = ""
 
-        can_nest = depth < max_depth
+        can_nest = depth < agent.max_depth
         if can_nest:
-            remaining = max_depth - depth
+            remaining = agent.max_depth - depth
             agent_system += (
                 f"AGENT CONTEXT: You are agent '{label}' (depth {depth}). "
                 f"You may spawn up to {agent.max_children} sub-agents "
@@ -482,7 +491,9 @@ class AgentManager:
             )
 
         # Filter tools based on depth
-        filtered_tools = filter_agent_tools(tools or [], depth=depth, max_depth=max_depth)
+        filtered_tools = filter_agent_tools(
+            tools or [], depth=depth, max_depth=agent.max_depth
+        )
 
         # Seed messages with the goal
         agent.messages = [{"role": "user", "content": goal}]

--- a/src/config/apply_registry.py
+++ b/src/config/apply_registry.py
@@ -519,20 +519,8 @@ FIELDS: dict[str, FieldSpec] = {
     ),
     "agents.max_nesting_depth": FieldSpec(
         apply_mode="live_for_new_work",
-        description="How deep an agent tree may nest.",
-        consumers=(
-            Consumer(
-                "spawn_agent",
-                "live_for_new_work",
-                "Each spawn reads the configured depth.",
-            ),
-            Consumer(
-                "spawn_loop_agents",
-                "activation_required",
-                "Loop-spawned agents use the built-in depth; this value is not "
-                "consulted on that path.",
-            ),
-        ),
+        description="How deep an agent tree may nest. Both spawn paths read "
+        "it at spawn time; running trees keep the depth they started with.",
     ),
     "agents.max_iterations": FieldSpec(
         apply_mode="live_for_new_work",

--- a/src/config/apply_registry.py
+++ b/src/config/apply_registry.py
@@ -500,12 +500,22 @@ FIELDS: dict[str, FieldSpec] = {
     ),
     # ---------------- agents ----------------
     "agents.max_children_per_agent": FieldSpec(
-        apply_mode="dormant",
-        description="Child limit for spawned agent trees.",
-        activation_policy="No spawn path reads this value: the limit comes "
-        "from a built-in constant, which is also what an agent's own prompt "
-        "advertises. There is no switch to turn on — the spawn path has to "
-        "start consulting it first.",
+        apply_mode="live_for_new_work",
+        description="Lifetime direct-child limit per agent (1-10). Counts "
+        "children ever spawned, not merely concurrent ones.",
+        consumers=(
+            Consumer(
+                "New agent trees",
+                "live_for_new_work",
+                "The root snapshots this at spawn; every descendant inherits "
+                "the root's value, and the agent's own prompt advertises it.",
+            ),
+            Consumer(
+                "Trees already running",
+                "live_for_new_work",
+                "A running tree keeps the limit its root started with.",
+            ),
+        ),
     ),
     "agents.max_nesting_depth": FieldSpec(
         apply_mode="live_for_new_work",

--- a/src/config/apply_registry.py
+++ b/src/config/apply_registry.py
@@ -350,6 +350,43 @@ MIXED_SECTIONS: frozenset[str] = frozenset({
     "observability",
 })
 
+#: Heading copy for every two-segment subgroup the page renders as a card.
+#: The page groups deeper-than-two-segment leaves by their first two path
+#: segments and shows this as the card's description — its OWN text, never a
+#: child's. The first cut of the page stole the first child's description as
+#: the group heading ("Ssh Retry: SSH retry attempts."), which is exactly the
+#: mislabeling this dict prevents. The CI gate requires an entry for every
+#: subgroup the schema actually produces.
+GROUP_DESCRIPTIONS: dict[str, str] = {
+    "email.imap": "How Odin reads mail: server, credentials, and polling.",
+    "email.smtp": "How Odin sends mail: server, credentials, and identity.",
+    "grafana_alerts.rules": "Per-alert routing and remediation rules.",
+    "image.openai": "Native OpenAI image generation behaviour.",
+    "mcp.servers": "Configured Model Context Protocol servers.",
+    "observability.context_trace": "What each per-turn context trace records, "
+    "and how large one may grow.",
+    "openai_codex.auxiliary": "A cheaper Codex model for the four background "
+    "jobs: compaction, reflection, consolidation, and follow-up.",
+    "openai_codex.connection_pool": "HTTP connection reuse for the Codex "
+    "client. Sized when the client's session is created.",
+    "openai_codex.context_compression": "Compress long tool loops before "
+    "they exceed the model's window.",
+    "openai_codex.retry": "How failed Codex requests are retried.",
+    "outbound_webhooks.targets": "Where lifecycle events are delivered.",
+    "personality.user_presets": "Saved custom identity presets.",
+    "tools.branch_freshness": "Warn when work starts from a stale git branch.",
+    "tools.bulkhead": "Concurrency ceilings per execution kind, so one busy "
+    "path cannot starve the others.",
+    "tools.governor": "The command safety governor: what it refuses, and who "
+    "may override it.",
+    "tools.hosts": "Named hosts commands may target over SSH.",
+    "tools.recovery": "Automatic recovery after a failed tool call.",
+    "tools.ssh_pool": "Reuse SSH connections across commands.",
+    "tools.ssh_retry": "How failed SSH connections are retried.",
+    "tools.streaming": "Stream long tool output as it is produced.",
+    "web.api_tokens": "Scoped API tokens defined in the config file.",
+}
+
 # --------------------------------------------------------------------------
 # Leaves
 # --------------------------------------------------------------------------
@@ -1730,6 +1767,53 @@ def _apply_state(
     return "applied"
 
 
+def _plain_effects(
+    apply_mode: ApplyMode, spec: FieldSpec
+) -> tuple[str, str | None]:
+    """The two sentences an operator actually needs: what saving does, and
+    what the running bot does now.
+
+    The settled copy for the two gated states is exact — implementer-speak
+    like "activation required" is what this replaces. Field-specific detail
+    (restart reasons, activation policies) rides in runtime_effect so the
+    save_effect sentence stays uniform and scannable.
+    """
+    if apply_mode == "live_read":
+        return (
+            "Saving updates config.yml and takes effect immediately.",
+            "Odin reads this value on its next use.",
+        )
+    if apply_mode == "live_apply":
+        handler = spec.apply_handler or "its dedicated endpoint"
+        return (
+            "Saving updates config.yml and reconfigures the running process.",
+            f"Applied live through {handler}.",
+        )
+    if apply_mode == "live_for_new_work":
+        return (
+            "Saving updates config.yml and applies to the next spawn or turn.",
+            "Work already running keeps the values it started with.",
+        )
+    if apply_mode == "restart":
+        return (
+            "Saving updates config.yml. Odin keeps its startup value until "
+            "restarted.",
+            spec.restart_reason,
+        )
+    if apply_mode == "activation_required":
+        return (
+            "Saving records your choice, but Odin continues using current "
+            "behavior until you apply it explicitly.",
+            spec.activation_policy,
+        )
+    # dormant
+    return (
+        "Saving updates config.yml. This version of Odin does not use this "
+        "setting. Restarting will not activate it.",
+        spec.activation_policy,
+    )
+
+
 def build_field_record(
     path: str,
     desired_value: Any,
@@ -1767,6 +1851,7 @@ def build_field_record(
         effective, effective_known = None, False
 
     configured = _configured(desired_value)
+    save_effect, runtime_effect = _plain_effects(apply_mode, spec)
     facts = _facts_for(path)
     # The schema is the authority on shape; the registry only overrides when it
     # knows something Pydantic cannot express.
@@ -1804,6 +1889,19 @@ def build_field_record(
         ],
         "restart_reason": spec.restart_reason,
         "activation_policy": spec.activation_policy,
+        "group_description": GROUP_DESCRIPTIONS.get(
+            ".".join(path.split(".")[:2])
+        ),
+        "save_effect": save_effect,
+        "runtime_effect": runtime_effect,
+        # Honest-buttons-only: a button renders ONLY when a real action
+        # exists. None do yet — the F-lanes add them — so the page must show
+        # plain words, never a disabled ritual switch.
+        "action_available": False,
+        "action_label": None,
+        "action_endpoint": None,
+        "action_method": "POST",
+        "action_body": None,
         "desired": desired,
         "effective": effective,
         "configured": configured,

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -133,6 +133,16 @@ class AgentsConfig(BaseModel):
             raise ValueError("agent limits must be >= 1")
         return v
 
+    @field_validator("max_children_per_agent")
+    @classmethod
+    def _children_bounded(cls, v):
+        # Direct-child breadth compounds with nesting depth; the tree-lifetime
+        # cap in the agent manager is the hard backstop, this keeps a single
+        # config value from asking for absurd fan-out in the first place.
+        if v > 10:
+            raise ValueError("max_children_per_agent must be between 1 and 10")
+        return v
+
     @field_validator("iteration_timeout_seconds", "max_lifetime_seconds")
     @classmethod
     def _agents_timeout_bounds(cls, v, info):

--- a/src/discord/delivery.py
+++ b/src/discord/delivery.py
@@ -173,6 +173,17 @@ class ResponseDelivery:
             discord.File(io.BytesIO(data), filename=fname) for data, fname in pending
         ]
 
+        # A deliberately-silent turn (work done, nothing to add) delivers
+        # nothing — Discord rejects empty content, and fabricating filler to
+        # satisfy the API would be worse. Files still go out: an attachment
+        # with no commentary is a complete reply.
+        if not text.strip():
+            if discord_files:
+                await self.send_with_retry(message, "", files=discord_files)
+            else:
+                log.debug("Empty response with no files — nothing to send")
+            return
+
         # If the response is extremely long, send as file
         if len(text) > DISCORD_MAX_LEN * 4:
             text_file = discord.File(

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -595,16 +595,27 @@ class AgentTaskTools:
         # the expected child depth from the parent so terminal children don't
         # even see spawn_agent in their tool list.
         parent_depth = 0
+        parent = None
         if parent_id_arg:
             parent = self._agent_manager._agents.get(parent_id_arg)
             if parent is not None:
                 parent_depth = parent.depth + 1
-        max_depth = getattr(
+        configured_max_depth = getattr(
             getattr(self._get_config(), "agents", None),
             "max_nesting_depth",
             2,
         )
-        tools = filter_agent_tools(all_tools, depth=parent_depth, max_depth=max_depth)
+        # A nested tree keeps the root's snapshot in both enforcement and its
+        # visible tool catalogue. Using live config here could hide spawn_agent
+        # from a tree whose original limit still permits it.
+        effective_max_depth = (
+            getattr(parent, "max_depth", configured_max_depth)
+            if parent is not None
+            else configured_max_depth
+        )
+        tools = filter_agent_tools(
+            all_tools, depth=parent_depth, max_depth=effective_max_depth
+        )
 
         # Iteration callback — wraps Codex chat_with_tools, returns dict
         async def _iteration_cb(
@@ -647,7 +658,10 @@ class AgentTaskTools:
             if tool_name == "spawn_agent":
                 # Nested spawn — forward this agent's id so AgentManager.spawn
                 # enforces max_nesting_depth and children linkage.
-                if _self_id["id"] and not tool_input.get("parent_id"):
+                if _self_id["id"]:
+                    # Invocation ancestry is authoritative. Chat-level callers
+                    # may still choose parent_id, but an agent invoking the tool
+                    # cannot select a different active tree to evade limits.
                     tool_input = {**tool_input, "parent_id": _self_id["id"]}
             elif tool_name in AGENT_BLOCKED_TOOLS:
                 # Other agent-management tools (kill/send_to/wait_for/get_results/
@@ -700,7 +714,7 @@ class AgentTaskTools:
             tools=tools,
             system_prompt=system_prompt,
             parent_id=parent_id_arg,
-            max_depth=max_depth,
+            max_depth=configured_max_depth,
             # Root snapshot: config read at spawn time; descendants inherit
             # the root's value inside the manager. Fallback stays the
             # manager's constant for omitted/None.

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -701,6 +701,12 @@ class AgentTaskTools:
             system_prompt=system_prompt,
             parent_id=parent_id_arg,
             max_depth=max_depth,
+            # Root snapshot: config read at spawn time; descendants inherit
+            # the root's value inside the manager. Fallback stays the
+            # manager's constant for omitted/None.
+            max_children=getattr(agents_cfg, "max_children_per_agent", None)
+            if agents_cfg
+            else None,
             tool_timeouts=self._get_config().tools.tool_timeouts,
             trajectory_saver=self._agent_trajectory_saver,
             max_iterations=iter_cap,
@@ -999,6 +1005,14 @@ class AgentTaskTools:
             max_iterations=self._get_config().agents.max_iterations,
             iteration_timeout=self._get_config().agents.iteration_timeout_seconds,
             max_lifetime=self._get_config().agents.max_lifetime_seconds,
+            # Close the loop-path gap: depth and child limits now reach
+            # loop-spawned agents too, instead of silently using built-ins.
+            max_depth=getattr(
+                self._get_config().agents, "max_nesting_depth", None
+            ),
+            max_children=getattr(
+                self._get_config().agents, "max_children_per_agent", None
+            ),
             context_compression_enabled=bool(cc),
             max_context_chars=cc.max_context_chars if cc else 750000,
             keep_recent_iterations=cc.keep_recent_iterations if cc else 30,

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -1373,7 +1373,20 @@ class ToolLoopRunner:
                 st.continuation_count += 1
                 return ("retry", None)
 
-        _final = llm_resp.text or _EMPTY_RESPONSE_FALLBACK
+        # Empty final text after a turn that DID its work is a choice, not a
+        # failure: the completion classifier has already judged the turn
+        # complete, and every anti-fabrication guard runs upstream of here.
+        # Converting that silence into "I couldn't generate a response" was
+        # itself the fabricated failure (thumbs-up reaction lands, apology
+        # follows; video posts with its commentary, apology follows). With no
+        # tools used, the fallback stands — a bare empty generation IS a
+        # failure worth reporting.
+        if llm_resp.text:
+            _final = llm_resp.text
+        elif st.tools_used_in_loop:
+            _final = ""
+        else:
+            _final = _EMPTY_RESPONSE_FALLBACK
         await self._turn_recorder._save_turn_trajectory(
             st._trajectory,
             final_response=_final,

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -66,6 +66,7 @@ ADMIN_ONLY_PREFIXES = (
     "/api/mcp", "/api/tokens", "/api/personality",
     "/api/tools/timeouts", "/api/pools",
     "/api/outbound-webhooks", "/api/grafana-alerts", "/api/slack",
+    "/api/restart",
 )
 
 

--- a/src/web/api/config_admin.py
+++ b/src/web/api/config_admin.py
@@ -477,6 +477,35 @@ def register_quick_actions(routes: web.RouteTableDef, bot) -> None:
     # Quick actions
     # ------------------------------------------------------------------
 
+    @routes.post("/api/restart")
+    async def restart_odin(request: web.Request) -> web.Response:
+        """Cleanly restart the running process, on operator request.
+
+        Exists for the Config page's pending-restart flow: restart-mode
+        settings are saved but keep their startup values until the process
+        comes back, so the page offers this instead of telling the operator
+        to find a shell. Same mechanism as the setup wizard: record restart
+        intent, return before dying, then a delayed SIGTERM lets main()
+        re-exec in place regardless of the unit's Restart= policy.
+
+        Idempotent while a restart is already scheduled, and deliberately
+        accepts NO body/env overrides — the wizard's env-override path is for
+        first boot only; this route must never become a way to mutate the
+        process environment.
+        """
+        denied = _require_admin(request)
+        if denied is not None:
+            return denied
+        if restart.restart_requested():
+            return web.json_response({"status": "restarting"}, status=202)
+        restart.request_restart()
+        import os as _os
+        import signal as _signal
+        loop = asyncio.get_running_loop()
+        loop.call_later(2.0, _os.kill, _os.getpid(), _signal.SIGTERM)
+        log.info("Restart requested via /api/restart")
+        return web.json_response({"status": "restarting"}, status=202)
+
     @routes.post("/api/sessions/clear-all")
     async def clear_all_sessions(request: web.Request) -> web.Response:
         denied = _require_admin(request)

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -324,116 +324,119 @@ async def _persist_or_response(
     return None, was_cancelled
 
 
-#: Nested Codex knobs the LLM page's Advanced panel edits. Each entry:
-#: (body group key or None for top-level, field, validator). The old handler
-#: silently DROPPED all of these — the panel toasted "saved" for a save that
-#: never happened — so acceptance here is what makes it real.
 def _parse_codex_advanced(body: dict, cfg) -> tuple[list, list, bool] | web.Response:
     """Validate the Advanced-panel keys out of a codex PUT body.
 
-    Returns ``(persist_changes, apply_ops, wants_reload)`` — persist tuples for
-    the config writer, ``(parent_attr | None, field, value)`` ops for live
-    config, and whether any live-appliable transport/retry key was present —
-    or an error Response. Bounds mirror the schema's validators, enforced here
-    because direct assignment skips Pydantic validation.
-    """
+    Returns ``(persist_changes, apply_ops, wants_reload)`` — persist tuples
+    for the config writer, ``(cfg attribute, new value)`` ops for live config,
+    and whether a live-appliable transport/retry key was present — or an error
+    Response.
 
-    def _num(value, name, lo, hi=None, *, integer=True):
-        try:
-            parsed = int(value) if integer else float(value)
-        except (TypeError, ValueError):
-            raise ValueError(f"{name} must be a number")
-        if parsed < lo or (hi is not None and parsed > hi):
-            bound = f"between {lo} and {hi}" if hi is not None else f">= {lo}"
-            raise ValueError(f"{name} must be {bound}")
+    Validation runs through the MERGED Pydantic models themselves, not a
+    hand-mirrored copy of their rules: the first cut re-implemented bounds and
+    got all four ways it can go wrong — int() truncated 1.9 to 1, bool()
+    turned the string "false" into True, a list where a dict belonged was
+    silently ignored with a 200, and an invented floor rejected values the
+    schema accepts. Constructing the real model gives schema-exact coercion
+    and rejection for free, forever.
+
+    Nested groups are applied by REPLACING the whole sub-model object, never
+    by mutating it in place: the boot-built context compressor holds the boot
+    config's nested object by identity, so in-place mutation made compression
+    thresholds live-before-rebind and stale-after — replacement makes
+    persist-only deterministic.
+    """
+    from pydantic import ValidationError
+
+    from ...config.schema import (
+        ConnectionPoolConfig,
+        ContextCompressionConfig,
+        RetryConfig,
+    )
+
+    def _schema_int(value, name, lo, hi):
+        # Schema-true integer: the config fields are ints with range
+        # validators; bool is an int subclass and 1.9 must not truncate.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{name} must be an integer")
+        if isinstance(value, float) and not value.is_integer():
+            raise ValueError(f"{name} must be an integer")
+        parsed = int(value)
+        if not lo <= parsed <= hi:
+            raise ValueError(f"{name} must be between {lo} and {hi}")
         return parsed
 
     persist: list = []
-    apply_ops: list = []
+    ops: list = []
     wants_reload = False
     try:
         if "request_timeout_seconds" in body:
-            value = _num(
+            value = _schema_int(
                 body["request_timeout_seconds"], "request_timeout_seconds", 60, 86400
             )
             persist.append((("openai_codex", "request_timeout_seconds"), value))
-            apply_ops.append((None, "request_timeout_seconds", value))
+            ops.append(("request_timeout_seconds", value))
             wants_reload = True
         if "stream_stall_timeout_seconds" in body:
-            value = _num(
+            value = _schema_int(
                 body["stream_stall_timeout_seconds"],
                 "stream_stall_timeout_seconds", 10, 3600,
             )
             persist.append((("openai_codex", "stream_stall_timeout_seconds"), value))
-            apply_ops.append((None, "stream_stall_timeout_seconds", value))
+            ops.append(("stream_stall_timeout_seconds", value))
             wants_reload = True
-        retry = body.get("retry")
-        if isinstance(retry, dict):
-            for field, integer in (
-                ("max_retries", True), ("base_delay", False), ("max_delay", False),
-            ):
-                if field in retry:
-                    value = _num(retry[field], f"retry.{field}", 0, integer=integer)
-                    persist.append((("openai_codex", "retry", field), value))
-                    apply_ops.append(("retry", field, value))
-                    wants_reload = True
-        pool = body.get("connection_pool")
-        if isinstance(pool, dict):
-            if "max_connections" in pool:
-                value = _num(
-                    pool["max_connections"], "connection_pool.max_connections", 1
-                )
-                persist.append(
-                    (("openai_codex", "connection_pool", "max_connections"), value)
-                )
-                apply_ops.append(("connection_pool", "max_connections", value))
-            if "keepalive_timeout" in pool:
-                value = _num(
-                    pool["keepalive_timeout"], "connection_pool.keepalive_timeout", 0
-                )
-                persist.append(
-                    (("openai_codex", "connection_pool", "keepalive_timeout"), value)
-                )
-                apply_ops.append(("connection_pool", "keepalive_timeout", value))
-        compression = body.get("context_compression")
-        if isinstance(compression, dict):
-            if "enabled" in compression:
-                value = bool(compression["enabled"])
-                persist.append((("openai_codex", "context_compression", "enabled"), value))
-                apply_ops.append(("context_compression", "enabled", value))
-            if "max_context_chars" in compression:
-                value = _num(
-                    compression["max_context_chars"],
-                    "context_compression.max_context_chars", 1000,
-                )
-                persist.append(
-                    (("openai_codex", "context_compression", "max_context_chars"), value)
-                )
-                apply_ops.append(("context_compression", "max_context_chars", value))
-            if "keep_recent_iterations" in compression:
-                value = _num(
-                    compression["keep_recent_iterations"],
-                    "context_compression.keep_recent_iterations", 0,
-                )
-                persist.append(
-                    (
-                        ("openai_codex", "context_compression", "keep_recent_iterations"),
-                        value,
-                    )
-                )
-                apply_ops.append(("context_compression", "keep_recent_iterations", value))
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
-    return persist, apply_ops, wants_reload
+
+    groups = (
+        ("retry", RetryConfig, True),
+        ("connection_pool", ConnectionPoolConfig, False),
+        ("context_compression", ContextCompressionConfig, False),
+    )
+    for group, model_cls, live in groups:
+        if group not in body:
+            continue
+        submitted = body[group]
+        if not isinstance(submitted, dict):
+            # A list here used to be silently ignored with a 200.
+            return web.json_response(
+                {"error": f"{group} must be an object of settings"}, status=400
+            )
+        unknown = set(submitted) - set(model_cls.model_fields)
+        if unknown:
+            return web.json_response(
+                {"error": f"unknown {group} field(s): {', '.join(sorted(unknown))}"},
+                status=400,
+            )
+        current = getattr(cfg, group)
+        try:
+            merged = model_cls(**{**current.model_dump(), **submitted})
+        except ValidationError as exc:
+            first = exc.errors()[0]
+            loc = ".".join(str(part) for part in first.get("loc", ()))
+            return web.json_response(
+                {"error": f"{group}.{loc}: {first.get('msg', 'invalid value')}"},
+                status=400,
+            )
+        ops.append((group, merged))
+        persist.extend(
+            (("openai_codex", group, key), getattr(merged, key)) for key in submitted
+        )
+        wants_reload = wants_reload or live
+    return persist, ops, wants_reload
 
 
 def _apply_ops(cfg, ops: list) -> list:
-    """Apply ``(parent, field, value)`` ops; return inverse ops for rollback."""
+    """Apply ``(attribute, value)`` ops on cfg; return inverse ops.
+
+    Nested groups arrive as whole model objects and REPLACE the previous
+    object — the inverse holds the prior object by identity, so rollback
+    restores exactly what boot-time captors still reference.
+    """
     inverse: list = []
-    for parent, field, value in ops:
-        target = getattr(cfg, parent) if parent else cfg
-        inverse.append((parent, field, getattr(target, field)))
-        setattr(target, field, value)
+    for attr, value in ops:
+        inverse.append((attr, getattr(cfg, attr)))
+        setattr(cfg, attr, value)
     return inverse
 
 
@@ -589,17 +592,18 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                             await bot.llm_gateway.reload_codex_inner()
                     except BaseException:
                         _set_fields(cfg, prior)
-                        _apply_ops(cfg, adv_inverse)  # restore nested live config
-                        adv_prior_persist = [
-                            (
-                                (
-                                    "openai_codex",
-                                    *((parent, field) if parent else (field,)),
-                                ),
-                                value,
-                            )
-                            for parent, field, value in adv_inverse
-                        ]
+                        _apply_ops(cfg, adv_inverse)  # restore prior objects
+                        adv_prior_persist = []
+                        for attr, prior_value in adv_inverse:
+                            if hasattr(prior_value, "model_dump"):
+                                adv_prior_persist.extend(
+                                    (("openai_codex", attr, key), val)
+                                    for key, val in prior_value.model_dump().items()
+                                )
+                            else:
+                                adv_prior_persist.append(
+                                    (("openai_codex", attr), prior_value)
+                                )
                         rollback_exc, rollback_cancelled = await persist_config_paths_locked(
                             [
                                 (("openai_codex", key), value)
@@ -614,6 +618,11 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                                 rollback_exc,
                             )
                             _set_fields(cfg, desired)
+                            # Disk kept the DESIRED nested values (their
+                            # rollback failed too) — runtime must republish
+                            # them as well, or transport/retry/pool split
+                            # between disk and process.
+                            _apply_ops(cfg, adv_ops)
                             if needs_reload:
                                 await bot.llm_gateway.reload_codex_inner()
                         elif needs_reload:

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -205,6 +205,36 @@ def register_llm_provider(routes: web.RouteTableDef, bot) -> None:
                     if bot.config.openai_codex.agent_model not in (None, "auto")
                     else bot.config.openai_codex.model
                 ),
+                # Advanced transport/retry/pool/compression — the LLM page's
+                # Advanced panel populates exclusively from this endpoint;
+                # omitting these left it displaying schema defaults forever
+                # regardless of config.yml truth.
+                "request_timeout_seconds": bot.config.openai_codex.request_timeout_seconds,
+                "stream_stall_timeout_seconds": (
+                    bot.config.openai_codex.stream_stall_timeout_seconds
+                ),
+                "retry": {
+                    "max_retries": bot.config.openai_codex.retry.max_retries,
+                    "base_delay": bot.config.openai_codex.retry.base_delay,
+                    "max_delay": bot.config.openai_codex.retry.max_delay,
+                },
+                "connection_pool": {
+                    "max_connections": (
+                        bot.config.openai_codex.connection_pool.max_connections
+                    ),
+                    "keepalive_timeout": (
+                        bot.config.openai_codex.connection_pool.keepalive_timeout
+                    ),
+                },
+                "context_compression": {
+                    "enabled": bot.config.openai_codex.context_compression.enabled,
+                    "max_context_chars": (
+                        bot.config.openai_codex.context_compression.max_context_chars
+                    ),
+                    "keep_recent_iterations": (
+                        bot.config.openai_codex.context_compression.keep_recent_iterations
+                    ),
+                },
             },
             "ollama": {
                 "configured": ollama_configured,
@@ -220,6 +250,10 @@ def register_llm_provider(routes: web.RouteTableDef, bot) -> None:
                 "enabled": kimi_cfg.enabled if kimi_cfg else False,
                 "model": kimi_cfg.model if kimi_cfg else "",
                 "max_tokens": kimi_cfg.max_tokens if kimi_cfg else 4096,
+                # Present for the same reason as ollama's: the Advanced panel
+                # reads it here — saving worked while display showed the
+                # default forever.
+                "timeout": kimi_cfg.timeout if kimi_cfg else 300,
                 "has_api_key": kimi_has_key,
             },
             "auxiliary": _auxiliary_status(bot),
@@ -288,6 +322,119 @@ async def _persist_or_response(
             False,
         )
     return None, was_cancelled
+
+
+#: Nested Codex knobs the LLM page's Advanced panel edits. Each entry:
+#: (body group key or None for top-level, field, validator). The old handler
+#: silently DROPPED all of these — the panel toasted "saved" for a save that
+#: never happened — so acceptance here is what makes it real.
+def _parse_codex_advanced(body: dict, cfg) -> tuple[list, list, bool] | web.Response:
+    """Validate the Advanced-panel keys out of a codex PUT body.
+
+    Returns ``(persist_changes, apply_ops, wants_reload)`` — persist tuples for
+    the config writer, ``(parent_attr | None, field, value)`` ops for live
+    config, and whether any live-appliable transport/retry key was present —
+    or an error Response. Bounds mirror the schema's validators, enforced here
+    because direct assignment skips Pydantic validation.
+    """
+
+    def _num(value, name, lo, hi=None, *, integer=True):
+        try:
+            parsed = int(value) if integer else float(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{name} must be a number")
+        if parsed < lo or (hi is not None and parsed > hi):
+            bound = f"between {lo} and {hi}" if hi is not None else f">= {lo}"
+            raise ValueError(f"{name} must be {bound}")
+        return parsed
+
+    persist: list = []
+    apply_ops: list = []
+    wants_reload = False
+    try:
+        if "request_timeout_seconds" in body:
+            value = _num(
+                body["request_timeout_seconds"], "request_timeout_seconds", 60, 86400
+            )
+            persist.append((("openai_codex", "request_timeout_seconds"), value))
+            apply_ops.append((None, "request_timeout_seconds", value))
+            wants_reload = True
+        if "stream_stall_timeout_seconds" in body:
+            value = _num(
+                body["stream_stall_timeout_seconds"],
+                "stream_stall_timeout_seconds", 10, 3600,
+            )
+            persist.append((("openai_codex", "stream_stall_timeout_seconds"), value))
+            apply_ops.append((None, "stream_stall_timeout_seconds", value))
+            wants_reload = True
+        retry = body.get("retry")
+        if isinstance(retry, dict):
+            for field, integer in (
+                ("max_retries", True), ("base_delay", False), ("max_delay", False),
+            ):
+                if field in retry:
+                    value = _num(retry[field], f"retry.{field}", 0, integer=integer)
+                    persist.append((("openai_codex", "retry", field), value))
+                    apply_ops.append(("retry", field, value))
+                    wants_reload = True
+        pool = body.get("connection_pool")
+        if isinstance(pool, dict):
+            if "max_connections" in pool:
+                value = _num(
+                    pool["max_connections"], "connection_pool.max_connections", 1
+                )
+                persist.append(
+                    (("openai_codex", "connection_pool", "max_connections"), value)
+                )
+                apply_ops.append(("connection_pool", "max_connections", value))
+            if "keepalive_timeout" in pool:
+                value = _num(
+                    pool["keepalive_timeout"], "connection_pool.keepalive_timeout", 0
+                )
+                persist.append(
+                    (("openai_codex", "connection_pool", "keepalive_timeout"), value)
+                )
+                apply_ops.append(("connection_pool", "keepalive_timeout", value))
+        compression = body.get("context_compression")
+        if isinstance(compression, dict):
+            if "enabled" in compression:
+                value = bool(compression["enabled"])
+                persist.append((("openai_codex", "context_compression", "enabled"), value))
+                apply_ops.append(("context_compression", "enabled", value))
+            if "max_context_chars" in compression:
+                value = _num(
+                    compression["max_context_chars"],
+                    "context_compression.max_context_chars", 1000,
+                )
+                persist.append(
+                    (("openai_codex", "context_compression", "max_context_chars"), value)
+                )
+                apply_ops.append(("context_compression", "max_context_chars", value))
+            if "keep_recent_iterations" in compression:
+                value = _num(
+                    compression["keep_recent_iterations"],
+                    "context_compression.keep_recent_iterations", 0,
+                )
+                persist.append(
+                    (
+                        ("openai_codex", "context_compression", "keep_recent_iterations"),
+                        value,
+                    )
+                )
+                apply_ops.append(("context_compression", "keep_recent_iterations", value))
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    return persist, apply_ops, wants_reload
+
+
+def _apply_ops(cfg, ops: list) -> list:
+    """Apply ``(parent, field, value)`` ops; return inverse ops for rollback."""
+    inverse: list = []
+    for parent, field, value in ops:
+        target = getattr(cfg, parent) if parent else cfg
+        inverse.append((parent, field, getattr(target, field)))
+        setattr(target, field, value)
+    return inverse
 
 
 def register_provider_config(routes: web.RouteTableDef, bot) -> None:
@@ -414,7 +561,12 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     ),
                     "agent_model": agent_model if agent_model_present else cfg.agent_model,
                 }
+                advanced = _parse_codex_advanced(body, cfg)
+                if isinstance(advanced, web.Response):
+                    return advanced
+                adv_persist, adv_ops, adv_reload = advanced
                 changes = _provider_changes("openai_codex", desired, body)
+                changes = changes + adv_persist
                 persist_response, was_cancelled = await _persist_or_response(
                     changes, "Codex"
                 )
@@ -423,7 +575,12 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                 if changes:
                     prior = {key: getattr(cfg, key) for key in desired}
                     _set_fields(cfg, desired)
-                    needs_reload = any(
+                    # Advanced transport/retry apply live through the same
+                    # reload the primary knobs use; pool and compression
+                    # persist only and surface as pending-restart. The old
+                    # handler dropped all of these silently and returned 200.
+                    adv_inverse = _apply_ops(cfg, adv_ops)
+                    needs_reload = adv_reload or any(
                         key in body
                         for key in ("enabled", "model", "max_tokens", "reasoning_effort")
                     )
@@ -432,12 +589,24 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                             await bot.llm_gateway.reload_codex_inner()
                     except BaseException:
                         _set_fields(cfg, prior)
+                        _apply_ops(cfg, adv_inverse)  # restore nested live config
+                        adv_prior_persist = [
+                            (
+                                (
+                                    "openai_codex",
+                                    *((parent, field) if parent else (field,)),
+                                ),
+                                value,
+                            )
+                            for parent, field, value in adv_inverse
+                        ]
                         rollback_exc, rollback_cancelled = await persist_config_paths_locked(
                             [
                                 (("openai_codex", key), value)
                                 for key, value in prior.items()
                                 if key in body
                             ]
+                            + adv_prior_persist
                         )
                         if rollback_exc is not None:
                             log.critical(

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import asyncio
 import ipaddress as _ipaddress
 import urllib.parse as _urlparse
+from typing import Any
 
 from aiohttp import web
+from pydantic import TypeAdapter, ValidationError
 
 from ...config.persistence import (
     config_transaction,
@@ -154,6 +156,36 @@ def _auxiliary_status(bot) -> dict:
     }
 
 
+def _boot_codex_group_status(
+    bot: Any,
+    group: str,
+    desired: dict[str, Any],
+) -> tuple[dict[str, Any] | None, bool | None]:
+    """Return boot-effective values and whether desired differs.
+
+    Connection-pool and context-compression objects are captured by runtime
+    components at boot. The desired config object is therefore not evidence
+    of what this process uses. ``None`` is deliberate when the boot snapshot
+    is unavailable: unknown is more honest than inventing an applied state.
+    """
+    # OdinClient records this once during construction. Read the concrete
+    # instance dictionary so permissive mocks/proxies cannot manufacture a
+    # pretend snapshot through __getattr__ and make status look authoritative.
+    boot = getattr(bot, "__dict__", {}).get("boot_config_snapshot")
+    if not isinstance(boot, dict):
+        return None, None
+    codex_boot = boot.get("openai_codex")
+    if not isinstance(codex_boot, dict):
+        return None, None
+    effective = codex_boot.get(group)
+    if not isinstance(effective, dict):
+        return None, None
+    # Only compare the public schema keys represented by desired. This keeps
+    # future boot-snapshot metadata from creating a false pending signal.
+    normalized = {key: effective.get(key) for key in desired}
+    return normalized, normalized != desired
+
+
 def register_llm_provider(routes: web.RouteTableDef, bot) -> None:
     """LLM provider management (verbatim from the monolith)."""
     # ------------------------------------------------------------------
@@ -171,6 +203,15 @@ def register_llm_provider(routes: web.RouteTableDef, bot) -> None:
         ollama_cfg = getattr(bot.config, "ollama", None)
         kimi_cfg = getattr(bot.config, "kimi", None)
         kimi_has_key = bool(kimi_cfg and kimi_cfg.api_key)
+
+        desired_pool = bot.config.openai_codex.connection_pool.model_dump()
+        desired_compression = bot.config.openai_codex.context_compression.model_dump()
+        effective_pool, pool_pending_restart = _boot_codex_group_status(
+            bot, "connection_pool", desired_pool
+        )
+        effective_compression, compression_pending_restart = _boot_codex_group_status(
+            bot, "context_compression", desired_compression
+        )
 
         result = {
             "active_provider": active,
@@ -218,23 +259,12 @@ def register_llm_provider(routes: web.RouteTableDef, bot) -> None:
                     "base_delay": bot.config.openai_codex.retry.base_delay,
                     "max_delay": bot.config.openai_codex.retry.max_delay,
                 },
-                "connection_pool": {
-                    "max_connections": (
-                        bot.config.openai_codex.connection_pool.max_connections
-                    ),
-                    "keepalive_timeout": (
-                        bot.config.openai_codex.connection_pool.keepalive_timeout
-                    ),
-                },
-                "context_compression": {
-                    "enabled": bot.config.openai_codex.context_compression.enabled,
-                    "max_context_chars": (
-                        bot.config.openai_codex.context_compression.max_context_chars
-                    ),
-                    "keep_recent_iterations": (
-                        bot.config.openai_codex.context_compression.keep_recent_iterations
-                    ),
-                },
+                "connection_pool": desired_pool,
+                "effective_connection_pool": effective_pool,
+                "connection_pool_pending_restart": pool_pending_restart,
+                "context_compression": desired_compression,
+                "effective_context_compression": effective_compression,
+                "context_compression_pending_restart": compression_pending_restart,
             },
             "ollama": {
                 "configured": ollama_configured,
@@ -302,7 +332,9 @@ def _set_fields(obj, values: dict[str, object]) -> None:
         setattr(obj, key, value)
 
 
-def _provider_changes(section: str, desired: dict[str, object], body: dict) -> list:
+def _provider_changes(
+    section: str, desired: dict[str, object], body: dict
+) -> list[tuple[tuple[str, ...], Any]]:
     return [((section, key), desired[key]) for key in desired if key in body]
 
 
@@ -346,28 +378,31 @@ def _parse_codex_advanced(body: dict, cfg) -> tuple[list, list, bool] | web.Resp
     thresholds live-before-rebind and stale-after — replacement makes
     persist-only deterministic.
     """
-    from pydantic import ValidationError
-
     from ...config.schema import (
         ConnectionPoolConfig,
         ContextCompressionConfig,
         RetryConfig,
     )
 
-    def _schema_int(value, name, lo, hi):
-        # Schema-true integer: the config fields are ints with range
-        # validators; bool is an int subclass and 1.9 must not truncate.
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
+    integer_adapter = TypeAdapter(int)
+
+    def _schema_int(value: Any, name: str, lo: int, hi: int) -> int:
+        # Match Pydantic's lax integer coercion (for example "600" -> 600),
+        # except JSON booleans stay forbidden at this HTTP boundary. Pydantic
+        # accepts bool as int for compatibility, but an operator checkbox is
+        # never a meaningful timeout.
+        if isinstance(value, bool):
             raise ValueError(f"{name} must be an integer")
-        if isinstance(value, float) and not value.is_integer():
-            raise ValueError(f"{name} must be an integer")
-        parsed = int(value)
+        try:
+            parsed = integer_adapter.validate_python(value)
+        except ValidationError as exc:
+            raise ValueError(f"{name} must be an integer") from exc
         if not lo <= parsed <= hi:
             raise ValueError(f"{name} must be between {lo} and {hi}")
         return parsed
 
-    persist: list = []
-    ops: list = []
+    persist: list[tuple[tuple[str, ...], Any]] = []
+    ops: list[tuple[str, Any]] = []
     wants_reload = False
     try:
         if "request_timeout_seconds" in body:
@@ -426,14 +461,14 @@ def _parse_codex_advanced(body: dict, cfg) -> tuple[list, list, bool] | web.Resp
     return persist, ops, wants_reload
 
 
-def _apply_ops(cfg, ops: list) -> list:
+def _apply_ops(cfg: Any, ops: list[tuple[str, Any]]) -> list[tuple[str, Any]]:
     """Apply ``(attribute, value)`` ops on cfg; return inverse ops.
 
     Nested groups arrive as whole model objects and REPLACE the previous
     object — the inverse holds the prior object by identity, so rollback
     restores exactly what boot-time captors still reference.
     """
-    inverse: list = []
+    inverse: list[tuple[str, Any]] = []
     for attr, value in ops:
         inverse.append((attr, getattr(cfg, attr)))
         setattr(cfg, attr, value)
@@ -593,7 +628,9 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     except BaseException:
                         _set_fields(cfg, prior)
                         _apply_ops(cfg, adv_inverse)  # restore prior objects
-                        adv_prior_persist = []
+                        adv_prior_persist: list[
+                            tuple[tuple[str, ...], Any]
+                        ] = []
                         for attr, prior_value in adv_inverse:
                             if hasattr(prior_value, "model_dump"):
                                 adv_prior_persist.extend(
@@ -604,13 +641,13 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                                 adv_prior_persist.append(
                                     (("openai_codex", attr), prior_value)
                                 )
+                        prior_persist: list[tuple[tuple[str, ...], Any]] = [
+                            (("openai_codex", key), value)
+                            for key, value in prior.items()
+                            if key in body
+                        ]
                         rollback_exc, rollback_cancelled = await persist_config_paths_locked(
-                            [
-                                (("openai_codex", key), value)
-                                for key, value in prior.items()
-                                if key in body
-                            ]
-                            + adv_prior_persist
+                            prior_persist + adv_prior_persist
                         )
                         if rollback_exc is not None:
                             log.critical(

--- a/tests/characterization/test_api_route_parity.py
+++ b/tests/characterization/test_api_route_parity.py
@@ -39,6 +39,7 @@ EXPECTED_ROUTES = [
     ("GET", "/api/config", "get_config"),
     ("GET", "/api/config/meta", "get_config_meta"),
     ("PUT", "/api/config", "update_config"),
+    ("POST", "/api/restart", "restart_odin"),
     ("POST", "/api/sessions/clear-all", "clear_all_sessions"),
     ("POST", "/api/reload", "reload_config"),
     ("GET", "/api/personality", "get_personality"),
@@ -234,7 +235,7 @@ class TestRouteTableParity:
     def test_exact_route_list_and_order(self):
         actual = _routes()
         expected = [tuple(e) for e in EXPECTED_ROUTES]
-        assert len(actual) == len(expected) == 187
+        assert len(actual) == len(expected) == 188
         # set equality first for a readable diff on failure
         missing = set(expected) - set(actual)
         added = set(actual) - set(expected)

--- a/tests/characterization/test_delivery.py
+++ b/tests/characterization/test_delivery.py
@@ -41,6 +41,27 @@ class TestSendChunked:
         for t in msg.all_delivered_texts():
             assert len(t) <= DISCORD_MAX_LEN
 
+    async def test_empty_text_with_no_files_sends_nothing(self, bot):
+        """A deliberately-silent turn delivers silence. Discord rejects empty
+        content, and the old path would have thrown that 400 after retries —
+        or worse, upstream fabricated an apology to have something to send."""
+        msg = FakeMessage("q")
+        await bot.delivery.send_chunked(msg, "")
+        # Raw lists, not reply_texts — that property filters falsy content,
+        # which is exactly how an empty send would hide from the assertion.
+        assert msg.replies == []
+        assert msg.channel.sent == []
+
+    async def test_empty_text_with_pending_files_still_delivers_the_files(self, bot):
+        """An attachment with no commentary is a complete reply — the video
+        case: the file went out, and there was nothing more to say."""
+        msg = FakeMessage("q")
+        bot.channel_state.pending_files[str(msg.channel.id)] = [(b"vid", "clip.mp4")]
+        await bot.delivery.send_chunked(msg, "")
+        assert len(msg.replies) == 1
+        assert msg.replies[0]["files"]
+        assert str(msg.channel.id) not in bot.channel_state.pending_files
+
     async def test_code_fence_reopened_across_chunks(self, bot):
         msg = FakeMessage("q")
         body = "\n".join("x = 1  # padding padding padding" for _ in range(90))

--- a/tests/test_apply_registry.py
+++ b/tests/test_apply_registry.py
@@ -564,7 +564,6 @@ class TestEffectiveIsNeverGuessed:
     @pytest.mark.parametrize(
         "path,value",
         [
-            ("agents.max_nesting_depth", 3),
             ("agents.hard_max_iterations", 250),
             ("agents.final_warning_iterations", [10, 2]),
         ],
@@ -576,6 +575,13 @@ class TestEffectiveIsNeverGuessed:
         assert record["apply_mode"] == "live_for_new_work"
         assert record["effective"] is None
         assert record["apply_state"] == "unknown"
+
+    def test_nesting_depth_is_knowable_now_both_paths_consult_it(self):
+        """Was in the non-adopting set; the loop path passes it since the
+        wiring PR, so the next unit of work IS the configured value."""
+        record = build_field_record("agents.max_nesting_depth", 3)
+        assert record["effective"] == 3
+        assert record["apply_state"] == "applied"
 
     @pytest.mark.parametrize("path", ["scrub_secrets", "verify_ssl"])
     def test_dropped_webhook_target_boot_value_is_not_reported_effective(self, path):

--- a/tests/test_apply_registry.py
+++ b/tests/test_apply_registry.py
@@ -761,3 +761,82 @@ class TestSpecConstruction:
         assert blank.apply_mode is None
         assert blank.consumers == ()
         assert blank.constraints == {}
+
+
+class TestPlainLanguageEffects:
+    """The two sentences an operator needs, replacing 'Activation required'.
+
+    The settled copy is exact for the gated states; drift in those words is
+    drift in meaning, so they are pinned verbatim.
+    """
+
+    def test_an_unwired_field_says_so_in_the_settled_words(self):
+        record = build_field_record("agents.max_children_per_agent", 9)
+        assert record["save_effect"] == (
+            "Saving updates config.yml. This version of Odin does not use "
+            "this setting. Restarting will not activate it."
+        )
+
+    def test_a_gated_field_says_current_behavior_is_kept(self):
+        record = build_field_record("usage.directory", "./x")
+        assert record["save_effect"] == (
+            "Saving records your choice, but Odin continues using current "
+            "behavior until you apply it explicitly."
+        )
+
+    def test_restart_fields_carry_their_reason_as_runtime_effect(self):
+        record = build_field_record("sessions.max_history", 50)
+        assert "startup value" in record["save_effect"]
+        assert record["runtime_effect"] == record["restart_reason"]
+
+    def test_live_apply_names_its_handler(self):
+        record = build_field_record("openai_codex.model", "sol")
+        assert "PUT /api/llm/codex/config" in record["runtime_effect"]
+
+    def test_every_record_carries_both_sentences(self):
+        from src.config.schema import Config
+
+        payload = build_meta_payload(Config(discord={"token": "x"}).model_dump())
+        assert all(f["save_effect"] for f in payload["fields"])
+
+    def test_action_buttons_are_honest_off_until_one_exists(self):
+        """No activation endpoints exist yet — a rendered button would be the
+        disabled ritual switch the redesign bans."""
+        record = build_field_record("mcp.enabled", False)
+        assert record["action_available"] is False
+        assert record["action_label"] is None
+        assert record["action_endpoint"] is None
+
+
+class TestGroupDescriptions:
+    """Subgroup cards carry their OWN heading copy.
+
+    The first cut of the page stole the first child's description as the
+    group heading — 'Ssh Retry: SSH retry attempts.' — so the copy now lives
+    server-side, one entry per subgroup, CI-gated for completeness.
+    """
+
+    def test_subgroup_records_carry_the_group_heading(self):
+        record = build_field_record("tools.ssh_retry.max_retries", 2)
+        assert record["group_description"] == "How failed SSH connections are retried."
+
+    def test_the_heading_is_not_a_child_description(self):
+        from src.config.apply_registry import GROUP_DESCRIPTIONS
+
+        record = build_field_record("tools.bulkhead.ssh_max_concurrent", 10)
+        assert record["group_description"] == GROUP_DESCRIPTIONS["tools.bulkhead"]
+        assert record["group_description"] != record["description"]
+
+    def test_top_level_leaves_carry_none(self):
+        assert build_field_record("timezone", "UTC")["group_description"] is None
+
+    def test_every_schema_subgroup_has_an_entry(self):
+        from src.config.apply_registry import GROUP_DESCRIPTIONS, schema_facts
+
+        subgroups = {
+            ".".join(k.split(".")[:2])
+            for k in schema_facts()
+            if k.count(".") >= 2
+        }
+        missing = subgroups - set(GROUP_DESCRIPTIONS)
+        assert missing == set(), f"subgroups without heading copy: {missing}"

--- a/tests/test_apply_registry.py
+++ b/tests/test_apply_registry.py
@@ -526,10 +526,18 @@ class TestEffectiveIsNeverGuessed:
     """
 
     def test_a_field_nothing_reads_reports_no_effective_value(self):
-        record = build_field_record("agents.max_children_per_agent", 9)
-        assert record["desired"] == 9
+        record = build_field_record("openai_codex.max_tokens", 9000)
+        assert record["desired"] == 9000
         assert record["effective"] is None
         assert record["apply_state"] == "dormant"
+
+    def test_the_wired_child_limit_reports_next_tree_semantics(self):
+        """Was THE dormant exemplar; the spawn path consults it now — root
+        snapshot, descendants inherit, so live_for_new_work is the truth."""
+        record = build_field_record("agents.max_children_per_agent", 5)
+        assert record["apply_mode"] == "live_for_new_work"
+        assert record["effective"] == 5
+        assert record["apply_state"] == "applied"
 
     def test_a_gated_field_reports_no_effective_value(self):
         record = build_field_record("usage.directory", "./data/usage")
@@ -771,7 +779,7 @@ class TestPlainLanguageEffects:
     """
 
     def test_an_unwired_field_says_so_in_the_settled_words(self):
-        record = build_field_record("agents.max_children_per_agent", 9)
+        record = build_field_record("openai_codex.max_tokens", 9000)
         assert record["save_effect"] == (
             "Saving updates config.yml. This version of Odin does not use "
             "this setting. Restarting will not activate it."

--- a/tests/test_config_schema_validators.py
+++ b/tests/test_config_schema_validators.py
@@ -255,3 +255,16 @@ class TestAgentModelConfig:
     def test_surrounding_whitespace_stripped(self):
         from src.config.schema import OpenAICodexConfig
         assert OpenAICodexConfig(agent_model=" gpt-5.5 ").agent_model == "gpt-5.5"
+
+
+def test_max_children_per_agent_upper_bound():
+    """1-10: breadth compounds with depth, so a single config value must not
+    ask for absurd fan-out; the manager's tree cap is the backstop."""
+    import pytest
+
+    from src.config.schema import Config
+
+    with pytest.raises(ValueError, match="between 1 and 10"):
+        Config(discord={"token": "x"}, agents={"max_children_per_agent": 11})
+    cfg = Config(discord={"token": "x"}, agents={"max_children_per_agent": 10})
+    assert cfg.agents.max_children_per_agent == 10

--- a/tests/test_loop_bridge.py
+++ b/tests/test_loop_bridge.py
@@ -125,3 +125,68 @@ class TestCleanupAndActive:
         active = b.get_active_loop_agents("loop1")
         assert len(active) == 1 and active[0]["status"] == "running"
         assert active[0]["label"] == "L0"
+
+
+class TestInvocationBoundToolCallback:
+    """A loop agent's nested spawn_agent must carry its own id as parent_id.
+
+    The shared callback used to be passed bare, so every loop-agent child
+    registered as a fresh ROOT and bypassed depth, child-limit, and tree-cap
+    enforcement entirely — reproduced during review by driving the callback
+    and watching the request arrive parentless.
+    """
+
+    def _bridge_and_captured(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from src.agents.loop_bridge import LoopAgentBridge
+
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            captured.update(kwargs)
+            return "agent123"
+
+        mgr = MagicMock()
+        mgr.spawn = fake_spawn
+        bridge = LoopAgentBridge(agent_manager=mgr, trajectory_saver=None)
+
+        async def shared_cb(tool_name, tool_input):
+            captured["dispatched"] = (tool_name, tool_input)
+            return "ok"
+
+        async def iter_cb(*a, **k):
+            return SimpleNamespace(text="", tool_calls=None)
+
+        ids = bridge.spawn_agents_for_loop(
+            loop_id="L1", iteration=1, loop_goal="g",
+            tasks=[{"label": "a", "goal": "g"}],
+            channel_id="c1", requester_id="u1", requester_name="user",
+            iteration_callback=iter_cb, tool_executor_callback=shared_cb,
+        )
+        assert ids == ["agent123"]
+        return captured
+
+    async def test_nested_spawn_gains_the_agents_own_parent_id(self):
+        captured = self._bridge_and_captured()
+        bound_cb = captured["tool_executor_callback"]
+        await bound_cb("spawn_agent", {"label": "child", "goal": "g"})
+        name, tool_input = captured["dispatched"]
+        assert name == "spawn_agent"
+        assert tool_input["parent_id"] == "agent123"
+
+    async def test_an_explicit_parent_id_is_not_overridden(self):
+        captured = self._bridge_and_captured()
+        bound_cb = captured["tool_executor_callback"]
+        await bound_cb("spawn_agent", {"label": "c", "goal": "g", "parent_id": "other"})
+        _, tool_input = captured["dispatched"]
+        assert tool_input["parent_id"] == "other"
+
+    async def test_other_tools_pass_through_untouched(self):
+        captured = self._bridge_and_captured()
+        bound_cb = captured["tool_executor_callback"]
+        await bound_cb("run_command", {"command": "ls"})
+        name, tool_input = captured["dispatched"]
+        assert name == "run_command"
+        assert "parent_id" not in tool_input

--- a/tests/test_loop_bridge.py
+++ b/tests/test_loop_bridge.py
@@ -176,12 +176,13 @@ class TestInvocationBoundToolCallback:
         assert name == "spawn_agent"
         assert tool_input["parent_id"] == "agent123"
 
-    async def test_an_explicit_parent_id_is_not_overridden(self):
+    async def test_an_explicit_parent_id_is_overridden_by_invoking_agent(self):
+        """A nested model cannot choose another tree and evade its limits."""
         captured = self._bridge_and_captured()
         bound_cb = captured["tool_executor_callback"]
         await bound_cb("spawn_agent", {"label": "c", "goal": "g", "parent_id": "other"})
         _, tool_input = captured["dispatched"]
-        assert tool_input["parent_id"] == "other"
+        assert tool_input["parent_id"] == "agent123"
 
     async def test_other_tools_pass_through_untouched(self):
         captured = self._bridge_and_captured()

--- a/tests/test_native_agents_tasks.py
+++ b/tests/test_native_agents_tasks.py
@@ -48,7 +48,8 @@ def _fake_gateway(client):
 def _cfg(tools_enabled=True):
     return SimpleNamespace(
         tools=SimpleNamespace(enabled=tools_enabled, tool_timeouts={}),
-        agents=SimpleNamespace(max_nesting_depth=2, hard_max_iterations=300,
+        agents=SimpleNamespace(max_nesting_depth=2, max_children_per_agent=3,
+                               hard_max_iterations=300,
                                max_iterations=120, scheduled_max_iterations=180,
                                final_warning_iterations=[20, 10, 5, 1],
                                iteration_timeout_seconds=900,
@@ -262,6 +263,49 @@ class TestSpawnAgent:
         t._agent_manager._agents = {}
         assert "Error" in await t._handle_spawn_agent(
             _message(), {"label": "w", "goal": "g"})
+
+    async def test_invocation_bound_callback_overwrites_explicit_parent_id(self):
+        """Agent-originated spawn ancestry is not model-selectable.
+
+        Chat-level calls still pass their requested parent_id to spawn(), but
+        once an agent invokes spawn_agent its own id is authoritative.
+        """
+        t = _tools()
+        t._agent_manager.spawn.return_value = "agent-self"
+        t._agent_manager._agents = {}
+        await t._handle_spawn_agent(_message(), {"label": "w", "goal": "g"})
+        callback = t._agent_manager.spawn.call_args.kwargs["tool_executor_callback"]
+        t._tool_loop.dispatch_loop_tool = AsyncMock(return_value="ok")
+
+        await callback(
+            "spawn_agent",
+            {"label": "child", "goal": "g", "parent_id": "other-tree"},
+        )
+
+        _, dispatched, *_ = t._tool_loop.dispatch_loop_tool.await_args.args
+        assert dispatched["parent_id"] == "agent-self"
+
+    async def test_nested_tool_filter_uses_the_parent_depth_snapshot(self):
+        """Live config cannot change the catalogue within a running tree."""
+        cfg = _cfg()
+        cfg.agents.max_nesting_depth = 1
+        t = _tools(
+            get_config=lambda: cfg,
+            tool_catalog=SimpleNamespace(merged_definitions=lambda: [
+                {"name": "spawn_agent"}, {"name": "run_command"},
+            ]),
+        )
+        t._agent_manager.spawn.return_value = "child-1"
+        # This tree began with depth limit 3 even though live config is now 1.
+        t._agent_manager._agents = {
+            "parent-1": SimpleNamespace(depth=0, max_depth=3)
+        }
+        await t._handle_spawn_agent(
+            _message(),
+            {"label": "child", "goal": "sub", "parent_id": "parent-1"},
+        )
+        tools = t._agent_manager.spawn.call_args.kwargs["tools"]
+        assert {tool["name"] for tool in tools} == {"spawn_agent", "run_command"}
 
     async def test_nested_with_parent_and_compressor(self):
         cc = SimpleNamespace(max_context_chars=500000, keep_recent_iterations=20)

--- a/tests/test_nested_agents.py
+++ b/tests/test_nested_agents.py
@@ -1,6 +1,7 @@
 """Tests for nested agent spawning — depth-limited sub-agent hierarchy."""
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from src.agents.manager import (
@@ -1100,3 +1101,113 @@ class TestEdgeCases:
         names = {t["name"] for t in result}
         assert "run_command" in names
         assert "read_file" in names
+
+
+# ---------------------------------------------------------------------------
+# Configured child limit — root snapshot, inherited by the whole tree
+# ---------------------------------------------------------------------------
+
+class TestConfiguredChildLimit:
+    """agents.max_children_per_agent finally reaches the spawn path.
+
+    The schema declared it configurable while spawn() and the prompt hardcoded
+    3 — the config page truthfully called it 'not wired', and the fix is
+    wiring, not wording. Contract: the ROOT snapshots the configured limit,
+    every descendant inherits the root's snapshot (a live config change never
+    yields a tree whose members disagree), and a tree-lifetime cap backstops
+    breadth x depth.
+    """
+
+    def _spawn(self, mgr, label, parent_id=None, max_children=None, max_depth=5):
+        return mgr.spawn(
+            label=label, goal="go", channel_id="c1",
+            requester_id="u1", requester_name="user",
+            iteration_callback=_make_iter_cb(),
+            tool_executor_callback=_make_tool_cb(),
+            parent_id=parent_id, max_children=max_children,
+            max_depth=max_depth,
+        )
+
+    async def test_root_snapshots_the_configured_limit(self):
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_children=5)
+        assert mgr._agents[root].max_children == 5
+        assert mgr._agents[root].root_id == root
+
+    async def test_omitted_limit_falls_back_to_the_constant(self):
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root")
+        assert mgr._agents[root].max_children == MAX_CHILDREN_PER_AGENT
+
+    async def test_descendants_inherit_the_roots_snapshot_not_live_config(self):
+        """A child spawned with a DIFFERENT configured value still runs under
+        the root's — mid-tree config changes cannot split the rules."""
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_children=5)
+        child = self._spawn(mgr, "child", parent_id=root, max_children=9)
+        assert mgr._agents[child].max_children == 5
+        assert mgr._agents[child].root_id == root
+        grandchild = self._spawn(mgr, "gc", parent_id=child, max_children=2)
+        assert mgr._agents[grandchild].max_children == 5
+        assert mgr._agents[grandchild].root_id == root
+
+    async def test_the_parents_snapshot_governs_enforcement(self):
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_children=2)
+        assert not self._spawn(mgr, "c1", parent_id=root).startswith("Error")
+        assert not self._spawn(mgr, "c2", parent_id=root).startswith("Error")
+        third = self._spawn(mgr, "c3", parent_id=root)
+        assert third.startswith("Error")
+        assert "maximum of 2 children" in third
+
+    async def test_the_agents_own_prompt_advertises_the_effective_limit(
+        self, monkeypatch
+    ):
+        """The prompt used to hardcode the constant — it lied to the agent
+        whenever config differed. Capture what the worker actually receives."""
+        import src.agents.manager as manager_mod
+
+        captured = {}
+
+        async def fake_run(agent, system_prompt, *args, **kwargs):
+            captured["system"] = system_prompt
+
+        monkeypatch.setattr(manager_mod, "_run_agent", fake_run)
+        mgr = AgentManager()
+        self._spawn(mgr, "root", max_children=7)
+        await asyncio.sleep(0)  # let the spawn task enter the stub
+        assert "up to 7 sub-agents" in captured["system"]
+
+    async def test_tree_lifetime_cap_backstops_breadth_times_depth(self):
+        from src.agents.manager import TREE_MAX_AGENTS
+
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_children=10)
+        # Fill the registry with tree members directly — spawning 24 real
+        # agents would be slow and beside the point; the cap counts REGISTERED
+        # tree members whatever their state.
+        # Different channel: the per-channel concurrency cap must not fire
+        # first — the TREE cap is what this test exercises.
+        for i in range(TREE_MAX_AGENTS - 1):
+            mgr._agents[f"fake{i}"] = type(mgr._agents[root])(
+                id=f"fake{i}", label="x", goal="g", channel_id="other",
+                requester_id="u1", requester_name="user", root_id=root,
+            )
+        blocked = self._spawn(mgr, "straw", parent_id=root)
+        assert blocked.startswith("Error")
+        assert "lifetime" in blocked and str(TREE_MAX_AGENTS) in blocked
+
+    async def test_a_second_tree_is_not_charged_for_the_first(self):
+        from src.agents.manager import TREE_MAX_AGENTS
+
+        mgr = AgentManager()
+        first = self._spawn(mgr, "root1", max_children=10)
+        for i in range(TREE_MAX_AGENTS):
+            mgr._agents[f"fake{i}"] = type(mgr._agents[first])(
+                id=f"fake{i}", label="x", goal="g", channel_id="c2",
+                requester_id="u1", requester_name="user", root_id=first,
+            )
+        second = self._spawn(mgr, "root2")
+        assert not second.startswith("Error")
+        child = self._spawn(mgr, "child2", parent_id=second)
+        assert not child.startswith("Error")

--- a/tests/test_nested_agents.py
+++ b/tests/test_nested_agents.py
@@ -1183,30 +1183,45 @@ class TestConfiguredChildLimit:
 
         mgr = AgentManager()
         root = self._spawn(mgr, "root", max_children=10)
-        # Fill the registry with tree members directly — spawning 24 real
-        # agents would be slow and beside the point; the cap counts REGISTERED
-        # tree members whatever their state.
-        # Different channel: the per-channel concurrency cap must not fire
-        # first — the TREE cap is what this test exercises.
-        for i in range(TREE_MAX_AGENTS - 1):
-            mgr._agents[f"fake{i}"] = type(mgr._agents[root])(
-                id=f"fake{i}", label="x", goal="g", channel_id="other",
-                requester_id="u1", requester_name="user", root_id=root,
-            )
+        # Drive the LIFETIME counter, not the registry — the cap is charged
+        # per spawn for the tree's whole life.
+        mgr._tree_spawn_counts[root] = TREE_MAX_AGENTS
         blocked = self._spawn(mgr, "straw", parent_id=root)
         assert blocked.startswith("Error")
         assert "lifetime" in blocked and str(TREE_MAX_AGENTS) in blocked
+
+    async def test_cleanup_does_not_refund_the_tree_budget(self):
+        """The cap is LIFETIME: janitor-removing finished children must not
+        let the tree respawn its whole budget every cleanup cycle — a
+        registry-derived count did exactly that."""
+        from src.agents.manager import TREE_MAX_AGENTS
+
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_children=10)
+        child = self._spawn(mgr, "child", parent_id=root)
+        assert not child.startswith("Error")
+        spent = mgr._tree_spawn_counts[root]
+        assert spent == 2  # root + child, charged at spawn
+        # Janitor removes the finished child; the budget must NOT come back.
+        assert mgr._remove_agent(child, source="test") is True
+        assert mgr._tree_spawn_counts[root] == spent
+        mgr._tree_spawn_counts[root] = TREE_MAX_AGENTS
+        blocked = self._spawn(mgr, "wave2", parent_id=root)
+        assert blocked.startswith("Error") and "lifetime" in blocked
+
+    async def test_the_counter_is_pruned_with_the_trees_last_member(self):
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root")
+        assert root in mgr._tree_spawn_counts
+        assert mgr._remove_agent(root, source="test") is True
+        assert root not in mgr._tree_spawn_counts
 
     async def test_a_second_tree_is_not_charged_for_the_first(self):
         from src.agents.manager import TREE_MAX_AGENTS
 
         mgr = AgentManager()
         first = self._spawn(mgr, "root1", max_children=10)
-        for i in range(TREE_MAX_AGENTS):
-            mgr._agents[f"fake{i}"] = type(mgr._agents[first])(
-                id=f"fake{i}", label="x", goal="g", channel_id="c2",
-                requester_id="u1", requester_name="user", root_id=first,
-            )
+        mgr._tree_spawn_counts[first] = TREE_MAX_AGENTS
         second = self._spawn(mgr, "root2")
         assert not second.startswith("Error")
         child = self._spawn(mgr, "child2", parent_id=second)

--- a/tests/test_nested_agents.py
+++ b/tests/test_nested_agents.py
@@ -1151,6 +1151,46 @@ class TestConfiguredChildLimit:
         assert mgr._agents[grandchild].max_children == 5
         assert mgr._agents[grandchild].root_id == root
 
+    async def test_descendants_inherit_the_roots_depth_snapshot(self):
+        """A live depth change applies only to the next root tree."""
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_depth=2)
+        assert mgr._agents[root].max_depth == 2
+        # Callers now offer a larger live value, but this tree stays at two.
+        child = self._spawn(mgr, "child", parent_id=root, max_depth=9)
+        grandchild = self._spawn(mgr, "gc", parent_id=child, max_depth=9)
+        assert mgr._agents[child].max_depth == 2
+        assert mgr._agents[grandchild].max_depth == 2
+        blocked = self._spawn(mgr, "too-deep", parent_id=grandchild, max_depth=9)
+        assert blocked.startswith("Error")
+        assert "Maximum nesting depth (2)" in blocked
+
+    async def test_depth_prompt_and_tools_use_the_root_snapshot(self, monkeypatch):
+        """The visible tool set and prompt must agree with enforcement."""
+        import src.agents.manager as manager_mod
+
+        captured = []
+
+        async def fake_run(agent, system_prompt, tools, *args, **kwargs):
+            captured.append((agent, system_prompt, tools))
+
+        monkeypatch.setattr(manager_mod, "_run_agent", fake_run)
+        mgr = AgentManager()
+        root = self._spawn(mgr, "root", max_depth=1)
+        child = mgr.spawn(
+            label="child", goal="go", channel_id="c1",
+            requester_id="u1", requester_name="user",
+            iteration_callback=_make_iter_cb(),
+            tool_executor_callback=_make_tool_cb(),
+            parent_id=root,
+            max_depth=9,
+            tools=[{"name": "spawn_agent"}, {"name": "run_command"}],
+        )
+        await asyncio.sleep(0)
+        child_record = next(item for item in captured if item[0].id == child)
+        assert "maximum nesting depth" in child_record[1]
+        assert {tool["name"] for tool in child_record[2]} == {"run_command"}
+
     async def test_the_parents_snapshot_governs_enforcement(self):
         mgr = AgentManager()
         root = self._spawn(mgr, "root", max_children=2)

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -744,3 +744,65 @@ class TestToolEventCallId:
         await runner._audit_tool_outcome(st, "t", {}, "r", 1, None, None)
         end = [e for e in events if e.get("event_type") == "tool_end"]
         assert end and end[0]["metadata"]["call_id"] is None
+
+
+class TestDeliberateSilence:
+    """Empty final text after a tool-using turn is a choice, not a failure.
+
+    Field reality, twice: a thumbs-up reaction landed, then Odin posted
+    "I couldn't generate a response. Please try again."; a video posted with
+    its commentary on the attachment, then the same apology. The classifier
+    had judged both turns complete — only the terminal fallback fabricated a
+    failure out of chosen silence. With NO tools used the fallback stands.
+    """
+
+    def _final_state(self, tools_used):
+        st = _stub_state()
+        st.tools_used_in_loop = list(tools_used)
+        st._validation_required = False
+        st._validation_retries = 0
+        st._max_validation_retries = 2
+        # Every response-guard flag set 'already retried' so the cascade
+        # falls through to the terminal fallback — the actor under test.
+        st.promise_retried = True
+        st.unavail_retried = True
+        st.hedging_retried = True
+        st.fabrication_retried = True
+        st.code_hedging_retried = True
+        st.premature_failure_retried = True
+        # Classifier already ran its budget — the fallback is the only actor.
+        st.continuation_count = 3
+        st.max_continuations = 3
+        return st
+
+    async def test_silence_after_work_is_delivered_as_silence(self):
+        runner, saved, cleared = _make_runner()
+        st = self._final_state(["add_reaction"])
+        kind, result = await runner._finalize_or_retry(
+            st, SimpleNamespace(text="", tool_calls=None)
+        )
+        assert kind == "done"
+        final = result[0]
+        assert final == ""
+        assert "couldn't generate" not in final
+        # Trajectory records the truthful empty final, not the apology.
+        assert saved and saved[0][1]["final_response"] == ""
+
+    async def test_empty_with_no_tools_is_still_reported_as_failure(self):
+        from src.discord.tool_loop_helpers import _EMPTY_RESPONSE_FALLBACK
+
+        runner, saved, cleared = _make_runner()
+        st = self._final_state([])
+        kind, result = await runner._finalize_or_retry(
+            st, SimpleNamespace(text="", tool_calls=None)
+        )
+        assert kind == "done"
+        assert result[0] == _EMPTY_RESPONSE_FALLBACK
+
+    async def test_real_text_is_untouched(self):
+        runner, saved, cleared = _make_runner()
+        st = self._final_state(["add_reaction"])
+        kind, result = await runner._finalize_or_retry(
+            st, SimpleNamespace(text="done, reacted.", tool_calls=None)
+        )
+        assert result[0] == "done, reacted."

--- a/tests/test_web_api_config_admin.py
+++ b/tests/test_web_api_config_admin.py
@@ -1317,3 +1317,19 @@ class TestRestartEndpoint:
         from src.health.server import _is_admin_only_path
 
         assert _is_admin_only_path("/api/restart")
+
+
+    @pytest.mark.asyncio
+    async def test_denied_without_admin_identity(self):
+        """Auth configured + no identity on the request = the gate refuses,
+        and nothing gets scheduled."""
+        from src import restart as restart_mod
+
+        app, bot = _app(register_quick_actions)
+        bot.api_token_manager = None
+        bot.config.web.api_token = "configured-token"
+        with patch.object(restart_mod, "request_restart") as req:
+            async with TestClient(TestServer(app)) as c:
+                resp = await c.post("/api/restart", json={})
+        assert resp.status == 403
+        req.assert_not_called()

--- a/tests/test_web_api_config_admin.py
+++ b/tests/test_web_api_config_admin.py
@@ -1019,7 +1019,10 @@ class TestConfigMeta:
         "path", "owner", "label", "description", "aliases", "unit", "examples",
         "type", "enum", "constraints", "default", "sensitivity", "secret_route",
         "apply_mode", "apply_handler", "consumers", "restart_reason",
-        "activation_policy", "desired", "effective", "configured", "provenance",
+        "activation_policy", "group_description", "save_effect",
+        "runtime_effect", "action_available", "action_label",
+        "action_endpoint", "action_method", "action_body",
+        "desired", "effective", "configured", "provenance",
         "valid", "validation_errors", "pending_restart", "drift", "last_apply",
         "apply_state",
     }

--- a/tests/test_web_api_config_admin.py
+++ b/tests/test_web_api_config_admin.py
@@ -1268,3 +1268,49 @@ class TestConfigMeta:
         assert record["pending_restart"] is False
         assert record["effective"] == record["desired"]
         assert record["apply_state"] == "applied"
+
+
+class TestRestartEndpoint:
+    """POST /api/restart — the Config page's pending-restart flow.
+
+    Restart-mode settings save but keep startup values; the page offers a
+    clean restart instead of pointing the operator at a shell. The wizard's
+    delayed-SIGTERM pattern lets the 202 flush before the process exits.
+    """
+
+    @pytest.mark.asyncio
+    async def test_restarts_cleanly_and_returns_202(self):
+        from src import restart as restart_mod
+
+        app, bot = _app(register_quick_actions)
+        bot.api_token_manager = None  # dev mode: no auth configured → gate allows
+        bot.config.web.api_token = ""
+        with patch.object(restart_mod, "request_restart") as req, \
+             patch.object(restart_mod, "restart_requested", return_value=False), \
+             patch("os.kill") as kill:
+            async with TestClient(TestServer(app)) as c:
+                resp = await c.post("/api/restart", json={})
+                body = await resp.json()
+            kill.assert_not_called()  # scheduled via call_later, not fired in-test
+        assert resp.status == 202
+        assert body["status"] == "restarting"
+        req.assert_called_once_with()  # NO env overrides — first-boot-only power
+
+    @pytest.mark.asyncio
+    async def test_idempotent_while_a_restart_is_scheduled(self):
+        from src import restart as restart_mod
+
+        app, bot = _app(register_quick_actions)
+        bot.api_token_manager = None
+        bot.config.web.api_token = ""
+        with patch.object(restart_mod, "request_restart") as req, \
+             patch.object(restart_mod, "restart_requested", return_value=True):
+            async with TestClient(TestServer(app)) as c:
+                resp = await c.post("/api/restart", json={})
+        assert resp.status == 202
+        req.assert_not_called()  # already scheduled — do not double-arm
+
+    def test_the_route_sits_behind_the_admin_gate(self):
+        from src.health.server import _is_admin_only_path
+
+        assert _is_admin_only_path("/api/restart")

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -1807,6 +1807,29 @@ class TestCodexAdvancedKnobs:
         assert bot.config.openai_codex.request_timeout_seconds == before
 
     @pytest.mark.asyncio
+    async def test_top_level_timeouts_use_schema_lax_integer_coercion(self):
+        """Pydantic accepts integer strings but this endpoint still rejects bool.
+
+        The first validator hand-mirrored the schema and incorrectly rejected
+        the value a YAML/JSON config load accepts.
+        """
+        app, bot = self._harness()
+        with patch("src.web.api.llm_admin.persist_config_paths_locked",
+                   new=AsyncMock(return_value=(None, False))):
+            async with TestClient(TestServer(app)) as c:
+                accepted = await c.put("/api/llm/codex/config", json={
+                    "request_timeout_seconds": "600.0",
+                    "stream_stall_timeout_seconds": "90",
+                })
+                rejected = await c.put("/api/llm/codex/config", json={
+                    "request_timeout_seconds": True,
+                })
+        assert accepted.status == 200
+        assert bot.config.openai_codex.request_timeout_seconds == 600
+        assert bot.config.openai_codex.stream_stall_timeout_seconds == 90
+        assert rejected.status == 400
+
+    @pytest.mark.asyncio
     async def test_nested_groups_are_replaced_not_mutated_in_place(self):
         """The boot-built compressor holds the boot config's nested object BY
         IDENTITY. In-place mutation made compression live-before-rebind and
@@ -1870,9 +1893,8 @@ class TestCodexAdvancedKnobs:
         assert bot.config.openai_codex.model == "gpt-5.6-terra"
 
     @pytest.mark.asyncio
-    async def test_status_reports_the_advanced_truth(self):
-        """The panel populates exclusively from /api/llm/status; before this,
-        an operator whose config said 7200 saw the 3600 default forever."""
+    async def test_status_reports_desired_boot_effective_and_pending_restart(self):
+        """The owner page must not present desired boot-bound values as live."""
         app, bot = _app(register_llm_provider)
         bot.llm_gateway.codex_client = object()
         bot.llm_gateway.ollama_client = None
@@ -1881,13 +1903,80 @@ class TestCodexAdvancedKnobs:
             model="gpt-5.5", provider_name="codex"
         )
         bot.llm_gateway.auxiliary_llm_client = None
+        bot.boot_config_snapshot = bot.config.model_dump()
+        boot_pool = dict(bot.boot_config_snapshot["openai_codex"]["connection_pool"])
+        boot_compression = dict(
+            bot.boot_config_snapshot["openai_codex"]["context_compression"]
+        )
         bot.config.openai_codex.request_timeout_seconds = 7200
         bot.config.openai_codex.retry.max_retries = 7
+        bot.config.openai_codex.connection_pool.max_connections += 1
+        bot.config.openai_codex.context_compression.enabled = not (
+            bot.config.openai_codex.context_compression.enabled
+        )
         bot.config.kimi.timeout = 123
         async with TestClient(TestServer(app)) as c:
             body = await (await c.get("/api/llm/status")).json()
-        assert body["codex"]["request_timeout_seconds"] == 7200
-        assert body["codex"]["retry"]["max_retries"] == 7
-        assert body["codex"]["connection_pool"]["max_connections"] >= 1
-        assert body["codex"]["context_compression"]["enabled"] in (True, False)
+        codex = body["codex"]
+        assert codex["request_timeout_seconds"] == 7200
+        assert codex["retry"]["max_retries"] == 7
+        assert codex["connection_pool"] != boot_pool
+        assert codex["effective_connection_pool"] == boot_pool
+        assert codex["connection_pool_pending_restart"] is True
+        assert codex["context_compression"] != boot_compression
+        assert codex["effective_context_compression"] == boot_compression
+        assert codex["context_compression_pending_restart"] is True
         assert body["kimi"]["timeout"] == 123
+
+    @pytest.mark.asyncio
+    async def test_status_reports_no_pending_restart_when_boot_values_match(self):
+        app, bot = _app(register_llm_provider)
+        bot.llm_gateway.codex_client = object()
+        bot.llm_gateway.ollama_client = None
+        bot.llm_gateway.kimi_client = None
+        bot.llm_gateway.active_client = None
+        bot.llm_gateway.auxiliary_llm_client = None
+        bot.boot_config_snapshot = bot.config.model_dump()
+        async with TestClient(TestServer(app)) as c:
+            codex = (await (await c.get("/api/llm/status")).json())["codex"]
+        assert codex["connection_pool_pending_restart"] is False
+        assert codex["context_compression_pending_restart"] is False
+        assert codex["effective_connection_pool"] == codex["connection_pool"]
+        assert codex["effective_context_compression"] == codex["context_compression"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("snapshot", [
+        {"openai_codex": None},
+        {"openai_codex": {"connection_pool": None, "context_compression": None}},
+    ])
+    async def test_status_rejects_malformed_boot_group_evidence(self, snapshot):
+        app, bot = _app(register_llm_provider)
+        bot.llm_gateway.codex_client = object()
+        bot.llm_gateway.ollama_client = None
+        bot.llm_gateway.kimi_client = None
+        bot.llm_gateway.active_client = None
+        bot.llm_gateway.auxiliary_llm_client = None
+        bot.boot_config_snapshot = snapshot
+        async with TestClient(TestServer(app)) as c:
+            codex = (await (await c.get("/api/llm/status")).json())["codex"]
+        assert codex["effective_connection_pool"] is None
+        assert codex["connection_pool_pending_restart"] is None
+        assert codex["effective_context_compression"] is None
+        assert codex["context_compression_pending_restart"] is None
+
+    @pytest.mark.asyncio
+    async def test_status_does_not_invent_effective_boot_values(self):
+        app, bot = _app(register_llm_provider)
+        bot.llm_gateway.codex_client = object()
+        bot.llm_gateway.ollama_client = None
+        bot.llm_gateway.kimi_client = None
+        bot.llm_gateway.active_client = None
+        bot.llm_gateway.auxiliary_llm_client = None
+        # A test harness or old embedder may not expose a boot snapshot.
+        del bot.boot_config_snapshot
+        async with TestClient(TestServer(app)) as c:
+            codex = (await (await c.get("/api/llm/status")).json())["codex"]
+        assert codex["effective_connection_pool"] is None
+        assert codex["connection_pool_pending_restart"] is None
+        assert codex["effective_context_compression"] is None
+        assert codex["context_compression_pending_restart"] is None

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -1717,3 +1717,102 @@ class TestAuxiliaryRoutePrepareProbeCAS:
             response = await request_task
         assert response.status == 200
         assert captured["plan"].desired_model == "gpt-5.6-terra"
+
+
+class TestCodexAdvancedKnobs:
+    """The LLM page's Advanced panel edits transport/retry/pool/compression.
+
+    The old handler silently DROPPED every one of these keys and returned
+    200 — the panel toasted "saved" for a save that never happened, and
+    /api/llm/status never returned them, so it displayed schema defaults
+    forever regardless of config.yml truth.
+    """
+
+    def _harness(self):
+        app, bot = _app(register_provider_config)
+        _gw(bot)
+        bot.llm_gateway.codex_client = object()
+        return app, bot
+
+    @pytest.mark.asyncio
+    async def test_advanced_keys_persist_and_apply(self):
+        app, bot = self._harness()
+        with patch("src.web.api.llm_admin.persist_config_paths_locked",
+                   new=AsyncMock(return_value=(None, False))) as persist:
+            async with TestClient(TestServer(app)) as c:
+                r = await c.put("/api/llm/codex/config", json={
+                    "request_timeout_seconds": 7200,
+                    "retry": {"max_retries": 5, "base_delay": 1.5},
+                    "connection_pool": {"max_connections": 20},
+                    "context_compression": {"max_context_chars": 500000},
+                })
+        assert r.status == 200
+        cfg = bot.config.openai_codex
+        assert cfg.request_timeout_seconds == 7200
+        assert cfg.retry.max_retries == 5
+        assert cfg.retry.base_delay == 1.5
+        assert cfg.connection_pool.max_connections == 20
+        assert cfg.context_compression.max_context_chars == 500000
+        persisted = {change[0] for change in persist.call_args[0][0]}
+        assert ("openai_codex", "request_timeout_seconds") in persisted
+        assert ("openai_codex", "retry", "max_retries") in persisted
+        assert ("openai_codex", "connection_pool", "max_connections") in persisted
+        # Transport/retry reach the live client through the reload path.
+        bot.llm_gateway.reload_codex_inner.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pool_and_compression_alone_do_not_reload(self):
+        """They are restart/rebuild-bound — persisting them must not churn
+        the live client or the auth pool."""
+        app, bot = self._harness()
+        with patch("src.web.api.llm_admin.persist_config_paths_locked",
+                   new=AsyncMock(return_value=(None, False))):
+            async with TestClient(TestServer(app)) as c:
+                r = await c.put("/api/llm/codex/config", json={
+                    "connection_pool": {"keepalive_timeout": 60},
+                    "context_compression": {"enabled": False},
+                })
+        assert r.status == 200
+        bot.llm_gateway.reload_codex_inner.assert_not_awaited()
+        assert bot.config.openai_codex.context_compression.enabled is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("body", "fragment"), [
+        ({"request_timeout_seconds": 30}, "between 60 and 86400"),
+        ({"stream_stall_timeout_seconds": 5}, "between 10 and 3600"),
+        ({"retry": {"max_retries": -1}}, ">= 0"),
+        ({"connection_pool": {"max_connections": 0}}, ">= 1"),
+        ({"request_timeout_seconds": "soon"}, "must be a number"),
+    ])
+    async def test_bounds_are_enforced_before_any_mutation(self, body, fragment):
+        app, bot = self._harness()
+        before = bot.config.openai_codex.request_timeout_seconds
+        async with TestClient(TestServer(app)) as c:
+            r = await c.put("/api/llm/codex/config", json=body)
+            payload = await r.json()
+        assert r.status == 400
+        assert fragment in payload["error"]
+        assert bot.config.openai_codex.request_timeout_seconds == before
+
+    @pytest.mark.asyncio
+    async def test_status_reports_the_advanced_truth(self):
+        """The panel populates exclusively from /api/llm/status; before this,
+        an operator whose config said 7200 saw the 3600 default forever."""
+        app, bot = _app(register_llm_provider)
+        bot.llm_gateway.codex_client = object()
+        bot.llm_gateway.ollama_client = None
+        bot.llm_gateway.kimi_client = None
+        bot.llm_gateway.active_client = SimpleNamespace(
+            model="gpt-5.5", provider_name="codex"
+        )
+        bot.llm_gateway.auxiliary_llm_client = None
+        bot.config.openai_codex.request_timeout_seconds = 7200
+        bot.config.openai_codex.retry.max_retries = 7
+        bot.config.kimi.timeout = 123
+        async with TestClient(TestServer(app)) as c:
+            body = await (await c.get("/api/llm/status")).json()
+        assert body["codex"]["request_timeout_seconds"] == 7200
+        assert body["codex"]["retry"]["max_retries"] == 7
+        assert body["codex"]["connection_pool"]["max_connections"] >= 1
+        assert body["codex"]["context_compression"]["enabled"] in (True, False)
+        assert body["kimi"]["timeout"] == 123

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -1742,9 +1742,13 @@ class TestCodexAdvancedKnobs:
             async with TestClient(TestServer(app)) as c:
                 r = await c.put("/api/llm/codex/config", json={
                     "request_timeout_seconds": 7200,
+                    "stream_stall_timeout_seconds": 240,
                     "retry": {"max_retries": 5, "base_delay": 1.5},
                     "connection_pool": {"max_connections": 20},
-                    "context_compression": {"max_context_chars": 500000},
+                    "context_compression": {
+                        "max_context_chars": 500000,
+                        "keep_recent_iterations": 12,
+                    },
                 })
         assert r.status == 200
         cfg = bot.config.openai_codex
@@ -1753,6 +1757,8 @@ class TestCodexAdvancedKnobs:
         assert cfg.retry.base_delay == 1.5
         assert cfg.connection_pool.max_connections == 20
         assert cfg.context_compression.max_context_chars == 500000
+        assert cfg.stream_stall_timeout_seconds == 240
+        assert cfg.context_compression.keep_recent_iterations == 12
         persisted = {change[0] for change in persist.call_args[0][0]}
         assert ("openai_codex", "request_timeout_seconds") in persisted
         assert ("openai_codex", "retry", "max_retries") in persisted

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -1788,7 +1788,13 @@ class TestCodexAdvancedKnobs:
         ({"stream_stall_timeout_seconds": 5}, "between 10 and 3600"),
         ({"retry": {"max_retries": -1}}, ">= 0"),
         ({"connection_pool": {"max_connections": 0}}, ">= 1"),
-        ({"request_timeout_seconds": "soon"}, "must be a number"),
+        ({"request_timeout_seconds": "soon"}, "must be an integer"),
+        # Schema-exact rejections the first hand-mirrored validator got wrong:
+        ({"retry": {"max_retries": 1.9}}, "integer"),
+        ({"retry": [1, 2]}, "must be an object"),
+        ({"retry": {"bogus_knob": 1}}, "unknown retry field"),
+        ({"request_timeout_seconds": True}, "must be an integer"),
+        ({"stream_stall_timeout_seconds": 90.5}, "must be an integer"),
     ])
     async def test_bounds_are_enforced_before_any_mutation(self, body, fragment):
         app, bot = self._harness()
@@ -1799,6 +1805,69 @@ class TestCodexAdvancedKnobs:
         assert r.status == 400
         assert fragment in payload["error"]
         assert bot.config.openai_codex.request_timeout_seconds == before
+
+    @pytest.mark.asyncio
+    async def test_nested_groups_are_replaced_not_mutated_in_place(self):
+        """The boot-built compressor holds the boot config's nested object BY
+        IDENTITY. In-place mutation made compression live-before-rebind and
+        stale-after; replacement makes persist-only deterministic."""
+        app, bot = self._harness()
+        boot_held = bot.config.openai_codex.context_compression
+        before = boot_held.max_context_chars
+        with patch("src.web.api.llm_admin.persist_config_paths_locked",
+                   new=AsyncMock(return_value=(None, False))):
+            async with TestClient(TestServer(app)) as c:
+                r = await c.put("/api/llm/codex/config", json={
+                    "context_compression": {"max_context_chars": 123456},
+                })
+        assert r.status == 200
+        assert boot_held.max_context_chars == before  # captor untouched
+        assert bot.config.openai_codex.context_compression is not boot_held
+        assert bot.config.openai_codex.context_compression.max_context_chars == 123456
+
+    @pytest.mark.asyncio
+    async def test_schema_lax_coercions_apply_not_hand_rolled_ones(self):
+        """bool("false") was True under the hand-rolled validator; the schema
+        model coerces the string honestly. And the invented floor on
+        max_context_chars is gone — the schema accepts 1, so this does."""
+        app, bot = self._harness()
+        with patch("src.web.api.llm_admin.persist_config_paths_locked",
+                   new=AsyncMock(return_value=(None, False))):
+            async with TestClient(TestServer(app)) as c:
+                r = await c.put("/api/llm/codex/config", json={
+                    "context_compression": {"enabled": "false", "max_context_chars": 1},
+                })
+        assert r.status == 200
+        assert bot.config.openai_codex.context_compression.enabled is False
+        assert bot.config.openai_codex.context_compression.max_context_chars == 1
+
+    @pytest.mark.asyncio
+    async def test_double_failure_republishes_nested_desired(self):
+        """Reload fails AND the persistence rollback fails: disk kept the
+        desired nested values, so runtime must follow them — the prior code
+        left runtime on the restored priors while disk held desired, a
+        split-brain between process and file."""
+        app, bot = self._harness()
+        bot.llm_gateway.reload_codex_inner = AsyncMock(
+            side_effect=[RuntimeError("apply blew up"), None]
+        )
+        persist = AsyncMock(side_effect=[
+            (None, False),                       # forward persist succeeds
+            (RuntimeError("disk full"), False),  # rollback persist fails
+        ])
+        with patch("src.web.api.llm_admin.persist_config_paths_locked", new=persist):
+            async with TestClient(TestServer(app)) as c:
+                r = await c.put("/api/llm/codex/config", json={
+                    "model": "gpt-5.6-terra",
+                    "retry": {"max_retries": 7},
+                    "request_timeout_seconds": 7200,
+                })
+                body_text = await r.text()
+        assert r.status == 500, body_text
+        # Runtime follows the disk it could not roll back.
+        assert bot.config.openai_codex.retry.max_retries == 7
+        assert bot.config.openai_codex.request_timeout_seconds == 7200
+        assert bot.config.openai_codex.model == "gpt-5.6-terra"
 
     @pytest.mark.asyncio
     async def test_status_reports_the_advanced_truth(self):


### PR DESCRIPTION
The server contract Odin's UI lane (#261) consumes, extracted from his page and verified by executing his exact reads against this branch's output. Merge order: this PR first, then #261 — his Advanced panel and restart flow are placebos until this lands.

## The five items

**A. `POST /api/restart`** — admin-gated (prefix added to `ADMIN_ONLY_PREFIXES`), 202 `{"status":"restarting"}`, idempotent while scheduled, env overrides refused by construction (the wizard's env path is first-boot power this route must never grow). Wizard mechanism: record intent, respond, delayed SIGTERM, in-place re-exec. Route parity 187→188.

**B. Registry metadata v2** — every field record now carries `save_effect`/`runtime_effect` (the two plain sentences replacing "Activation required", settled copy pinned verbatim in tests), `group_description` (21 entries, CI-gated both directions — the page previously stole the first child's description as the group heading), and the five `action_*` keys shipped honest-off: no button can render until a real activation endpoint exists.

**C. Codex PUT extension** — `PUT /api/llm/codex/config` accepts, validates, persists, and applies the ten transport/retry/pool/compression keys the Advanced panel submits. The old handler silently dropped all ten and returned 200. Transport+retry live-apply through the existing reload; pool+compression persist only and surface as pending-restart. Rollback restores and re-persists nested priors.

**D. Status truth** — `/api/llm/status` gains the ten codex keys plus kimi's `timeout`; the panel populates exclusively from this endpoint and previously displayed schema defaults forever.

**E. `max_children_per_agent` wired** — the "Not wired" badge becomes false the right way. Root snapshots the configured limit (schema-bounded 1–10), descendants inherit the root's snapshot, enforcement uses the parent's snapshot, the agent's own prompt advertises the effective number, and `TREE_MAX_AGENTS=25` backstops breadth×depth. Both spawn paths pass config at call time; the loop path also gains `max_depth`, which it previously ignored entirely. Registry reclassified `dormant → live_for_new_work`.

## Verification

Contract parity executed, not asserted: all 52 grouped records carry `group_description`, every record carries `save_effect`, `action_available` is False everywhere, all modes within the page vocabulary.

Mutation-verified throughout: dropping advanced persistence, the live apply, or status truth each fails tests; reverting constant enforcement, root inheritance, the tree cap, or the prompt truth each fails tests; restart idempotency and no-overrides pinned.

```
coverage gate  findings=0 @ 89.2%  (caught 8 dark lines of mine first; covered)
ruff clean · type gate new=0 · lint gate new=0 · registry gate 265 leaves / 21 groups / 0 findings
```

Not for master. Merges into `feat/config-center`, then #261 follows.