### PR TITLE
Rewrite README around verified capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,322 +1,329 @@
 # Odin
 
-An autonomous execution agent on Discord. Norse god of wisdom and war, stuck managing mortal infrastructure for eternity.
+[![Tests](https://github.com/Calmingstorm/Odin/actions/workflows/test.yml/badge.svg)](https://github.com/Calmingstorm/Odin/actions/workflows/test.yml)
+[![WebUI](https://github.com/Calmingstorm/Odin/actions/workflows/ui.yml/badge.svg)](https://github.com/Calmingstorm/Odin/actions/workflows/ui.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Odin executes real work from Discord: incident response, deploys, investigations, code review, automation, and scheduled operations across 74 built-in tools plus user-created skills. It runs shell commands on managed hosts, uses browser automation, orchestrates agents and workflows, and verifies results automatically after service changes.
+Odin is a self-hosted execution agent for Discord. It gives a language model a controlled tool interface for infrastructure operations, software work, research, scheduled automation, and other operator-directed tasks. It also includes a web management interface and an HTTP API.
 
-## Why operators pick Odin
+Odin is designed to execute work, not only describe it. A request can result in shell commands on managed hosts, repository changes, service operations, browser interaction, scheduled jobs, or a multi-agent workflow. Tool access is subject to permission, host-access, and command-governance controls; tool activity is recorded in the audit log.
 
-Most AI bots stop at advice. Odin executes.
+## Capabilities
 
-- **Runs real systems** — SSH on managed hosts, Docker, Kubernetes, Terraform, browser automation, and file operations from chat.
-- **Finishes multi-step work** — scheduling, background workflows, autonomous loops, and sub-agents for fan-out tasks.
-- **Verifies outcomes** — `validate_action` auto-triggers after service restarts, deploys, and config changes. HMAC-signed audit trail for every tool call.
-- **Stays operationally useful** — persistent memory, knowledge search, web UI, and trajectory logging keep context attached to the work.
+### Systems and software operations
 
-## Quick examples
+- Run commands and scripts on local or remote managed hosts over SSH.
+- Read and write files, manage long-running processes, and transfer generated artifacts.
+- Work with Git repositories, Docker, Kubernetes, and Terraform.
+- Probe HTTP endpoints and run post-change checks against services, ports, processes, logs, commands, and URLs.
+- Use Playwright for rendered page inspection, screenshots, table extraction, form entry, clicks, and JavaScript evaluation.
 
-Tell Odin things like:
+### Automation
 
-- `@Odin restart nginx and verify the site is healthy`
-- `@Odin investigate why backups failed last night and summarize the root cause`
-- `@Odin deploy this branch to staging, run validation, and post the diff`
-- `@Odin schedule a disk check every 6 hours and alert if usage exceeds 85%`
+- Run recurring cron schedules, one-time jobs, and webhook-triggered workflows.
+- Delegate sequential background workflows with conditional steps.
+- Run autonomous monitoring loops with explicit iteration and stop limits.
+- Spawn isolated sub-agents for parallel or nested work and collect their results into the parent task.
+- Preserve turn state across model-capacity interruptions without automatically repeating interrupted side effects.
 
-## What It Can Do
+### State and retrieval
 
-**Infrastructure & DevOps**
-- Shell execution on managed hosts (`run_command`, `run_script`, `run_command_multi`)
-- Git operations, Docker management, kubectl, Terraform
-- HTTP endpoint probing with timing breakdown
-- Post-change validation (`validate_action`) — auto-verifies service health after restarts, deploys, config writes
-- Scheduled health checks, daily infrastructure digests
+- Persist channel sessions and compact long conversations against configurable context budgets.
+- Store operator-approved personal or global memory notes.
+- Search conversation history and the tool audit log.
+- Ingest and search a knowledge base using full-text and vector retrieval.
+- Record per-turn trajectories, tool use, timing, and model usage.
 
-**AI & Code**
-- Claude Code delegation for code generation, review, and analysis
-- Multi-LLM: Codex (GPT-5.5), Kimi (K2.6), Ollama (local) — switchable at runtime
-- ComfyUI image generation
-- PDF analysis, image analysis, web search, browser automation
+### Extensibility
 
-**Automation**
-- Autonomous loops with stuck-detection and backoff
-- Sub-agent spawning (parallel, nested up to depth 2)
-- User-created Python skills with hot-reload and AST validation
-- Cron scheduling with webhook triggers (Gitea, Grafana, GitHub, GitLab)
+- Create, edit, enable, disable, import, export, and invoke Python skills at runtime.
+- Configure skills with JSON schemas, dependencies, and operator-managed settings.
+- Integrate external systems through webhooks, email, issue trackers, MCP servers, Slack, Grafana alerts, and custom skill code.
 
-**Knowledge & Memory**
-- Persistent memory (per-user and global key-value notes)
-- Knowledge base with FTS5 + vector search, dedup, versioning
-- Conversation session management with adaptive compaction
-- Trajectory saving for every interaction (per-turn JSONL)
+### Management interface
 
-**Security**
-- CommandGovernor: blocks destructive shell commands and exfiltration patterns before execution
-- Permission tiers (admin/user/guest) with per-tool RBAC
-- Per-user host access control with configurable defaults (WebUI-managed)
-- Secret scrubbing on all input/output paths (API keys, tokens, JWTs, AWS keys, database URIs)
-- SSRF validation on all URL-accepting endpoints
-- DOMPurify-sanitized markdown rendering in web UI
-- AST-based skill validation (no exec during validation)
-- Web API authentication with session isolation and CSRF protection
+The web interface provides grouped views for:
 
-**Web UI** (19 pages)
-- Dashboard, chat, sessions, tools, skills, knowledge
-- Schedules, loops, agents, processes, audit log
-- Config editor, memory viewer, traces, health, resources
-- Real-time tool execution viewer with streaming output
+- chat and current system posture;
+- active execution, agents, loops, processes, and schedules;
+- audit records, sessions, traces, and model usage;
+- tools, skills, knowledge, memory, and learned context;
+- health, resources, logs, configuration, permissions, host access, and updates.
 
-## Architecture
+The API currently exposes 188 decorated management routes plus health, metrics, webhook, WebSocket, and static-interface routes. Route parity is covered by characterization tests.
 
-```
-Discord ──> OdinBot (client.py)
-               │
-               ├── Tool Executor ──> 74 tools (shell, browser, git, docker, email, etc.)
-               │       │
-               │       ├── CommandGovernor (blocks dangerous commands)
-               │       ├── Risk Classifier (observability tags)
-               │       └── Bulkhead isolation (concurrency limits)
-               │
-               ├── Codex Client ──> GPT-5.5 (tool loop with up to 500 iterations)
-               │       │
-               │       ├── Response Guards (fabrication, hedging, premature failure)
-               │       ├── Completion Classifier (fail-open)
-               │       └── Context Compressor (adaptive)
-               │
-               ├── Agent Manager ──> Sub-agents (parallel, nested)
-               ├── Loop Manager ──> Autonomous monitoring loops
-               ├── Scheduler ──> Cron + one-shot + webhook triggers
-               ├── Skill Manager ──> User-created Python tools
-               ├── Knowledge Store ──> FTS5 + vector search
-               ├── Session Manager ──> Per-channel history + compaction
-               ├── Browser (native Playwright) ──> Screenshots, page reading, JS eval
-               └── Web API (aiohttp) ──> 183 REST endpoints + WebSocket
+## Execution model
+
+```text
+Discord / Web API / CLI
+          |
+          v
+  request admission and identity
+          |
+          v
+  selected LLM provider
+          |
+          v
+      tool loop
+          |
+          +---- built-in tool dispatcher ---- managed hosts and services
+          |
+          +---- native Discord handlers
+          |
+          +---- user-created skills
+          |
+          v
+ audit, trajectory, and result delivery
 ```
 
-## Install
+For a normal Discord request:
 
-### Debian / Ubuntu (recommended)
+1. The intake pipeline applies channel, user, mention, bot, and permission policy.
+2. Odin assembles session history, configured context, and the tools available to that requester.
+3. The active provider returns text, tool calls, or both.
+4. The tool loop validates and dispatches calls until the request completes or an iteration, time, or cancellation limit is reached.
+5. Tool results are recorded and returned to the model for the next step.
+6. Successful mutations that require operational verification cause the tool loop to require `validate_action` before the final response.
+7. The final response and turn trajectory are persisted and delivered to Discord or the API caller.
 
-Odin ships as a `.deb` on the [releases page](https://github.com/Calmingstorm/Odin/releases). It installs to `/opt/odin`, runs as a dedicated `odin` system user under systemd, and keeps config in `/etc/odin` and data in `/var/lib/odin` (FHS layout).
+Odin supports three model backends:
+
+| Provider | Authentication | Notes |
+|---|---|---|
+| OpenAI Codex | OAuth device or browser flow | Primary provider path; supports account rotation and separate spawned-agent model settings |
+| Kimi | Moonshot API key | Alternative hosted provider |
+| Ollama | Local or remote endpoint; optional bearer token | Self-hosted provider path |
+
+The provider can be changed through configuration or the web interface. The Codex Advanced panel uses an explicit save action. Codex connection-pool and context-compression changes are saved immediately but require an Odin restart. Provider support does not imply that every model has equivalent tool-calling behavior or context limits.
+
+## Built-in tools
+
+The current release registers 74 built-in tools. The registry is assembled from ordered definition modules under `src/tools/defs/`; tests pin the catalog order and prevent duplicate names.
+
+| Area | Tools |
+|---|---|
+| Shell and files | `run_command`, `run_script`, `run_command_multi`, `read_file`, `write_file`, `generate_file`, `post_file`, `manage_process` |
+| Infrastructure | `git_ops`, `docker_ops`, `kubectl`, `terraform_ops`, `http_probe`, `validate_action` |
+| Scheduling and workflows | `schedule_task`, schedule management, delegated tasks, autonomous loops |
+| Agents | spawn, message, inspect, wait for, collect, and terminate agents |
+| Browser and web | web search and fetch, screenshots, rendered page and table reads, clicks, form entry, JavaScript evaluation |
+| Knowledge and state | history and audit search, knowledge ingestion and retrieval, memory, lists |
+| Skills | create, edit, invoke, import, export, inspect, enable, disable, and delete skills |
+| Communication and media | Discord operations, email, PDF and image analysis, image generation |
+
+The complete catalog is defined in [`src/tools/registry.py`](src/tools/registry.py) and [`src/tools/defs/`](src/tools/defs/).
+
+## Safety and access control
+
+Odin can change real systems. It should be deployed as an administrative service and configured accordingly.
+
+The implementation includes the following controls:
+
+- **Permission tiers:** `admin`, `user`, and `guest`. The `user` tier excludes arbitrary shell execution and administrative tools, but its allowlist includes limited stateful operations such as list management. The tracked deployment template sets the effective default tier to `admin`; operators should change it if that is not appropriate for their server.
+- **Host access policy:** per-user host allowlists and default-host selection, with request-scoped restrictions for API callers.
+- **CommandGovernor:** classifies shell commands before execution. Depending on configuration and caller tier, it can reject critical or exfiltration patterns, annotate high-risk commands, or allow an administrator override. The tracked template enables administrator override.
+- **Workspace isolation:** local commands run from a dedicated private workspace outside the application and data directories. Local command execution fails closed if that workspace is missing, incorrectly owned, or not mode `0700`.
+- **Secret handling:** model input, tool output, attachments, and stored records pass through secret-detection and redaction paths.
+- **Network request guards:** browser automation and general web-fetch paths validate destinations and redirect hops to reduce SSRF and DNS-rebinding risk. Individual integration tools may apply narrower policies appropriate to their purpose.
+- **Audit logging:** tool calls are written to append-only JSONL records. Optional HMAC chaining provides tamper evidence, and rotation limits unbounded growth.
+- **Post-change validation:** recognized mutations are marked as requiring follow-up validation before the tool loop can finish normally.
+- **Web authentication:** bearer-token and session authentication are available for the management API and interface.
+
+These are application controls, not a security boundary equivalent to a virtual machine. Skills execute in the Odin process as trusted plugins. The Debian installer also grants the `odin` service account passwordless sudo by default because host administration is a primary use case; production operators should restrict `/etc/sudoers.d/99-odin-passwordless` to the commands their deployment needs.
+
+The tracked configuration binds the web server to `0.0.0.0` and leaves API authentication disabled when no API token is configured. Before exposing it beyond a controlled network, configure an API token or token identity, transport security, and appropriate network controls.
+
+See [`docs/security.md`](docs/security.md) for the detailed security model.
+
+## Selected operational record
+
+The following examples are drawn from completed operator sessions and repository records. They describe work performed through Odin rather than synthetic capability claims.
+
+- **Repository integration and concurrency safety:** [Calmingstorm/wanderer#2](https://github.com/Calmingstorm/wanderer/pull/2), merged on 2026-08-01, rebased a maintained fork onto upstream and added guarded signature imports, reconciliation previews, transactional updates, and serialization around concurrent graph mutations.
+- **Security review and remediation:** during review of a payout-transfer change, Odin identified an unauthenticated execution route, moved execution behind the administrative API and authenticated actor context, updated the API smoke test, reran the project checks, and merged the corrected change.
+- **Minecraft release operations:** Odin has prepared and published versioned modpack artifacts, updated AMP-managed servers while preserving worlds and local files, and validated application state, listening ports, mod loading, KubeJS checks, and server tick rate after restart.
+- **Infrastructure recovery:** Odin traced loss of apparent audit history to rotation and restart behavior, hardened a backup guard to treat active and rotated audit segments as one store, added JSON and high-water validation, and completed a subsequent Restic backup with the protected data included.
+- **Runtime extension:** deployment-specific skills have been added for AMP management, Cloudflare DNS, Linode operations, CurseForge publishing, Minecraft modpack updates, UPS status, and application-specific release workflows. These skills enforce their own confirmation and validation requirements in addition to the built-in tool controls.
+
+Operational results depend on credentials, host access, third-party availability, project state, and the quality of the selected model. Odin records tool outcomes so an operator can distinguish completed work from attempted or interrupted work.
+
+## Installation
+
+### Debian or Ubuntu package
+
+Releases include an amd64 `.deb` package. Download the current package from the [releases page](https://github.com/Calmingstorm/Odin/releases), then install it with APT:
 
 ```bash
-# Download the latest release .deb, then:
-sudo apt install ./odin_*.deb
+sudo apt install ./odin_*_amd64.deb
 ```
 
-The installer provisions the service (system user, Python venv + dependencies, SSH key, systemd unit) **non-interactively** and prints the first-time-setup steps. It does **not** start Odin automatically — you set the Discord token and LLM credentials first (below). Requires Python ≥ 3.11 (`python3-venv`); dependencies are pulled automatically.
+The package installs:
 
-Upgrades preserve `/etc/odin` and `/var/lib/odin` and restart the service if it was running.
+| Purpose | Path |
+|---|---|
+| Application | `/opt/odin` |
+| Configuration | `/etc/odin/config.yml` |
+| Environment file | `/etc/odin/.env` |
+| Persistent data | `/var/lib/odin` |
+| Local command workspace | `/var/lib/odin-workspace` |
+| Logs | `/var/log/odin` |
+| Systemd unit | `/usr/lib/systemd/system/odin.service` |
 
-### From source (development)
+The package installs the application files and systemd unit. Its post-install script creates the `odin` service account, virtual environment, SSH key, data directories, configuration links, and local command workspace. A new installation is enabled but is not started until credentials are configured. Upgrades preserve configuration and data and restart the service only if it was already running.
+
+### First-time setup
+
+1. Create a Discord application and bot in the [Discord developer portal](https://discord.com/developers/applications). Enable **Message Content Intent**.
+2. Set the Discord token:
+
+```bash
+sudoedit /etc/odin/.env
+# DISCORD_TOKEN=...
+```
+
+3. Authenticate Codex, or configure Kimi or Ollama later through the web interface:
+
+```bash
+sudo -u odin /opt/odin/.venv/bin/python \
+  /opt/odin/scripts/codex_login.py \
+  --credentials-path /var/lib/odin/codex_auth.json \
+  --device
+```
+
+4. Review hosts, permissions, the command workspace, and the web API token:
+
+```bash
+sudoedit /etc/odin/config.yml
+```
+
+5. Start the service and inspect startup:
+
+```bash
+sudo systemctl start odin
+sudo systemctl status odin
+sudo journalctl -u odin -f
+```
+
+The web interface listens on the configured `web.port`, which defaults to `3000`.
+
+### From source
+
+Python 3.11 or newer is required. CI currently runs on Python 3.12.
 
 ```bash
 git clone https://github.com/Calmingstorm/Odin.git
 cd Odin
+
+python3 -m venv .venv
+. .venv/bin/activate
 pip install -e ".[dev]"
-playwright install chromium          # optional — enables browser_* tools
 
-cp .env.example .env                 # set DISCORD_TOKEN
-$EDITOR config.yml                   # hosts, LLM, permissions
+# Optional browser support
+pip install -e ".[browser]"
+python -m playwright install chromium
 
-# Local commands run in a workspace OUTSIDE the install, so a bare relative
-# path (e.g. cleaning up after extracting an archive whose internal layout
-# starts with `data/`) can never resolve against your live data. It must
-# exist, be private, and be owned by you — validation fails closed rather
-# than silently falling back to the install directory.
-sudo install -d -m 0700 -o "$USER" -g "$(id -gn)" /var/lib/odin-workspace
-# …or point `tools.local_working_dir` in config.yml at any private directory
-# outside the checkout, e.g.:
-#   mkdir -p -m 0700 ~/.local/share/odin-workspace
+cp .env.example .env
+# Set DISCORD_TOKEN in .env and review config.yml.
+
+# Local shell tools require a private workspace outside the checkout.
+mkdir -p ~/.local/share/odin-workspace
+chmod 0700 ~/.local/share/odin-workspace
+# Set tools.local_working_dir to this absolute path in config.yml.
 
 python -m src
 ```
 
-The web UI starts automatically on the configured port (default **3000**). Set `web.api_token` in `config.yml` to require authentication.
-
-## First-time setup
-
-After installing the `.deb`, complete these three steps (the service is enabled but not yet started):
-
-**1. Discord bot token.** Create a bot at the [Discord developer portal](https://discord.com/developers/applications), enable **MESSAGE CONTENT INTENT** under Bot settings, then:
-
-```bash
-sudoedit /etc/odin/.env              # set DISCORD_TOKEN=...
-```
-
-**2. LLM backend.** Odin's primary backend is OpenAI Codex (a ChatGPT Plus/Team account). Authenticate as the `odin` user with the installed virtualenv:
-
-```bash
-sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py \
-     --credentials-path /var/lib/odin/codex_auth.json
-# headless server? add --device for the browserless device-code flow
-```
-
-Repeat to add more accounts for automatic rate-limit rotation. You can instead configure **Kimi** or **Ollama** from the web UI — see [LLM Configuration](#llm-configuration).
-
-**3. Review config and start.**
-
-```bash
-sudoedit /etc/odin/config.yml        # hosts, permissions (localhost + admin tier ship by default)
-sudo systemctl start odin
-sudo journalctl -u odin -f           # watch it connect
-```
-
-Then open the dashboard at **http://localhost:3000**. Set `web.api_token` in `config.yml` to require authentication before exposing it.
-
-*(From-source installs use `data/codex_auth.json` under the repo and `python scripts/codex_login.py` instead of the `/opt/odin` paths above.)*
-
-## LLM Configuration
-
-Odin supports three LLM backends, switchable at runtime from the WebUI (System > LLM Config):
-
-| Provider | Auth | Best For |
-|----------|------|----------|
-| **Codex** (OpenAI) | OAuth device flow | Primary — GPT-5 family via ChatGPT subscription |
-| **Kimi** (Moonshot AI) | API key | Alternative cloud — K2.6, 262K context, competitive pricing |
-| **Ollama** (Local/Remote) | None / bearer token | Self-hosted open-source models (Qwen, Llama, etc.) |
-
-All providers are configured from the WebUI without editing the config file. Provider toggles, API keys, model selection, and provider switching save and apply live; the Codex Advanced panel uses an explicit save action. Codex connection-pool and context-compression changes are saved immediately but require an Odin restart.
-
-### Codex Authentication
-
-Codex uses OpenAI OAuth tokens stored in `data/codex_auth.json`. On a `.deb` install, run the login script with the installed virtualenv as the `odin` user and an **absolute** credentials path (the script writes relative to the caller's cwd otherwise): `sudo -u odin /opt/odin/.venv/bin/python /opt/odin/scripts/codex_login.py --credentials-path /var/lib/odin/codex_auth.json`. The commands below are the from-source equivalents.
-
-**Browser login** (machine with a browser):
-```bash
-python scripts/codex_login.py
-```
-
-**Device login** (headless servers):
-```bash
-python scripts/codex_login.py --device
-```
-This displays a code to enter at `https://auth.openai.com/codex/device` — no local browser needed.
-
-**WebUI**: System > LLM Config shows account status and supports device flow login.
-
-**Multi-account**: Store multiple credential sets as a JSON array in `data/codex_auth.json`. Odin rotates between them on rate limits automatically.
-
-Tokens auto-refresh at runtime. Re-run the login script if the bot is offline for more than ~8 days (refresh token expiry).
-
-### Kimi Setup
-
-1. Get an API key from [platform.kimi.ai](https://platform.kimi.ai)
-2. In WebUI > LLM Config > Kimi: enable, paste API key, press Enter
-3. Select model from dropdown (kimi-k2.6 recommended)
-
-### Ollama Setup
-
-1. Install [Ollama](https://ollama.com) and pull a model (`ollama pull qwen3:14b`)
-2. In WebUI > LLM Config > Ollama: enable, set base URL, select model from dropdown
-3. For remote instances: set the API key if your reverse proxy requires one
+For a source installation using Codex, run `python scripts/codex_login.py --device` to create `data/codex_auth.json`.
 
 ## Configuration
 
-| File | Purpose |
-|------|---------|
-| `config.yml` | Main config: Discord, tools, LLM, browser, scheduling, web UI, permissions |
-| `.env` | Secrets: `DISCORD_TOKEN` |
-| `data/codex_auth.json` | Codex OAuth credentials (generated via `scripts/codex_login.py`) |
-| `data/context/*.md` | Infrastructure context files injected into every LLM prompt |
+Odin loads `config.yml` at startup and supports `${VAR}` and `${VAR:-default}` environment substitution.
 
-### Key Config Sections
+Important sections include:
 
-- **`discord`**: token, allowed users/channels, mention-only mode, bot interaction
-- **`openai_codex`**: model, credentials, model routing, transport, connection pooling, context compression
-- **`tools`**: SSH hosts, command timeout, per-tool timeout overrides, Claude Code host
-- **`browser`**: native Playwright (empty `cdp_url`) or remote CDP endpoint
-- **`web`**: port, API token, session timeout
-- **`permissions`**: default tier, per-user overrides
+| Section | Purpose |
+|---|---|
+| `discord` | token source, user and channel admission, mention and bot policy |
+| `openai_codex`, `kimi`, `ollama`, `llm_provider` | provider credentials, model selection, retry and context settings |
+| `tools` | managed hosts, SSH paths, command timeouts, workspace, tool limits |
+| `permissions` | default tier and per-user overrides |
+| `agents` | nesting, concurrency, iteration, and lifetime limits |
+| `sessions`, `context`, `turn_state` | conversation persistence, compaction, context files, suspended-turn recovery |
+| `browser`, `image`, `comfyui` | browser and image backends |
+| `web`, `webhook` | management API, interface, and inbound events |
+| `audit`, `observability`, `usage`, `logging` | audit integrity, health, metrics, usage, and logs |
 
-## Tools (74)
+Markdown files placed under the configured context directory (by default `data/context/`) are included as infrastructure context. Runtime permission overrides and other state are stored under `data/`.
 
-| Category | Tools |
-|----------|-------|
-| Shell & Files | `run_command`, `run_script`, `run_command_multi`, `read_file`, `write_file`, `generate_file`, `post_file`, `manage_process` |
-| Infrastructure | `git_ops`, `docker_ops`, `kubectl`, `terraform_ops`, `http_probe` |
-| Agents & Orchestration | `delegate_task`, `list_tasks`, `cancel_task`, `spawn_agent`, `send_to_agent`, `list_agents`, `kill_agent`, `get_agent_results`, `wait_for_agents`, `spawn_loop_agents`, `collect_loop_agents` |
-| Scheduling & Loops | `schedule_task`, `list_schedules`, `update_schedule`, `delete_schedule`, `parse_time`, `start_loop`, `stop_loop`, `list_loops` |
-| AI & Code | `claude_code`, `generate_image`, `analyze_image`, `analyze_pdf` |
-| Skills | `create_skill`, `edit_skill`, `delete_skill`, `list_skills`, `enable_skill`, `disable_skill`, `install_skill`, `export_skill`, `skill_status`, `invoke_skill` |
-| Knowledge & Memory | `memory_manage`, `manage_list`, `search_history`, `search_audit`, `search_knowledge`, `ingest_document`, `bulk_ingest_knowledge`, `list_knowledge`, `delete_knowledge` |
-| Web & Browser | `web_search`, `fetch_url`, `browser_screenshot`, `browser_read_page`, `browser_read_table`, `browser_click`, `browser_fill`, `browser_evaluate` |
-| Email | `email_send`, `email_search`, `email_read`, `email_list_recent` |
-| Discord | `read_channel`, `add_reaction`, `create_poll`, `purge_messages` |
-| Validation & Security | `validate_action`, `set_permission`, `issue_tracker` |
+See [`docs/configuration.md`](docs/configuration.md) for the configuration reference.
 
-## Testing
+## Skills
+
+A skill is a Python module that exports a `SKILL_DEFINITION` dictionary and an asynchronous `execute` function. Definitions include a JSON input schema and can optionally declare dependencies and a configuration schema.
+
+Skills are AST-validated before loading, can be hot-reloaded, and receive a bounded context API for host execution, selected tool calls, HTTP, memory, knowledge, scheduling, and Discord delivery. Default execution limits cover runtime, output size, tool calls, HTTP requests, messages, files, and dependency count.
+
+Skills are trusted code. AST validation prevents validation-time execution and catches prohibited constructs, but it does not provide process isolation.
+
+See [`docs/skills.md`](docs/skills.md) for the skill contract and context API.
+
+## Development and testing
+
+Python checks:
 
 ```bash
-# Full suite (134 files, 6,000+ tests; asyncio auto mode)
-pytest tests/ -q
-
-# One file or pattern
-pytest tests/test_client.py -q
-pytest tests/ -k scheduler -q
+pip install -e ".[dev]"
+pytest -q
+ruff check src tests
 ```
 
-## Project Structure
+Web interface checks:
 
+```bash
+npm ci
+npm run check
 ```
+
+`npm run check` validates templates and bindings, runs targeted interface invariants, and builds the Vite output. The generated `ui/dist/` tree is committed; CI fails if it differs from source.
+
+The GitHub Actions test workflow runs:
+
+- the Python suite;
+- real Chromium request-guard tests;
+- no-new-finding lint and type gates;
+- configuration-application classification checks;
+- a per-file no-regression coverage gate.
+
+The interface workflow runs the complete JavaScript check and build pipeline. Characterization tests pin behavior at decomposition boundaries such as the tool catalog, API routes, chat tool loop, and autonomous loop.
+
+## Repository structure
+
+```text
 src/
-  __main__.py              Entry point
-  config/schema.py         Pydantic config models
-  discord/
-    client.py              OdinBot — composition + Discord lifecycle
-    wiring.py              Composition root (services + components)
-    intake_pipeline.py     on_message gating chain + message pipeline
-    tool_loop.py           Chat + autonomous tool-execution pipelines
-    native_tools/          Discord-native tool domains + dispatch table
-    prompts.py             System-prompt assembly + caches
-    llm_gateway.py         Provider clients, reloads, guarded calls
-    delivery.py            Presence, retries, chunked sends
-    channel_state.py       Per-channel mutable state registry
-    scheduled_events.py    Scheduler/digest/monitor callbacks
-    turn_recorder.py       Trajectories, traces, reflection dispatch
-    completion.py          Completion classifier
-    housekeeping.py        Periodic cache maintenance
-    response_guards.py     Fabrication, hedging, premature failure detection
-    tool_loop_helpers.py   Request preamble + shared leaf helpers
-    cogs/                  9 moderation/utility cog extensions
-  tools/
-    executor.py            Tool dispatch + recovery
-    registry.py            74 built-in tool definitions
-    skill_manager.py       Skill CRUD + AST validation
-    risk_classifier.py    CommandGovernor + risk classification
-    post_validation.py     validate_action implementation
-    recovery.py            Error classification + retry
-    browser.py             Native Playwright browser
-  web/
-    api/                   REST API — composition root + 13 domain modules
-    api_common.py          Shared web helpers (redaction, validation, admin gate)
-    chat.py                Web chat pipeline entry
-  llm/
-    system_prompt.py       Identity, execution policy, tool hierarchy
-    openai_codex.py        Codex streaming client
-    auxiliary.py            Smart model routing (cheap/strong)
-    secret_scrubber.py     Secret detection and redaction
-    context_compressor.py  Adaptive context compression
-  async_utils.py           fire_and_forget helper for background tasks
-  permissions/
-    manager.py             Permission tiers + RBAC
-    host_access.py         Per-user host access control
-  agents/manager.py        Sub-agent lifecycle + state machine
-  scheduler/scheduler.py   Cron + one-shot + webhook triggers
-  sessions/manager.py      Per-channel history + compaction + topic detection
-  knowledge/store.py       FTS5 + vector knowledge base
-  health/server.py         aiohttp web server + auth middleware
-  web/
-    api.py                 183 REST endpoints
-    websocket.py           Live event streaming + WS chat
-  audit/logger.py          HMAC-chainable audit log
-  learning/reflector.py    Cross-conversation learning (90-day expiry)
-  trajectories/saver.py    Per-turn JSONL trajectory logging
-
-ui/                        Vue 3 + Tailwind web dashboard (19 pages)
-tests/                     134 files, 6,000+ tests
-config.yml                 Default configuration template
+  __main__.py             process startup and shutdown
+  config/                 schema, loading, and live-apply metadata
+  discord/                Discord intake, tool loop, delivery, and session wiring
+  tools/                  registry, execution, handlers, safeguards, and skills
+  llm/                    Codex, Kimi, Ollama, routing, recovery, and redaction
+  agents/                 spawned-agent lifecycle
+  scheduler/              cron, one-time, webhook, and workflow scheduling
+  sessions/               channel history, persistence, and compaction
+  knowledge/              full-text and vector knowledge store
+  permissions/            permission tiers and host access
+  audit/                   append-only and optionally HMAC-chained audit records
+  trajectories/           per-turn execution records
+  web/                     management API, chat API, and WebSocket support
+  health/                  health, readiness, metrics, web server, and static UI
+ui/
+  js/pages/               Vue page modules
+  js/                     API client and shared interface behavior
+  css/                    interface styles
+  dist/                   committed production build
+packaging/                Debian package metadata and systemd scripts
+tests/                    unit, integration, security, and characterization tests
+docs/                     configuration, security, skills, and engineering plans
 ```
 
 ## License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- replace the marketing-heavy README with a factual description of Odin's current execution model and supported interfaces
- document the actual tool, provider, automation, state, skill, and management surfaces
- state security boundaries and shipped defaults explicitly, including administrator tier, governor override, passwordless sudo, web bind address, and unauthenticated empty-token behavior
- add a restrained operational record based on completed work and repository evidence
- correct stale tool, API, test, UI, installation, and repository-structure details

## Validation

- `git diff --check`
- Python suite: `9163 passed, 6 skipped`
- `npm run check`
- verified 74 registered built-in tools
- verified 188 decorated API routes
- verified all local README links resolve
- verified `ui/dist` is unchanged after the interface build
