### PR TITLE
ci: run trusted events on self-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         run: pytest -q
 
   browser-network-guard:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,13 @@ jobs:
       - name: Install browser test dependencies
         run: |
           pip install -e ".[dev,browser]"
-          python -m playwright install --with-deps chromium
+          # Hosted images need system libs installed each run; the self-hosted
+          # runner already has them (and its user has no passwordless sudo).
+          if [ "${{ runner.environment }}" = "self-hosted" ]; then
+            python -m playwright install chromium
+          else
+            python -m playwright install --with-deps chromium
+          fi
       - name: Exercise real Chromium request guard paths
         env:
           # The tests may skip on developer machines without Chromium, but this
@@ -50,7 +56,7 @@ jobs:
             tests/test_browser_automation.py::test_real_browser_blocks_redirects_and_subresources_to_private_loopback
 
   lint-no-new:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +74,7 @@ jobs:
         run: python scripts/ci/lint_gate.py
 
   types-no-new:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +96,7 @@ jobs:
         run: python scripts/ci/type_gate.py
 
   config-apply-classified:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +115,7 @@ jobs:
         run: python scripts/ci/apply_registry_gate.py
 
   coverage-no-drop:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,11 @@
+# Trust routing: push events and same-repo pull requests run on the
+# repository's self-hosted runners (label odin-ci); fork pull requests run on
+# GitHub-hosted ubuntu-latest. The LOAD-BEARING guard is the repository
+# setting "Require approval for all outside collaborators" (fork-PR approval
+# policy: all_external_contributors) — a fork can edit this file, so the
+# runs-on expressions below are defense-in-depth, not the boundary itself.
+# MAINTAINERS: never approve a fork PR that touches .github/workflows without
+# line-reviewing the workflow diff first.
 name: Tests
 
 on:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,3 +1,11 @@
+# Trust routing: push events and same-repo pull requests run on the
+# repository's self-hosted runners (label odin-ci); fork pull requests run on
+# GitHub-hosted ubuntu-latest. The LOAD-BEARING guard is the repository
+# setting "Require approval for all outside collaborators" (fork-PR approval
+# policy: all_external_contributors) — a fork can edit this file, so the
+# runs-on expressions below are defense-in-depth, not the boundary itself.
+# MAINTAINERS: never approve a fork PR that touches .github/workflows without
+# line-reviewing the workflow diff first.
 name: WebUI
 
 on:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'odin-ci' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
GitHub Actions hosted runners are mid-outage (today's master run failed at 'Set up job' before any code ran). This routes CI to the repository's two self-hosted runners for trusted events only:

- **push events and same-repo pull requests** → `odin-ci` (two registered runners, so jobs still parallelize)
- **fork pull requests** → `ubuntu-latest` — external code never executes on the runner host
- browser-network-guard installs Playwright system deps only on hosted images (the runner host already provides them; its user has no passwordless sudo)
- release.yml intentionally unchanged in this pass

This PR itself is a same-repo PR, so its checks are the live proof the runners work before merge.