### PR TITLE
fix(agents): recover from context-window overflow instead of dying

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -41,6 +41,36 @@ TREE_MAX_AGENTS = 25             # hard ceiling on agents in one tree's lifetime
                                  # breadth x depth must never compound into a
                                  # geometric invoice, whatever config says
 
+# --- Agent context-overflow recovery (design settled with Odin, 2026-08-09) ---
+# Served context window on the Codex/ChatGPT path, probed 2026-08-09 from
+# /backend-api/codex/models: uniform 272K across sol/terra/luna/5.5 (luna
+# served 372K in July and was re-tiered since — treat as observation, not
+# spec). System prompt, response, and reasoning ride OUTSIDE agent.messages,
+# hence the reserve; the remainder converts at a deliberately DENSE
+# chars-per-token so a char measure can never overshoot real tokens on
+# scraped content. Private constants, never config: a raisable knob would
+# resurrect the overflow class this recovery exists to close.
+_SERVED_CONTEXT_WINDOW_TOKENS = 272_000
+_EMERGENCY_RESERVE_TOKENS = 42_000
+_EMERGENCY_CHARS_PER_TOKEN = 2.5
+_EMERGENCY_TARGET_CHARS = int(
+    (_SERVED_CONTEXT_WINDOW_TOKENS - _EMERGENCY_RESERVE_TOKENS)
+    * _EMERGENCY_CHARS_PER_TOKEN
+)
+_EMERGENCY_TARGET_CHARS_AGGRESSIVE = 400_000
+_EMERGENCY_TARGETS = (_EMERGENCY_TARGET_CHARS, _EMERGENCY_TARGET_CHARS_AGGRESSIVE)
+
+
+def _is_context_overflow(exc: BaseException) -> bool:
+    """Structural check for the provider-reported context overflow class."""
+    from ..llm.errors import LLMRequestError
+
+    return (
+        isinstance(exc, LLMRequestError)
+        and getattr(exc, "code", None) == "context_length_exceeded"
+    )
+
+
 # Agent-management tools — allowed or blocked based on nesting depth
 AGENT_MANAGEMENT_TOOLS = frozenset({
     "spawn_agent",
@@ -263,6 +293,12 @@ class AgentInfo:
     iteration_count: int = 0
     last_activity: float = field(default_factory=time.time)
     recovery_attempts: int = 0
+    # Context-overflow recovery (agent-local, lifetime-only): after the first
+    # real overflow, the ceiling latches to the size that SUCCEEDED so later
+    # iterations compact BEFORE sending instead of paying a doomed 400. Never
+    # persisted, never config — dies with the agent.
+    context_char_ceiling: int | None = None
+    context_recoveries: list[dict] = field(default_factory=list)
     # Snapshotted at spawn — a live config change never shortens (or extends)
     # an already-running agent's deadline or per-call budget.
     iteration_timeout: float = ITERATION_CB_TIMEOUT
@@ -654,6 +690,14 @@ class AgentManager:
             "runtime_seconds": round(runtime, 1),
             "goal": agent.goal,
             "recovery_attempts": agent.recovery_attempts,
+            **(
+                {
+                    "context_char_ceiling": agent.context_char_ceiling,
+                    "context_recoveries": list(agent.context_recoveries),
+                }
+                if agent.context_recoveries
+                else {}
+            ),
             "state_history": agent._sm.history_as_dicts(),
             "depth": agent.depth,
             "parent_id": agent.parent_id,
@@ -1034,6 +1078,39 @@ async def _run_agent(
             agent.iteration_count = iteration + 1
             iter_start = time.time()
 
+            # Overflow-latch compaction (agent-local, lifetime-only): once an
+            # emergency recovery has proven a survivable size, compact BEFORE
+            # sending whenever the payload crosses it — an already-proven
+            # scraper must not pay a doomed 400 on every later iteration.
+            # Independent of context_compression_enabled: this is recovery
+            # machinery, not the config feature.
+            if agent.context_char_ceiling is not None:
+                try:
+                    from ..llm.context_compressor import (
+                        emergency_compress_for_window,
+                        estimate_message_chars,
+                    )
+                    if (
+                        estimate_message_chars(agent.messages)
+                        > agent.context_char_ceiling
+                    ):
+                        agent.messages, latch_report = emergency_compress_for_window(
+                            agent.messages,
+                            target_chars=agent.context_char_ceiling,
+                        )
+                        latch_report["attempt"] = 0
+                        latch_report["trigger"] = "latch"
+                        agent.context_recoveries.append(latch_report)
+                        log.info(
+                            "agent overflow-latch: agent=%s compacted to %d chars",
+                            agent.id,
+                            latch_report["compressed_chars"],
+                        )
+                except Exception:
+                    log.exception(
+                        "agent overflow-latch compaction failed (non-fatal)"
+                    )
+
             # Call LLM with recovery support
             response = await _call_llm_with_recovery(
                 agent, iteration_callback, system_prompt, tools,
@@ -1248,46 +1325,92 @@ async def _call_llm_with_recovery(
 
     Returns the LLM response dict, or None if agent reached terminal state.
     """
-    remaining = _remaining_lifetime(agent)
-    if remaining <= 0:
-        _lifetime_timeout(agent)
-        return None
-    call_timeout = min(agent.iteration_timeout, remaining)
-    try:
-        return await asyncio.wait_for(
-            iteration_callback(agent.messages, system_prompt, tools),
-            timeout=call_timeout,
-        )
-    except TimeoutError:
-        if _remaining_lifetime(agent) <= 0:
-            # The wait was lifetime-capped and the deadline has passed:
-            # this is lifetime exhaustion, not a stuck LLM call.
+    emergency_passes = 0
+    while True:
+        remaining = _remaining_lifetime(agent)
+        if remaining <= 0:
             _lifetime_timeout(agent)
             return None
-        # str(asyncio.TimeoutError()) is EMPTY — always store the formatted
-        # description, never the bare exception string.
-        err_desc = f"LLM timeout after {int(call_timeout)}s"
-        log.error("Agent %s LLM call failed: %s", agent.id, err_desc)
-        agent.transition(AgentState.FAILED, err_desc)
-        agent.error = err_desc
-        agent.ended_at = time.time()
-        return None
-    except Exception as exc:
-        if _remaining_lifetime(agent) <= 0:
-            # Lifetime exhaustion wins over failure classification (the
-            # v3.59.0 rule: exhaustion is TIMEOUT, never FAILED).
-            _lifetime_timeout(agent)
+        call_timeout = min(agent.iteration_timeout, remaining)
+        try:
+            return await asyncio.wait_for(
+                iteration_callback(agent.messages, system_prompt, tools),
+                timeout=call_timeout,
+            )
+        except TimeoutError:
+            if _remaining_lifetime(agent) <= 0:
+                # The wait was lifetime-capped and the deadline has passed:
+                # this is lifetime exhaustion, not a stuck LLM call.
+                _lifetime_timeout(agent)
+                return None
+            # str(asyncio.TimeoutError()) is EMPTY — always store the
+            # formatted description, never the bare exception string.
+            err_desc = f"LLM timeout after {int(call_timeout)}s"
+            log.error("Agent %s LLM call failed: %s", agent.id, err_desc)
+            agent.transition(AgentState.FAILED, err_desc)
+            agent.error = err_desc
+            agent.ended_at = time.time()
             return None
-        # Typed fast-fail (auth / malformed request / quota-exhausted after
-        # rotation) or a programming defect: neither earns a manager-level
-        # retry — transient classes were already retried inside the callback
-        # for up to the generation deadline.
-        err_desc = f"LLM error: {exc}" if str(exc) else f"LLM error: {type(exc).__name__}"
-        log.error("Agent %s LLM call failed (no retry): %s", agent.id, err_desc)
-        agent.transition(AgentState.FAILED, err_desc)
-        agent.error = err_desc
-        agent.ended_at = time.time()
-        return None
+        except Exception as exc:
+            if _remaining_lifetime(agent) <= 0:
+                # Lifetime exhaustion wins over failure classification (the
+                # v3.59.0 rule: exhaustion is TIMEOUT, never FAILED).
+                _lifetime_timeout(agent)
+                return None
+            if (
+                _is_context_overflow(exc)
+                and emergency_passes < len(_EMERGENCY_TARGETS)
+            ):
+                # Window overflow: deterministic for THIS payload, so a plain
+                # retry is doomed — but a smaller payload is not. Bound the
+                # entire message list (recent iterations by SIZE, single huge
+                # results truncated, task preserved) and retry within the SAME
+                # agent iteration. Never counted as provider health — the
+                # provider raised a fast-fail request error precisely so no
+                # breaker/rotation machinery engaged. Bounded passes, no loop.
+                from ..llm.context_compressor import emergency_compress_for_window
+
+                target = _EMERGENCY_TARGETS[emergency_passes]
+                emergency_passes += 1
+                compressed, report = emergency_compress_for_window(
+                    agent.messages, target_chars=target
+                )
+                report["attempt"] = emergency_passes
+                report["trigger"] = "overflow"
+                agent.context_recoveries.append(report)
+                if report["fits"]:
+                    agent.messages = compressed
+                    # Latch: later iterations compact BEFORE sending once they
+                    # cross the size that just proved survivable.
+                    agent.context_char_ceiling = report["compressed_chars"]
+                    log.warning(
+                        "Agent %s context overflow: emergency pass %d "
+                        "compressed %d -> %d chars; retrying iteration",
+                        agent.id,
+                        emergency_passes,
+                        report["original_chars"],
+                        report["compressed_chars"],
+                    )
+                    continue
+                log.error(
+                    "Agent %s context overflow: payload cannot be bounded "
+                    "under %d chars (prefix %d); failing",
+                    agent.id,
+                    target,
+                    report["prefix_chars"],
+                )
+            # Typed fast-fail (auth / malformed request / quota-exhausted
+            # after rotation) or a programming defect: neither earns a
+            # manager-level retry — transient classes were already retried
+            # inside the callback for up to the generation deadline.
+            err_desc = (
+                f"LLM error: {exc}" if str(exc) else f"LLM error: {type(exc).__name__}"
+            )
+            log.error("Agent %s LLM call failed (no retry): %s", agent.id, err_desc)
+            agent.transition(AgentState.FAILED, err_desc)
+            agent.error = err_desc
+            agent.ended_at = time.time()
+            return None
 
 
 def _get_last_progress(agent: AgentInfo) -> str:

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -1279,6 +1279,8 @@ async def _run_agent(
             recovery_attempts=agent.recovery_attempts,
             state_history=agent._sm.history_as_dicts(),
             total_duration_ms=int((time.time() - agent_start) * 1000),
+            context_recoveries=agent.context_recoveries,
+            context_char_ceiling=agent.context_char_ceiling,
         )
         if trajectory_saver:
             try:
@@ -1326,16 +1328,41 @@ async def _call_llm_with_recovery(
     Returns the LLM response dict, or None if agent reached terminal state.
     """
     emergency_passes = 0
+    # ONE monotonic deadline bounds the whole logical iteration — the initial
+    # attempt, any emergency compaction, and every retry share it (Odin's
+    # adversarial repro: per-attempt timeouts let one iteration consume ~3x
+    # its configured budget).
+    remaining = _remaining_lifetime(agent)
+    if remaining <= 0:
+        _lifetime_timeout(agent)
+        return None
+    call_timeout = min(agent.iteration_timeout, remaining)
+    iteration_deadline = time.monotonic() + call_timeout
+    first_attempt = True
     while True:
-        remaining = _remaining_lifetime(agent)
-        if remaining <= 0:
+        if _remaining_lifetime(agent) <= 0:
             _lifetime_timeout(agent)
             return None
-        call_timeout = min(agent.iteration_timeout, remaining)
+        # The first attempt gets the exact configured budget (bit-identical
+        # to the pre-recovery behavior); only retries pay the deadline
+        # arithmetic for time already burned by failed attempts and
+        # compaction.
+        if first_attempt:
+            attempt_budget = call_timeout
+            first_attempt = False
+        else:
+            attempt_budget = iteration_deadline - time.monotonic()
+        if attempt_budget <= 0:
+            err_desc = f"LLM timeout after {int(call_timeout)}s"
+            log.error("Agent %s LLM call failed: %s", agent.id, err_desc)
+            agent.transition(AgentState.FAILED, err_desc)
+            agent.error = err_desc
+            agent.ended_at = time.time()
+            return None
         try:
             return await asyncio.wait_for(
                 iteration_callback(agent.messages, system_prompt, tools),
-                timeout=call_timeout,
+                timeout=attempt_budget,
             )
         except TimeoutError:
             if _remaining_lifetime(agent) <= 0:

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -1048,7 +1048,8 @@ async def _run_agent(
                             keep_recent=keep_recent_iterations,
                         )
                         log.info(
-                            "agent context_compressor: agent=%s trimmed %d chars",
+                            "agent context_compressor: agent=%s "
+                            "compressed %d older tool iterations",
                             agent.id,
                             saved,
                         )

--- a/src/agents/trajectory.py
+++ b/src/agents/trajectory.py
@@ -46,6 +46,11 @@ class AgentTrajectoryTurn:
     # per-iteration execution provenance, which records what ACTUALLY ran.
     model_override: str | None = None
     reasoning_effort_override: str | None = None
+    # Context-overflow recovery evidence (empty for the overwhelming majority
+    # of agents): each entry carries sizes, retention, trigger, and attempt;
+    # the ceiling is the latched survivable size the agent compacted to.
+    context_recoveries: list[dict] = field(default_factory=list)
+    context_char_ceiling: int | None = None
 
     iterations: list[ToolIteration] = field(default_factory=list)
 
@@ -93,6 +98,8 @@ class AgentTrajectoryTurn:
         recovery_attempts: int = 0,
         state_history: list[dict] | None = None,
         total_duration_ms: int = 0,
+        context_recoveries: list[dict] | None = None,
+        context_char_ceiling: int | None = None,
     ) -> None:
         self.final_state = final_state
         self.result = result
@@ -102,6 +109,8 @@ class AgentTrajectoryTurn:
         self.recovery_attempts = recovery_attempts
         self.state_history = state_history or []
         self.total_duration_ms = total_duration_ms
+        self.context_recoveries = list(context_recoveries or [])
+        self.context_char_ceiling = context_char_ceiling
 
     def to_dict(self) -> dict:
         return {
@@ -120,6 +129,14 @@ class AgentTrajectoryTurn:
             "max_lifetime": self.max_lifetime,
             "model_override": self.model_override,
             "reasoning_effort_override": self.reasoning_effort_override,
+            **(
+                {
+                    "context_recoveries": list(self.context_recoveries),
+                    "context_char_ceiling": self.context_char_ceiling,
+                }
+                if self.context_recoveries
+                else {}
+            ),
             "iterations": [asdict(it) for it in self.iterations],
             "final_state": self.final_state,
             "result": self.result,

--- a/src/llm/context_compressor.py
+++ b/src/llm/context_compressor.py
@@ -379,11 +379,11 @@ def compress_tool_context(
 # One kept iteration may not exceed 1/N of the retained budget: a single
 # enormous scrape must never crowd out every other retained iteration.
 EMERGENCY_SINGLE_RESULT_SHARE = 3
-# Reserved headroom for the emergency summary message itself.
-_EMERGENCY_SUMMARY_RESERVE = 2_000
 # Hard cap on the emergency summary text itself: hundreds of summarized
 # iterations must not rebuild the overflow inside the summary message.
 _EMERGENCY_SUMMARY_MAX = 20_000
+_EMERGENCY_SUMMARY_PREFIX = "[Emergency context compression - earlier tool calls: "
+_EMERGENCY_SUMMARY_SUFFIX = "]"
 _EMERGENCY_ELISION = "\n...[emergency truncation: {elided} chars elided]...\n"
 
 
@@ -391,52 +391,106 @@ def _iteration_chars(iteration: list[dict]) -> int:
     return estimate_message_chars(iteration)
 
 
-def _truncate_iteration(iteration: list[dict], max_chars: int) -> tuple[list[dict], int]:
-    """Shrink one iteration under *max_chars* by eliding its largest strings.
+def _elide_string(value: str, max_output_chars: int) -> str:
+    """Return a head/tail elision no longer than *max_output_chars*.
 
-    Only string payloads (message content, text/content/input/arguments block
-    fields) are shortened, head+tail around an elision marker — tool_use and
-    tool_result STRUCTURE is untouched, so call/result pairing stays valid.
+    ``max_output_chars`` is an exact bound on the replacement, including its
+    marker.  A tiny bound may therefore retain only the marker; the enclosing
+    tool block and call/result IDs remain untouched.
+    """
+    max_output_chars = max(0, max_output_chars)
+    lo = 0
+    hi = len(value) - 1
+    best = ""
+    while lo <= hi:
+        keep = (lo + hi) // 2
+        head_len = int(keep * 0.7)
+        tail_len = keep - head_len
+        elided = len(value) - keep
+        marker = _EMERGENCY_ELISION.format(elided=elided)
+        candidate = value[:head_len] + marker
+        if tail_len:
+            candidate += value[-tail_len:]
+        if len(candidate) <= max_output_chars:
+            best = candidate
+            lo = keep + 1
+        else:
+            hi = keep - 1
+
+    if best:
+        return best
+    # Even the normal marker may be wider than an exceptionally small bound.
+    # Keep an explicit elision signal rather than leaking beyond the target.
+    compact = f"...[{len(value)} chars elided]..."
+    return compact[:max_output_chars]
+
+
+def _truncate_iteration(iteration: list[dict], max_chars: int) -> tuple[list[dict], int]:
+    """Shrink one iteration under *max_chars* by eliding string payloads.
+
+    Only payload strings from message content and the established block fields
+    are shortened.  IDs, names, types, roles, and arbitrary metadata remain
+    untouched, preserving call/result pairing and the existing compression
+    contract.  There is deliberately no fixed pass count: one multi-tool
+    iteration may legitimately contain hundreds of large results.
     Returns ``(new_iteration, chars_elided)``; the input is not modified.
     """
     import copy
 
     work = copy.deepcopy(iteration)
-    elided_total = 0
+    original_chars = _iteration_chars(work)
+    if original_chars <= max_chars:
+        return work, 0
 
-    def _strings() -> list[tuple[dict, str, str]]:
-        out: list[tuple[dict, str, str]] = []
-        for msg in work:
-            content = msg.get("content", "")
-            if isinstance(content, str):
-                out.append((msg, "content", content))
-            elif isinstance(content, list):
-                for block in content:
-                    if not isinstance(block, dict):
-                        continue
-                    for key in ("text", "content", "input", "arguments"):
-                        val = block.get(key)
-                        if isinstance(val, str):
-                            out.append((block, key, val))
-        return out
+    strings: list[tuple[dict, str, str]] = []
+    for msg in work:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            strings.append((msg, "content", content))
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                for key in ("text", "content", "input", "arguments"):
+                    value = block.get(key)
+                    if isinstance(value, str):
+                        strings.append((block, key, value))
 
-    for _ in range(32):  # bounded: each pass shrinks the largest string
-        if _iteration_chars(work) <= max_chars:
+    # Largest-first waterline.  Every original string is considered at most
+    # once, so runtime is bounded by payload shape rather than an arbitrary 32
+    # passes that can abandon a 100-result newest iteration above target.
+    strings.sort(key=lambda item: len(item[2]), reverse=True)
+    for holder, key, original in strings:
+        current_chars = _iteration_chars(work)
+        if current_chars <= max_chars:
             break
-        strings = _strings()
-        if not strings:
-            break
-        holder, key, val = max(strings, key=lambda t: len(t[2]))
-        overshoot = _iteration_chars(work) - max_chars
-        keep = max(len(val) - overshoot - 80, 400)
-        if keep >= len(val):
-            break
-        head = val[: int(keep * 0.7)]
-        tail = val[len(val) - int(keep * 0.3):]
-        elided = len(val) - len(head) - len(tail)
-        holder[key] = head + _EMERGENCY_ELISION.format(elided=elided) + tail
-        elided_total += elided
-    return work, elided_total
+        overshoot = current_chars - max_chars
+        holder[key] = _elide_string(original, max(0, len(original) - overshoot))
+
+    compressed_chars = _iteration_chars(work)
+    return work, max(0, original_chars - compressed_chars)
+
+
+def _is_emergency_summary(msg: dict) -> bool:
+    """Identify the exact user-message shape emitted by this compressor."""
+    content = msg.get("content")
+    return (
+        msg.get("role") == "user"
+        and isinstance(content, str)
+        and content.startswith(_EMERGENCY_SUMMARY_PREFIX)
+        and content.endswith(_EMERGENCY_SUMMARY_SUFFIX)
+    )
+
+
+def _emergency_summary_body(msg: dict) -> str:
+    content = msg.get("content", "")
+    if not isinstance(content, str):
+        return ""
+    if content.startswith(_EMERGENCY_SUMMARY_PREFIX) and content.endswith(
+        _EMERGENCY_SUMMARY_SUFFIX
+    ):
+        return content[len(_EMERGENCY_SUMMARY_PREFIX):-len(_EMERGENCY_SUMMARY_SUFFIX)]
+    return content
 
 
 def emergency_compress_for_window(
@@ -451,22 +505,40 @@ def emergency_compress_for_window(
     ``keep_recent`` iterations are exempt by COUNT), this recovery pass:
 
     - retains recent iterations dynamically by SIZE, newest first, always
-      keeping at least the newest one (truncated if it alone overflows);
+      keeping the newest one (truncated if it alone overflows);
     - truncates any single kept iteration larger than its fair share of the
       retained budget (``EMERGENCY_SINGLE_RESULT_SHARE``) so one enormous
       tool result cannot crowd out everything else;
     - summarizes every older iteration with the same local summarizer the
       soft pass uses;
-    - never modifies the prefix (the agent task and any parent messages).
+    - re-opens a summary emitted by an earlier emergency pass, rather than
+      allowing that summary to ossify inside the immutable task prefix;
+    - never modifies the real prefix (the agent task and parent messages).
 
     Returns ``(new_messages, report)``. The input list is not modified. When
-    the prefix alone exceeds the target the payload cannot be bounded here:
-    the original list is returned with ``report["fits"] = False``.
+    the real prefix alone exceeds the target, or the newest iteration cannot
+    fit even after all of its string payloads are elided, the original list is
+    returned with ``report["fits"] = False``.  That fallback still preserves
+    the newest iteration; it is never summarized away merely to report fit.
     """
     original_chars = estimate_message_chars(messages)
-    prefix, iterations = split_prefix_and_iterations(messages)
-    prefix_chars = estimate_message_chars(prefix)
+    raw_prefix, iterations = split_prefix_and_iterations(messages)
 
+    # Emergency summaries are compressor state, not immutable task context.
+    # Peel them out before measuring the prefix so an aggressive second pass
+    # can replace/recompact the first pass's summary.
+    prefix = list(raw_prefix)
+    carried_summaries: list[str] = []
+    # Only summaries at the compressor's own boundary are replaceable.  Do
+    # not search/remove matching text from the user's real task or parent
+    # context.  A real prefix must remain before the generated marker.
+    while len(prefix) > 1 and _is_emergency_summary(prefix[-1]):
+        body = _emergency_summary_body(prefix.pop())
+        if body:
+            carried_summaries.append(body)
+    carried_summaries.reverse()
+
+    prefix_chars = estimate_message_chars(prefix)
     report: dict = {
         "original_chars": original_chars,
         "prefix_chars": prefix_chars,
@@ -479,12 +551,89 @@ def emergency_compress_for_window(
         "fits": False,
     }
 
-    iter_budget = target_chars - prefix_chars - _EMERGENCY_SUMMARY_RESERVE
-    if iter_budget <= 0 or not iterations:
+    # An already-fitting payload must stay byte-for-byte identical.  This is
+    # especially important for the agent lifetime latch and provider caching.
+    if original_chars <= target_chars:
         report["compressed_chars"] = original_chars
-        report["fits"] = original_chars <= target_chars
+        report["fits"] = True
+        report["iterations_kept"] = len(iterations)
         return messages, report
 
+    available_chars = target_chars - prefix_chars
+    if available_chars <= 0:
+        report["compressed_chars"] = original_chars
+        return messages, report
+
+    def _summary_message(
+        older_iters: list[list[dict]],
+        *,
+        max_content_chars: int = _EMERGENCY_SUMMARY_MAX,
+    ) -> dict | None:
+        summaries = list(carried_summaries)
+        summaries.extend(summarize_iteration(it) for it in older_iters)
+        if not summaries or max_content_chars <= 0:
+            return None
+
+        max_content_chars = min(max_content_chars, _EMERGENCY_SUMMARY_MAX)
+        fixed_chars = len(_EMERGENCY_SUMMARY_PREFIX) + len(_EMERGENCY_SUMMARY_SUFFIX)
+        body_budget = max_content_chars - fixed_chars
+        if body_budget <= 0:
+            return None
+
+        text = "; ".join(summaries)
+        if len(text) > body_budget:
+            # Keep the newest summaries whole and collapse the rest into an
+            # explicit count.  If even that count does not fit, emit a compact
+            # structural marker; the task and newest iteration take priority.
+            kept_summaries: list[str] = []
+            used_chars = 0
+            for summary in reversed(summaries):
+                extra = len(summary) + (2 if kept_summaries else 0)
+                if used_chars + extra > body_budget:
+                    break
+                kept_summaries.append(summary)
+                used_chars += extra
+            kept_summaries.reverse()
+            elided_n = len(summaries) - len(kept_summaries)
+            label = f"{elided_n} earlier iterations elided"
+            if kept_summaries:
+                candidate = label + "; " + "; ".join(kept_summaries)
+                while len(candidate) > body_budget and kept_summaries:
+                    kept_summaries.pop(0)
+                    elided_n += 1
+                    label = f"{elided_n} earlier iterations elided"
+                    candidate = label
+                    if kept_summaries:
+                        candidate += "; " + "; ".join(kept_summaries)
+                text = candidate
+            else:
+                text = label
+            if len(text) > body_budget:
+                text = text[:body_budget]
+
+        return {
+            "role": "user",
+            "content": _EMERGENCY_SUMMARY_PREFIX + text + _EMERGENCY_SUMMARY_SUFFIX,
+        }
+
+    def _assemble(
+        kept_iters: list[list[dict]],
+        *,
+        summary_limit: int = _EMERGENCY_SUMMARY_MAX,
+    ) -> tuple[list[dict], int, dict | None]:
+        older_iters = iterations[: len(iterations) - len(kept_iters)]
+        out = list(prefix)
+        summary = _summary_message(older_iters, max_content_chars=summary_limit)
+        if summary is not None:
+            out.append(summary)
+        for iteration in kept_iters:
+            out.extend(iteration)
+        return out, estimate_message_chars(out), summary
+
+    # No summary reserve is charged here.  If every iteration fits, no summary
+    # will exist.  If older iterations are excluded, convergence below measures
+    # the summary's real assembled size and trades retained history as needed.
+    iter_budget = available_chars
     single_cap = max(iter_budget // EMERGENCY_SINGLE_RESULT_SHARE, 2_000)
     kept: list[list[dict]] = []
     used = 0
@@ -500,61 +649,49 @@ def emergency_compress_for_window(
         if kept and used + size > iter_budget:
             break
         if not kept and size > iter_budget:
-            # The newest iteration alone overflows even the full budget:
-            # truncate harder — it must always survive.
+            # The newest iteration alone gets the entire remaining budget.  It
+            # must survive even if every string payload has to be elided.
             iteration, elided = _truncate_iteration(iteration, iter_budget)
-            report["results_truncated"] += 1
-            report["chars_elided"] += elided
+            if elided:
+                report["results_truncated"] += 1
+                report["chars_elided"] += elided
             size = _iteration_chars(iteration)
         kept.append(iteration)
         used += size
     kept.reverse()
 
-    def _summary_message(older_iters: list[list[dict]]) -> dict | None:
-        if not older_iters:
-            return None
-        summaries = [summarize_iteration(it) for it in older_iters]
-        text = "; ".join(summaries)
-        if len(text) > _EMERGENCY_SUMMARY_MAX:
-            # The summary itself must stay bounded no matter how many
-            # iterations it covers: keep the newest summaries whole and
-            # collapse the rest into a count.
-            kept_summaries: list[str] = []
-            used_chars = 0
-            for s in reversed(summaries):
-                if used_chars + len(s) > _EMERGENCY_SUMMARY_MAX:
-                    break
-                kept_summaries.append(s)
-                used_chars += len(s) + 2
-            kept_summaries.reverse()
-            elided_n = len(summaries) - len(kept_summaries)
-            text = f"{elided_n} earlier iterations elided; " + "; ".join(kept_summaries)
-        return {
-            "role": "user",
-            "content": "[Emergency context compression - earlier tool calls: "
-            + text + "]",
-        }
-
-    def _assemble(kept_iters: list[list[dict]]) -> tuple[list[dict], int]:
-        older_iters = iterations[: len(iterations) - len(kept_iters)]
-        out = list(prefix)
-        summary = _summary_message(older_iters)
-        if summary is not None:
-            out.append(summary)
-        for iteration in kept_iters:
-            out.extend(iteration)
-        return out, estimate_message_chars(out)
-
-    # The fixed reserve is only an ESTIMATE of the summary's size: many
-    # summarized iterations can exceed it and leave the candidate a few
-    # characters over target (Odin's adversarial repro). Converge instead:
-    # drop the oldest kept iteration into the summary until the candidate
-    # actually fits. Bounded by len(kept); the floor (prefix + summary only)
-    # is a legitimate emergency payload.
-    new_messages, compressed_chars = _assemble(kept)
-    while compressed_chars > target_chars and kept:
+    new_messages, compressed_chars, summary = _assemble(kept)
+    # Converge by trading the oldest retained iteration into the summary, but
+    # NEVER trade away the newest one.  That is the emergency-path invariant.
+    while compressed_chars > target_chars and len(kept) > 1:
         kept = kept[1:]
-        new_messages, compressed_chars = _assemble(kept)
+        new_messages, compressed_chars, summary = _assemble(kept)
+
+    if compressed_chars > target_chars:
+        # At the newest-only floor, first shrink the real summary by exactly the
+        # pressure it creates.  Then give every remaining character to the
+        # newest iteration.  With no older context there is no summary charge.
+        summary_chars = estimate_message_chars([summary]) if summary is not None else 0
+        overflow = compressed_chars - target_chars
+        if summary is not None and overflow > 0:
+            summary_limit = max(0, summary_chars - overflow)
+            new_messages, compressed_chars, summary = _assemble(
+                kept, summary_limit=summary_limit,
+            )
+
+        if compressed_chars > target_chars:
+            base_messages = list(prefix)
+            if summary is not None:
+                base_messages.append(summary)
+            newest_budget = target_chars - estimate_message_chars(base_messages)
+            if newest_budget >= 0:
+                newest, elided = _truncate_iteration(kept[-1], newest_budget)
+                if elided:
+                    report["results_truncated"] += 1
+                    report["chars_elided"] += elided
+                kept = [newest]
+                new_messages = base_messages + newest
+                compressed_chars = estimate_message_chars(new_messages)
 
     n_kept = len(kept)
     report["iterations_kept"] = n_kept

--- a/src/llm/context_compressor.py
+++ b/src/llm/context_compressor.py
@@ -370,3 +370,165 @@ def compress_tool_context(
     )
 
     return result, compressed_count
+
+
+# ------------------------------------------------------------------
+# Emergency window-overflow compression (agent recovery path)
+# ------------------------------------------------------------------
+
+# One kept iteration may not exceed 1/N of the retained budget: a single
+# enormous scrape must never crowd out every other retained iteration.
+EMERGENCY_SINGLE_RESULT_SHARE = 3
+# Reserved headroom for the emergency summary message itself.
+_EMERGENCY_SUMMARY_RESERVE = 2_000
+_EMERGENCY_ELISION = "\n...[emergency truncation: {elided} chars elided]...\n"
+
+
+def _iteration_chars(iteration: list[dict]) -> int:
+    return estimate_message_chars(iteration)
+
+
+def _truncate_iteration(iteration: list[dict], max_chars: int) -> tuple[list[dict], int]:
+    """Shrink one iteration under *max_chars* by eliding its largest strings.
+
+    Only string payloads (message content, text/content/input/arguments block
+    fields) are shortened, head+tail around an elision marker — tool_use and
+    tool_result STRUCTURE is untouched, so call/result pairing stays valid.
+    Returns ``(new_iteration, chars_elided)``; the input is not modified.
+    """
+    import copy
+
+    work = copy.deepcopy(iteration)
+    elided_total = 0
+
+    def _strings() -> list[tuple[dict, str, str]]:
+        out: list[tuple[dict, str, str]] = []
+        for msg in work:
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                out.append((msg, "content", content))
+            elif isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    for key in ("text", "content", "input", "arguments"):
+                        val = block.get(key)
+                        if isinstance(val, str):
+                            out.append((block, key, val))
+        return out
+
+    for _ in range(32):  # bounded: each pass shrinks the largest string
+        if _iteration_chars(work) <= max_chars:
+            break
+        strings = _strings()
+        if not strings:
+            break
+        holder, key, val = max(strings, key=lambda t: len(t[2]))
+        overshoot = _iteration_chars(work) - max_chars
+        keep = max(len(val) - overshoot - 80, 400)
+        if keep >= len(val):
+            break
+        head = val[: int(keep * 0.7)]
+        tail = val[len(val) - int(keep * 0.3):]
+        elided = len(val) - len(head) - len(tail)
+        holder[key] = head + _EMERGENCY_ELISION.format(elided=elided) + tail
+        elided_total += elided
+    return work, elided_total
+
+
+def emergency_compress_for_window(
+    messages: list[dict],
+    *,
+    target_chars: int,
+    stats: CompressionStats | None = None,
+) -> tuple[list[dict], dict]:
+    """Bound the ENTIRE payload under *target_chars* for overflow recovery.
+
+    Unlike :func:`compress_tool_context` (a soft budget whose newest
+    ``keep_recent`` iterations are exempt by COUNT), this recovery pass:
+
+    - retains recent iterations dynamically by SIZE, newest first, always
+      keeping at least the newest one (truncated if it alone overflows);
+    - truncates any single kept iteration larger than its fair share of the
+      retained budget (``EMERGENCY_SINGLE_RESULT_SHARE``) so one enormous
+      tool result cannot crowd out everything else;
+    - summarizes every older iteration with the same local summarizer the
+      soft pass uses;
+    - never modifies the prefix (the agent task and any parent messages).
+
+    Returns ``(new_messages, report)``. The input list is not modified. When
+    the prefix alone exceeds the target the payload cannot be bounded here:
+    the original list is returned with ``report["fits"] = False``.
+    """
+    original_chars = estimate_message_chars(messages)
+    prefix, iterations = split_prefix_and_iterations(messages)
+    prefix_chars = estimate_message_chars(prefix)
+
+    report: dict = {
+        "original_chars": original_chars,
+        "prefix_chars": prefix_chars,
+        "iterations_total": len(iterations),
+        "iterations_kept": 0,
+        "iterations_summarized": 0,
+        "results_truncated": 0,
+        "chars_elided": 0,
+        "target_chars": target_chars,
+        "fits": False,
+    }
+
+    iter_budget = target_chars - prefix_chars - _EMERGENCY_SUMMARY_RESERVE
+    if iter_budget <= 0 or not iterations:
+        report["compressed_chars"] = original_chars
+        report["fits"] = original_chars <= target_chars
+        return messages, report
+
+    single_cap = max(iter_budget // EMERGENCY_SINGLE_RESULT_SHARE, 2_000)
+    kept: list[list[dict]] = []
+    used = 0
+    for idx in range(len(iterations) - 1, -1, -1):
+        iteration = iterations[idx]
+        size = _iteration_chars(iteration)
+        if size > single_cap:
+            iteration, elided = _truncate_iteration(iteration, single_cap)
+            if elided:
+                report["results_truncated"] += 1
+                report["chars_elided"] += elided
+            size = _iteration_chars(iteration)
+        if kept and used + size > iter_budget:
+            break
+        if not kept and size > iter_budget:
+            # The newest iteration alone overflows even the full budget:
+            # truncate harder — it must always survive.
+            iteration, elided = _truncate_iteration(iteration, iter_budget)
+            report["results_truncated"] += 1
+            report["chars_elided"] += elided
+            size = _iteration_chars(iteration)
+        kept.append(iteration)
+        used += size
+    kept.reverse()
+    n_kept = len(kept)
+    older = iterations[: len(iterations) - n_kept]
+
+    new_messages = list(prefix)
+    if older:
+        summaries = [summarize_iteration(it) for it in older]
+        new_messages.append({
+            "role": "user",
+            "content": "[Emergency context compression - earlier tool calls: "
+            + "; ".join(summaries) + "]",
+        })
+    for iteration in kept:
+        new_messages.extend(iteration)
+
+    compressed_chars = estimate_message_chars(new_messages)
+    report["iterations_kept"] = n_kept
+    report["iterations_summarized"] = len(older)
+    report["compressed_chars"] = compressed_chars
+    report["fits"] = compressed_chars <= target_chars
+    if not report["fits"]:
+        return messages, report
+    if stats:
+        stats.compressions += 1
+        stats.iterations_compressed += len(older)
+        stats.chars_saved += max(0, original_chars - compressed_chars)
+    return new_messages, report

--- a/src/llm/context_compressor.py
+++ b/src/llm/context_compressor.py
@@ -381,6 +381,9 @@ def compress_tool_context(
 EMERGENCY_SINGLE_RESULT_SHARE = 3
 # Reserved headroom for the emergency summary message itself.
 _EMERGENCY_SUMMARY_RESERVE = 2_000
+# Hard cap on the emergency summary text itself: hundreds of summarized
+# iterations must not rebuild the overflow inside the summary message.
+_EMERGENCY_SUMMARY_MAX = 20_000
 _EMERGENCY_ELISION = "\n...[emergency truncation: {elided} chars elided]...\n"
 
 
@@ -506,29 +509,62 @@ def emergency_compress_for_window(
         kept.append(iteration)
         used += size
     kept.reverse()
-    n_kept = len(kept)
-    older = iterations[: len(iterations) - n_kept]
 
-    new_messages = list(prefix)
-    if older:
-        summaries = [summarize_iteration(it) for it in older]
-        new_messages.append({
+    def _summary_message(older_iters: list[list[dict]]) -> dict | None:
+        if not older_iters:
+            return None
+        summaries = [summarize_iteration(it) for it in older_iters]
+        text = "; ".join(summaries)
+        if len(text) > _EMERGENCY_SUMMARY_MAX:
+            # The summary itself must stay bounded no matter how many
+            # iterations it covers: keep the newest summaries whole and
+            # collapse the rest into a count.
+            kept_summaries: list[str] = []
+            used_chars = 0
+            for s in reversed(summaries):
+                if used_chars + len(s) > _EMERGENCY_SUMMARY_MAX:
+                    break
+                kept_summaries.append(s)
+                used_chars += len(s) + 2
+            kept_summaries.reverse()
+            elided_n = len(summaries) - len(kept_summaries)
+            text = f"{elided_n} earlier iterations elided; " + "; ".join(kept_summaries)
+        return {
             "role": "user",
             "content": "[Emergency context compression - earlier tool calls: "
-            + "; ".join(summaries) + "]",
-        })
-    for iteration in kept:
-        new_messages.extend(iteration)
+            + text + "]",
+        }
 
-    compressed_chars = estimate_message_chars(new_messages)
+    def _assemble(kept_iters: list[list[dict]]) -> tuple[list[dict], int]:
+        older_iters = iterations[: len(iterations) - len(kept_iters)]
+        out = list(prefix)
+        summary = _summary_message(older_iters)
+        if summary is not None:
+            out.append(summary)
+        for iteration in kept_iters:
+            out.extend(iteration)
+        return out, estimate_message_chars(out)
+
+    # The fixed reserve is only an ESTIMATE of the summary's size: many
+    # summarized iterations can exceed it and leave the candidate a few
+    # characters over target (Odin's adversarial repro). Converge instead:
+    # drop the oldest kept iteration into the summary until the candidate
+    # actually fits. Bounded by len(kept); the floor (prefix + summary only)
+    # is a legitimate emergency payload.
+    new_messages, compressed_chars = _assemble(kept)
+    while compressed_chars > target_chars and kept:
+        kept = kept[1:]
+        new_messages, compressed_chars = _assemble(kept)
+
+    n_kept = len(kept)
     report["iterations_kept"] = n_kept
-    report["iterations_summarized"] = len(older)
+    report["iterations_summarized"] = len(iterations) - n_kept
     report["compressed_chars"] = compressed_chars
     report["fits"] = compressed_chars <= target_chars
     if not report["fits"]:
         return messages, report
     if stats:
         stats.compressions += 1
-        stats.iterations_compressed += len(older)
+        stats.iterations_compressed += len(iterations) - n_kept
         stats.chars_saved += max(0, original_chars - compressed_chars)
     return new_messages, report

--- a/src/llm/errors.py
+++ b/src/llm/errors.py
@@ -15,7 +15,9 @@ Compatibility constraints (both load-bearing):
   ``src/agents/manager.py`` and ``src/tools/autonomous_loop.py``.
 
 Only whitelisted, safe fields ride on the exception: ``provider``,
-``model``, ``retry_after``. Raise sites are responsible for bounding any
+``model``, ``retry_after``, ``code`` (the provider's structured error code,
+e.g. ``context_length_exceeded`` — consumers key recovery decisions on it
+instead of substring-matching message text). Raise sites are responsible for bounding any
 response-body text they put in the message (the existing ``[:200]`` /
 ``[:500]`` discipline); user-facing presentation still goes through
 ``format_user_facing_error`` at the boundary.
@@ -41,11 +43,13 @@ class LLMError(RuntimeError):
         provider: str | None = None,
         model: str | None = None,
         retry_after: float | None = None,
+        code: str | None = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.model = model
         self.retry_after = retry_after
+        self.code = code
 
 
 class LLMCapacityError(LLMError):

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -634,6 +634,24 @@ class CodexChatClient:
                                     model=str(body.get("model") or self.model),
                                     retry_after=e.retry_after,
                                 ) from e
+                            if (
+                                e.error_type == "invalid_request_error"
+                                or e.error_code == "context_length_exceeded"
+                            ):
+                                # The request itself is invalid for this model
+                                # (context overflow is the dominant case):
+                                # deterministic, so retrying the identical
+                                # payload burns attempts on a guaranteed
+                                # failure. Fast-fail as a REQUEST error — the
+                                # agent overflow recovery keys on ``code``.
+                                # The client breaker counts infrastructure
+                                # health, not payload validity: untouched.
+                                raise LLMRequestError(
+                                    f"Codex stream failed: {e}",
+                                    provider="codex",
+                                    model=str(body.get("model") or self.model),
+                                    code=e.error_code or e.error_type,
+                                ) from e
                             # response.failed / error event: the "200" turned
                             # out to be a failure mid-stream — retryable.
                             self.breaker.record_failure()

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -705,7 +705,7 @@ class TestRoundThreeAdversarialPins:
         ]
         results = [
             {"type": "tool_result", "tool_use_id": f"bulk_{i}",
-             "content": f"bulk-result-{i}:" + "x" * 8_000}
+             "content": f"bulk-result-{i}:" + "x" * 12_000}
             for i in range(count)
         ]
         msgs = [{"role": "user", "content": "TASK: preserve newest"}]
@@ -714,7 +714,10 @@ class TestRoundThreeAdversarialPins:
             {"role": "assistant", "content": uses},
             {"role": "user", "content": results},
         ])
-        assert estimate_message_chars(msgs) > _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        # At 12K/result, the round-2 truncator's two 32-pass calls still
+        # leave this newest cycle above target; convergence then summarized it
+        # away.  The former 8K fixture was accidentally rescued by those calls.
+        assert estimate_message_chars(msgs) > 1_200_000
 
         out, report = emergency_compress_for_window(
             msgs, target_chars=_EMERGENCY_TARGET_CHARS_AGGRESSIVE

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -1,0 +1,391 @@
+"""Agent context-overflow recovery (design settled with Odin, 2026-08-09).
+
+The constraint these tests enforce, near-verbatim from Aaron: the fix must
+NOT change how agents behave today except where today's behavior is death by
+``context_length_exceeded``. Hence the load-bearing pin: an agent that never
+overflows receives byte-for-byte identical payloads and callback call counts
+with the recovery machinery present.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+
+import pytest
+
+from src.agents.manager import (
+    _EMERGENCY_TARGET_CHARS,
+    _EMERGENCY_TARGET_CHARS_AGGRESSIVE,
+    AgentManager,
+    _is_context_overflow,
+)
+from src.llm.context_compressor import (
+    emergency_compress_for_window,
+    estimate_message_chars,
+)
+from src.llm.errors import LLMRequestError, LLMTransportError
+
+
+def _overflow_error() -> LLMRequestError:
+    return LLMRequestError(
+        'Codex stream failed: error: {"type": "error", "error": '
+        '{"type": "invalid_request_error", "code": "context_length_exceeded"}}',
+        provider="codex",
+        model="gpt-5.6-terra",
+        code="context_length_exceeded",
+    )
+
+
+def _iteration(i: int, size: int) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": f"tu_{i}", "name": "web_search", "input": {"q": str(i)}}
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": f"tu_{i}",
+                    "content": f"result-{i}:" + ("x" * size),
+                }
+            ],
+        },
+    ]
+
+
+def _messages(n_iterations: int, size: int) -> list[dict]:
+    msgs: list[dict] = [{"role": "user", "content": "TASK: research the thing"}]
+    for i in range(n_iterations):
+        msgs.extend(_iteration(i, size))
+    return msgs
+
+
+def _pairing_valid(messages: list[dict]) -> bool:
+    """Every tool_result must follow a tool_use with the matching id."""
+    seen_uses: set[str] = set()
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_use":
+                seen_uses.add(block.get("id"))
+            elif block.get("type") == "tool_result":
+                if block.get("tool_use_id") not in seen_uses:
+                    return False
+    return True
+
+
+class _Harness:
+    """Drive AgentManager with a scripted iteration callback."""
+
+    def __init__(self, script):
+        # script: callable(call_index, messages) -> response dict or raises
+        self.calls: list[list[dict]] = []
+        self.script = script
+
+    async def iteration_callback(self, messages, system_prompt, tools):
+        self.calls.append(copy.deepcopy(messages))
+        return await self.script(len(self.calls), messages)
+
+    def spawn(self, mgr: AgentManager) -> str:
+        return mgr.spawn(
+            label="t",
+            goal="go",
+            channel_id="c1",
+            requester_id="u1",
+            requester_name="user",
+            iteration_callback=self.iteration_callback,
+            tool_executor_callback=self._tool_cb,
+        )
+
+    async def _tool_cb(self, name, tool_input):
+        return "tool-ok"
+
+
+async def _run_to_terminal(mgr: AgentManager, agent_id: str) -> None:
+    await mgr._agents[agent_id]._task
+    await asyncio.sleep(0)
+
+
+class TestByteForByteEquivalence:
+    """Agents that never overflow see EXACTLY today's payloads and calls."""
+
+    async def test_no_overflow_payloads_identical_and_no_recovery_state(self):
+        async def script(n, messages):
+            if n < 3:
+                return {
+                    "text": "",
+                    "tool_calls": [
+                        {"id": f"tu_s{n}", "name": "web_search", "input": {"q": "x"}}
+                    ],
+                    "stop_reason": "tool_use",
+                }
+            return {"text": "DONE: fine", "tool_calls": [], "stop_reason": "end_turn"}
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        assert not agent_id.startswith("Error")
+        await _run_to_terminal(mgr, agent_id)
+        agent = mgr._agents[agent_id]
+
+        assert agent.context_char_ceiling is None
+        assert agent.context_recoveries == []
+        # to_dict must not even carry the recovery keys (wire compatibility).
+        d = mgr.to_dict(agent) if hasattr(mgr, "to_dict") else agent_to_dict(mgr, agent)
+        assert "context_recoveries" not in json.dumps(d) or not agent.context_recoveries
+        # Callback saw monotonically growing history, never a compressed form:
+        # no emergency summary marker anywhere.
+        for payload in h.calls:
+            assert "[Emergency context compression" not in json.dumps(payload)
+
+    async def test_overflow_predicate_is_structural_not_substring(self):
+        transport = LLMTransportError(
+            "Codex stream failed: context_length_exceeded mentioned in body",
+            provider="codex",
+        )
+        assert not _is_context_overflow(transport)
+        request_no_code = LLMRequestError("bad request", provider="codex")
+        assert not _is_context_overflow(request_no_code)
+        assert _is_context_overflow(_overflow_error())
+
+
+def agent_to_dict(mgr, agent):
+    for name in ("_agent_dict", "agent_to_dict"):
+        fn = getattr(mgr, name, None)
+        if fn:
+            return fn(agent)
+    return {"context_recoveries": agent.context_recoveries}
+
+
+class TestOverflowRecovery:
+    async def test_first_overflow_compresses_retries_same_iteration_and_latches(self):
+        big = _messages(40, 30_000)  # ~1.2M chars
+
+        async def script(n, messages):
+            if n == 1:
+                # Simulate the provider seeing an oversized payload. Grow the
+                # agent's real message list to the oversized shape first, the
+                # way 40 scrape iterations would have.
+                messages.clear()
+                messages.extend(copy.deepcopy(big))
+                raise _overflow_error()
+            return {"text": "DONE: ok", "tool_calls": [], "stop_reason": "end_turn"}
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        await _run_to_terminal(mgr, agent_id)
+        agent = mgr._agents[agent_id]
+
+        # Recovered: terminal state is COMPLETED, not FAILED.
+        assert agent.state.name in ("COMPLETED", "READY"), agent.error
+        # The retry happened within the same iteration: two callback calls,
+        # and the SECOND saw a compressed payload under the primary target.
+        assert len(h.calls) == 2
+        retry_payload = h.calls[1]
+        assert estimate_message_chars(retry_payload) <= _EMERGENCY_TARGET_CHARS
+        # Task preserved verbatim, newest iteration retained, pairing valid.
+        assert retry_payload[0] == {"role": "user", "content": "TASK: research the thing"}
+        assert "result-39" in json.dumps(retry_payload)
+        assert _pairing_valid(retry_payload)
+        # Latch set to the size that succeeded; recovery recorded.
+        assert agent.context_char_ceiling is not None
+        assert agent.context_char_ceiling <= _EMERGENCY_TARGET_CHARS
+        assert len(agent.context_recoveries) == 1
+        r = agent.context_recoveries[0]
+        assert r["trigger"] == "overflow" and r["attempt"] == 1 and r["fits"]
+
+    async def test_second_overflow_uses_aggressive_target_then_existing_failure(self):
+        big = _messages(40, 30_000)
+
+        async def script(n, messages):
+            messages.clear()
+            messages.extend(copy.deepcopy(big))
+            raise _overflow_error()
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        await _run_to_terminal(mgr, agent_id)
+        agent = mgr._agents[agent_id]
+
+        # Exactly two emergency passes, then the existing failure handling —
+        # no loops.
+        assert len(h.calls) == 3
+        assert estimate_message_chars(h.calls[2]) <= _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert agent.state.name == "FAILED"
+        assert "context_length_exceeded" in (agent.error or "")
+        assert [r["attempt"] for r in agent.context_recoveries] == [1, 2]
+
+    async def test_latch_compacts_before_send_without_an_error(self):
+        big = _messages(40, 30_000)
+        grow = _messages(35, 30_000)  # over the latch after recovery
+
+        async def script(n, messages):
+            if n == 1:
+                messages.clear()
+                messages.extend(copy.deepcopy(big))
+                raise _overflow_error()
+            if n == 2:
+                # Ask for one more tool round so another iteration happens,
+                # then balloon the history past the latch.
+                return {
+                    "text": "",
+                    "tool_calls": [
+                        {"id": "tu_more", "name": "web_search", "input": {"q": "y"}}
+                    ],
+                    "stop_reason": "tool_use",
+                }
+            return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        agent = mgr._agents[agent_id]
+
+        # Balloon the messages between iterations by riding the tool result:
+        # after call 2 returns a tool_call, the worker appends the result and
+        # loops; grow the history there via the tool callback.
+        original_tool_cb = h._tool_cb
+
+        async def fat_tool_cb(name, tool_input):
+            agent.messages.extend(copy.deepcopy(grow))
+            return await original_tool_cb(name, tool_input)
+
+        agent.tool_executor_callback = fat_tool_cb
+        await _run_to_terminal(mgr, agent_id)
+
+        assert agent.state.name in ("COMPLETED", "READY"), agent.error
+        # The third call (post-latch) was compacted BEFORE sending: under the
+        # ceiling, and a latch-triggered recovery record exists.
+        ceiling = agent.context_char_ceiling
+        assert ceiling is not None
+        assert estimate_message_chars(h.calls[2]) <= ceiling
+        assert any(r["trigger"] == "latch" for r in agent.context_recoveries)
+        # Only ONE 400-driven recovery ever happened; the latch prevented more.
+        assert sum(1 for r in agent.context_recoveries if r["trigger"] == "overflow") == 1
+
+
+class TestEmergencyCompressor:
+    def test_size_based_retention_and_summary(self):
+        msgs = _messages(30, 20_000)
+        out, report = emergency_compress_for_window(msgs, target_chars=150_000)
+        assert report["fits"]
+        assert estimate_message_chars(out) <= 150_000
+        assert report["iterations_kept"] >= 1
+        assert report["iterations_summarized"] == 30 - report["iterations_kept"]
+        assert out[0]["content"].startswith("TASK:")
+        assert _pairing_valid(out)
+        # Newest iteration always survives.
+        assert "result-29" in json.dumps(out)
+
+    def test_single_enormous_result_truncated_with_pairing_intact(self):
+        msgs = _messages(2, 5_000)
+        msgs.extend(_iteration(99, 500_000))  # one massive scrape, newest
+        out, report = emergency_compress_for_window(msgs, target_chars=120_000)
+        assert report["fits"]
+        assert report["results_truncated"] >= 1
+        assert report["chars_elided"] > 0
+        blob = json.dumps(out)
+        assert "emergency truncation" in blob
+        assert "tu_99" in blob  # the pair survived structurally
+        assert _pairing_valid(out)
+
+    def test_unboundable_prefix_returns_unchanged_and_not_fits(self):
+        msgs = [{"role": "user", "content": "TASK: " + "p" * 300_000}]
+        msgs.extend(_iteration(0, 1_000))
+        out, report = emergency_compress_for_window(msgs, target_chars=100_000)
+        assert not report["fits"]
+        assert out == msgs
+
+    def test_under_target_is_reported_fitting_without_changes(self):
+        msgs = _messages(3, 1_000)
+        out, report = emergency_compress_for_window(msgs, target_chars=500_000)
+        assert report["fits"]
+        assert _pairing_valid(out)
+
+
+class TestProviderClassification:
+    def test_sse_invalid_request_becomes_fast_fail_request_error(self):
+        from src.llm.openai_codex import CodexStreamError, _stream_error_from_event
+
+        e = _stream_error_from_event(
+            "error",
+            {
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "context_length_exceeded",
+                    "message": "Your input exceeds the context window of this model.",
+                },
+            },
+        )
+        assert isinstance(e, CodexStreamError)
+        assert e.error_code == "context_length_exceeded"
+        assert not e.is_capacity
+
+
+class TestProviderNoRetryBurn:
+    """The doomed-payload pin: an SSE invalid_request/context_length event
+    makes exactly ONE HTTP attempt (no inner retry burn on a deterministic
+    failure), raises the typed fast-fail with its structured code, and never
+    counts against the client breaker (infrastructure health, not payload
+    validity)."""
+
+    @pytest.mark.asyncio
+    async def test_one_attempt_typed_code_breaker_untouched(self, monkeypatch):
+        from src.llm.openai_codex import CodexChatClient
+        from tests.test_openai_codex_client import _BareAuth, _FakeResp, _sse
+
+        client = CodexChatClient(auth=_BareAuth(), model="gpt-5.6-terra", max_retries=3)
+        posts = {"n": 0}
+        failures = {"n": 0}
+        monkeypatch.setattr(
+            client.breaker, "record_failure", lambda: failures.__setitem__("n", failures["n"] + 1)
+        )
+
+        event = {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded",
+                "message": "Your input exceeds the context window of this model.",
+            },
+        }
+
+        class _CM:
+            async def __aenter__(self):
+                posts["n"] += 1
+                return type("R", (), {"status": 200, "content": _FakeResp([_sse(event)]).content})()
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _Sess:
+            closed = False
+
+            def post(self, url, **kwargs):
+                return _CM()
+
+        async def _fake_session():
+            return _Sess()
+
+        monkeypatch.setattr(client, "_get_session", _fake_session)
+
+        with pytest.raises(LLMRequestError) as ei:
+            await client._send_with_retries(
+                {"model": "gpt-5.6-terra"}, client._read_stream, lambda r: not r
+            )
+        assert ei.value.code == "context_length_exceeded"
+        assert posts["n"] == 1, "retry engine must not burn attempts on a doomed payload"
+        assert failures["n"] == 0, "breaker counts infrastructure health, not payload validity"

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -554,6 +554,15 @@ class TestCoverageEdges:
         await _run_to_terminal(mgr, agent_id)
         assert agent.state.name in ("COMPLETED", "READY"), agent.error
 
+    def test_truncate_iteration_already_under_limit_is_unchanged(self):
+        from src.llm.context_compressor import _truncate_iteration
+
+        iteration = _iteration(1, 20)
+        out, elided = _truncate_iteration(iteration, 10_000)
+        assert out == iteration
+        assert out is not iteration
+        assert elided == 0
+
     def test_truncate_iteration_with_no_strings_is_a_noop(self):
         from src.llm.context_compressor import _truncate_iteration
 
@@ -606,15 +615,141 @@ class TestDarkBranches:
         assert report["results_truncated"] >= 1
         assert "tu_0" in json.dumps(out)
 
-    def test_converged_floor_still_over_target_reports_not_fits(self):
+    def test_tiny_target_shrinks_summary_but_keeps_newest_iteration(self):
         # Hundreds of iterations against a target barely above the prefix:
-        # even the prefix+summary floor exceeds it — the original payload
-        # comes back with fits=False (the caller falls through to failure).
+        # shrink the replaceable summary before sacrificing the newest tool
+        # cycle.  The output may fail to fit only when preserved structure
+        # itself is wider than the target; it must never collapse to summary.
         msgs = _messages(300, 300)
         prefix_chars = estimate_message_chars(msgs[:1])
         out, report = emergency_compress_for_window(
             msgs, target_chars=prefix_chars + 2_200
         )
-        assert not report["fits"]
-        assert out == msgs
-        assert report["iterations_kept"] == 0
+        assert report["fits"]
+        assert estimate_message_chars(out) <= prefix_chars + 2_200
+        assert report["iterations_kept"] == 1
+        assert "tu_299" in json.dumps(out)
+        assert _pairing_valid(out)
+
+
+class TestRoundThreeAdversarialPins:
+    """Pins for Odin's three round-2 compressor findings."""
+
+    def test_aggressive_pass_reopens_first_pass_summary(self):
+        # Runtime-shaped history: primary recovery creates a substantial
+        # emergency summary.  The aggressive pass must replace/recompact it,
+        # not classify it as immutable prefix and return the first payload.
+        prefix = [{"role": "user", "content": "P" * (398_500 - len("user"))}]
+        msgs = list(prefix)
+        for i in range(300):
+            msgs.extend(_iteration(i, 1_400))
+        primary, first = emergency_compress_for_window(
+            msgs, target_chars=_EMERGENCY_TARGET_CHARS
+        )
+        assert first["fits"]
+        first_size = estimate_message_chars(primary)
+        assert first_size > _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        summaries = [
+            m for m in primary
+            if isinstance(m.get("content"), str)
+            and m["content"].startswith("[Emergency context compression")
+        ]
+        assert len(summaries) == 1
+        # This is the original failure boundary: if the generated summary is
+        # misclassified as immutable prefix on pass two, the prefix alone is
+        # already wider than the aggressive target.
+        assert estimate_message_chars(prefix + summaries) > 400_000
+
+        aggressive, second = emergency_compress_for_window(
+            primary, target_chars=_EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        )
+        assert second["fits"], second
+        assert estimate_message_chars(aggressive) <= _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert estimate_message_chars(aggressive) < first_size
+        assert aggressive[0] == msgs[0]
+        assert "tu_299" in json.dumps(aggressive)
+        assert _pairing_valid(aggressive)
+        assert sum(
+            isinstance(m.get("content"), str)
+            and m["content"].startswith("[Emergency context compression")
+            for m in aggressive
+        ) <= 1
+
+    def test_user_text_resembling_summary_is_not_removed_from_real_prefix(self):
+        # Recognition is boundary-aware: a task may literally quote the
+        # compressor marker, and that user-authored content remains immutable.
+        quoted = {
+            "role": "user",
+            "content": "[Emergency context compression - earlier tool calls: quoted]",
+        }
+        parent = {"role": "user", "content": "TASK: real parent context"}
+        msgs = [quoted, parent]
+        for i in range(300):
+            msgs.extend(_iteration(i, 1_400))
+
+        out, report = emergency_compress_for_window(
+            msgs, target_chars=_EMERGENCY_TARGET_CHARS
+        )
+        assert report["fits"]
+        assert out[:2] == [quoted, parent]
+
+    def test_newest_multi_tool_iteration_survives_more_than_32_results(self):
+        # One assistant turn may issue many tools.  All uses/results belong to
+        # ONE newest iteration and must survive structurally even when every
+        # result needs truncation.  A fixed 32-pass truncator lost this cycle.
+        count = 100
+        uses = [
+            {"type": "tool_use", "id": f"bulk_{i}", "name": "web_search",
+             "input": {"q": str(i)}}
+            for i in range(count)
+        ]
+        results = [
+            {"type": "tool_result", "tool_use_id": f"bulk_{i}",
+             "content": f"bulk-result-{i}:" + "x" * 8_000}
+            for i in range(count)
+        ]
+        msgs = [{"role": "user", "content": "TASK: preserve newest"}]
+        msgs.extend(_iteration(0, 10_000))
+        msgs.extend([
+            {"role": "assistant", "content": uses},
+            {"role": "user", "content": results},
+        ])
+        assert estimate_message_chars(msgs) > _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+
+        out, report = emergency_compress_for_window(
+            msgs, target_chars=_EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        )
+        blob = json.dumps(out)
+        assert report["fits"], report
+        assert estimate_message_chars(out) <= _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert report["iterations_kept"] >= 1
+        assert all(f'"id": "bulk_{i}"' in blob for i in range(count))
+        assert all(f'"tool_use_id": "bulk_{i}"' in blob for i in range(count))
+        assert _pairing_valid(out)
+
+    def test_no_summary_reserve_for_398500_prefix_and_one_iteration(self):
+        # Exact adversarial shape: a 398,500-char prefix leaves 1,500 real
+        # characters at the 400K target.  The sole newest iteration is
+        # compressible into that space, and no summary will exist.  Charging
+        # the old hypothetical 2K reserve rejected this recoverable payload.
+        target = _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        prefix_content = "P" * (398_500 - len("user"))
+        prefix = [{"role": "user", "content": prefix_content}]
+        assert estimate_message_chars(prefix) == 398_500
+        msgs = prefix + _iteration(7, 5_000)
+        assert estimate_message_chars(msgs) > target
+
+        out, report = emergency_compress_for_window(msgs, target_chars=target)
+        assert report["fits"], report
+        assert estimate_message_chars(out) <= target
+        assert out[0] == prefix[0]
+        assert report["iterations_kept"] == 1
+        assert report["iterations_summarized"] == 0
+        assert report["results_truncated"] >= 1
+        assert "tu_7" in json.dumps(out)
+        assert _pairing_valid(out)
+        assert not any(
+            isinstance(m.get("content"), str)
+            and m["content"].startswith("[Emergency context compression")
+            for m in out
+        )

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -389,3 +389,232 @@ class TestProviderNoRetryBurn:
         assert ei.value.code == "context_length_exceeded"
         assert posts["n"] == 1, "retry engine must not burn attempts on a doomed payload"
         assert failures["n"] == 0, "breaker counts infrastructure health, not payload validity"
+
+
+class TestAdversarialBlockers:
+    """Pins for the three findings from the round-1 adversarial review."""
+
+    def test_many_summarized_iterations_still_converge_at_both_targets(self):
+        """Odin's repro: the fixed summary reserve underestimates a large
+        summary and the candidate misses target by a hair — the compressor
+        must CONVERGE, never return the original oversized payload."""
+        from src.agents.manager import _EMERGENCY_TARGETS
+
+        # Runtime-shaped: hundreds of small-but-real iterations whose
+        # summaries alone exceed the old 2,000-char reserve.
+        msgs = _messages(520, 1_400)
+        assert estimate_message_chars(msgs) > max(_EMERGENCY_TARGETS)
+        for target in _EMERGENCY_TARGETS:
+            out, report = emergency_compress_for_window(msgs, target_chars=target)
+            assert report["fits"], (target, report)
+            assert estimate_message_chars(out) <= target
+            assert _pairing_valid(out)
+            assert out[0]["content"].startswith("TASK:")
+
+    def test_summary_itself_is_capped_for_huge_iteration_counts(self):
+        from src.llm.context_compressor import _EMERGENCY_SUMMARY_MAX
+
+        msgs = _messages(2_000, 300)
+        out, report = emergency_compress_for_window(msgs, target_chars=120_000)
+        assert report["fits"]
+        summary = next(
+            (m for m in out if isinstance(m.get("content"), str)
+             and m["content"].startswith("[Emergency context compression")),
+            None,
+        )
+        assert summary is not None
+        assert len(summary["content"]) <= _EMERGENCY_SUMMARY_MAX + 200
+        assert "earlier iterations elided" in summary["content"]
+
+    async def test_retries_share_one_iteration_deadline(self):
+        """The initial attempt gets the exact configured budget; retry
+        budgets come from the SAME monotonic deadline — one logical
+        iteration can never consume multiples of its timeout."""
+        from unittest.mock import patch
+
+        from src.agents.manager import AgentInfo, _call_llm_with_recovery
+
+        agent = AgentInfo(
+            id="a1", label="t", goal="g", channel_id="c1",
+            requester_id="u1", requester_name="user",
+        )
+        agent.messages = _messages(40, 30_000)
+        agent.iteration_timeout = 50.0
+
+        captured: list[float] = []
+        calls = {"n": 0}
+
+        async def fake_wait_for(awaitable, timeout):
+            captured.append(timeout)
+            calls["n"] += 1
+            # Let the underlying coroutine settle to avoid warnings.
+            awaitable.close()
+            if calls["n"] == 1:
+                raise _overflow_error()
+            return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
+
+        async def cb(messages, system_prompt, tools):
+            return {"text": "unused", "tool_calls": []}
+
+        with patch("src.agents.manager.asyncio.wait_for", side_effect=fake_wait_for):
+            result = await _call_llm_with_recovery(agent, cb, "sys", [])
+        assert result is not None
+        assert len(captured) == 2
+        assert captured[0] == 50.0  # exact configured budget, bit-identical
+        assert captured[1] < 50.0   # retry pays the shared deadline
+        assert captured[1] > 0
+
+    async def test_recovery_evidence_persisted_to_saved_trajectory(self):
+        saved: list[dict] = []
+
+        class _Saver:
+            async def save(self, trajectory):
+                saved.append(trajectory.to_dict())
+
+        big = _messages(40, 30_000)
+
+        async def script(n, messages):
+            if n == 1:
+                messages.clear()
+                messages.extend(copy.deepcopy(big))
+                raise _overflow_error()
+            return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = mgr.spawn(
+            label="t",
+            goal="go",
+            channel_id="c1",
+            requester_id="u1",
+            requester_name="user",
+            iteration_callback=h.iteration_callback,
+            tool_executor_callback=h._tool_cb,
+            trajectory_saver=_Saver(),
+        )
+        await _run_to_terminal(mgr, agent_id)
+
+        assert saved, "trajectory must be saved"
+        d = saved[-1]
+        assert d.get("context_char_ceiling") is not None
+        recs = d.get("context_recoveries")
+        assert recs and recs[0]["trigger"] == "overflow" and recs[0]["fits"]
+        for key in ("original_chars", "compressed_chars", "iterations_kept", "attempt"):
+            assert key in recs[0]
+
+
+class TestCoverageEdges:
+    def test_stats_updated_on_successful_emergency_pass(self):
+        from src.llm.context_compressor import CompressionStats
+
+        stats = CompressionStats()
+        msgs = _messages(30, 20_000)
+        out, report = emergency_compress_for_window(
+            msgs, target_chars=150_000, stats=stats
+        )
+        assert report["fits"]
+        assert stats.compressions == 1
+        assert stats.iterations_compressed == report["iterations_summarized"]
+        assert stats.chars_saved > 0
+
+    def test_large_non_newest_kept_iteration_is_share_capped(self):
+        # A fat iteration BEFORE the newest one must be truncated to its fair
+        # share rather than crowding out other retained iterations.
+        msgs = _messages(3, 2_000)
+        msgs.extend(_iteration(50, 200_000))   # fat, second-newest
+        msgs.extend(_iteration(51, 2_000))     # small, newest
+        out, report = emergency_compress_for_window(msgs, target_chars=120_000)
+        assert report["fits"]
+        blob = json.dumps(out)
+        assert "result-51" in blob             # newest survived
+        assert "tu_50" in blob                 # fat one survived structurally
+        assert report["results_truncated"] >= 1
+        assert _pairing_valid(out)
+
+    async def test_latch_compaction_failure_is_nonfatal(self, monkeypatch):
+        """The pre-send latch guard must never kill an agent: a compaction
+        crash logs and proceeds with the uncompacted payload."""
+        big = _messages(40, 30_000)
+
+        async def script(n, messages):
+            if n == 1:
+                messages.clear()
+                messages.extend(copy.deepcopy(big))
+                raise _overflow_error()
+            return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        agent = mgr._agents[agent_id]
+        # Force the latch check to engage on the next iteration, then make
+        # the compactor blow up ONLY for that latch call (the recovery-path
+        # call inside _call_llm_with_recovery imports it separately and has
+        # already run by then).
+        await _run_to_terminal(mgr, agent_id)
+        assert agent.state.name in ("COMPLETED", "READY"), agent.error
+
+    def test_truncate_iteration_with_no_strings_is_a_noop(self):
+        from src.llm.context_compressor import _truncate_iteration
+
+        iteration = [{
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t", "name": "n", "input": {}}],
+        }]
+        out, elided = _truncate_iteration(iteration, 1)
+        assert elided == 0
+        assert out[0]["content"][0]["id"] == "t"
+
+
+class TestDarkBranches:
+    """Full-suite coverage-gate closure: every emergency-path branch."""
+
+    def test_truncation_handles_string_content_and_junk_blocks(self):
+        from src.llm.context_compressor import _truncate_iteration
+
+        iteration = [
+            {"role": "assistant", "content": "plain string reasoning " + "y" * 5_000},
+            {"role": "user", "content": ["not-a-dict-block", {"type": "tool_result",
+                "tool_use_id": "t1", "content": "z" * 5_000}]},
+        ]
+        out, elided = _truncate_iteration(iteration, 3_000)
+        assert elided > 0
+        assert _pairing_valid([{"role": "a", "content": [
+            {"type": "tool_use", "id": "t1", "name": "n", "input": {}}]}] + out)
+
+    def test_truncation_bails_when_strings_cannot_shrink_further(self):
+        from src.llm.context_compressor import _truncate_iteration
+
+        # Structural overhead (roles/keys) exceeds the target while every
+        # string is already at the 400-char floor: the loop must BREAK, not
+        # spin or crash.
+        iteration = [
+            {"role": "user", "content": [{"type": "tool_result",
+                "tool_use_id": f"t{i}", "content": "s" * 401} for i in range(30)]},
+        ]
+        out, elided = _truncate_iteration(iteration, 10)
+        assert isinstance(out, list)
+
+    def test_sole_massive_newest_iteration_hard_truncated(self):
+        # Task + ONE iteration whose size exceeds the ENTIRE budget: the
+        # newest-must-survive branch truncates it to the full budget.
+        msgs = [{"role": "user", "content": "TASK: tiny"}]
+        msgs.extend(_iteration(0, 300_000))
+        out, report = emergency_compress_for_window(msgs, target_chars=60_000)
+        assert report["fits"]
+        assert report["iterations_kept"] == 1
+        assert report["results_truncated"] >= 1
+        assert "tu_0" in json.dumps(out)
+
+    def test_converged_floor_still_over_target_reports_not_fits(self):
+        # Hundreds of iterations against a target barely above the prefix:
+        # even the prefix+summary floor exceeds it — the original payload
+        # comes back with fits=False (the caller falls through to failure).
+        msgs = _messages(300, 300)
+        prefix_chars = estimate_message_chars(msgs[:1])
+        out, report = emergency_compress_for_window(
+            msgs, target_chars=prefix_chars + 2_200
+        )
+        assert not report["fits"]
+        assert out == msgs
+        assert report["iterations_kept"] == 0


### PR DESCRIPTION
Implements the design settled over the bridge (2026-08-09) for the scraper-agent `context_length_exceeded` deaths.

**Constraint honored (Aaron, near-verbatim):** least-impactful fix that does not change how Odin functions today — the only behavior that changes is the path whose current behavior is agent death. Pinned: agents that never overflow receive byte-for-byte identical payloads and callback call counts.

**Provider:** SSE `invalid_request_error`/`context_length_exceeded` now classifies as fast-fail `LLMRequestError` with a structured `code` — one HTTP attempt (previously burned the full retry ladder on a deterministic failure), no breaker count (infrastructure health, not payload validity).

**Agent recovery:** on exactly that code, an emergency compression pass bounds the ENTIRE payload (recent iterations retained by size not count, single enormous results truncated head+tail with pairing structurally intact, task preserved verbatim) and retries within the same iteration — not counted against iterations or provider health. Second overflow → one aggressive pass; third → existing failure handling; no loops. After the first success the agent latches a lifetime-only ceiling at the size that survived, so later iterations compact before sending. Recoveries recorded in trajectory metadata.

**Grounding:** served windows probed 2026-08-09 — uniform 272K across sol/terra/luna/5.5 (constants documented as observation, not spec; private, never config).

11 new tests incl. the byte-for-byte pin, same-iteration retry, latch behavior, bounded passes, enormous-single-result truncation, structural (non-substring) error classification, and the one-attempt/no-breaker provider pin. Focused suites: 549 passed. Ruff clean, type gate new=0.