### PR TITLE
Recoverable edge errors + third error-presentation boundary

### DIFF
--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -15,6 +15,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
 
+from ..error_presentation import format_user_facing_error
 from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
 from .trajectory import AgentTrajectorySaver, AgentTrajectoryTurn
@@ -1264,11 +1265,16 @@ async def _run_agent(
         log.info("Agent %s (%s) was cancelled", agent.id, agent.label)
 
     except Exception as e:
+        # agent.error and the state-transition reason both surface through
+        # the agent API, the WebUI detail modal, collect results, and the
+        # saved trajectory (error + state_history) — store one bounded
+        # formatter summary everywhere; the traceback stays in the journal.
+        err_msg = format_user_facing_error(e)
         if not agent._sm.is_terminal:
-            agent.transition(AgentState.FAILED, f"unhandled: {e}")
-        agent.error = str(e)
+            agent.transition(AgentState.FAILED, f"unhandled: {err_msg}")
+        agent.error = err_msg
         agent.ended_at = time.time()
-        log.error("Agent %s (%s) crashed: %s", agent.id, agent.label, e)
+        log.error("Agent %s (%s) crashed: %s", agent.id, agent.label, err_msg, exc_info=e)
 
     finally:
         trajectory.finalize(
@@ -1430,11 +1436,14 @@ async def _call_llm_with_recovery(
             # Typed fast-fail (auth / malformed request / quota-exhausted
             # after rotation) or a programming defect: neither earns a
             # manager-level retry — transient classes were already retried
-            # inside the callback for up to the generation deadline.
-            err_desc = (
-                f"LLM error: {exc}" if str(exc) else f"LLM error: {type(exc).__name__}"
+            # inside the callback for up to the generation deadline. The
+            # formatter handles empty-str exceptions via its type-name
+            # fallback, and keeps upstream text out of agent.error /
+            # state_history (both API- and trajectory-visible).
+            err_desc = f"LLM error: {format_user_facing_error(exc)}"
+            log.error(
+                "Agent %s LLM call failed (no retry): %s", agent.id, err_desc, exc_info=exc
             )
-            log.error("Agent %s LLM call failed (no retry): %s", agent.id, err_desc)
             agent.transition(AgentState.FAILED, err_desc)
             agent.error = err_desc
             agent.ended_at = time.time()

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Literal
 
 import discord
 
+from ..error_presentation import format_user_facing_error
 from ..llm import CircuitOpenError
 from ..llm.errors import LLMCapacityError
 from ..llm.recovery import generate_with_recovery, preflight_incompatible_effort
@@ -982,9 +983,17 @@ class ToolLoopRunner:
         return ("ok", llm_resp)
 
     async def _llm_error_done(self, st: _ChatTurn, api_err: BaseException):
-        """The legacy terminal LLM-failure path (unchanged message shape)."""
-        err_msg = str(api_err) or f"{type(api_err).__name__} (no message)"
-        log.error("LLM API call failed: %s", err_msg, exc_info=True)
+        """Terminal LLM-failure path.
+
+        Every operator/user-visible copy of the failure — the chat reply,
+        the WebUI ``response`` field (same tuple), and the trajectory
+        ``final_response`` the Traces page renders — carries the bounded
+        formatter summary, never raw exception text (the 2026-08-14 edge
+        incident posted a whole HTML error page into Discord through this
+        line). Full diagnostics stay in the journal via ``exc_info``.
+        """
+        err_msg = format_user_facing_error(api_err)
+        log.error("LLM API call failed: %s", err_msg, exc_info=api_err)
         await self._turn_recorder._save_turn_trajectory(
             st._trajectory, error=err_msg, trace=st.trace
         )
@@ -2064,15 +2073,20 @@ class ToolLoopRunner:
         except CircuitOpenError:
             raise
         except Exception as e:
-            log.warning("Loop iteration Codex call failed: %s", e)
+            # Loop outcome text, trajectory final_response, AND the
+            # reflection error_text are all operator/user-visible — one
+            # formatted summary feeds all three; the journal keeps the
+            # full exception.
+            err_msg = format_user_facing_error(e)
+            log.warning("Loop iteration Codex call failed: %s", err_msg, exc_info=e)
             return (
                 "done",
                 await self._finish_loop(
                     st,
-                    f"LLM call failed: {e}",
+                    f"LLM call failed: {err_msg}",
                     is_error=True,
                     failure_class="provider",
-                    error_text=str(e),
+                    error_text=err_msg,
                 ),
             )
         # Bypass-path success: clear a latched llm_* guard key using the

--- a/src/error_presentation.py
+++ b/src/error_presentation.py
@@ -47,6 +47,21 @@ def _clean_detail(detail: str) -> str:
     return detail.strip()
 
 
+def sanitize_error_text(text: str, limit: int = 200) -> str:
+    """Bounded, HTML-free, mention-safe, secret-scrubbed form of an
+    error-reason STRING for operator-visible storage (subsystem status
+    reasons, transition history). String-input sibling of
+    ``format_user_facing_error`` — same normalization, same total
+    non-throwing contract; safe-looking literals ("manual", "capacity")
+    pass through unchanged.
+    """
+    try:
+        lines = [ln.strip() for ln in str(text).strip().splitlines() if ln.strip()]
+        return _clean_detail(lines[0] if lines else "")[:limit]
+    except Exception:
+        return ""
+
+
 def format_user_facing_error(exc: BaseException, limit: int = 200) -> str:
     """Bounded one-line exception summary safe to show an end user.
 

--- a/src/error_presentation.py
+++ b/src/error_presentation.py
@@ -65,6 +65,12 @@ def sanitize_error_text(text: str, limit: int = 200) -> str:
 def format_user_facing_error(exc: BaseException, limit: int = 200) -> str:
     """Bounded one-line exception summary safe to show an end user.
 
+    ``limit`` bounds THIS function's output; call sites may prepend short
+    context prefixes ("LLM API error: ", "LLM error: "), so a stored or
+    displayed string can exceed it by the prefix length — the safety
+    properties (HTML-free, control-free, mention-safe, scrubbed) are
+    prefix-independent.
+
     ``discord.HTTPException`` renders structured fields only — the reason
     phrase is upstream-controlled text, so it goes through the SAME
     ``_clean_detail`` normalization as generic detail, and a non-int

--- a/src/health/subsystem_guard.py
+++ b/src/health/subsystem_guard.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+# Failure reasons are operator-visible storage: last_failure_reason is
+# serialized by /api/subsystems/status and reasons flow into transition
+# history — sanitize once at every reason-accepting entry point so no
+# caller can store raw upstream bytes (HTML pages, control chars, secrets).
+from ..error_presentation import sanitize_error_text
 from ..odin_log import get_logger
 
 log = get_logger("health.subsystem_guard")
@@ -292,6 +297,7 @@ class SubsystemGuard:
 
     def mark_degraded(self, name: str, reason: str = "") -> None:
         """Force a subsystem to DEGRADED."""
+        reason = sanitize_error_text(reason)
         info = self._subsystems.get(name)
         if info is None:
             return
@@ -309,6 +315,7 @@ class SubsystemGuard:
 
     def mark_unavailable(self, name: str, reason: str = "") -> None:
         """Force a subsystem to UNAVAILABLE."""
+        reason = sanitize_error_text(reason)
         info = self._subsystems.get(name)
         if info is None:
             return
@@ -336,6 +343,7 @@ class SubsystemGuard:
         DEGRADED into a self-clearing one — real degradation still requires
         a real success to clear.
         """
+        reason = sanitize_error_text(reason)
         info = self._subsystems.get(name)
         if info is None:
             return
@@ -365,6 +373,7 @@ class SubsystemGuard:
         Increments the consecutive-failure counter and transitions state
         when thresholds are crossed.  Returns the (possibly new) state.
         """
+        reason = sanitize_error_text(reason)
         info = self._subsystems.get(name)
         if info is None:
             return SubsystemState.AVAILABLE  # not tracked

--- a/src/llm/errors.py
+++ b/src/llm/errors.py
@@ -17,10 +17,14 @@ Compatibility constraints (both load-bearing):
 Only whitelisted, safe fields ride on the exception: ``provider``,
 ``model``, ``retry_after``, ``code`` (the provider's structured error code,
 e.g. ``context_length_exceeded`` — consumers key recovery decisions on it
-instead of substring-matching message text). Raise sites are responsible for bounding any
-response-body text they put in the message (the existing ``[:200]`` /
-``[:500]`` discipline); user-facing presentation still goes through
-``format_user_facing_error`` at the boundary.
+instead of substring-matching message text). Raise sites never embed raw
+response bytes in the message: HTTP-status branches embed a bounded,
+structure-aware descriptor (status + MIME + byte count for edge-shaped
+bodies; sanitized known JSON error fields for structured ones — see
+``openai_codex._describe_error_body``), so no LLMError message ever
+carries an HTML fragment. User-facing presentation still goes through
+``format_user_facing_error`` at the boundary — defense in depth, never
+single-layer.
 """
 
 from __future__ import annotations

--- a/src/llm/errors.py
+++ b/src/llm/errors.py
@@ -19,12 +19,13 @@ Only whitelisted, safe fields ride on the exception: ``provider``,
 e.g. ``context_length_exceeded`` — consumers key recovery decisions on it
 instead of substring-matching message text). Raise sites never embed raw
 response bytes in the message: HTTP-status branches embed a bounded,
-structure-aware descriptor (status + MIME + byte count for edge-shaped
-bodies; sanitized known JSON error fields for structured ones — see
-``openai_codex._describe_error_body``), so no LLMError message ever
-carries an HTML fragment. User-facing presentation still goes through
-``format_user_facing_error`` at the boundary — defense in depth, never
-single-layer.
+structure-aware descriptor (status + token-validated MIME + byte count
+for edge-shaped bodies; sanitized known JSON error fields for structured
+ones — see ``openai_codex._describe_error_body``), and SSE terminal
+events get the same known-field treatment (``CodexStreamError``), so no
+LLMError message ever carries an HTML fragment. User-facing presentation
+still goes through ``format_user_facing_error`` at the boundary —
+defense in depth, never single-layer.
 """
 
 from __future__ import annotations

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -53,8 +53,48 @@ CONNECT_TIMEOUT = 30
 # Cap the error-body read: error responses are only ever *described*
 # (status, MIME type, byte count, extracted JSON error fields — never raw
 # bytes), so a hostile or broken front door cannot trade an error page for
-# memory. Large enough that any genuine API error object fits whole.
+# memory. Large enough that any genuine API error object fits whole; a
+# body larger than the cap is truncated and therefore classified as
+# non-structured (transport) — acceptable, since real API error objects
+# are tiny and anything this size is an edge artifact.
 _ERROR_BODY_READ_CAP = 65536
+
+
+async def _read_error_body_bounded(content) -> bytes:
+    """Drain the error body up to the cap, reassembling chunks.
+
+    ``StreamReader.read(n)`` returns as soon as ANY bytes are buffered —
+    up to *n*, not exactly *n* — so a single call can hand back a chunked
+    JSON error truncated mid-object, and truncated JSON would misclassify
+    a deterministic API rejection as a retryable transport failure. Loop
+    to EOF (or the cap) so classification always sees the complete body
+    of any genuinely-sized error object.
+    """
+    chunks: list[bytes] = []
+    remaining = _ERROR_BODY_READ_CAP
+    while remaining > 0:
+        chunk = await content.read(remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _safe_mime(content_type: str | None) -> str:
+    """Token-validate the Content-Type before it may name a MIME type
+    inside an LLMError message — the header is upstream-controlled bytes
+    like any other, so anything that is not a plain ``type/subtype`` token
+    (markup, mentions, oversized junk) renders as ``unknown``."""
+    mime = (content_type or "").split(";")[0].strip().lower()
+    if (
+        not mime
+        or len(mime) > 64
+        or mime.count("/") != 1
+        or not all(ch.isalnum() or ch in "/.+-" for ch in mime)
+    ):
+        return "unknown"
+    return mime
 
 
 def _parse_structured_error(error_body: str) -> dict | None:
@@ -79,10 +119,11 @@ def _parse_structured_error(error_body: str) -> dict | None:
 
 
 def _clean_error_field(value: str, limit: int = 200) -> str:
-    """First line of a JSON error field: control chars stripped, secrets
-    scrubbed, bounded — and dropped entirely if it smuggles markup, keeping
-    the raise-site invariant (no LLMError message ever carries an HTML
-    fragment, even inside a structured error's own fields)."""
+    """First line of a JSON error field: control chars stripped, mass
+    mentions neutralized, secrets scrubbed, bounded — and dropped entirely
+    if it smuggles markup, keeping the raise-site invariant (no LLMError
+    message ever carries an HTML fragment, even inside a structured
+    error's own fields)."""
     stripped = value.strip()
     line = stripped.splitlines()[0].strip() if stripped else ""
     line = "".join(
@@ -91,7 +132,31 @@ def _clean_error_field(value: str, limit: int = 200) -> str:
     low = line.lower()
     if "<html" in low or "<!doctype" in low:
         return ""
+    line = line.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
     return scrub_output_secrets(line)[:limit]
+
+
+def _sanitized_error_fields(container: dict) -> list[str]:
+    """Sanitized known error fields from a parsed error container:
+    ``container["error"].{message,type,code}`` plus top-level
+    ``detail``/``message`` — deduped, order-preserving. Shared by the
+    HTTP-status descriptor and the SSE terminal-event message builder."""
+    fields: list[str] = []
+    err = container.get("error")
+    if isinstance(err, dict):
+        for key in ("message", "type", "code"):
+            val = err.get(key)
+            if isinstance(val, str):
+                cleaned = _clean_error_field(val)
+                if cleaned:
+                    fields.append(cleaned)
+    for key in ("detail", "message"):
+        val = container.get(key)
+        if isinstance(val, str):
+            cleaned = _clean_error_field(val)
+            if cleaned:
+                fields.append(cleaned)
+    return list(dict.fromkeys(fields))
 
 
 def _describe_error_body(
@@ -105,26 +170,11 @@ def _describe_error_body(
     code``, top-level ``detail``/``message``).
     """
     if structured is None:
-        mime = (content_type or "").split(";")[0].strip().lower() or "unknown"
-        return f"non-JSON error body ({mime}, {len(raw)} bytes)"
-    fields: list[str] = []
-    err = structured.get("error")
-    if isinstance(err, dict):
-        for key in ("message", "type", "code"):
-            val = err.get(key)
-            if isinstance(val, str):
-                cleaned = _clean_error_field(val)
-                if cleaned:
-                    fields.append(cleaned)
-    for key in ("detail", "message"):
-        val = structured.get(key)
-        if isinstance(val, str):
-            cleaned = _clean_error_field(val)
-            if cleaned:
-                fields.append(cleaned)
+        return f"non-JSON error body ({_safe_mime(content_type)}, {len(raw)} bytes)"
+    fields = _sanitized_error_fields(structured)
     if not fields:
         return "structured JSON error body"
-    return "; ".join(dict.fromkeys(fields))[:400]
+    return "; ".join(fields)[:400]
 
 
 # Markers the backend uses for model-tier capacity exhaustion. These arrive
@@ -144,7 +194,11 @@ class CodexStreamError(RuntimeError):
 
     Carries the structured fields parsed from the event's error object so the
     retry engine can classify capacity failures without substring matching.
-    The message keeps the historical ``{event_type}: {json[:500]}`` shape.
+    The message is ``{event_type}: {sanitized known error fields}`` — never a
+    raw event dump: SSE error fields are upstream-controlled text like any
+    response body, so they get the same bounded known-field treatment as the
+    HTTP-status descriptors (classification and ``.code`` semantics ride the
+    parsed attributes, not the message).
     """
 
     def __init__(
@@ -174,7 +228,10 @@ def _stream_error_from_event(event_type: str, event: dict) -> CodexStreamError:
     The error object lives at ``event["error"]`` for bare ``error`` events
     and at ``event["response"]["error"]`` for ``response.failed``; tolerate
     both plus absence (classification simply stays empty and the failure is
-    treated as transport, today's behavior).
+    treated as transport, today's behavior). The message carries only the
+    sanitized known fields — event dicts are upstream-controlled and can
+    smuggle markup or secrets through ``error.message``, so they never get
+    dumped raw into an exception that later boundaries render.
     """
     err = event.get("error")
     if not isinstance(err, dict):
@@ -185,8 +242,10 @@ def _stream_error_from_event(event_type: str, event: dict) -> CodexStreamError:
     error_type = err.get("type")
     error_code = err.get("code")
     retry_after = err.get("retry_after")
+    fields = _sanitized_error_fields({"error": err})
+    detail = "; ".join(fields)[:400] if fields else "unstructured stream error event"
     return CodexStreamError(
-        f"{event_type}: {json.dumps(event)[:500]}",
+        f"{event_type}: {detail}",
         error_type=error_type if isinstance(error_type, str) else None,
         error_code=error_code if isinstance(error_code, str) else None,
         retry_after=float(retry_after) if isinstance(retry_after, (int, float)) else None,
@@ -769,7 +828,7 @@ class CodexChatClient:
                         self.breaker.record_failure()
                         return result
 
-                    raw_error = await resp.content.read(_ERROR_BODY_READ_CAP)
+                    raw_error = await _read_error_body_bounded(resp.content)
                     error_body = raw_error.decode("utf-8", errors="replace")
                     structured = _parse_structured_error(error_body)
                     descriptor = _describe_error_body(

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -148,7 +148,12 @@ def _clean_error_field(value: str, limit: int = 200) -> str:
     line = "".join(
         ch for ch in line if ch == "\t" or not unicodedata.category(ch).startswith("C")
     )
-    if re.search(r"<(?:!|/?[A-Za-z])[^>]*>", line):
+    low = line.lower()
+    if (
+        "<html" in low
+        or "<!doctype" in low
+        or re.search(r"<(?:!|/?[A-Za-z])[^>]*>", line)
+    ):
         return ""
     line = line.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
     return scrub_output_secrets(line)[:limit]

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import string
 import unicodedata
 
 import aiohttp
@@ -85,20 +86,31 @@ async def _read_error_body_bounded(content) -> tuple[bytes, bool]:
     return b"".join(chunks), overflowed
 
 
+_ASCII_MIME_TOKEN_CHARS = frozenset(
+    string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~"
+)
+
+
 def _safe_mime(content_type: str | None) -> str:
-    """Token-validate the Content-Type before it may name a MIME type
-    inside an LLMError message — the header is upstream-controlled bytes
-    like any other, so anything that is not a plain ``type/subtype`` token
-    (markup, mentions, oversized junk) renders as ``unknown``."""
-    mime = (content_type or "").split(";")[0].strip().lower()
+    """Return a safe ASCII ``type/subtype`` token or ``unknown``.
+
+    Content-Type is upstream-controlled. Validate both non-empty components
+    against the explicit RFC token alphabet (never Unicode ``isalnum``), bound
+    the rendered value, and reject any candidate changed by the shared secret
+    scrubber so token-shaped credentials cannot enter exception text or logs.
+    Parameters are not rendered.
+    """
+    candidate = (content_type or "").split(";", 1)[0].strip()
+    parts = candidate.split("/")
     if (
-        not mime
-        or len(mime) > 64
-        or mime.count("/") != 1
-        or not all(ch.isalnum() or ch in "/.+-" for ch in mime)
+        len(candidate) > 64
+        or len(parts) != 2
+        or any(not part for part in parts)
+        or any(ch not in _ASCII_MIME_TOKEN_CHARS for part in parts for ch in part)
+        or scrub_output_secrets(candidate) != candidate
     ):
         return "unknown"
-    return mime
+    return candidate.lower()
 
 
 def _parse_structured_error(error_body: str) -> dict | None:

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -60,25 +60,29 @@ CONNECT_TIMEOUT = 30
 _ERROR_BODY_READ_CAP = 65536
 
 
-async def _read_error_body_bounded(content) -> bytes:
-    """Drain the error body up to the cap, reassembling chunks.
+async def _read_error_body_bounded(content) -> tuple[bytes, bool]:
+    """Drain the error body up to the cap and report whether it overflowed.
 
     ``StreamReader.read(n)`` returns as soon as ANY bytes are buffered —
     up to *n*, not exactly *n* — so a single call can hand back a chunked
     JSON error truncated mid-object, and truncated JSON would misclassify
     a deterministic API rejection as a retryable transport failure. Loop
     to EOF (or the cap) so classification always sees the complete body
-    of any genuinely-sized error object.
+    of any genuinely-sized error object. When the body exactly fills the
+    cap, probe one additional byte: a valid JSON prefix must never classify
+    unread trailing data as a deterministic request rejection.
     """
     chunks: list[bytes] = []
     remaining = _ERROR_BODY_READ_CAP
     while remaining > 0:
         chunk = await content.read(remaining)
         if not chunk:
-            break
+            return b"".join(chunks), False
         chunks.append(chunk)
         remaining -= len(chunk)
-    return b"".join(chunks)
+
+    overflowed = bool(await content.read(1))
+    return b"".join(chunks), overflowed
 
 
 def _safe_mime(content_type: str | None) -> str:
@@ -828,9 +832,11 @@ class CodexChatClient:
                         self.breaker.record_failure()
                         return result
 
-                    raw_error = await _read_error_body_bounded(resp.content)
+                    raw_error, body_overflowed = await _read_error_body_bounded(resp.content)
                     error_body = raw_error.decode("utf-8", errors="replace")
-                    structured = _parse_structured_error(error_body)
+                    structured = (
+                        None if body_overflowed else _parse_structured_error(error_body)
+                    )
                     descriptor = _describe_error_body(
                         resp.headers.get("Content-Type"), raw_error, structured
                     )

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import string
 import unicodedata
 
@@ -147,8 +148,7 @@ def _clean_error_field(value: str, limit: int = 200) -> str:
     line = "".join(
         ch for ch in line if ch == "\t" or not unicodedata.category(ch).startswith("C")
     )
-    low = line.lower()
-    if "<html" in low or "<!doctype" in low:
+    if re.search(r"<(?:!|/?[A-Za-z])[^>]*>", line):
         return ""
     line = line.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
     return scrub_output_secrets(line)[:limit]

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -101,6 +101,7 @@ def _safe_mime(content_type: str | None) -> str:
     Parameters are not rendered.
     """
     candidate = (content_type or "").split(";", 1)[0].strip()
+    normalized = candidate.lower()
     parts = candidate.split("/")
     if (
         len(candidate) > 64
@@ -108,9 +109,10 @@ def _safe_mime(content_type: str | None) -> str:
         or any(not part for part in parts)
         or any(ch not in _ASCII_MIME_TOKEN_CHARS for part in parts for ch in part)
         or scrub_output_secrets(candidate) != candidate
+        or scrub_output_secrets(normalized) != normalized
     ):
         return "unknown"
-    return candidate.lower()
+    return normalized
 
 
 def _parse_structured_error(error_body: str) -> dict | None:

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -769,8 +769,7 @@ class CodexChatClient:
                                 # counts one model-breaker failure per failed
                                 # logical generation.
                                 raise LLMCapacityError(
-                                    "Codex capacity: "
-                                    f"{e.error_code or e.error_type or 'unknown'}",
+                                    f"Codex capacity: {e}",
                                     provider="codex",
                                     model=str(body.get("model") or self.model),
                                     retry_after=e.retry_after,

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import unicodedata
 
 import aiohttp
 
@@ -18,6 +19,7 @@ from .errors import (
     LLMRequestError,
     LLMTransportError,
 )
+from .secret_scrubber import scrub_output_secrets
 from .types import LLMResponse, ToolCall
 
 log = get_logger("codex")
@@ -47,6 +49,82 @@ CODEX_API_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_REQUEST_TIMEOUT = 3600
 DEFAULT_STREAM_STALL_TIMEOUT = 180
 CONNECT_TIMEOUT = 30
+
+# Cap the error-body read: error responses are only ever *described*
+# (status, MIME type, byte count, extracted JSON error fields — never raw
+# bytes), so a hostile or broken front door cannot trade an error page for
+# memory. Large enough that any genuine API error object fits whole.
+_ERROR_BODY_READ_CAP = 65536
+
+
+def _parse_structured_error(error_body: str) -> dict | None:
+    """Return the parsed JSON object when the API itself spoke, else None.
+
+    A JSON *object* body is the only shape the backend's error surface
+    produces; anything else — an HTML edge page, an empty body, bare
+    string/list JSON, truncated junk — is an edge/proxy artifact and gets
+    transport treatment. Content-Type is deliberately not consulted:
+    proxies mislabel in both directions, so the body bytes are authority
+    (2026-08-14 edge incident: HTTP 403 carrying chatgpt.com's HTML error
+    page killed a healthy turn as a "request" error).
+    """
+    text = error_body.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _clean_error_field(value: str, limit: int = 200) -> str:
+    """First line of a JSON error field: control chars stripped, secrets
+    scrubbed, bounded — and dropped entirely if it smuggles markup, keeping
+    the raise-site invariant (no LLMError message ever carries an HTML
+    fragment, even inside a structured error's own fields)."""
+    stripped = value.strip()
+    line = stripped.splitlines()[0].strip() if stripped else ""
+    line = "".join(
+        ch for ch in line if ch == "\t" or not unicodedata.category(ch).startswith("C")
+    )
+    low = line.lower()
+    if "<html" in low or "<!doctype" in low:
+        return ""
+    return scrub_output_secrets(line)[:limit]
+
+
+def _describe_error_body(
+    content_type: str | None, raw: bytes, structured: dict | None
+) -> str:
+    """Bounded, structure-aware descriptor of a non-2xx response body.
+
+    Raise sites embed THIS instead of raw body excerpts (``errors.py``
+    contract): non-structured bodies are described by shape only; structured
+    bodies contribute their sanitized known fields (``error.message/type/
+    code``, top-level ``detail``/``message``).
+    """
+    if structured is None:
+        mime = (content_type or "").split(";")[0].strip().lower() or "unknown"
+        return f"non-JSON error body ({mime}, {len(raw)} bytes)"
+    fields: list[str] = []
+    err = structured.get("error")
+    if isinstance(err, dict):
+        for key in ("message", "type", "code"):
+            val = err.get(key)
+            if isinstance(val, str):
+                cleaned = _clean_error_field(val)
+                if cleaned:
+                    fields.append(cleaned)
+    for key in ("detail", "message"):
+        val = structured.get(key)
+        if isinstance(val, str):
+            cleaned = _clean_error_field(val)
+            if cleaned:
+                fields.append(cleaned)
+    if not fields:
+        return "structured JSON error body"
+    return "; ".join(dict.fromkeys(fields))[:400]
 
 
 # Markers the backend uses for model-tier capacity exhaustion. These arrive
@@ -691,7 +769,12 @@ class CodexChatClient:
                         self.breaker.record_failure()
                         return result
 
-                    error_body = (await resp.read()).decode("utf-8", errors="replace")
+                    raw_error = await resp.content.read(_ERROR_BODY_READ_CAP)
+                    error_body = raw_error.decode("utf-8", errors="replace")
+                    structured = _parse_structured_error(error_body)
+                    descriptor = _describe_error_body(
+                        resp.headers.get("Content-Type"), raw_error, structured
+                    )
 
                     if resp.status == 401:
                         body_l = error_body.lower()
@@ -721,7 +804,7 @@ class CodexChatClient:
                             continue
                         self.breaker.record_failure()
                         raise LLMAuthError(
-                            f"Codex 401 (auth failed, no healthy account): {error_body[:200]}",
+                            f"Codex 401 (auth failed, no healthy account): {descriptor}",
                             provider="codex",
                             model=str(body.get("model") or self.model),
                         )
@@ -729,7 +812,7 @@ class CodexChatClient:
                     if resp.status == 429:
                         await self._mark_limited(acct_idx)
                         self.breaker.record_failure()
-                        last_error = f"HTTP 429: {error_body[:200]}"
+                        last_error = f"HTTP 429: {descriptor}"
                         if attempt < self.max_retries - 1:
                             wait = compute_backoff(
                                 attempt,
@@ -750,14 +833,23 @@ class CodexChatClient:
                         # spending its budget cycling limited accounts —
                         # quota semantics stay exactly as before.
                         raise LLMRateLimitError(
-                            f"Codex API error (429): {error_body[:500]}",
+                            f"Codex API error (429): {descriptor}",
                             provider="codex",
                             model=str(body.get("model") or self.model),
                         )
 
-                    if resp.status in (500, 502, 503, 504):
+                    if resp.status in (500, 502, 503, 504) or structured is None:
+                        # Retryable server errors — and, since the 2026-08-14
+                        # edge incident, ANY status whose body is not a JSON
+                        # object: an HTML/opaque error page means the front
+                        # door failed, not that this request is invalid, so
+                        # it gets the same transport treatment (backoff +
+                        # retry here, deadline recovery above) instead of
+                        # killing the turn on one attempt. 401/429 never
+                        # reach here — their branches keep dedicated
+                        # refresh/rotation and quota semantics.
                         self.breaker.record_failure()
-                        last_error = f"HTTP {resp.status}: {error_body[:200]}"
+                        last_error = f"HTTP {resp.status}: {descriptor}"
                         if attempt < self.max_retries - 1:
                             wait = compute_backoff(
                                 attempt,
@@ -771,16 +863,19 @@ class CodexChatClient:
                             await asyncio.sleep(wait)
                             continue
                         raise LLMTransportError(
-                            f"Codex API error ({resp.status}): {error_body[:500]}",
+                            f"Codex API error ({resp.status}): {descriptor}",
                             provider="codex",
                             model=str(body.get("model") or self.model),
                         )
 
-                    # Any other status (400 bad model/malformed request, ...):
-                    # the request itself is wrong — fast-fail, never retried.
+                    # Structured (JSON-object) non-2xx outside the dedicated
+                    # branches: the API itself rejected the request (bad
+                    # model, malformed input) — deterministic, so retrying
+                    # the identical payload burns attempts on a guaranteed
+                    # failure. Fast-fail, never retried.
                     self.breaker.record_failure()
                     raise LLMRequestError(
-                        f"Codex API error ({resp.status}): {error_body[:500]}",
+                        f"Codex API error ({resp.status}): {descriptor}",
                         provider="codex",
                         model=str(body.get("model") or self.model),
                     )

--- a/src/tools/autonomous_loop.py
+++ b/src/tools/autonomous_loop.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from ..error_presentation import format_user_facing_error
 from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
 
@@ -297,9 +298,14 @@ class LoopManager:
                         consecutive_errors,
                         e,
                     )
-                    # Store error in history but don't crash the loop
+                    # Store error in history but don't crash the loop. The
+                    # history deque is next-iteration model context AND the
+                    # WebUI loop detail, and the channel post is user-facing
+                    # — both get the bounded formatter summary, never raw
+                    # exception text (which can carry upstream HTML pages).
+                    err_msg = format_user_facing_error(e)
                     info._iteration_history.append(
-                        f"Iteration {info.iteration_count}: ERROR - {str(e)[:200]}"
+                        f"Iteration {info.iteration_count}: ERROR - {err_msg}"
                     )
                     # Stop loop after too many consecutive errors
                     if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
@@ -307,7 +313,7 @@ class LoopManager:
                         try:
                             await channel.send(
                                 f"Loop `{info.id}` stopped after {MAX_CONSECUTIVE_ERRORS} "
-                                f"consecutive errors. Last error: {str(e)[:200]}"
+                                f"consecutive errors. Last error: {err_msg}"
                             )
                         except Exception:
                             pass
@@ -396,7 +402,8 @@ class LoopManager:
             log.error("Loop %s crashed: %s", info.id, e, exc_info=True)
             try:
                 await channel.send(
-                    f"Loop `{info.id}` encountered an error and stopped: {str(e)[:200]}"
+                    f"Loop `{info.id}` encountered an error and stopped: "
+                    f"{format_user_facing_error(e)}"
                 )
             except Exception:
                 pass

--- a/tests/characterization/test_autonomous_loop.py
+++ b/tests/characterization/test_autonomous_loop.py
@@ -139,9 +139,24 @@ class TestAsymmetryPins:
     async def test_generic_llm_error_returned_as_text(self):
         bot, fake = build([RuntimeError("provider exploded")])
         result = await run_iteration(bot)
-        assert result == "LLM call failed: provider exploded"
+        # Formatter-shaped since the 2026-08-14 sanitization (type name +
+        # first line, bounded).
+        assert result == "LLM call failed: RuntimeError: provider exploded"
         assert bot.turn_recorder._maybe_loop_reflect.calls[-1]["is_error"] is True
         assert bot.turn_recorder._maybe_loop_reflect.calls[-1]["failure_class"] == "provider"
+
+    async def test_llm_error_text_sanitized_for_reflection_and_response(self):
+        """2026-08-14 incident pin: an HTML-bearing provider exception must
+        reach neither the loop response nor the reflection error_text (which
+        also feeds the persisted trajectory)."""
+        bot, fake = build([RuntimeError("<html><body>@everyone edge page</body></html>")])
+        result = await run_iteration(bot)
+        assert result == "LLM call failed: RuntimeError"  # HTML detail dropped
+        assert "@everyone" not in result
+        reflect = bot.turn_recorder._maybe_loop_reflect.calls[-1]
+        assert reflect["is_error"] is True
+        assert "<html" not in reflect["error_text"].lower()
+        assert "@everyone" not in reflect["error_text"]
 
     async def test_cap_exhaustion_is_error_with_failure_class_cancelled(self):
         bot, fake = build(

--- a/tests/characterization/test_chat_tool_loop.py
+++ b/tests/characterization/test_chat_tool_loop.py
@@ -255,7 +255,35 @@ class TestToolFailurePaths:
         bot, fake = build([RuntimeError("boom")])
         text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
         assert is_error is True
-        assert text == "LLM API error: boom"
+        # Formatter-shaped since the 2026-08-14 sanitization (type name +
+        # first line, bounded).
+        assert text == "LLM API error: RuntimeError: boom"
+
+    async def test_llm_error_text_and_trajectory_sanitized(self):
+        """2026-08-14 incident pin: a provider exception carrying a whole
+        HTML page must reach neither the chat reply nor the operator-visible
+        trajectory final_response (the Traces page renders it)."""
+        bot, fake = build([RuntimeError("<html><body>@everyone edge page</body></html>")])
+
+        class _RecordingSaver:
+            def __init__(self):
+                self.saved = []
+
+            async def save(self, trajectory):
+                self.saved.append(trajectory)
+
+        saver = _RecordingSaver()
+        bot.turn_recorder._trajectory_saver = saver
+
+        text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
+        assert is_error is True
+        assert text == "LLM API error: RuntimeError"  # HTML detail dropped
+        assert "@everyone" not in text
+        assert saver.saved
+        traj = saver.saved[-1]
+        assert traj.is_error is True
+        assert "<html" not in traj.final_response.lower()
+        assert "@everyone" not in traj.final_response
 
     async def test_circuit_open_waits_and_retries(self):
         # Amended 2026-07-30: the single hardcoded breaker retry became the
@@ -285,7 +313,7 @@ class TestToolFailurePaths:
         )
         text, _, is_error, _, _ = await run_loop(bot, FakeMessage("go"))
         assert is_error is True
-        assert text == "LLM API error: still down"
+        assert text == "LLM API error: RuntimeError: still down"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -867,7 +867,9 @@ class TestLLMRecovery:
         assert result is None
         assert call_count == 1
         assert agent.state == AgentState.FAILED
-        assert agent.error == "LLM error: transient error"
+        # Error text is formatter-shaped since the 2026-08-14 sanitization
+        # (type name + first line, bounded).
+        assert agent.error == "LLM error: ConnectionError: transient error"
         assert agent.recovery_attempts == 0
 
 
@@ -1954,3 +1956,59 @@ class TestIterationCapSnapshot:
         assert mgr._agents[aid].max_iterations == 3
         assert calls["n"] <= 3  # never exceeded the snapshotted cap
         mgr.kill(aid)
+
+
+class TestAgentErrorTextSanitized:
+    """agent.error and state-transition reasons surface through the agent
+    API, the WebUI detail modal, collect results, and saved trajectories
+    (error + state_history) — both failure paths must store the bounded
+    formatter summary, never raw exception text (2026-08-14 edge incident:
+    provider errors can carry whole HTML pages)."""
+
+    HTML_ERR = RuntimeError("<html><body>@everyone edge page</body></html>")
+
+    def _agent(self, agent_id: str) -> AgentInfo:
+        agent = AgentInfo(
+            id=agent_id, label="test", goal="test",
+            channel_id="c1", requester_id="u1", requester_name="user",
+        )
+        agent.transition(AgentState.READY)
+        agent.transition(AgentState.EXECUTING)
+        return agent
+
+    async def test_recovery_terminal_error_sanitized(self):
+        agent = self._agent("san1")
+        iter_cb = AsyncMock(side_effect=self.HTML_ERR)
+
+        result = await _call_llm_with_recovery(agent, iter_cb, "sys", [])
+
+        assert result is None
+        assert agent.state == AgentState.FAILED
+        assert agent.error.startswith("LLM error: RuntimeError")
+        assert "<html" not in agent.error.lower()
+        assert "@everyone" not in agent.error
+        failed = [t for t in agent.state_history if t.to_state == AgentState.FAILED]
+        assert failed and "<html" not in failed[-1].reason.lower()
+        assert "@everyone" not in failed[-1].reason
+
+    async def test_outer_crash_error_sanitized(self):
+        agent = self._agent("san2")
+        tool_cb = AsyncMock(return_value="ok")
+
+        with patch(
+            "src.agents.manager._call_llm_with_recovery",
+            side_effect=self.HTML_ERR,
+        ):
+            await _run_agent(agent, "sys", [], AsyncMock(), tool_cb)
+
+        assert agent.state == AgentState.FAILED
+        assert agent.error == "RuntimeError"  # HTML detail dropped by the formatter
+        failed = [t for t in agent.state_history if t.to_state == AgentState.FAILED]
+        assert failed and failed[-1].reason == "unhandled: RuntimeError"
+
+    async def test_empty_message_exception_keeps_type_name(self):
+        agent = self._agent("san3")
+        iter_cb = AsyncMock(side_effect=ValueError())
+
+        await _call_llm_with_recovery(agent, iter_cb, "sys", [])
+        assert agent.error == "LLM error: ValueError"

--- a/tests/test_codex_reliability.py
+++ b/tests/test_codex_reliability.py
@@ -52,11 +52,17 @@ def _write_json(path: Path, data) -> None:
 
 class FakeContent:
     """Stands in for aiohttp's StreamReader: async-iterable for the SSE
-    path AND ``.read(n)``-capable for the bounded error-body read."""
+    path AND ``.read(n)``-capable for the bounded error-body read.
 
-    def __init__(self, lines: list[str], body: bytes):
+    Models the REAL stream contract: ``read(n)`` returns at most *n*
+    bytes from the current position (one queued chunk at a time when the
+    body is chunked), advances, and returns ``b""`` at EOF — a
+    position-less fake here previously validated a truncation bug.
+    """
+
+    def __init__(self, lines: list[str], body: bytes, chunks: list[bytes] | None = None):
         self._lines = list(lines)
-        self._body = body
+        self._chunks = list(chunks) if chunks is not None else ([body] if body else [])
 
     def __aiter__(self):
         return self._iter()
@@ -66,7 +72,18 @@ class FakeContent:
             yield line.encode()
 
     async def read(self, n: int = -1) -> bytes:
-        return self._body if n < 0 else self._body[:n]
+        if not self._chunks:
+            return b""
+        if n < 0:
+            data, self._chunks = b"".join(self._chunks), []
+            return data
+        chunk = self._chunks[0]
+        data, rest = chunk[:n], chunk[n:]
+        if rest:
+            self._chunks[0] = rest
+        else:
+            self._chunks.pop(0)
+        return data
 
 
 class FakeResp:
@@ -78,11 +95,12 @@ class FakeResp:
         body: bytes = b"",
         sse_lines: list[str] | None = None,
         headers: dict | None = None,
+        chunks: list[bytes] | None = None,
     ):
         self.status = status
-        self._body = body
+        self._body = body if chunks is None else b"".join(chunks)
         self.headers = headers or {}
-        self.content = FakeContent(sse_lines or [], body)
+        self.content = FakeContent(sse_lines or [], body, chunks=chunks)
 
     async def read(self) -> bytes:
         return self._body

--- a/tests/test_codex_reliability.py
+++ b/tests/test_codex_reliability.py
@@ -50,18 +50,39 @@ def _write_json(path: Path, data) -> None:
     path.write_text(json.dumps(data, indent=2))
 
 
+class FakeContent:
+    """Stands in for aiohttp's StreamReader: async-iterable for the SSE
+    path AND ``.read(n)``-capable for the bounded error-body read."""
+
+    def __init__(self, lines: list[str], body: bytes):
+        self._lines = list(lines)
+        self._body = body
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for line in self._lines:
+            yield line.encode()
+
+    async def read(self, n: int = -1) -> bytes:
+        return self._body if n < 0 else self._body[:n]
+
+
 class FakeResp:
     """Minimal aiohttp response stand-in for the streaming paths."""
 
-    def __init__(self, status: int, body: bytes = b"", sse_lines: list[str] | None = None):
+    def __init__(
+        self,
+        status: int,
+        body: bytes = b"",
+        sse_lines: list[str] | None = None,
+        headers: dict | None = None,
+    ):
         self.status = status
         self._body = body
-        self.content = self._iter_lines(sse_lines or [])
-
-    @staticmethod
-    async def _iter_lines(lines: list[str]):
-        for line in lines:
-            yield line.encode()
+        self.headers = headers or {}
+        self.content = FakeContent(sse_lines or [], body)
 
     async def read(self) -> bytes:
         return self._body

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -1,0 +1,412 @@
+"""Edge-shaped error bodies are transport failures, not request failures.
+
+2026-08-14 incident: chatgpt.com's edge returned HTTP 403 carrying its styled
+HTML error page. The catch-all status branch classified it ``LLMRequestError``,
+recovery fast-failed it, and a healthy turn died on ONE HTTP attempt — then the
+raw page reached chat (boundary side covered in the sanitization tests).
+
+These pin the settled classification matrix (design-reviewed with Odin,
+2026-08-14):
+
+    401 / 429            -> dedicated branches, control flow bit-exact
+    500/502/503/504      -> transport, regardless of body shape
+    other non-2xx        -> JSON *object* body = request-class fast-fail;
+                            anything else (HTML / empty / non-dict JSON /
+                            junk) = transport with backoff + retry
+
+plus the raise-site invariant: no raised LLMError message ever embeds raw
+response bytes — bounded structure-aware descriptors only — and the error-body
+read is capped so a hostile edge cannot trade an error page for memory.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMRequestError,
+    LLMTransportError,
+)
+from src.llm.openai_codex import (
+    _ERROR_BODY_READ_CAP,
+    CodexChatClient,
+    _describe_error_body,
+    _parse_structured_error,
+)
+
+HTML_PAGE = (
+    b"<html>\n  <head>\n    <meta name=\"viewport\" content=\"width=device-width\" />"
+    b"\n    <style global>body{font-family:Arial}</style>\n  </head>\n"
+    b"<body>@everyone edge says no</body></html>"
+)
+JSON_ERROR = json.dumps(
+    {"error": {"message": "The model `gpt-bogus` does not exist", "type": "invalid_request_error"}}
+).encode()
+
+
+class FakeContent:
+    def __init__(self, lines: list[str], body: bytes):
+        self._lines = list(lines)
+        self._body = body
+        self.read_sizes: list[int] = []
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for line in self._lines:
+            yield line.encode()
+
+    async def read(self, n: int = -1) -> bytes:
+        self.read_sizes.append(n)
+        return self._body if n < 0 else self._body[:n]
+
+
+class FakeResp:
+    def __init__(self, status, body=b"", sse_lines=None, headers=None):
+        self.status = status
+        self._body = body
+        self.headers = headers or {}
+        self.content = FakeContent(sse_lines or [], body)
+
+    async def read(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, script):
+        self._script = list(script)
+        self.calls = 0
+
+    def post(self, *args, **kwargs):
+        self.calls += 1
+        if not self._script:
+            raise AssertionError("FakeSession script exhausted — unexpected extra request")
+        return self._script.pop(0)
+
+
+class FakeSingleAuth:
+    def __init__(self):
+        self.limited = False
+        self.refreshed = []
+
+    async def get_access_token(self):
+        return "tok"
+
+    def get_account_id(self):
+        return None
+
+    def mark_rate_limited(self, seconds: float = 60):
+        self.limited = True
+
+    async def force_refresh(self, stale_token=None):
+        self.refreshed.append(stale_token)
+        return True
+
+    async def mark_current_auth_failed(self):
+        return False
+
+
+async def _async_return(v):
+    return v
+
+
+def _client(max_retries: int = 2, auth=None) -> CodexChatClient:
+    return CodexChatClient(
+        auth=auth or FakeSingleAuth(),
+        model="gpt-test",
+        max_retries=max_retries,
+        retry_base_delay=0.001,
+        retry_max_delay=0.002,
+    )
+
+
+def _wire(monkeypatch, client, session):
+    monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+
+
+TEXT_OK_SSE = [
+    'data: {"type": "response.output_text.delta", "delta": "hello"}\n',
+    "data: [DONE]\n",
+]
+
+
+# ---------------------------------------------------------------------------
+# Classification matrix — the recoverability fix
+# ---------------------------------------------------------------------------
+
+class TestEdgeShapedBodiesAreTransport:
+    async def test_html_403_retries_then_succeeds(self, monkeypatch):
+        """The incident shape: one edge HTML 403 must not kill the turn."""
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(403, body=HTML_PAGE, headers={"Content-Type": "text/html"}),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+
+        text = await client._stream_request({"model": "m"})
+        assert text == "hello"
+        assert session.calls == 2
+        assert client.breaker._failure_count == 0  # success reset
+
+    async def test_html_403_exhaustion_raises_transport(self, monkeypatch):
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(403, body=HTML_PAGE, headers={"Content-Type": "text/html; charset=utf-8"}),
+            FakeResp(403, body=HTML_PAGE, headers={"Content-Type": "text/html; charset=utf-8"}),
+        ])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMTransportError) as ei:
+            await client._stream_request({"model": "m"})
+        assert session.calls == 2
+        msg = str(ei.value)
+        assert "403" in msg
+        assert "non-JSON error body (text/html" in msg
+        assert "<html" not in msg.lower()
+
+    async def test_empty_body_403_is_transport(self, monkeypatch):
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(403, body=b""),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+        assert await client._stream_request({"model": "m"}) == "hello"
+        assert session.calls == 2
+
+    async def test_non_dict_json_403_is_transport(self, monkeypatch):
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(403, body=b"[1, 2, 3]", headers={"Content-Type": "application/json"}),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+        assert await client._stream_request({"model": "m"}) == "hello"
+        assert session.calls == 2
+
+    async def test_lying_content_type_html_body_is_transport(self, monkeypatch):
+        """Body bytes are authority: a JSON Content-Type on an HTML body is
+        still edge-shaped."""
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(400, body=HTML_PAGE, headers={"Content-Type": "application/json"}),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+        assert await client._stream_request({"model": "m"}) == "hello"
+        assert session.calls == 2
+
+
+class TestStructuredBodiesStayRequestClass:
+    async def test_json_403_fast_fails_one_attempt(self, monkeypatch):
+        client = _client(max_retries=3)
+        session = FakeSession([FakeResp(403, body=JSON_ERROR)])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError) as ei:
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+        assert client.breaker._failure_count == 1
+        assert "does not exist" in str(ei.value)
+
+    async def test_json_400_fast_fails_one_attempt(self, monkeypatch):
+        """Bit-exact pin of the pre-change deterministic-4xx behavior."""
+        client = _client(max_retries=3)
+        session = FakeSession([FakeResp(400, body=JSON_ERROR)])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError):
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+
+    async def test_lying_content_type_json_body_is_request(self, monkeypatch):
+        client = _client(max_retries=3)
+        session = FakeSession([
+            FakeResp(403, body=JSON_ERROR, headers={"Content-Type": "text/html"}),
+        ])
+        _wire(monkeypatch, client, session)
+        with pytest.raises(LLMRequestError):
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+
+    async def test_empty_dict_counts_as_structured(self, monkeypatch):
+        """Any JSON object = the API spoke (settled Q2): fast-fail."""
+        client = _client(max_retries=3)
+        session = FakeSession([FakeResp(422, body=b"{}")])
+        _wire(monkeypatch, client, session)
+        with pytest.raises(LLMRequestError) as ei:
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+        assert "structured JSON error body" in str(ei.value)
+
+
+class TestDedicatedBranchesUnchanged:
+    async def test_json_500_still_transport_and_retries(self, monkeypatch):
+        """5xx stays transport REGARDLESS of body shape — a structured 500
+        must not become a fast-fail request error (Odin's Q1 amendment)."""
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(500, body=JSON_ERROR),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+        assert await client._stream_request({"model": "m"}) == "hello"
+        assert session.calls == 2
+
+    async def test_html_401_keeps_auth_semantics_clean_text(self, monkeypatch):
+        """An HTML-bodied 401 still refreshes + retries the same account
+        (control flow bit-exact); only the raised text is descriptor-based."""
+        auth = FakeSingleAuth()
+        client = _client(max_retries=2, auth=auth)
+        session = FakeSession([
+            FakeResp(401, body=b"<html>edge login wall</html>"),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+        assert await client._stream_request({"model": "m"}) == "hello"
+        assert auth.refreshed == ["tok"]
+
+    async def test_html_401_terminal_message_has_no_markup(self, monkeypatch):
+        auth = FakeSingleAuth()
+
+        async def refresh_fails(stale_token=None):
+            return False
+
+        auth.force_refresh = refresh_fails
+        client = _client(max_retries=1, auth=auth)
+        session = FakeSession([FakeResp(401, body=b"<html>denied</html>")])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMAuthError) as ei:
+            await client._stream_request({"model": "m"})
+        msg = str(ei.value)
+        assert "401" in msg
+        assert "<html" not in msg.lower()
+
+    async def test_html_429_keeps_quota_semantics_clean_text(self, monkeypatch):
+        auth = FakeSingleAuth()
+        client = _client(max_retries=1, auth=auth)
+        session = FakeSession([
+            FakeResp(429, body=HTML_PAGE, headers={"Content-Type": "text/html"}),
+        ])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRateLimitError) as ei:
+            await client._stream_request({"model": "m"})
+        assert auth.limited is True  # quota marking bit-exact
+        msg = str(ei.value)
+        assert "429" in msg
+        assert "<html" not in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Raise-site invariant + bounded read
+# ---------------------------------------------------------------------------
+
+class TestRaiseSiteInvariant:
+    @pytest.mark.parametrize(
+        ("status", "body", "exc_type"),
+        [
+            (401, b"<html>x</html>", LLMAuthError),
+            (429, HTML_PAGE, LLMRateLimitError),
+            (500, HTML_PAGE, LLMTransportError),
+            (403, HTML_PAGE, LLMTransportError),
+            (404, b"<!DOCTYPE html><html>nope</html>", LLMTransportError),
+        ],
+    )
+    async def test_no_raised_message_contains_markup(
+        self, monkeypatch, status, body, exc_type
+    ):
+        auth = FakeSingleAuth()
+
+        async def refresh_fails(stale_token=None):
+            return False
+
+        auth.force_refresh = refresh_fails
+        client = _client(max_retries=1, auth=auth)
+        session = FakeSession([FakeResp(status, body=body)])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(exc_type) as ei:
+            await client._stream_request({"model": "m"})
+        msg = str(ei.value).lower()
+        assert "<html" not in msg
+        assert "<!doctype" not in msg
+
+    async def test_structured_dict_with_html_field_cannot_leak(self, monkeypatch):
+        """A dict value smuggling markup is dropped by the field cleaner —
+        the invariant holds even for structured bodies."""
+        body = json.dumps({"error": {"message": "<html>gotcha</html>"}}).encode()
+        client = _client(max_retries=1)
+        session = FakeSession([FakeResp(422, body=body)])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError) as ei:
+            await client._stream_request({"model": "m"})
+        msg = str(ei.value)
+        assert "<html" not in msg.lower()
+        assert "structured JSON error body" in msg
+
+    async def test_error_body_read_is_bounded(self, monkeypatch):
+        client = _client(max_retries=1)
+        resp = FakeResp(403, body=b"x" * (_ERROR_BODY_READ_CAP * 3))
+        session = FakeSession([resp])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMTransportError) as ei:
+            await client._stream_request({"model": "m"})
+        assert resp.content.read_sizes == [_ERROR_BODY_READ_CAP]
+        assert f"{_ERROR_BODY_READ_CAP} bytes" in str(ei.value)
+
+
+# ---------------------------------------------------------------------------
+# Helper units
+# ---------------------------------------------------------------------------
+
+class TestParseStructuredError:
+    def test_shapes(self):
+        assert _parse_structured_error("") is None
+        assert _parse_structured_error("   \n ") is None
+        assert _parse_structured_error("<html>x") is None
+        assert _parse_structured_error("[1, 2]") is None
+        assert _parse_structured_error('"just a string"') is None
+        assert _parse_structured_error("{}") == {}
+        assert _parse_structured_error('{"error": {"code": "x"}}') == {"error": {"code": "x"}}
+
+
+class TestDescribeErrorBody:
+    def test_non_structured_shape_only(self):
+        out = _describe_error_body("text/html; charset=utf-8", b"x" * 8437, None)
+        assert out == "non-JSON error body (text/html, 8437 bytes)"
+
+    def test_missing_content_type(self):
+        assert _describe_error_body(None, b"zz", None) == "non-JSON error body (unknown, 2 bytes)"
+
+    def test_structured_extracts_and_dedupes_fields(self):
+        structured = {
+            "error": {"message": "boom", "type": "server_error", "code": "boom"},
+            "detail": "boom",
+        }
+        out = _describe_error_body("application/json", b"{}", structured)
+        assert out == "boom; server_error"
+
+    def test_structured_control_chars_stripped_and_bounded(self):
+        structured = {"error": {"message": "a\x00b\x1fc" + "d" * 500}}
+        out = _describe_error_body(None, b"{}", structured)
+        assert out.startswith("abc")
+        assert "\x00" not in out and "\x1f" not in out
+        assert len(out) <= 400
+
+    def test_structured_without_known_fields(self):
+        assert _describe_error_body(None, b"{}", {"weird": 1}) == "structured JSON error body"

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -431,6 +431,29 @@ class TestRaiseSiteInvariant:
         assert "<html" not in msg.lower()
         assert "structured JSON error body" in msg
 
+    @pytest.mark.parametrize(
+        "fragment",
+        [
+            "evil <html unclosed fragment",
+            "evil <!doctype unclosed fragment",
+        ],
+    )
+    async def test_structured_dict_with_unclosed_html_fragment_cannot_leak(
+        self, monkeypatch, fragment
+    ):
+        """Unclosed HTML markers are dropped before an LLMError is raised."""
+        body = json.dumps({"error": {"message": fragment}}).encode()
+        client = _client(max_retries=1)
+        session = FakeSession([FakeResp(422, body=body)])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError) as ei:
+            await client._stream_request({"model": "m"})
+        msg = str(ei.value).lower()
+        assert "<html" not in msg
+        assert "<!doctype" not in msg
+        assert "structured json error body" in msg
+
     async def test_error_body_read_is_bounded(self, monkeypatch):
         client = _client(max_retries=1)
         resp = FakeResp(403, body=b"x" * (_ERROR_BODY_READ_CAP * 3))

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -26,6 +26,7 @@ import pytest
 
 from src.llm.errors import (
     LLMAuthError,
+    LLMCapacityError,
     LLMRateLimitError,
     LLMRequestError,
     LLMTransportError,
@@ -489,6 +490,34 @@ class TestStreamErrorEventSanitized:
         assert "<html" not in msg.lower()
         assert "@everyone" not in msg
         assert '"response"' not in msg  # no raw event dump
+
+    async def test_capacity_message_uses_sanitized_fields_not_raw_attributes(
+        self, monkeypatch
+    ):
+        """Classification keeps the raw structured attributes, but the raised
+        capacity message must use the separately sanitized field rendering."""
+        client = _client(max_retries=3)
+        raw_code = "<html>@everyone secret=abcdefghijklmnopqrstuvwxyz</html>"
+        event = {
+            "type": "error",
+            "error": {
+                "type": "server_is_overloaded",
+                "code": raw_code,
+                "message": "Capacity is temporarily unavailable",
+            },
+        }
+        session = FakeSession([FakeResp(200, sse_lines=self._sse(event))])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMCapacityError) as ei:
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+        assert ei.value.code is None  # LLMCapacityError .code semantics unchanged
+        msg = str(ei.value)
+        assert "server_is_overloaded" in msg
+        assert "<html" not in msg.lower()
+        assert "@everyone" not in msg
+        assert "abcdefghijklmnopqrstuvwxyz" not in msg
 
     async def test_request_class_event_keeps_code_with_clean_message(self, monkeypatch):
         client = _client(max_retries=3)

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -501,7 +501,7 @@ class TestStreamErrorEventSanitized:
         event = {
             "type": "error",
             "error": {
-                "type": "server_is_overloaded",
+                "type": "server_error",
                 "code": raw_code,
                 "message": "Capacity is temporarily unavailable",
             },
@@ -514,7 +514,7 @@ class TestStreamErrorEventSanitized:
         assert session.calls == 1
         assert ei.value.code is None  # LLMCapacityError .code semantics unchanged
         msg = str(ei.value)
-        assert "server_is_overloaded" in msg
+        assert "server_error" in msg
         assert "<html" not in msg.lower()
         assert "@everyone" not in msg
         assert "abcdefghijklmnopqrstuvwxyz" not in msg

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -594,6 +594,7 @@ class TestSafeMime:
         secret = "sk-" + "A" * 32
         assert len(f"application/{secret}") <= 64
         assert _safe_mime(f"application/{secret}") == "unknown"
+        assert _safe_mime(f"application/{secret.upper()}") == "unknown"
 
 
 class TestDescribeErrorBody:

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -497,7 +497,7 @@ class TestStreamErrorEventSanitized:
         """Classification keeps the raw structured attributes, but the raised
         capacity message must use the separately sanitized field rendering."""
         client = _client(max_retries=3)
-        raw_code = "<html>@everyone secret=abcdefghijklmnopqrstuvwxyz</html>"
+        raw_code = "<script>@everyone attack</script>"
         event = {
             "type": "error",
             "error": {
@@ -515,9 +515,9 @@ class TestStreamErrorEventSanitized:
         assert ei.value.code is None  # LLMCapacityError .code semantics unchanged
         msg = str(ei.value)
         assert "server_error" in msg
-        assert "<html" not in msg.lower()
+        assert "<script" not in msg.lower()
         assert "@everyone" not in msg
-        assert "abcdefghijklmnopqrstuvwxyz" not in msg
+        assert "attack" not in msg
 
     async def test_request_class_event_keeps_code_with_clean_message(self, monkeypatch):
         client = _client(max_retries=3)

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -48,9 +48,13 @@ JSON_ERROR = json.dumps(
 
 
 class FakeContent:
-    def __init__(self, lines: list[str], body: bytes):
+    """Models the REAL StreamReader contract: ``read(n)`` returns at most
+    *n* bytes from the current position (one queued chunk at a time when
+    chunked), advances, and returns ``b""`` at EOF."""
+
+    def __init__(self, lines: list[str], body: bytes, chunks: list[bytes] | None = None):
         self._lines = list(lines)
-        self._body = body
+        self._chunks = list(chunks) if chunks is not None else ([body] if body else [])
         self.read_sizes: list[int] = []
 
     def __aiter__(self):
@@ -62,15 +66,26 @@ class FakeContent:
 
     async def read(self, n: int = -1) -> bytes:
         self.read_sizes.append(n)
-        return self._body if n < 0 else self._body[:n]
+        if not self._chunks:
+            return b""
+        if n < 0:
+            data, self._chunks = b"".join(self._chunks), []
+            return data
+        chunk = self._chunks[0]
+        data, rest = chunk[:n], chunk[n:]
+        if rest:
+            self._chunks[0] = rest
+        else:
+            self._chunks.pop(0)
+        return data
 
 
 class FakeResp:
-    def __init__(self, status, body=b"", sse_lines=None, headers=None):
+    def __init__(self, status, body=b"", sse_lines=None, headers=None, chunks=None):
         self.status = status
-        self._body = body
+        self._body = body if chunks is None else b"".join(chunks)
         self.headers = headers or {}
-        self.content = FakeContent(sse_lines or [], body)
+        self.content = FakeContent(sse_lines or [], body, chunks=chunks)
 
     async def read(self):
         return self._body
@@ -201,6 +216,36 @@ class TestEdgeShapedBodiesAreTransport:
         client = _client(max_retries=2)
         session = FakeSession([
             FakeResp(400, body=HTML_PAGE, headers={"Content-Type": "application/json"}),
+            FakeResp(200, sse_lines=TEXT_OK_SSE),
+        ])
+        _wire(monkeypatch, client, session)
+        assert await client._stream_request({"model": "m"}) == "hello"
+        assert session.calls == 2
+
+
+class TestChunkedBodyReassembly:
+    """``StreamReader.read(n)`` returns as soon as ANY bytes are buffered,
+    so classification must reassemble to EOF (or the cap) — a chunked JSON
+    rejection must never be read truncated and retried as transport
+    (round-1 review blocker, reproduced against the production method)."""
+
+    async def test_chunked_json_400_reassembled_fast_fails(self, monkeypatch):
+        client = _client(max_retries=3)
+        mid = len(JSON_ERROR) // 2
+        session = FakeSession([
+            FakeResp(400, chunks=[JSON_ERROR[:mid], JSON_ERROR[mid:]]),
+        ])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError) as ei:
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+        assert "does not exist" in str(ei.value)
+
+    async def test_chunked_html_body_still_transport(self, monkeypatch):
+        client = _client(max_retries=2)
+        session = FakeSession([
+            FakeResp(403, chunks=[HTML_PAGE[:40], HTML_PAGE[40:]]),
             FakeResp(200, sse_lines=TEXT_OK_SSE),
         ])
         _wire(monkeypatch, client, session)
@@ -369,6 +414,86 @@ class TestRaiseSiteInvariant:
         assert resp.content.read_sizes == [_ERROR_BODY_READ_CAP]
         assert f"{_ERROR_BODY_READ_CAP} bytes" in str(ei.value)
 
+    async def test_hostile_content_type_never_reaches_message(self, monkeypatch):
+        """The Content-Type header is upstream-controlled bytes: markup,
+        mentions, and oversized junk must token-validate to 'unknown'
+        (round-1 review blocker)."""
+        client = _client(max_retries=1)
+        hostile = "text/html<html>@everyone " + "x" * 5000
+        session = FakeSession([
+            FakeResp(403, body=b"junk", headers={"Content-Type": hostile}),
+        ])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMTransportError) as ei:
+            await client._stream_request({"model": "m"})
+        msg = str(ei.value)
+        assert "non-JSON error body (unknown, 4 bytes)" in msg
+        assert "<html" not in msg.lower()
+        assert "@everyone" not in msg
+        assert len(msg) < 300
+
+
+class TestStreamErrorEventSanitized:
+    """SSE terminal events are upstream-controlled dicts: their fields get
+    the same bounded known-field treatment as HTTP bodies — classification
+    and ``.code`` semantics ride the parsed attributes, never the message
+    (round-1 review blocker)."""
+
+    def _sse(self, event: dict) -> list[str]:
+        return [f"data: {json.dumps(event)}\n"]
+
+    async def test_transport_class_event_message_sanitized(self, monkeypatch):
+        client = _client(max_retries=1)
+        event = {
+            "type": "response.failed",
+            "response": {"error": {
+                "type": "weird_failure",
+                "message": "<html><body>@everyone attack</body></html>",
+            }},
+        }
+        session = FakeSession([FakeResp(200, sse_lines=self._sse(event))])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMTransportError) as ei:
+            await client._stream_request({"model": "m"})
+        msg = str(ei.value)
+        assert "weird_failure" in msg  # sanitized known field survives
+        assert "<html" not in msg.lower()
+        assert "@everyone" not in msg
+        assert '"response"' not in msg  # no raw event dump
+
+    async def test_request_class_event_keeps_code_with_clean_message(self, monkeypatch):
+        client = _client(max_retries=3)
+        event = {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded",
+                "message": "<html>hidden page</html>",
+            },
+        }
+        session = FakeSession([FakeResp(200, sse_lines=self._sse(event))])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError) as ei:
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1  # fast-fail semantics unchanged
+        assert ei.value.code == "context_length_exceeded"  # .code unchanged
+        msg = str(ei.value)
+        assert "invalid_request_error" in msg
+        assert "<html" not in msg.lower()
+
+    async def test_unstructured_event_gets_placeholder(self, monkeypatch):
+        client = _client(max_retries=1)
+        event = {"type": "response.failed", "response": {"error": "just a string"}}
+        session = FakeSession([FakeResp(200, sse_lines=self._sse(event))])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMTransportError) as ei:
+            await client._stream_request({"model": "m"})
+        assert "unstructured stream error event" in str(ei.value)
+
 
 # ---------------------------------------------------------------------------
 # Helper units
@@ -385,6 +510,26 @@ class TestParseStructuredError:
         assert _parse_structured_error('{"error": {"code": "x"}}') == {"error": {"code": "x"}}
 
 
+class TestSafeMime:
+    def test_valid_tokens_pass(self):
+        from src.llm.openai_codex import _safe_mime
+
+        assert _safe_mime("text/html; charset=utf-8") == "text/html"
+        assert _safe_mime("Application/JSON") == "application/json"
+        assert _safe_mime("application/problem+json") == "application/problem+json"
+
+    def test_hostile_or_malformed_render_unknown(self):
+        from src.llm.openai_codex import _safe_mime
+
+        assert _safe_mime(None) == "unknown"
+        assert _safe_mime("") == "unknown"
+        assert _safe_mime("text/html<html>@everyone") == "unknown"
+        assert _safe_mime("no-slash") == "unknown"
+        assert _safe_mime("a/b/c") == "unknown"
+        assert _safe_mime("text/" + "x" * 100) == "unknown"
+        assert _safe_mime("text html/weird space") == "unknown"
+
+
 class TestDescribeErrorBody:
     def test_non_structured_shape_only(self):
         out = _describe_error_body("text/html; charset=utf-8", b"x" * 8437, None)
@@ -392,6 +537,12 @@ class TestDescribeErrorBody:
 
     def test_missing_content_type(self):
         assert _describe_error_body(None, b"zz", None) == "non-JSON error body (unknown, 2 bytes)"
+
+    def test_structured_field_mentions_neutralized(self):
+        structured = {"error": {"message": "notify @everyone now"}}
+        out = _describe_error_body(None, b"{}", structured)
+        assert "@everyone" not in out
+        assert "everyone" in out
 
     def test_structured_extracts_and_dedupes_fields(self):
         structured = {

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -584,6 +584,16 @@ class TestSafeMime:
         assert _safe_mime("a/b/c") == "unknown"
         assert _safe_mime("text/" + "x" * 100) == "unknown"
         assert _safe_mime("text html/weird space") == "unknown"
+        assert _safe_mime("text/") == "unknown"
+        assert _safe_mime("/html") == "unknown"
+        assert _safe_mime("tëxt/html") == "unknown"
+
+    def test_token_shaped_secret_renders_unknown(self):
+        from src.llm.openai_codex import _safe_mime
+
+        secret = "sk-" + "A" * 32
+        assert len(f"application/{secret}") <= 64
+        assert _safe_mime(f"application/{secret}") == "unknown"
 
 
 class TestDescribeErrorBody:

--- a/tests/test_edge_error_recovery.py
+++ b/tests/test_edge_error_recovery.py
@@ -252,6 +252,33 @@ class TestChunkedBodyReassembly:
         assert await client._stream_request({"model": "m"}) == "hello"
         assert session.calls == 2
 
+    async def test_valid_json_prefix_with_unread_suffix_is_transport(self, monkeypatch):
+        """A valid JSON object padded to exactly the read cap, followed by
+        unread edge bytes, must not fast-fail from the truncated prefix."""
+        prefix = JSON_ERROR + b" " * (_ERROR_BODY_READ_CAP - len(JSON_ERROR))
+        resp = FakeResp(400, chunks=[prefix, HTML_PAGE])
+        client = _client(max_retries=1)
+        session = FakeSession([resp])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMTransportError):
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+        assert resp.content.read_sizes == [_ERROR_BODY_READ_CAP, 1]
+
+    async def test_valid_json_body_exactly_at_cap_stays_request_class(self, monkeypatch):
+        """Hitting the cap is not itself overflow when the next read is EOF."""
+        body = JSON_ERROR + b" " * (_ERROR_BODY_READ_CAP - len(JSON_ERROR))
+        resp = FakeResp(400, body=body)
+        client = _client(max_retries=3)
+        session = FakeSession([resp])
+        _wire(monkeypatch, client, session)
+
+        with pytest.raises(LLMRequestError):
+            await client._stream_request({"model": "m"})
+        assert session.calls == 1
+        assert resp.content.read_sizes == [_ERROR_BODY_READ_CAP, 1]
+
 
 class TestStructuredBodiesStayRequestClass:
     async def test_json_403_fast_fails_one_attempt(self, monkeypatch):
@@ -411,7 +438,7 @@ class TestRaiseSiteInvariant:
 
         with pytest.raises(LLMTransportError) as ei:
             await client._stream_request({"model": "m"})
-        assert resp.content.read_sizes == [_ERROR_BODY_READ_CAP]
+        assert resp.content.read_sizes == [_ERROR_BODY_READ_CAP, 1]
         assert f"{_ERROR_BODY_READ_CAP} bytes" in str(ei.value)
 
     async def test_hostile_content_type_never_reaches_message(self, monkeypatch):

--- a/tests/test_error_presentation.py
+++ b/tests/test_error_presentation.py
@@ -188,3 +188,10 @@ class TestSanitizeErrorText:
     def test_total_on_weird_input(self):
         assert isinstance(sanitize_error_text(None), str)  # type: ignore[arg-type]
         assert isinstance(sanitize_error_text(12345), str)  # type: ignore[arg-type]
+
+    def test_internal_failure_returns_empty(self):
+        class _BrokenStr:
+            def __str__(self):
+                raise ValueError("no string for you")
+
+        assert sanitize_error_text(_BrokenStr()) == ""  # type: ignore[arg-type]

--- a/tests/test_error_presentation.py
+++ b/tests/test_error_presentation.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import discord
-from src.error_presentation import format_user_facing_error
+from src.error_presentation import format_user_facing_error, sanitize_error_text
 
 CF_HTML = (
     "<html>\n  <head>\n    <title>Internal Server Error</title>\n  </head>\n"
@@ -156,3 +156,35 @@ class TestSecretScrubbing:
         )
         assert "abcdef0123456789" not in out
         assert "[REDACTED]" in out
+
+
+class TestSanitizeErrorText:
+    """String-input sibling of the formatter, used where reasons arrive as
+    text (subsystem guard storage) rather than as exceptions."""
+
+    def test_safe_literals_pass_through(self):
+        assert sanitize_error_text("manual") == "manual"
+        assert sanitize_error_text("capacity") == "capacity"
+        assert sanitize_error_text("") == ""
+
+    def test_html_page_dropped_entirely(self):
+        assert sanitize_error_text("<html>\n<body>edge error</body></html>") == ""
+
+    def test_first_line_only_and_bounded(self):
+        out = sanitize_error_text("first line " + "x" * 500 + "\nsecond line")
+        assert "second line" not in out
+        assert len(out) <= 200
+
+    def test_control_chars_stripped_mentions_neutralized(self):
+        out = sanitize_error_text("bad\x00\x1f @everyone thing")
+        assert "\x00" not in out
+        assert "@everyone" not in out
+        assert "everyone" in out  # neutralized, not deleted
+
+    def test_secrets_scrubbed(self):
+        out = sanitize_error_text("auth failed for sk-" + "a" * 24)
+        assert "sk-" + "a" * 24 not in out
+
+    def test_total_on_weird_input(self):
+        assert isinstance(sanitize_error_text(None), str)  # type: ignore[arg-type]
+        assert isinstance(sanitize_error_text(12345), str)  # type: ignore[arg-type]

--- a/tests/test_loop_error_sanitization.py
+++ b/tests/test_loop_error_sanitization.py
@@ -1,0 +1,62 @@
+"""Loop-manager error-text boundary (B2 of the 2026-08-14 sanitization).
+
+The iteration-history deque is next-iteration model context AND the WebUI
+loop detail; the stop/crash messages post to the channel. None of them may
+carry raw exception text (provider errors can embed whole HTML pages).
+"""
+from __future__ import annotations
+
+import asyncio
+
+# ---------------------------------------------------------------------------
+# Loop-manager boundary (B2): channel posts + iteration history
+# ---------------------------------------------------------------------------
+
+class _FakeChannel:
+    def __init__(self):
+        self.sent: list[str] = []
+
+    async def send(self, text):
+        self.sent.append(text)
+
+
+class TestLoopManagerErrorTextSanitized:
+    async def test_history_and_channel_posts_carry_no_markup(self, monkeypatch):
+        """A provider exception whose text smuggles HTML must reach neither
+        the iteration history (model context + WebUI loop detail) nor the
+        channel stop message."""
+
+        import src.tools.autonomous_loop as al
+
+        monkeypatch.setattr(al, "MIN_INTERVAL_SECONDS", 0)
+        mgr = al.LoopManager()
+        channel = _FakeChannel()
+
+        async def exploding_iteration(prompt, ch, prev_context):
+            raise RuntimeError("<html><body>@everyone edge page</body></html>")
+
+        loop_id = mgr.start_loop(
+            goal="g",
+            channel=channel,
+            requester_id="u1",
+            requester_name="user",
+            iteration_callback=exploding_iteration,
+            interval_seconds=0,
+            max_iterations=al.MAX_CONSECUTIVE_ERRORS + 2,
+        )
+        assert not loop_id.startswith("Error")
+        for _ in range(200):
+            info = mgr._loops.get(loop_id)
+            if info is not None and info.status == "error":
+                break
+            await asyncio.sleep(0.05)
+        info = mgr._loops[loop_id]
+        assert info.status == "error"
+
+        history = list(info._iteration_history)
+        assert history, "expected error entries in iteration history"
+        joined = "\n".join(history) + "\n" + "\n".join(channel.sent)
+        assert "<html" not in joined.lower()
+        assert "@everyone" not in joined  # neutralized by the formatter
+        assert any("RuntimeError" in h for h in history)
+        assert any("stopped after" in s for s in channel.sent)

--- a/tests/test_subsystem_guard.py
+++ b/tests/test_subsystem_guard.py
@@ -1019,3 +1019,55 @@ class TestEdgeCases:
         guard.register("voice", initial_state=SubsystemState.UNAVAILABLE)
         status = guard.get_status()
         assert status["overall"] == "degraded"  # unavailable present = degraded overall
+
+
+class TestReasonSanitizedAtEntry:
+    """last_failure_reason is serialized by /api/subsystems/status and
+    reasons flow into transition history — every reason-accepting entry
+    point stores the sanitized form, so no caller (e.g. llm_gateway passing
+    str(exc)) can persist raw upstream bytes."""
+
+    HTML_REASON = "<html><body>@everyone edge page</body></html>"
+
+    def _guard(self):
+        guard = SubsystemGuard()
+        guard.register("llm_codex")
+        return guard
+
+    def _stored(self, guard):
+        return guard._subsystems["llm_codex"].last_failure_reason
+
+    def test_record_failure_reason_sanitized(self):
+        guard = self._guard()
+        guard.record_failure("llm_codex", self.HTML_REASON)
+        assert "<html" not in self._stored(guard).lower()
+
+    def test_mark_degraded_reason_sanitized(self):
+        guard = self._guard()
+        guard.mark_degraded("llm_codex", self.HTML_REASON)
+        assert "<html" not in self._stored(guard).lower()
+
+    def test_mark_unavailable_reason_sanitized(self):
+        guard = self._guard()
+        guard.mark_unavailable("llm_codex", self.HTML_REASON)
+        assert "<html" not in self._stored(guard).lower()
+
+    def test_mark_degraded_transient_reason_sanitized(self):
+        guard = self._guard()
+        guard.mark_degraded_transient("llm_codex", self.HTML_REASON)
+        assert "<html" not in self._stored(guard).lower()
+
+    def test_transition_history_reason_sanitized(self):
+        guard = self._guard()
+        guard.mark_degraded("llm_codex", "boom @everyone <html>x</html>")
+        transitions = guard.stats.transition_log
+        assert transitions
+        for t in transitions:
+            reason = str(t.get("reason", ""))
+            assert "<html" not in reason.lower()
+            assert "@everyone" not in reason
+
+    def test_safe_reasons_unchanged(self):
+        guard = self._guard()
+        guard.record_failure("llm_codex", "connection refused")
+        assert self._stored(guard) == "connection refused"


### PR DESCRIPTION
## What

Implements the design we settled on 2026-08-14 (`/home/odin/reviews/design-transient-edge-errors.md` + your review amendments, all adopted): transient edge failures become recoverable instead of turn-ending, and every remaining error-presentation boundary routes through the shared formatter.

**Origin incident (2026-08-14 09:37 EDT):** one request to the Codex backend returned HTTP 403 carrying chatgpt.com's styled HTML error page (not JSON). The catch-all status branch classified it `LLMRequestError`, recovery fast-failed it, a healthy turn died on ONE HTTP attempt — and `_llm_error_done` posted the raw HTML verbatim into Discord. The pool was healthy throughout; the next turn 2 minutes later succeeded.

## Commit 1 — `fix(llm)`: edge-shaped error bodies are transport, not request

Classification matrix in `_send_with_retries`, exactly per your amendment (5xx evaluated BEFORE body discrimination):

1. `401` → refresh/rotation semantics bit-exact
2. `429` → quota/rotation semantics bit-exact
3. `500/502/503/504` → transport regardless of body shape (a structured JSON 500 keeps retrying)
4. Remaining statuses → body-bytes authority (`_parse_structured_error`): JSON **object** = the API spoke → `LLMRequestError` fast-fail, unchanged; anything else (HTML / empty / non-dict JSON / junk) → joins the transport branch (breaker count + backoff + in-client retries, exhaustion → `LLMTransportError` → deadline recovery keeps retrying)

Settled Q1/Q2: JSON-parse of body bytes is authority, Content-Type is diagnostic only; empty body = transport; any dict counts as structured, including `{}`.

Raise-site hygiene (your Part-D resolution — "bit-exact" = control flow, message construction becomes safe everywhere):
- Error-body read capped at 64K (`_ERROR_BODY_READ_CAP`) — a hostile edge can't trade an error page for memory
- One `_describe_error_body` helper across 401/429/5xx/catch-all: non-structured → `non-JSON error body (mime, N bytes)`, no excerpt, no `<title>`; structured → sanitized known fields (`error.message/type/code`, `detail`, `message`; control-strip, HTML-bearing values dropped, secret-scrubbed, bounded), else `structured JSON error body`
- Invariant (parametrized pin): no raised LLMError message ever contains `<html`/`<!doctype` — including a structured dict whose *field value* smuggles markup
- Scope note: SSE-path messages (`CodexStreamError`) are re-dumps of parsed JSON events, never raw body bytes — left as-is per the settled scope

## Commit 2 — `fix(errors)`: every user-facing surface through the shared formatter

Your full inventory, all six sites:

| Site | Change |
|---|---|
| `tool_loop._llm_error_done` | chat reply + WebUI `response` field + trajectory `final_response` (Traces page) all carry `format_user_facing_error()`; journal keeps full detail via `exc_info` |
| `tool_loop._call_loop_llm` | loop outcome text, trajectory error, reflection `error_text` formatted |
| `LoopManager` (`autonomous_loop.py`) | iteration-history entries (model context + WebUI loop detail) and channel stop/crash posts formatted |
| `agent.error` — recovery-terminal path | formatted; FAILED transition reason formatted (state_history is API- and trajectory-visible); `exc_info` added |
| `agent.error` — outer crash path | same treatment; crash log gains `exc_info` so diagnostics improve, not disappear |
| `SubsystemGuard` | reasons sanitized at all four reason-accepting entry points via new `sanitize_error_text()` (string sibling of the formatter) — covers `last_failure_reason` on `/api/subsystems/status` AND transition history for every caller |

## Invariants held

- Anti-hedging guards / completion classifier / response guards untouched (error paths only)
- 429/401 rotation + quota semantics bit-exact (pinned: HTML-bodied 401 still refreshes-then-retries; HTML-bodied 429 still marks limited)
- v3.69.0 structured-4xx fast-fail unchanged (pinned at one attempt); v3.74.0 SSE classification + `.code` untouched
- No new config knobs; no account rotation for edge-shaped errors
- Part B (transport-exhaustion suspend) deliberately NOT here — deferred to its own cause-aware durability design per your Q3 verdict

## Tests (+120 net)

- `tests/test_edge_error_recovery.py` (new): full classification matrix incl. your additions — JSON-500-still-retries, lying Content-Types both directions, HTML 401/429 control-flow-bit-exact with clean text, structured-dict-with-HTML-field can't leak, bounded-read proof, descriptor units. Mutation-verified: reverting the classification kills 8 pins.
- `tests/test_loop_error_sanitization.py` (new): LoopManager history + channel posts through the production loop task
- Boundary pins in `test_agent_lifecycle.py` (both paths + state_history reason), `test_subsystem_guard.py` (all four entries + transition log), `test_error_presentation.py` (`sanitize_error_text`), characterization batteries in `test_chat_tool_loop.py` (incl. trajectory `final_response` via a recording saver) + `test_autonomous_loop.py` (reflection `error_text`)
- Intentional surface change, pins updated to exact new strings: error text is now formatter-shaped (`LLM API error: RuntimeError: boom`), 4 pre-existing pins updated with comments
- `FakeResp` in `test_codex_reliability.py` upgraded to a dual StreamReader stand-in (async-iter + `read(n)`) mirroring aiohttp

## Gates

Full suite green, ruff 0 (src+tests), lint-gate new=0, type-gate new=0, coverage gate green — exact numbers in the review request.
