### PR TITLE
Context-budget campaign phase 1: contracts & configuration kernel

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -46,7 +46,9 @@ openai_codex:
     keepalive_timeout: 30
   context_compression:
     enabled: true
-    max_context_chars: 750000
+    # null = auto: the ceiling derives from the active model's input budget
+    # (a number only lowers the derived target, never raises it)
+    max_context_chars: null
     keep_recent_iterations: 30
   # Auxiliary model: when enabled, a cheaper Codex model runs the background
   # jobs (compaction, reflection, consolidation, background follow-up) with

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -66,10 +66,10 @@
   "statements": 30
  },
  "src/config/migrations.py": {
-  "covered": 44,
-  "missing": 2,
-  "percent": 95.65,
-  "statements": 46
+  "covered": 49,
+  "missing": 0,
+  "percent": 100.0,
+  "statements": 49
  },
  "src/config/schema.py": {
   "covered": 628,

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -66,16 +66,16 @@
   "statements": 30
  },
  "src/config/migrations.py": {
-  "covered": 49,
+  "covered": 184,
   "missing": 0,
   "percent": 100.0,
-  "statements": 49
+  "statements": 184
  },
  "src/config/schema.py": {
-  "covered": 628,
+  "covered": 706,
   "missing": 1,
-  "percent": 99.84,
-  "statements": 629
+  "percent": 99.86,
+  "statements": 707
  },
  "src/constants.py": {
   "covered": 17,

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -65,6 +65,12 @@
   "percent": 100.0,
   "statements": 30
  },
+ "src/config/migrations.py": {
+  "covered": 44,
+  "missing": 2,
+  "percent": 95.65,
+  "statements": 46
+ },
  "src/config/schema.py": {
   "covered": 628,
   "missing": 1,
@@ -436,6 +442,12 @@
   "missing": 27,
   "percent": 93.28,
   "statements": 402
+ },
+ "src/llm/context_budget.py": {
+  "covered": 45,
+  "missing": 0,
+  "percent": 100.0,
+  "statements": 45
  },
  "src/llm/context_compressor.py": {
   "covered": 165,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,12 +82,23 @@ openai_codex:
     max_delay: 30.0
   context_compression:
     enabled: true
-    max_context_chars: 48000
+    max_context_chars: null      # null = auto (model-derived ceiling); a number only lowers it
     keep_recent_iterations: 3
+  # Per-model usable-input-budget overrides (tokens, 50192-2000000). Empty =
+  # built-in known-safe floors. Consumed by the context-budget resolver.
+  context_budget_overrides: {}
+  # Working-set policy: percent of the effective budget compaction targets
+  # (30-100). Never reduces budgets at or below 272K tokens.
+  context_utilization: 60
   auxiliary:                     # cheaper model for background jobs
     enabled: false
     model: gpt-5.6-luna
 ```
+
+A persisted `max_context_chars: 750000` from the pre-campaign default is
+migrated to auto once (a provenance marker under `data/` records it, and one
+warning names the marker); saving the compression settings afterwards makes
+any explicit value — including 750000 — stick permanently.
 
 Reasoning effort `max` is served only by the gpt-5.6 family (sol/terra/luna);
 gpt-5.5 rejects it per-request. Odin refuses a known-incompatible model/effort

--- a/src/config/apply_registry.py
+++ b/src/config/apply_registry.py
@@ -1007,9 +1007,26 @@ FIELDS: dict[str, FieldSpec] = {
     "openai_codex.context_compression.max_context_chars": FieldSpec(
         apply_mode="restart",
         unit="characters",
-        description="Context size at which compression begins.",
+        description="Context size at which compression begins. Null means "
+        "auto: the per-model budget resolver derives the ceiling once wired "
+        "(context-budget campaign); until then auto equals the legacy "
+        "750,000. An explicit value only lowers the derived target.",
         restart_reason="The compressor holds the configuration object it was "
         "built with, which a save replaces rather than updates.",
+    ),
+    "openai_codex.context_budget_overrides": FieldSpec(
+        apply_mode="dormant",
+        unit="tokens",
+        description="Stored per-model usable-input-budget overrides; the "
+        "budget resolver that consumes them is not wired to any runtime "
+        "surface yet (context-budget campaign phase 3).",
+    ),
+    "openai_codex.context_utilization": FieldSpec(
+        apply_mode="dormant",
+        unit="percent",
+        description="Stored working-set utilization policy; the budget "
+        "resolver that consumes it is not wired to any runtime surface yet "
+        "(context-budget campaign phase 3).",
     ),
     "openai_codex.context_compression.keep_recent_iterations": FieldSpec(
         apply_mode="restart",

--- a/src/config/migrations.py
+++ b/src/config/migrations.py
@@ -1,36 +1,40 @@
-"""One-time, provenance-gated config migrations.
+"""One-time config migrations.
 
-Currently one migration: the legacy soft-compaction ceiling. For years the
-shipped default was ``max_context_chars: 750_000`` and most persisted
-configs materialized it verbatim. The context-budget campaign makes null
-("auto", model-derived) the schema default — a stale materialized 750_000
-would silently pin every install to the pre-campaign ceiling and defeat the
-feature (settled design, 2026-08-17).
+Currently one: the legacy soft-compaction ceiling. For years the shipped
+default was ``max_context_chars: 750_000`` and most persisted configs
+materialized it verbatim. The context-budget campaign makes null ("auto",
+model-derived) the schema default — a stale materialized 750_000 would
+silently pin every install to the pre-campaign ceiling and defeat the
+feature (plan of record R2, 2026-08-17).
 
-Mechanism — the "records migration completion" branch of the settled design:
-``load_config`` never rewrites config.yml (the file may carry environment
-placeholders and operator comments a YAML round-trip would destroy).
-Instead the marker file under ``data/`` is a two-state provenance ledger for
-the standing persisted value:
+Mechanism — the R2 primary branch: a genuine one-time ``750000 → null``
+rewrite of the config file, through the persistence layer's surgical
+comment/placeholder-preserving writer, gated by a completion marker:
 
-- value equals the legacy default EXACTLY and no marker exists → legacy
-  provenance: interpret as auto in memory, log one WARNING, write the
-  marker. The file itself is untouched.
-- marker exists WITHOUT operator provenance → the standing 750_000 is still
-  legacy: keep the auto interpretation, log at INFO (the file still says
-  750_000, so the reinterpretation must never be silent).
-- marker carries ``operator_saved`` → the persistence layer has since
-  written the compression section deliberately: whatever the file says —
-  including an intentional 750_000 — is honored verbatim, forever.
+- No marker + the file LITERALLY says ``750000`` (checked on the
+  UNSUBSTITUTED text — a ``${VAR}`` placeholder that happens to resolve to
+  750000 is deliberate operator configuration, never migrated): rewrite that
+  one leaf to null, log ONE warning, record completion. The ambiguous
+  standing value is gone from disk, so nothing can later mistake it for an
+  explicit choice.
+- No marker + any other value (null, absent, explicit, placeholder): record
+  completion vacuously. This closes the fresh-install hole — an operator who
+  later hand-writes ``750000`` is past the gate and honored verbatim.
+- Marker present: the gate never fires again. Whatever the file says —
+  including a deliberate post-migration ``750000`` — loads verbatim.
 
-The save path never DELETES the marker (a bare deletion would make the
-still-materialized 750_000 look legacy again on the next load); it stamps
-operator provenance onto it. Hand-editors who want exactly 750_000 without
-saving through the UI can stamp the marker themselves; every log line names
-the file.
+Failure honesty: if the rewrite cannot be persisted, the value is
+interpreted as auto for THIS boot only, a warning says so, and NO completion
+is recorded — the migration retries next boot. If the rewrite lands but the
+marker write fails, the next boot takes the vacuous branch (the file no
+longer says 750000) and self-heals the marker.
 
-A marker-write failure degrades gracefully: the in-memory interpretation
-still applies for this boot and the migration simply retries next boot.
+Paths on packaged installs: ``/opt/odin/config.yml`` is a symlink into
+``/etc/odin``. The REWRITE resolves the symlink and patches the real target
+(the atomic writer replaces its destination inode — writing the unresolved
+path would sever the link). The MARKER deliberately does NOT resolve: the
+durable data directory lives beside the symlink (``/opt/odin/data``), which
+is what the data backup covers.
 """
 
 from __future__ import annotations
@@ -40,122 +44,110 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
+import yaml
+
 from .schema import LEGACY_MAX_CONTEXT_CHARS
 
 log = logging.getLogger("odin.config")
 
 LEGACY_CEILING_MARKER_NAME = "context_ceiling_migration.json"
 
+_CEILING_PATH = ("openai_codex", "context_compression", "max_context_chars")
+
 
 def ceiling_marker_path(config_path: str | Path) -> Path:
-    """Marker location: the ``data`` dir beside the config file."""
-    return Path(config_path).resolve().parent / "data" / LEGACY_CEILING_MARKER_NAME
+    """Completion marker beside the config path AS GIVEN (symlink unresolved)."""
+    return Path(config_path).absolute().parent / "data" / LEGACY_CEILING_MARKER_NAME
 
 
-def apply_legacy_ceiling_migration(data: dict, config_path: str | Path) -> None:
-    """Reinterpret a legacy-default soft-compaction ceiling as auto.
+def _literal_ceiling_value(original_raw: str) -> object:
+    """The ceiling value as WRITTEN in the file, before env substitution.
 
-    Mutates the RAW config dict (pre-pydantic) in place. Only the exact
-    legacy default is ever touched; any other explicit value — and a
-    deliberate 750_000 whose marker carries operator provenance — passes
-    through untouched.
+    Returns the parsed scalar (int for a literal number, str for a ``${VAR}``
+    placeholder) or None when absent/unparseable — only an exact literal
+    ``750000`` int qualifies as the legacy default.
     """
-    codex = data.get("openai_codex")
-    if not isinstance(codex, dict):
-        return
-    compression = codex.get("context_compression")
-    if not isinstance(compression, dict):
-        return
-    if compression.get("max_context_chars") != LEGACY_MAX_CONTEXT_CHARS:
-        return
+    try:
+        node: object = yaml.safe_load(original_raw)
+    except yaml.YAMLError:
+        return None
+    for segment in _CEILING_PATH:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(segment)
+    return node
 
+
+def _record_completion(marker: Path, reason: str) -> None:
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(
+            json.dumps(
+                {
+                    "migration": "legacy_max_context_chars_to_auto",
+                    "reason": reason,
+                    "completed_at": datetime.now(UTC).isoformat(),
+                },
+                indent=2,
+            )
+        )
+    except OSError as exc:
+        # Self-healing: after a successful rewrite the file no longer says
+        # 750000, so the next boot records completion via the vacuous branch.
+        log.warning(
+            "Could not record ceiling-migration completion at %s: %s", marker, exc
+        )
+
+
+def apply_legacy_ceiling_migration(
+    data: dict, config_path: str | Path, original_raw: str
+) -> None:
+    """Run the one-time legacy-ceiling migration gate.
+
+    ``data`` is the substituted raw config dict (pre-pydantic), mutated in
+    place only when the migration fires; ``original_raw`` is the file text
+    BEFORE env substitution, used to distinguish a literal legacy default
+    from a placeholder-resolved value.
+    """
     marker = ceiling_marker_path(config_path)
     if marker.exists():
-        if _marker_has_operator_provenance(marker):
-            # The compression section was deliberately saved at some point:
-            # the persisted value is operator-authored, honor it verbatim.
-            return
-        compression["max_context_chars"] = None
-        log.info(
-            "max_context_chars %d carries legacy provenance; interpreting as "
-            "auto (model-derived). Save the compression settings once to make "
-            "an explicit value stick (provenance ledger: %s).",
-            LEGACY_MAX_CONTEXT_CHARS,
-            marker,
+        return
+
+    if _literal_ceiling_value(original_raw) != LEGACY_MAX_CONTEXT_CHARS:
+        _record_completion(marker, reason="not_applicable")
+        return
+
+    try:
+        # Resolve the symlink so the atomic replace lands on the real file
+        # instead of severing a packaged /opt→/etc link. The surgical writer
+        # preserves comments, ordering, and unrelated ${VAR} placeholders.
+        from .persistence import patch_config_paths
+
+        patch_config_paths(
+            [(_CEILING_PATH, None)], path=Path(config_path).resolve()
+        )
+    except Exception as exc:  # noqa: BLE001 — boot must not die on migration I/O
+        compression = data.get("openai_codex", {}).get("context_compression")
+        if isinstance(compression, dict):
+            compression["max_context_chars"] = None
+        log.warning(
+            "Could not rewrite legacy max_context_chars to auto (%s); "
+            "interpreting as auto for this boot only — the migration retries "
+            "next boot.",
+            exc,
         )
         return
 
-    compression["max_context_chars"] = None
-
+    compression = data.get("openai_codex", {}).get("context_compression")
+    if isinstance(compression, dict):
+        compression["max_context_chars"] = None
     log.warning(
-        "Migrated legacy max_context_chars %d to auto (model-derived). The "
-        "config file is not modified; provenance is recorded at %s. Saving "
-        "the compression settings makes any explicit value — including "
-        "%d — stick permanently.",
+        "Migrated legacy max_context_chars %d to auto (model-derived): the "
+        "config file now records null for this setting. Completion recorded "
+        "at %s; any explicit value set from now on — including %d — is "
+        "honored verbatim.",
         LEGACY_MAX_CONTEXT_CHARS,
         marker,
         LEGACY_MAX_CONTEXT_CHARS,
     )
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(
-            json.dumps(
-                {
-                    "migration": "legacy_max_context_chars_to_auto",
-                    "legacy_value": LEGACY_MAX_CONTEXT_CHARS,
-                    "migrated_at": datetime.now(UTC).isoformat(),
-                },
-                indent=2,
-            )
-        )
-    except OSError as exc:
-        log.warning(
-            "Could not record the ceiling-migration marker at %s (%s); the "
-            "auto interpretation still applies this boot and the migration "
-            "retries next boot.",
-            marker,
-            exc,
-        )
-
-
-def _marker_has_operator_provenance(marker: Path) -> bool:
-    try:
-        recorded = json.loads(marker.read_text())
-    except (OSError, ValueError):
-        # Unreadable/corrupt marker: fail toward the legacy interpretation —
-        # the conservative direction (auto), and the next deliberate save
-        # rewrites the marker cleanly.
-        return False
-    return isinstance(recorded, dict) and bool(recorded.get("operator_saved"))
-
-
-def record_ceiling_operator_provenance(config_path: str | Path) -> None:
-    """Deliberate persistence of compression settings stamps operator provenance.
-
-    Called by the config persistence layer whenever the compression section
-    is written: from that moment the persisted value is operator-authored
-    and must be honored verbatim on every future load — including a
-    deliberate re-set of the legacy 750_000. The marker is stamped, never
-    deleted: a bare deletion would make a still-materialized 750_000 look
-    legacy again on the next load.
-    """
-    marker = ceiling_marker_path(config_path)
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(
-            json.dumps(
-                {
-                    "migration": "legacy_max_context_chars_to_auto",
-                    "operator_saved": True,
-                    "saved_at": datetime.now(UTC).isoformat(),
-                },
-                indent=2,
-            )
-        )
-    except OSError as exc:
-        log.warning(
-            "Could not stamp operator provenance on %s: %s — a persisted "
-            "legacy-equal ceiling may keep its auto interpretation.",
-            marker,
-            exc,
-        )
+    _record_completion(marker, reason="migrated")

--- a/src/config/migrations.py
+++ b/src/config/migrations.py
@@ -1,0 +1,161 @@
+"""One-time, provenance-gated config migrations.
+
+Currently one migration: the legacy soft-compaction ceiling. For years the
+shipped default was ``max_context_chars: 750_000`` and most persisted
+configs materialized it verbatim. The context-budget campaign makes null
+("auto", model-derived) the schema default — a stale materialized 750_000
+would silently pin every install to the pre-campaign ceiling and defeat the
+feature (settled design, 2026-08-17).
+
+Mechanism — the "records migration completion" branch of the settled design:
+``load_config`` never rewrites config.yml (the file may carry environment
+placeholders and operator comments a YAML round-trip would destroy).
+Instead the marker file under ``data/`` is a two-state provenance ledger for
+the standing persisted value:
+
+- value equals the legacy default EXACTLY and no marker exists → legacy
+  provenance: interpret as auto in memory, log one WARNING, write the
+  marker. The file itself is untouched.
+- marker exists WITHOUT operator provenance → the standing 750_000 is still
+  legacy: keep the auto interpretation, log at INFO (the file still says
+  750_000, so the reinterpretation must never be silent).
+- marker carries ``operator_saved`` → the persistence layer has since
+  written the compression section deliberately: whatever the file says —
+  including an intentional 750_000 — is honored verbatim, forever.
+
+The save path never DELETES the marker (a bare deletion would make the
+still-materialized 750_000 look legacy again on the next load); it stamps
+operator provenance onto it. Hand-editors who want exactly 750_000 without
+saving through the UI can stamp the marker themselves; every log line names
+the file.
+
+A marker-write failure degrades gracefully: the in-memory interpretation
+still applies for this boot and the migration simply retries next boot.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .schema import LEGACY_MAX_CONTEXT_CHARS
+
+log = logging.getLogger("odin.config")
+
+LEGACY_CEILING_MARKER_NAME = "context_ceiling_migration.json"
+
+
+def ceiling_marker_path(config_path: str | Path) -> Path:
+    """Marker location: the ``data`` dir beside the config file."""
+    return Path(config_path).resolve().parent / "data" / LEGACY_CEILING_MARKER_NAME
+
+
+def apply_legacy_ceiling_migration(data: dict, config_path: str | Path) -> None:
+    """Reinterpret a legacy-default soft-compaction ceiling as auto.
+
+    Mutates the RAW config dict (pre-pydantic) in place. Only the exact
+    legacy default is ever touched; any other explicit value — and a
+    deliberate 750_000 whose marker carries operator provenance — passes
+    through untouched.
+    """
+    codex = data.get("openai_codex")
+    if not isinstance(codex, dict):
+        return
+    compression = codex.get("context_compression")
+    if not isinstance(compression, dict):
+        return
+    if compression.get("max_context_chars") != LEGACY_MAX_CONTEXT_CHARS:
+        return
+
+    marker = ceiling_marker_path(config_path)
+    if marker.exists():
+        if _marker_has_operator_provenance(marker):
+            # The compression section was deliberately saved at some point:
+            # the persisted value is operator-authored, honor it verbatim.
+            return
+        compression["max_context_chars"] = None
+        log.info(
+            "max_context_chars %d carries legacy provenance; interpreting as "
+            "auto (model-derived). Save the compression settings once to make "
+            "an explicit value stick (provenance ledger: %s).",
+            LEGACY_MAX_CONTEXT_CHARS,
+            marker,
+        )
+        return
+
+    compression["max_context_chars"] = None
+
+    log.warning(
+        "Migrated legacy max_context_chars %d to auto (model-derived). The "
+        "config file is not modified; provenance is recorded at %s. Saving "
+        "the compression settings makes any explicit value — including "
+        "%d — stick permanently.",
+        LEGACY_MAX_CONTEXT_CHARS,
+        marker,
+        LEGACY_MAX_CONTEXT_CHARS,
+    )
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(
+            json.dumps(
+                {
+                    "migration": "legacy_max_context_chars_to_auto",
+                    "legacy_value": LEGACY_MAX_CONTEXT_CHARS,
+                    "migrated_at": datetime.now(UTC).isoformat(),
+                },
+                indent=2,
+            )
+        )
+    except OSError as exc:
+        log.warning(
+            "Could not record the ceiling-migration marker at %s (%s); the "
+            "auto interpretation still applies this boot and the migration "
+            "retries next boot.",
+            marker,
+            exc,
+        )
+
+
+def _marker_has_operator_provenance(marker: Path) -> bool:
+    try:
+        recorded = json.loads(marker.read_text())
+    except (OSError, ValueError):
+        # Unreadable/corrupt marker: fail toward the legacy interpretation —
+        # the conservative direction (auto), and the next deliberate save
+        # rewrites the marker cleanly.
+        return False
+    return isinstance(recorded, dict) and bool(recorded.get("operator_saved"))
+
+
+def record_ceiling_operator_provenance(config_path: str | Path) -> None:
+    """Deliberate persistence of compression settings stamps operator provenance.
+
+    Called by the config persistence layer whenever the compression section
+    is written: from that moment the persisted value is operator-authored
+    and must be honored verbatim on every future load — including a
+    deliberate re-set of the legacy 750_000. The marker is stamped, never
+    deleted: a bare deletion would make a still-materialized 750_000 look
+    legacy again on the next load.
+    """
+    marker = ceiling_marker_path(config_path)
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(
+            json.dumps(
+                {
+                    "migration": "legacy_max_context_chars_to_auto",
+                    "operator_saved": True,
+                    "saved_at": datetime.now(UTC).isoformat(),
+                },
+                indent=2,
+            )
+        )
+    except OSError as exc:
+        log.warning(
+            "Could not stamp operator provenance on %s: %s — a persisted "
+            "legacy-equal ceiling may keep its auto interpretation.",
+            marker,
+            exc,
+        )

--- a/src/config/migrations.py
+++ b/src/config/migrations.py
@@ -1,50 +1,35 @@
-"""One-time config migrations.
+"""One-time configuration migrations.
 
-Currently one: the legacy soft-compaction ceiling. For years the shipped
-default was ``max_context_chars: 750_000`` and most persisted configs
-materialized it verbatim. The context-budget campaign makes null ("auto",
-model-derived) the schema default — a stale materialized 750_000 would
-silently pin every install to the pre-campaign ceiling and defeat the
-feature (plan of record R2, 2026-08-17).
+The context-budget campaign changes the historical soft-compaction default
+from a materialized ``max_context_chars: 750000`` to ``null`` (automatic,
+model-derived).  This module performs that rewrite exactly once without
+mistaking a later operator-authored 750000 for the shipped default.
 
-Mechanism — the R2 primary branch: a genuine one-time ``750000 → null``
-rewrite of the config file, through the persistence layer's surgical
-comment/placeholder-preserving writer, gated by a completion marker:
+Only the exact scalar shipped in config.yml qualifies.  YAML construction is
+not evidence: it normalizes spellings such as ``750000.0``, ``0xB71B0``, and
+``750_000`` to values equal to 750000.  The gate therefore checks the original
+scalar's token, tag, and style.
 
-- No marker + the file LITERALLY says ``750000`` (checked on the
-  UNSUBSTITUTED text — a ``${VAR}`` placeholder that happens to resolve to
-  750000 is deliberate operator configuration, never migrated): rewrite that
-  one leaf to null, log ONE warning, record completion. The ambiguous
-  standing value is gone from disk, so nothing can later mistake it for an
-  explicit choice.
-- No marker + any other value (null, absent, explicit, placeholder): record
-  completion vacuously. This closes the fresh-install hole — an operator who
-  later hand-writes ``750000`` is past the gate and honored verbatim.
-- Marker present: the gate never fires again. Whatever the file says —
-  including a deliberate post-migration ``750000`` — loads verbatim.
-
-Failure honesty: if the rewrite cannot be persisted, the value is
-interpreted as auto for THIS boot only, a warning says so, and NO completion
-is recorded — the migration retries next boot. If the rewrite lands but the
-marker write fails, the next boot takes the vacuous branch (the file no
-longer says 750000) and self-heals the marker.
-
-Paths on packaged installs: ``/opt/odin/config.yml`` is a symlink into
-``/etc/odin``. The REWRITE resolves the symlink and patches the real target
-(the atomic writer replaces its destination inode — writing the unresolved
-path would sever the link). The MARKER deliberately does NOT resolve: the
-durable data directory lives beside the symlink (``/opt/odin/data``), which
-is what the data backup covers.
+Completion is a versioned, validated record under the unresolved config path's
+sibling ``data`` directory.  Marker path existence alone proves nothing.  The
+record is committed by temp-file write, file fsync, and atomic replacement.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
-from datetime import UTC, datetime
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode
 
 from .schema import LEGACY_MAX_CONTEXT_CHARS
 
@@ -53,83 +38,333 @@ log = logging.getLogger("odin.config")
 LEGACY_CEILING_MARKER_NAME = "context_ceiling_migration.json"
 
 _CEILING_PATH = ("openai_codex", "context_compression", "max_context_chars")
+_MIGRATION_ID = "legacy_max_context_chars_to_auto"
+_MARKER_VERSION = 2
+_COMPLETION_REASONS = frozenset(
+    {
+        "migrated",
+        "not_applicable",
+        "prior_operator_saved",
+        "upgraded_preversioned_completion",
+    }
+)
+
+
+class MigrationCompletionError(RuntimeError):
+    """The migration could not establish durable, unambiguous provenance."""
+
+
+class _MarkerKind(Enum):
+    MISSING = "missing"
+    COMPLETE = "complete"
+    ROUND1_LEGACY = "round1_legacy"
+    ROUND1_OPERATOR = "round1_operator"
+    PREVERSIONED_COMPLETE = "preversioned_complete"
+    EMPTY = "empty"
+    CORRUPT = "corrupt"
+    DIRECTORY = "directory"
+    UNKNOWN = "unknown"
+    UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class _ScalarLexeme:
+    value: str
+    tag: str
+    style: str | None
+    token: str
 
 
 def ceiling_marker_path(config_path: str | Path) -> Path:
-    """Completion marker beside the config path AS GIVEN (symlink unresolved)."""
+    """Return the marker beside *config_path* as given (symlink unresolved)."""
     return Path(config_path).absolute().parent / "data" / LEGACY_CEILING_MARKER_NAME
 
 
-def _literal_ceiling_value(original_raw: str) -> object:
-    """The ceiling value as WRITTEN in the file, before env substitution.
+def _mapping_value(node: Node, key: str) -> Node | None:
+    """Return one unambiguous mapping value; duplicate keys prove nothing."""
+    if not isinstance(node, MappingNode):
+        return None
+    matches = [
+        value_node
+        for key_node, value_node in node.value
+        if isinstance(key_node, ScalarNode)
+        and key_node.tag == "tag:yaml.org,2002:str"
+        and key_node.value == key
+    ]
+    return matches[0] if len(matches) == 1 else None
 
-    Returns the parsed scalar (int for a literal number, str for a ``${VAR}``
-    placeholder) or None when absent/unparseable — only an exact literal
-    ``750000`` int qualifies as the legacy default.
-    """
+
+def _literal_ceiling_lexeme(original_raw: str) -> _ScalarLexeme | None:
+    """Return original token/tag/style evidence for the configured scalar."""
     try:
-        node: object = yaml.safe_load(original_raw)
+        node = yaml.compose(original_raw, Loader=yaml.SafeLoader)
     except yaml.YAMLError:
         return None
+    if node is None:
+        return None
+    current: Node | None = node
     for segment in _CEILING_PATH:
-        if not isinstance(node, dict):
+        if current is None:
             return None
-        node = node.get(segment)
-    return node
+        current = _mapping_value(current, segment)
+    if not isinstance(current, ScalarNode):
+        return None
+    return _ScalarLexeme(
+        value=current.value,
+        tag=current.tag,
+        style=current.style,
+        token=original_raw[current.start_mark.index : current.end_mark.index],
+    )
 
 
-def _record_completion(marker: Path, reason: str) -> None:
+def _is_shipped_legacy_literal(original_raw: str) -> bool:
+    """Only the shipped implicit, unstyled, plain-decimal token qualifies."""
+    scalar = _literal_ceiling_lexeme(original_raw)
+    return bool(
+        scalar is not None
+        and scalar.value == str(LEGACY_MAX_CONTEXT_CHARS)
+        and scalar.tag == "tag:yaml.org,2002:int"
+        and scalar.style is None
+        and scalar.token == str(LEGACY_MAX_CONTEXT_CHARS)
+    )
+
+
+def _is_utc_timestamp(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
     try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(
-            json.dumps(
-                {
-                    "migration": "legacy_max_context_chars_to_auto",
-                    "reason": reason,
-                    "completed_at": datetime.now(UTC).isoformat(),
-                },
-                indent=2,
-            )
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None and parsed.utcoffset() == timedelta(0)
+
+
+def _classify_record(record: object) -> _MarkerKind:
+    if not isinstance(record, dict):
+        return _MarkerKind.UNKNOWN
+
+    if set(record) == {
+        "version",
+        "migration",
+        "state",
+        "reason",
+        "completed_at",
+    }:
+        valid = (
+            type(record["version"]) is int
+            and record["version"] == _MARKER_VERSION
+            and record["migration"] == _MIGRATION_ID
+            and record["state"] == "completed"
+            and isinstance(record["reason"], str)
+            and record["reason"] in _COMPLETION_REASONS
+            and _is_utc_timestamp(record["completed_at"])
         )
+        return _MarkerKind.COMPLETE if valid else _MarkerKind.UNKNOWN
+
+    # Round 1 recorded in-memory reinterpretation without rewriting config.yml.
+    if set(record) == {"migration", "legacy_value", "migrated_at"}:
+        valid = (
+            record["migration"] == _MIGRATION_ID
+            and type(record["legacy_value"]) is int
+            and record["legacy_value"] == LEGACY_MAX_CONTEXT_CHARS
+            and _is_utc_timestamp(record["migrated_at"])
+        )
+        return _MarkerKind.ROUND1_LEGACY if valid else _MarkerKind.UNKNOWN
+
+    # Round 1 could also affirm that a compression save was operator-authored.
+    if set(record) == {"migration", "operator_saved", "saved_at"}:
+        valid = (
+            record["migration"] == _MIGRATION_ID
+            and record["operator_saved"] is True
+            and _is_utc_timestamp(record["saved_at"])
+        )
+        return _MarkerKind.ROUND1_OPERATOR if valid else _MarkerKind.UNKNOWN
+
+    # The first R2 implementation emitted this unversioned completion shape.
+    if set(record) == {"migration", "reason", "completed_at"}:
+        valid = (
+            record["migration"] == _MIGRATION_ID
+            and isinstance(record["reason"], str)
+            and record["reason"] in {"migrated", "not_applicable"}
+            and _is_utc_timestamp(record["completed_at"])
+        )
+        return _MarkerKind.PREVERSIONED_COMPLETE if valid else _MarkerKind.UNKNOWN
+
+    return _MarkerKind.UNKNOWN
+
+
+def _read_marker(marker: Path) -> _MarkerKind:
+    try:
+        raw = marker.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _MarkerKind.MISSING
+    except IsADirectoryError:
+        return _MarkerKind.DIRECTORY
+    except (OSError, UnicodeError):
+        return _MarkerKind.UNREADABLE
+    if not raw.strip():
+        return _MarkerKind.EMPTY
+    try:
+        record: Any = json.loads(raw)
+    except json.JSONDecodeError:
+        return _MarkerKind.CORRUPT
+    return _classify_record(record)
+
+
+def _atomic_write_marker(marker: Path, record: dict[str, object]) -> None:
+    """Commit one marker revision via temp-file, file fsync, and replace."""
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(record, indent=2, sort_keys=True) + "\n"
+    fd, temporary_name = tempfile.mkstemp(
+        dir=marker.parent,
+        prefix=f".{marker.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    stream = None
+    try:
+        os.fchmod(fd, 0o600)
+        stream = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        stream = None
+        os.replace(temporary, marker)
+    except BaseException:
+        if stream is not None:
+            with contextlib.suppress(OSError):
+                stream.close()
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(OSError):
+            temporary.unlink()
+        raise
+
+    # The replace is already committed.  Directory fsync is best effort on
+    # filesystems that support it and cannot truthfully roll that commit back.
+    with contextlib.suppress(OSError):
+        directory_fd = os.open(marker.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+
+def _completion_record(reason: str) -> dict[str, object]:
+    return {
+        "version": _MARKER_VERSION,
+        "migration": _MIGRATION_ID,
+        "state": "completed",
+        "reason": reason,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _write_required(marker: Path, reason: str, purpose: str) -> None:
+    try:
+        _atomic_write_marker(marker, _completion_record(reason))
     except OSError as exc:
-        # Self-healing: after a successful rewrite the file no longer says
-        # 750000, so the next boot records completion via the vacuous branch.
+        log.error("Could not %s at %s: %s", purpose, marker, exc)
+        raise MigrationCompletionError(
+            f"could not {purpose}; configuration was left unchanged"
+        ) from exc
+
+
+def _record_after_rewrite(marker: Path) -> None:
+    try:
+        _atomic_write_marker(marker, _completion_record("migrated"))
+    except OSError as exc:
+        # The ambiguous value is already gone.  A later load takes the
+        # non-legacy branch and safely retries this completion write.
         log.warning(
-            "Could not record ceiling-migration completion at %s: %s", marker, exc
+            "Could not record ceiling-migration completion at %s: %s; "
+            "the rewritten config is safe and completion retries next boot.",
+            marker,
+            exc,
         )
 
 
-def apply_legacy_ceiling_migration(
-    data: dict, config_path: str | Path, original_raw: str
-) -> None:
-    """Run the one-time legacy-ceiling migration gate.
+def _set_runtime_auto(data: dict) -> None:
+    codex = data.get("openai_codex")
+    if not isinstance(codex, dict):
+        return
+    compression = codex.get("context_compression")
+    if isinstance(compression, dict):
+        compression["max_context_chars"] = None
 
-    ``data`` is the substituted raw config dict (pre-pydantic), mutated in
-    place only when the migration fires; ``original_raw`` is the file text
-    BEFORE env substitution, used to distinguish a literal legacy default
-    from a placeholder-resolved value.
+
+def apply_legacy_ceiling_migration(data: dict, config_path: str | Path, original_raw: str) -> None:
+    """Apply the versioned one-time legacy-ceiling migration.
+
+    A vacuous completion write is mandatory.  If it is blocked, startup fails
+    rather than pretending the one-time gate closed; this prevents a later
+    intentional 750000 from being erased on a subsequent load.
     """
     marker = ceiling_marker_path(config_path)
-    if marker.exists():
+    marker_kind = _read_marker(marker)
+
+    if marker_kind is _MarkerKind.COMPLETE:
         return
 
-    if _literal_ceiling_value(original_raw) != LEGACY_MAX_CONTEXT_CHARS:
-        _record_completion(marker, reason="not_applicable")
+    if marker_kind is _MarkerKind.ROUND1_OPERATOR:
+        _write_required(
+            marker,
+            "prior_operator_saved",
+            "upgrade the ceiling-migration completion record",
+        )
+        return
+
+    if marker_kind is _MarkerKind.PREVERSIONED_COMPLETE:
+        _write_required(
+            marker,
+            "upgraded_preversioned_completion",
+            "upgrade the ceiling-migration completion record",
+        )
+        return
+
+    invalid = {
+        _MarkerKind.EMPTY,
+        _MarkerKind.CORRUPT,
+        _MarkerKind.DIRECTORY,
+        _MarkerKind.UNKNOWN,
+        _MarkerKind.UNREADABLE,
+    }
+    if marker_kind in invalid:
+        # Invalid prior state cannot safely distinguish an interrupted
+        # migration from a completed gate followed by an intentional 750000.
+        # Do not overwrite the only remaining provenance evidence.
+        log.error(
+            "Ceiling-migration record at %s is %s; refusing to guess at migration provenance.",
+            marker,
+            marker_kind.value,
+        )
+        raise MigrationCompletionError(
+            "ceiling-migration record is invalid or unreadable; inspect it before retrying"
+        )
+
+    if marker_kind is _MarkerKind.ROUND1_LEGACY:
+        log.info("Upgrading round-1 legacy migration provenance at %s.", marker)
+
+    if not _is_shipped_legacy_literal(original_raw):
+        _write_required(
+            marker,
+            "not_applicable",
+            "record vacuous ceiling-migration completion",
+        )
         return
 
     try:
-        # Resolve the symlink so the atomic replace lands on the real file
-        # instead of severing a packaged /opt→/etc link. The surgical writer
-        # preserves comments, ordering, and unrelated ${VAR} placeholders.
+        # Resolve only the rewrite target.  Replacing the unresolved packaged
+        # config path would sever its /opt -> /etc symlink; the marker remains
+        # beside the unresolved path in the backed-up data directory.
         from .persistence import patch_config_paths
 
-        patch_config_paths(
-            [(_CEILING_PATH, None)], path=Path(config_path).resolve()
-        )
-    except Exception as exc:  # noqa: BLE001 — boot must not die on migration I/O
-        compression = data.get("openai_codex", {}).get("context_compression")
-        if isinstance(compression, dict):
-            compression["max_context_chars"] = None
+        patch_config_paths([(_CEILING_PATH, None)], path=Path(config_path).resolve())
+    except Exception as exc:  # noqa: BLE001 — boot retains safe runtime behavior
+        _set_runtime_auto(data)
         log.warning(
             "Could not rewrite legacy max_context_chars to auto (%s); "
             "interpreting as auto for this boot only — the migration retries "
@@ -138,16 +373,12 @@ def apply_legacy_ceiling_migration(
         )
         return
 
-    compression = data.get("openai_codex", {}).get("context_compression")
-    if isinstance(compression, dict):
-        compression["max_context_chars"] = None
+    _set_runtime_auto(data)
     log.warning(
         "Migrated legacy max_context_chars %d to auto (model-derived): the "
-        "config file now records null for this setting. Completion recorded "
-        "at %s; any explicit value set from now on — including %d — is "
-        "honored verbatim.",
+        "config file now records null. Any later explicit value — including "
+        "%d — is honored verbatim.",
         LEGACY_MAX_CONTEXT_CHARS,
-        marker,
         LEGACY_MAX_CONTEXT_CHARS,
     )
-    _record_completion(marker, reason="migrated")
+    _record_after_rewrite(marker)

--- a/src/config/persistence.py
+++ b/src/config/persistence.py
@@ -351,17 +351,6 @@ def patch_config_paths(
 
     _dump_atomic(document, config_path, orig_mode)
 
-    # A deliberate save of the compression section establishes operator
-    # provenance: from now on the persisted value — including an intentional
-    # legacy-equal 750_000 — is honored verbatim on every load.
-    if any(
-        tuple(change[0][:2]) == ("openai_codex", "context_compression")
-        for change in changes
-    ):
-        from .migrations import record_ceiling_operator_provenance
-
-        record_ceiling_operator_provenance(config_path)
-
 
 async def _run_settled(write: Callable[[], None]) -> PersistOutcome:
     """Run a sync write to settlement; report result and cancellation.

--- a/src/config/persistence.py
+++ b/src/config/persistence.py
@@ -351,6 +351,17 @@ def patch_config_paths(
 
     _dump_atomic(document, config_path, orig_mode)
 
+    # A deliberate save of the compression section establishes operator
+    # provenance: from now on the persisted value — including an intentional
+    # legacy-equal 750_000 — is honored verbatim on every load.
+    if any(
+        tuple(change[0][:2]) == ("openai_codex", "context_compression")
+        for change in changes
+    ):
+        from .migrations import record_ceiling_operator_provenance
+
+        record_ceiling_operator_provenance(config_path)
+
 
 async def _run_settled(write: Callable[[], None]) -> PersistOutcome:
     """Run a sync write to settlement; report result and cancellation.

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -1197,9 +1197,9 @@ def set_active_config_path(path: str | Path | None) -> None:
 
 def load_config(path: str | Path = "config.yml") -> Config:
     path = Path(path)
-    raw = path.read_text()
+    original_raw = path.read_text()
     try:
-        raw = _substitute_env_vars(raw)
+        raw = _substitute_env_vars(original_raw)
     except ValueError as exc:
         raise SystemExit(
             f"Configuration error: {exc}\n"
@@ -1224,12 +1224,13 @@ def load_config(path: str | Path = "config.yml") -> Config:
     # and the intended setting never applies. We warn rather than error
     # (extra="forbid") so a slightly-ahead config can't hard-fail boot.
     _warn_unknown_config_keys(data)
-    # Legacy-default soft-compaction ceiling → auto (one-time, provenance-
-    # gated; see src/config/migrations.py). Runs on the raw dict so pydantic
-    # validates what will actually apply.
+    # One-time legacy-ceiling migration gate (see src/config/migrations.py).
+    # Runs on the raw dict so pydantic validates what will actually apply;
+    # the unsubstituted text distinguishes a literal legacy default from a
+    # deliberate ${VAR} placeholder.
     from .migrations import apply_legacy_ceiling_migration
 
-    apply_legacy_ceiling_migration(data, path)
+    apply_legacy_ceiling_migration(data, path, original_raw)
     try:
         cfg = Config(**data)
     except Exception as exc:

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -187,10 +187,42 @@ class ConnectionPoolConfig(BaseModel):
         return v
 
 
+# The pre-campaign soft-compaction ceiling. For years this was the shipped
+# default of ``max_context_chars`` and is materialized verbatim in most
+# persisted configs — the legacy-ceiling migration (src/config/migrations.py)
+# keys off this exact value.
+LEGACY_MAX_CONTEXT_CHARS = 750_000
+
+
 class ContextCompressionConfig(BaseModel):
     enabled: bool = True
-    max_context_chars: int = 750_000
+    # None = "auto": the ceiling derives from the active model's input budget.
+    # Until the per-model resolver is wired to the runtime surfaces (context-
+    # budget campaign phase 3), auto resolves to the legacy constant so
+    # behavior is bit-identical to pre-campaign installs. An explicit value
+    # can only LOWER the derived target, never raise it (the resolver takes
+    # min(explicit, derived)).
+    max_context_chars: int | None = None
     keep_recent_iterations: int = 30
+
+    @field_validator("max_context_chars")
+    @classmethod
+    def _validate_max_context_chars(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
+            raise ValueError("max_context_chars must be positive, or null for auto")
+        return v
+
+    @property
+    def resolved_max_context_chars(self) -> int:
+        """The ceiling consumers compare against — legacy value when auto.
+
+        Campaign phase 3 replaces consumer reads with the per-model budget
+        resolver; until then this property keeps every consumer total (no
+        None comparisons) and byte-identical to pre-campaign behavior.
+        """
+        if self.max_context_chars is not None:
+            return self.max_context_chars
+        return LEGACY_MAX_CONTEXT_CHARS
 
 
 class GovernorConfig(BaseModel):
@@ -402,6 +434,73 @@ def effort_incompatibility_error(model: str | None, effort: str | None) -> str |
         f"{str(model).strip()!r} (allowed for this model: {allowed})"
     )
 
+# --- Per-model usable input budgets (context-budget campaign, 2026-08-17) ---
+# Values are KNOWN-SAFE USABLE INPUT BUDGETS (floors): each model's own
+# highest server-accepted input observation (usage-echo bracketing, Pro and
+# Team accounts served identically) — NOT vendor context-window claims. They
+# already sit below the server's output reservation; never subtract another
+# output reserve from them. A floor never exceeds its evidence: only sol
+# received the fine-refinement acceptances, which is why sol reads 921_601
+# while its window-mates read 917_506. The served models catalog reports
+# 272000 for every slug (stale through three regime changes) — never consume
+# it. Serving moves silently in both directions; these floors are refreshed
+# by manual probes, bounded downward at runtime only by observed clamps.
+CODEX_MODEL_INPUT_BUDGETS: dict[str, int] = {
+    "gpt-5.6-sol": 921_601,
+    "gpt-5.6-terra": 917_506,
+    "gpt-5.6-luna": 917_506,
+    "gpt-5.4": 917_506,
+    "gpt-5.5": 270_001,
+    "gpt-5.4-mini": 262_146,
+    "gpt-5.3-codex-spark": 124_001,
+}
+
+# Unknown exact slugs assume the pre-campaign uniform window, so a new or
+# renamed model degrades to the long-proven conservative math — not a guess.
+CODEX_UNKNOWN_MODEL_INPUT_BUDGET = 272_000
+
+# Slugs the backend serves under another model's identity (probed via the
+# served_model echo). Canonicalization maps them BEFORE any registry,
+# override, or observer lookup — they are never registry rows themselves.
+_CODEX_MODEL_ALIASES: dict[str, str] = {
+    "codex-auto-review": "gpt-5.6-luna",
+}
+
+
+def canonical_codex_model(model: str | None) -> str:
+    """THE Codex model canonicalizer: trim, map aliases, preserve spelling.
+
+    Single authority for budget-registry lookups, override keys, observer
+    keys, and UI capability data — the UI consumes canonical keys served by
+    the backend and never reimplements this. Unknown models pass through
+    with their spelling preserved (no case folding: the server is the
+    authority on model names).
+    """
+    trimmed = str(model or "").strip()
+    return _CODEX_MODEL_ALIASES.get(trimmed, trimmed)
+
+
+def input_budget_floor_for_model(model: str | None) -> int:
+    """Known-safe usable input budget for ``model``.
+
+    Callers pass RAW model names; canonicalization happens here so no lookup
+    site can forget it. Unknown slugs get the conservative default.
+    """
+    return CODEX_MODEL_INPUT_BUDGETS.get(
+        canonical_codex_model(model), CODEX_UNKNOWN_MODEL_INPUT_BUDGET
+    )
+
+
+# Operator override bounds for per-model input budgets. The floor guarantees
+# a positive compactable allowance above the fixed 42K-token request envelope
+# (50_192 = 42_000 + 8_192); the ceiling bounds serialization/memory cost of
+# derived character targets. Observed clamps (runtime evidence) deliberately
+# BYPASS these bounds — evidence stays exact and the budget resolver is a
+# total function under any clamp value.
+CONTEXT_BUDGET_OVERRIDE_MIN = 50_192
+CONTEXT_BUDGET_OVERRIDE_MAX = 2_000_000
+
+
 # Sentinel for the agent model/effort config axes meaning "let the spawner pick
 # per-spawn from the exposed catalogue". Deliberately NOT a member of
 # CODEX_REASONING_EFFORTS — that set is the values legal to SEND to Codex; "auto"
@@ -498,6 +597,49 @@ class OpenAICodexConfig(BaseModel):
     connection_pool: ConnectionPoolConfig = ConnectionPoolConfig()
     auxiliary: AuxiliaryLLMConfig = AuxiliaryLLMConfig()
     context_compression: ContextCompressionConfig = ContextCompressionConfig()
+    # Per-model usable-input-budget overrides (tokens), keyed by canonical
+    # model name. Empty = built-in floors (CODEX_MODEL_INPUT_BUDGETS). An
+    # override may exceed the known-safe floor — overflow recovery is what
+    # makes that experimentation tolerable — but stays inside process-safety
+    # bounds. Consumed from campaign phase 3 (budget resolver).
+    context_budget_overrides: dict[str, int] = Field(default_factory=dict)
+    # Working-set policy: percent of the effective budget compaction actually
+    # targets (quality/latency/cost posture — NOT a capability claim). The
+    # resolver never lets utilization reduce budgets at or below 272K, so
+    # changing this may have no effect on smaller models by design.
+    context_utilization: int = 60
+
+    @field_validator("context_utilization")
+    @classmethod
+    def _validate_context_utilization(cls, v: int) -> int:
+        if isinstance(v, bool) or not 30 <= v <= 100:
+            raise ValueError("context_utilization must be an integer percent between 30 and 100")
+        return v
+
+    @field_validator("context_budget_overrides")
+    @classmethod
+    def _validate_context_budget_overrides(cls, v: dict[str, int]) -> dict[str, int]:
+        canonical: dict[str, int] = {}
+        for raw_key, value in v.items():
+            key = canonical_codex_model(raw_key)
+            if not key:
+                raise ValueError(
+                    "context_budget_overrides keys must be non-empty model names"
+                )
+            if key in canonical:
+                raise ValueError(
+                    f"context_budget_overrides: {raw_key!r} duplicates "
+                    f"{key!r} after canonicalization"
+                )
+            if isinstance(value, bool) or not (
+                CONTEXT_BUDGET_OVERRIDE_MIN <= value <= CONTEXT_BUDGET_OVERRIDE_MAX
+            ):
+                raise ValueError(
+                    f"context_budget_overrides[{key!r}] must be an integer between "
+                    f"{CONTEXT_BUDGET_OVERRIDE_MIN} and {CONTEXT_BUDGET_OVERRIDE_MAX} tokens"
+                )
+            canonical[key] = value
+        return canonical
 
     @model_validator(mode="after")
     def _validate_effort_model_pairs(self):
@@ -1082,6 +1224,12 @@ def load_config(path: str | Path = "config.yml") -> Config:
     # and the intended setting never applies. We warn rather than error
     # (extra="forbid") so a slightly-ahead config can't hard-fail boot.
     _warn_unknown_config_keys(data)
+    # Legacy-default soft-compaction ceiling → auto (one-time, provenance-
+    # gated; see src/config/migrations.py). Runs on the raw dict so pydantic
+    # validates what will actually apply.
+    from .migrations import apply_legacy_ceiling_migration
+
+    apply_legacy_ceiling_migration(data, path)
     try:
         cfg = Config(**data)
     except Exception as exc:

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -1228,9 +1228,16 @@ def load_config(path: str | Path = "config.yml") -> Config:
     # Runs on the raw dict so pydantic validates what will actually apply;
     # the unsubstituted text distinguishes a literal legacy default from a
     # deliberate ${VAR} placeholder.
-    from .migrations import apply_legacy_ceiling_migration
+    from .migrations import MigrationCompletionError, apply_legacy_ceiling_migration
 
-    apply_legacy_ceiling_migration(data, path, original_raw)
+    try:
+        apply_legacy_ceiling_migration(data, path, original_raw)
+    except MigrationCompletionError as exc:
+        raise SystemExit(
+            f"Configuration migration failed for {path}: {exc}\n"
+            "Inspect the ceiling-migration record and retry; Odin will not "
+            "guess at operator provenance."
+        ) from exc
     try:
         cfg = Config(**data)
     except Exception as exc:

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -730,7 +730,7 @@ class AgentTaskTools:
             model_override=model_override,
             reasoning_effort_override=effort_override,
             context_compression_enabled=bool(self._get_context_compressor()),
-            max_context_chars=self._get_context_compressor().max_context_chars
+            max_context_chars=self._get_context_compressor().resolved_max_context_chars
             if self._get_context_compressor()
             else 750000,
             keep_recent_iterations=self._get_context_compressor().keep_recent_iterations
@@ -1028,7 +1028,7 @@ class AgentTaskTools:
                 self._get_config().agents, "max_children_per_agent", None
             ),
             context_compression_enabled=bool(cc),
-            max_context_chars=cc.max_context_chars if cc else 750000,
+            max_context_chars=cc.resolved_max_context_chars if cc else 750000,
             keep_recent_iterations=cc.keep_recent_iterations if cc else 30,
         )
 

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -886,10 +886,10 @@ class ToolLoopRunner:
                 )
 
                 _cc = self._get_context_compressor()
-                if estimate_message_chars(st.messages) > _cc.max_context_chars:
+                if estimate_message_chars(st.messages) > _cc.resolved_max_context_chars:
                     st.messages, _saved = compress_tool_context(
                         st.messages,
-                        max_context_chars=_cc.max_context_chars,
+                        max_context_chars=_cc.resolved_max_context_chars,
                         keep_recent=_cc.keep_recent_iterations,
                         stats=self._get_compression_stats(),
                     )

--- a/src/llm/context_budget.py
+++ b/src/llm/context_budget.py
@@ -1,0 +1,173 @@
+"""Per-model context-budget resolution (pure functions; campaign phase 1).
+
+The single derivation authority from capability (budget floors and operator
+overrides), evidence (observed clamps), and policy (utilization, explicit
+character ceiling) down to the character targets compaction consumes:
+
+    base_budget        = override[model] ?? floor[model] ?? 272_000
+    effective_budget   = min(base_budget, observed_clamp)      # when present
+    working_budget     = min(effective_budget,
+                             max(272_000, effective_budget × utilization%))
+    compactable_tokens = max(0, working_budget − 42_000)       # total: never negative
+    derived_chars      = compactable_tokens × 2.5
+    primary_chars      = min(derived_chars, explicit ceiling)  # when non-null
+    rung_1             = primary_chars × 0.7
+    rung_2             = min(rung_1, 400_000)
+    ladder             = positive rungs only, deduplicated, non-increasing
+
+All arithmetic is exact integer math (×2.5 as ×5//2, percentages and the 0.7
+ratio as integer products before floor division) — identical to the settled
+floor()-form for non-negative operands, with no float drift.
+
+Semantics settled with Odin (plan of record R2, 2026-08-17):
+
+- Budgets are known-safe usable INPUT floors, already below the server's
+  output reservation — nothing here subtracts an output reserve.
+- The 42K envelope reserve covers the fixed request material that rides
+  outside compactable history (system prompt, tool schemas).
+- Observed clamps are runtime evidence and deliberately bypass the operator
+  override bounds; the resolver is TOTAL under any clamp value — when no
+  positive rescue rung exists, recovery must fail honestly rather than
+  fabricate a target.
+- The 272K legacy floor means utilization never reduces a budget at or below
+  272K: small models keep their full derived targets; the policy knob only
+  bites above ~453K budgets.
+- 400_000 chars is the rescue ceiling for models with a ≥272K usable budget
+  (it survives every historically served ≥272K window class); the ``min``
+  keeps smaller models and low overrides/clamps on their own smaller rung —
+  recovery never enlarges context.
+- Resolution is snapshotted per logical generation: the model and its budget
+  travel together through retries and rescue rungs; live configuration
+  changes reach the NEXT generation only.
+
+Nothing consumes this module at runtime yet — phase 3 wires it into the
+agent, chat, and loop surfaces. Until then it is contract plus tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..config.schema import (
+    CODEX_MODEL_INPUT_BUDGETS,
+    CODEX_UNKNOWN_MODEL_INPUT_BUDGET,
+    canonical_codex_model,
+)
+
+#: Tokens reserved for the fixed request envelope (system prompt, tool
+#: schemas, non-history material) — NOT an output reserve; the server already
+#: holds its own output reservation outside the usable input budget.
+FIXED_ENVELOPE_RESERVE_TOKENS = 42_000
+
+#: Deliberately DENSE chars-per-token so a character measure can never
+#: overshoot real tokens on scraped content. Expressed as a ratio of two
+#: integers (5/2) so derivations stay exact.
+EMERGENCY_CHARS_PER_TOKEN = 2.5
+
+#: Utilization never reduces budgets at or below the pre-campaign uniform
+#: window — models of that class keep their full derived working set.
+LEGACY_UTILIZATION_FLOOR_TOKENS = 272_000
+
+#: Final-rung ceiling for models with a ≥272K usable budget: ~202K estimated
+#: input tokens, which fits every historically served ≥272K window class,
+#: including a silent 922K→372K regression.
+RESCUE_CEILING_CHARS = 400_000
+
+#: First rescue rung as a fraction of the final primary target (7/10, exact).
+RESCUE_RATIO = 0.7
+
+_BASE_SOURCE_OVERRIDE = "override"
+_BASE_SOURCE_FLOOR = "floor"
+_BASE_SOURCE_UNKNOWN = "unknown_default"
+
+
+@dataclass(frozen=True)
+class ContextBudgetSnapshot:
+    """One resolved (model, budget, targets) unit, frozen per logical generation.
+
+    Retries and rescue rungs of the same generation reuse this snapshot;
+    a fresh generation resolves a fresh one (that is where live config and
+    clamp changes take effect).
+    """
+
+    canonical_model: str
+    base_budget: int
+    base_source: str  # "override" | "floor" | "unknown_default"
+    effective_budget: int
+    clamp_applied: bool
+    working_budget: int
+    compactable_tokens: int
+    derived_chars: int
+    primary_chars: int
+    ceiling_applied: bool
+    ladder: tuple[int, ...]
+
+
+def resolve_context_budget(
+    model: str | None,
+    *,
+    overrides: dict[str, int] | None = None,
+    utilization: int = 60,
+    max_context_chars: int | None = None,
+    observed_clamp: int | None = None,
+) -> ContextBudgetSnapshot:
+    """Resolve the full derivation chain for ``model``. Total by construction.
+
+    ``overrides`` carries canonical keys (the config validator normalizes
+    them); the raw ``model`` is canonicalized here so no caller can forget.
+    ``observed_clamp`` is exact runtime evidence and may be arbitrarily low —
+    the chain absorbs it without ever going negative or fabricating a rung.
+    """
+    canonical = canonical_codex_model(model)
+    overrides = overrides or {}
+
+    if canonical in overrides:
+        base_budget, base_source = overrides[canonical], _BASE_SOURCE_OVERRIDE
+    elif canonical in CODEX_MODEL_INPUT_BUDGETS:
+        base_budget, base_source = CODEX_MODEL_INPUT_BUDGETS[canonical], _BASE_SOURCE_FLOOR
+    else:
+        base_budget, base_source = CODEX_UNKNOWN_MODEL_INPUT_BUDGET, _BASE_SOURCE_UNKNOWN
+
+    if observed_clamp is not None and observed_clamp < base_budget:
+        effective_budget, clamp_applied = observed_clamp, True
+    else:
+        effective_budget, clamp_applied = base_budget, False
+
+    # Integer form of floor(effective × utilization/100).
+    working_budget = min(
+        effective_budget,
+        max(LEGACY_UTILIZATION_FLOOR_TOKENS, effective_budget * utilization // 100),
+    )
+    # Totality: an evidence clamp below the envelope reserve must yield an
+    # empty compactable allowance, never a negative one.
+    compactable_tokens = max(0, working_budget - FIXED_ENVELOPE_RESERVE_TOKENS)
+    # Integer form of floor(compactable × 2.5).
+    derived_chars = compactable_tokens * 5 // 2
+
+    if max_context_chars is not None and max_context_chars < derived_chars:
+        primary_chars, ceiling_applied = max_context_chars, True
+    else:
+        primary_chars, ceiling_applied = derived_chars, False
+
+    # Integer form of floor(primary × 0.7).
+    rung_1 = primary_chars * 7 // 10
+    rung_2 = min(rung_1, RESCUE_CEILING_CHARS)
+    ladder = tuple(
+        rung
+        for i, rung in enumerate((rung_1, rung_2))
+        if rung > 0 and (i == 0 or rung != rung_1)
+    )
+
+    return ContextBudgetSnapshot(
+        canonical_model=canonical,
+        base_budget=base_budget,
+        base_source=base_source,
+        effective_budget=effective_budget,
+        clamp_applied=clamp_applied,
+        working_budget=working_budget,
+        compactable_tokens=compactable_tokens,
+        derived_chars=derived_chars,
+        primary_chars=primary_chars,
+        ceiling_applied=ceiling_applied,
+        ladder=ladder,
+    )

--- a/tests/test_apply_registry.py
+++ b/tests/test_apply_registry.py
@@ -186,7 +186,7 @@ class TestResolution:
         from src.config.apply_registry import schema_facts
 
         facts = schema_facts()
-        assert len(facts) == 262
+        assert len(facts) == 264
         assert "graceful_degradation.enabled" not in facts
         assert "grafana_alerts.enabled" not in facts
         for path in (

--- a/tests/test_config_ceiling_migration.py
+++ b/tests/test_config_ceiling_migration.py
@@ -1,186 +1,283 @@
-"""Legacy soft-compaction-ceiling migration (campaign phase 1).
+"""Legacy soft-compaction-ceiling migration (campaign phase 1, review round 2).
 
-Pins the provenance-gated contract: only the EXACT legacy default is ever
-reinterpreted, one WARNING at migration time, marker-stable INFO thereafter,
-deliberate persistence clears provenance, and failures degrade to this-boot
-interpretation without crashing the loader.
+Pins the R2 primary-branch contract: a genuine ONE-TIME ``750000 → null``
+file rewrite through the surgical persistence writer, completion-marker
+gated, with the three review-round-1 reproductions closed: a fresh-null
+install's later hand-written 750000 is honored (vacuous completion), a
+``${VAR}`` placeholder resolving to 750000 is deliberate configuration and
+never migrated, and no save of an unrelated compression field can resurrect
+the legacy value (nothing ambiguous remains on disk to resurrect).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 
 import yaml
 
 from src.config.migrations import (
     apply_legacy_ceiling_migration,
     ceiling_marker_path,
-    record_ceiling_operator_provenance,
 )
 from src.config.persistence import patch_config_paths
 from src.config.schema import LEGACY_MAX_CONTEXT_CHARS, load_config
 
+_LEGACY_YAML = (
+    "discord:\n"
+    '  token: "t"\n'
+    "openai_codex:\n"
+    "  # operator comment that must survive the rewrite\n"
+    "  model: gpt-5.6-sol\n"
+    "  context_compression:\n"
+    "    enabled: true\n"
+    f"    max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}\n"
+    "    keep_recent_iterations: 30\n"
+)
 
-def _legacy_data() -> dict:
-    return {
-        "openai_codex": {
-            "context_compression": {
-                "enabled": True,
-                "max_context_chars": LEGACY_MAX_CONTEXT_CHARS,
-                "keep_recent_iterations": 30,
-            }
-        }
-    }
+
+def _migrate(config_path, caplog_level=logging.INFO, caplog=None):
+    original = config_path.read_text()
+    data = yaml.safe_load(original)
+    apply_legacy_ceiling_migration(data, config_path, original)
+    return data
 
 
-class TestApplyMigration:
-    def test_legacy_default_becomes_auto_and_marker_recorded(self, tmp_path, caplog):
+class TestOneTimeRewrite:
+    def test_literal_legacy_rewritten_once_with_one_warning(self, tmp_path, caplog):
         config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
-        data = _legacy_data()
+        config_path.write_text(_LEGACY_YAML)
         with caplog.at_level(logging.INFO, logger="odin.config"):
-            apply_legacy_ceiling_migration(data, config_path)
+            data = _migrate(config_path)
+        # In-memory value is auto for this boot.
         assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+        # THE FILE ITSELF now records null — nothing ambiguous remains.
+        on_disk = yaml.safe_load(config_path.read_text())
+        assert on_disk["openai_codex"]["context_compression"]["max_context_chars"] is None
+        # Surgical write: comments and unrelated keys survive.
+        assert "operator comment that must survive" in config_path.read_text()
+        assert on_disk["openai_codex"]["model"] == "gpt-5.6-sol"
         marker = ceiling_marker_path(config_path)
-        assert marker.is_file()
-        recorded = json.loads(marker.read_text())
-        assert recorded["legacy_value"] == LEGACY_MAX_CONTEXT_CHARS
-        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warnings) == 1
+        assert json.loads(marker.read_text())["reason"] == "migrated"
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
 
-    def test_marker_present_keeps_auto_at_info_level(self, tmp_path, caplog):
+        # One-time: a second pass is gated by the marker and changes nothing.
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="odin.config"):
+            _migrate(config_path)
+        assert not caplog.records
+
+    def test_marker_gates_even_a_literal_750k(self, tmp_path):
+        """Post-migration, a deliberately written 750000 is honored verbatim."""
         config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
+        config_path.write_text(_LEGACY_YAML)
         marker = ceiling_marker_path(config_path)
         marker.parent.mkdir(parents=True)
         marker.write_text("{}")
-        before = marker.read_text()
-        data = _legacy_data()
-        with caplog.at_level(logging.INFO, logger="odin.config"):
-            apply_legacy_ceiling_migration(data, config_path)
-        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
-        # Subsequent boots reinterpret at INFO — never silent, never a second
-        # WARNING, marker untouched.
-        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert [r for r in caplog.records if r.levelno == logging.INFO]
-        assert marker.read_text() == before
-
-    def test_non_legacy_values_untouched_and_no_marker(self, tmp_path):
-        config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
-        for value in (LEGACY_MAX_CONTEXT_CHARS + 1, 1, None):
-            data = _legacy_data()
-            data["openai_codex"]["context_compression"]["max_context_chars"] = value
-            apply_legacy_ceiling_migration(data, config_path)
-            assert (
-                data["openai_codex"]["context_compression"]["max_context_chars"]
-                == value
-            )
-        assert not ceiling_marker_path(config_path).exists()
-
-    def test_absent_sections_are_noops(self, tmp_path):
-        config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
-        for data in ({}, {"openai_codex": None}, {"openai_codex": {}},
-                     {"openai_codex": {"context_compression": None}}):
-            apply_legacy_ceiling_migration(data, config_path)  # must not raise
-        assert not ceiling_marker_path(config_path).exists()
-
-    def test_marker_write_failure_still_interprets_auto(self, tmp_path, caplog):
-        config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
-        # Occupy the data-dir path with a FILE so mkdir(parents=True) fails.
-        (tmp_path / "data").write_text("not a directory")
-        data = _legacy_data()
-        with caplog.at_level(logging.WARNING, logger="odin.config"):
-            apply_legacy_ceiling_migration(data, config_path)
-        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
-        assert any("retries next boot" in r.getMessage() for r in caplog.records)
-
-
-class TestOperatorProvenance:
-    def test_operator_stamp_makes_legacy_value_verbatim(self, tmp_path):
-        config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
-        record_ceiling_operator_provenance(config_path)
-        marker = ceiling_marker_path(config_path)
-        assert json.loads(marker.read_text())["operator_saved"] is True
-        data = _legacy_data()
-        apply_legacy_ceiling_migration(data, config_path)
-        # Operator provenance: the literal legacy value is honored verbatim.
+        data = _migrate(config_path)
         assert (
             data["openai_codex"]["context_compression"]["max_context_chars"]
             == LEGACY_MAX_CONTEXT_CHARS
         )
+        # File untouched.
+        assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in config_path.read_text()
 
-    def test_corrupt_marker_fails_toward_auto(self, tmp_path):
-        config_path = tmp_path / "config.yml"
-        config_path.write_text("x: 1")
-        marker = ceiling_marker_path(config_path)
-        marker.parent.mkdir(parents=True)
-        marker.write_text("not json {")
-        data = _legacy_data()
-        apply_legacy_ceiling_migration(data, config_path)
-        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
 
-    def test_persisting_compression_section_stamps_provenance(self, tmp_path):
+class TestVacuousCompletion:
+    def test_fresh_null_then_hand_written_750k_is_honored(self, tmp_path):
+        """Review-round-1 reproduction #1: the fresh-install hole."""
         config_path = tmp_path / "config.yml"
         config_path.write_text(
-            "openai_codex:\n  context_compression:\n    max_context_chars: 750000\n"
+            "discord:\n  token: \"t\"\n"
+            "openai_codex:\n  context_compression:\n    max_context_chars: null\n"
         )
+        data = _migrate(config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
         marker = ceiling_marker_path(config_path)
-        marker.parent.mkdir(parents=True)
-        marker.write_text("{}")  # legacy provenance until a deliberate save
-        patch_config_paths(
-            [
-                (
-                    ("openai_codex", "context_compression", "max_context_chars"),
-                    LEGACY_MAX_CONTEXT_CHARS,
-                )
-            ],
-            path=config_path,
-        )
-        assert json.loads(marker.read_text())["operator_saved"] is True
-        persisted = yaml.safe_load(config_path.read_text())
+        assert json.loads(marker.read_text())["reason"] == "not_applicable"
+
+        # An operator later hand-writes the literal legacy number: past the
+        # gate, it is an intentional value and loads verbatim.
+        config_path.write_text(_LEGACY_YAML)
+        data2 = _migrate(config_path)
         assert (
-            persisted["openai_codex"]["context_compression"]["max_context_chars"]
+            data2["openai_codex"]["context_compression"]["max_context_chars"]
             == LEGACY_MAX_CONTEXT_CHARS
         )
 
-    def test_unrelated_persistence_does_not_stamp(self, tmp_path):
+    def test_non_legacy_values_marked_and_untouched(self, tmp_path):
+        for value in ("750001", "1", "null"):
+            config_path = tmp_path / f"config-{value}.yml"
+            config_path.write_text(
+                "openai_codex:\n  context_compression:\n"
+                f"    max_context_chars: {value}\n"
+            )
+            before = config_path.read_text()
+            _migrate(config_path)
+            assert config_path.read_text() == before
+            assert ceiling_marker_path(config_path).exists()
+
+    def test_absent_sections_complete_vacuously(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        config_path.write_text("openai_codex:\n  model: gpt-5.5\n")
-        marker = ceiling_marker_path(config_path)
-        marker.parent.mkdir(parents=True)
-        marker.write_text("{}")
-        patch_config_paths(
-            [(("openai_codex", "model"), "gpt-5.6-sol")], path=config_path
+        config_path.write_text("discord:\n  token: \"t\"\n")
+        _migrate(config_path)  # must not raise
+        assert ceiling_marker_path(config_path).exists()
+
+
+class TestPlaceholderIsDeliberate:
+    def test_env_placeholder_resolving_to_750k_never_migrated(
+        self, tmp_path, monkeypatch
+    ):
+        """Review-round-1 reproduction #2: substitution happens before the
+        migration, but the UNSUBSTITUTED text is the authority — a ${VAR}
+        is operator configuration, not the legacy shipped default."""
+        monkeypatch.setenv("MAX_CTX_TEST", str(LEGACY_MAX_CONTEXT_CHARS))
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(
+            "discord:\n  token: \"t\"\n"
+            "openai_codex:\n  context_compression:\n"
+            "    max_context_chars: ${MAX_CTX_TEST}\n"
         )
-        assert json.loads(marker.read_text()) == {}
+        cfg = load_config(config_path)
+        assert (
+            cfg.openai_codex.context_compression.max_context_chars
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+        # File untouched — the placeholder survives.
+        assert "${MAX_CTX_TEST}" in config_path.read_text()
+        assert json.loads(ceiling_marker_path(config_path).read_text())[
+            "reason"
+        ] == "not_applicable"
+
+
+class TestNoResurrection:
+    def test_unrelated_compression_save_cannot_resurrect_750k(self, tmp_path):
+        """Review-round-1 reproduction #3: after the rewrite nothing ambiguous
+        remains on disk, so saving a sibling leaf changes nothing about the
+        ceiling."""
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(_LEGACY_YAML)
+        _migrate(config_path)
+        patch_config_paths(
+            [(("openai_codex", "context_compression", "enabled"), False)],
+            path=config_path,
+        )
+        on_disk = yaml.safe_load(config_path.read_text())
+        assert on_disk["openai_codex"]["context_compression"]["enabled"] is False
+        assert on_disk["openai_codex"]["context_compression"]["max_context_chars"] is None
+        data = _migrate(config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+
+
+class TestFailureHonesty:
+    def test_rewrite_failure_is_this_boot_only_and_retries(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(_LEGACY_YAML)
+        os.chmod(tmp_path, 0o555)  # atomic writer cannot create its tempfile
+        try:
+            with caplog.at_level(logging.WARNING, logger="odin.config"):
+                data = _migrate(config_path)
+        finally:
+            os.chmod(tmp_path, 0o755)
+        # In-memory auto so behavior is consistent this boot…
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+        assert any("retries next boot" in r.getMessage() for r in caplog.records)
+        # …but NO completion recorded and the file untouched: the gate refires.
+        assert not ceiling_marker_path(config_path).exists()
+        assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in config_path.read_text()
+
+        data2 = _migrate(config_path)
+        assert data2["openai_codex"]["context_compression"]["max_context_chars"] is None
+        assert yaml.safe_load(config_path.read_text())["openai_codex"][
+            "context_compression"
+        ]["max_context_chars"] is None
+        assert ceiling_marker_path(config_path).exists()
+
+
+class TestDegenerateInputs:
+    def test_unparseable_original_text_completes_vacuously(self, tmp_path):
+        """If the pre-substitution text cannot be parsed, literality cannot be
+        proven — the safe direction is no mutation, gate closed."""
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(_LEGACY_YAML)
+        data = yaml.safe_load(config_path.read_text())
+        apply_legacy_ceiling_migration(data, config_path, ":: ]]] not yaml [[[")
+        assert (
+            data["openai_codex"]["context_compression"]["max_context_chars"]
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+        assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in config_path.read_text()
+        assert json.loads(ceiling_marker_path(config_path).read_text())[
+            "reason"
+        ] == "not_applicable"
+
+    def test_marker_write_failure_after_rewrite_self_heals(self, tmp_path, caplog):
+        """Rewrite lands but the completion record cannot be written: the next
+        boot takes the vacuous branch (the file no longer says 750000) and
+        heals the marker."""
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(_LEGACY_YAML)
+        (tmp_path / "data").write_text("not a directory")  # blocks mkdir
+        with caplog.at_level(logging.WARNING, logger="odin.config"):
+            data = _migrate(config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+        assert yaml.safe_load(config_path.read_text())["openai_codex"][
+            "context_compression"
+        ]["max_context_chars"] is None
+        assert any(
+            "Could not record ceiling-migration completion" in r.getMessage()
+            for r in caplog.records
+        )
+        (tmp_path / "data").unlink()
+        _migrate(config_path)
+        assert json.loads(ceiling_marker_path(config_path).read_text())[
+            "reason"
+        ] == "not_applicable"
+
+
+class TestPackagedSymlink:
+    def test_rewrite_lands_on_target_marker_beside_link(self, tmp_path):
+        """Review blocker #4: the packaged /opt→/etc config symlink. The
+        rewrite must write THROUGH the link (never sever it); the marker
+        anchors beside the link, where the durable data dir lives."""
+        etc = tmp_path / "etc"
+        opt = tmp_path / "opt"
+        etc.mkdir()
+        opt.mkdir()
+        real = etc / "config.yml"
+        real.write_text(_LEGACY_YAML)
+        link = opt / "config.yml"
+        link.symlink_to(real)
+
+        original = link.read_text()
+        data = yaml.safe_load(original)
+        apply_legacy_ceiling_migration(data, link, original)
+
+        assert link.is_symlink()  # the link survives
+        assert yaml.safe_load(real.read_text())["openai_codex"][
+            "context_compression"
+        ]["max_context_chars"] is None
+        assert ceiling_marker_path(link) == opt / "data" / "context_ceiling_migration.json"
+        assert (opt / "data" / "context_ceiling_migration.json").is_file()
+        assert not (etc / "data").exists()
 
 
 class TestLoadConfigIntegration:
-    def test_load_config_migrates_then_honors_operator_750k(self, tmp_path, caplog):
+    def test_load_migrates_then_honors_explicit_750k(self, tmp_path, caplog):
         config_path = tmp_path / "config.yml"
-        config_path.write_text(
-            "discord:\n"
-            '  token: "t"\n'
-            "openai_codex:\n"
-            "  context_compression:\n"
-            "    enabled: true\n"
-            f"    max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}\n"
-            "    keep_recent_iterations: 30\n"
-        )
+        config_path.write_text(_LEGACY_YAML)
         with caplog.at_level(logging.INFO, logger="odin.config"):
             cfg = load_config(config_path)
         cc = cfg.openai_codex.context_compression
         assert cc.max_context_chars is None
         assert cc.resolved_max_context_chars == LEGACY_MAX_CONTEXT_CHARS
-        assert ceiling_marker_path(config_path).is_file()
+        assert yaml.safe_load(config_path.read_text())["openai_codex"][
+            "context_compression"
+        ]["max_context_chars"] is None
 
-        # An operator save of the section clears provenance; the SAME literal
-        # value now loads verbatim — the one-time gate, not eternal coercion.
+        # A deliberate explicit set of the SAME literal value now persists:
+        # the one-time gate, not eternal coercion.
         patch_config_paths(
             [
                 (

--- a/tests/test_config_ceiling_migration.py
+++ b/tests/test_config_ceiling_migration.py
@@ -14,10 +14,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+from datetime import UTC, datetime
 
+import pytest
 import yaml
 
 from src.config.migrations import (
+    MigrationCompletionError,
+    _atomic_write_marker,
     apply_legacy_ceiling_migration,
     ceiling_marker_path,
 )
@@ -59,7 +63,10 @@ class TestOneTimeRewrite:
         assert "operator comment that must survive" in config_path.read_text()
         assert on_disk["openai_codex"]["model"] == "gpt-5.6-sol"
         marker = ceiling_marker_path(config_path)
-        assert json.loads(marker.read_text())["reason"] == "migrated"
+        record = json.loads(marker.read_text())
+        assert record["version"] == 2
+        assert record["state"] == "completed"
+        assert record["reason"] == "migrated"
         assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
 
         # One-time: a second pass is gated by the marker and changes nothing.
@@ -68,19 +75,26 @@ class TestOneTimeRewrite:
             _migrate(config_path)
         assert not caplog.records
 
-    def test_marker_gates_even_a_literal_750k(self, tmp_path):
+    def test_valid_versioned_marker_gates_even_a_literal_750k(self, tmp_path):
         """Post-migration, a deliberately written 750000 is honored verbatim."""
         config_path = tmp_path / "config.yml"
         config_path.write_text(_LEGACY_YAML)
         marker = ceiling_marker_path(config_path)
-        marker.parent.mkdir(parents=True)
-        marker.write_text("{}")
+        _atomic_write_marker(
+            marker,
+            {
+                "version": 2,
+                "migration": "legacy_max_context_chars_to_auto",
+                "state": "completed",
+                "reason": "not_applicable",
+                "completed_at": datetime.now(UTC).isoformat(),
+            },
+        )
         data = _migrate(config_path)
         assert (
             data["openai_codex"]["context_compression"]["max_context_chars"]
             == LEGACY_MAX_CONTEXT_CHARS
         )
-        # File untouched.
         assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in config_path.read_text()
 
 
@@ -89,7 +103,7 @@ class TestVacuousCompletion:
         """Review-round-1 reproduction #1: the fresh-install hole."""
         config_path = tmp_path / "config.yml"
         config_path.write_text(
-            "discord:\n  token: \"t\"\n"
+            'discord:\n  token: "t"\n'
             "openai_codex:\n  context_compression:\n    max_context_chars: null\n"
         )
         data = _migrate(config_path)
@@ -107,48 +121,56 @@ class TestVacuousCompletion:
         )
 
     def test_non_legacy_values_marked_and_untouched(self, tmp_path):
-        for value in ("750001", "1", "null"):
-            config_path = tmp_path / f"config-{value}.yml"
+        for value in (
+            "750001",
+            "1",
+            "null",
+            "750000.0",
+            "0xB71B0",
+            "750_000",
+            "+750000",
+            "!!int 750000",
+            "'750000'",
+            '"750000"',
+        ):
+            safe_name = str(abs(hash(value)))
+            config_path = tmp_path / f"config-{safe_name}.yml"
             config_path.write_text(
-                "openai_codex:\n  context_compression:\n"
-                f"    max_context_chars: {value}\n"
+                f"openai_codex:\n  context_compression:\n    max_context_chars: {value}\n"
             )
             before = config_path.read_text()
             _migrate(config_path)
             assert config_path.read_text() == before
-            assert ceiling_marker_path(config_path).exists()
+            record = json.loads(ceiling_marker_path(config_path).read_text())
+            assert record["version"] == 2
+            assert record["reason"] == "not_applicable"
 
     def test_absent_sections_complete_vacuously(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        config_path.write_text("discord:\n  token: \"t\"\n")
+        config_path.write_text('discord:\n  token: "t"\n')
         _migrate(config_path)  # must not raise
         assert ceiling_marker_path(config_path).exists()
 
 
 class TestPlaceholderIsDeliberate:
-    def test_env_placeholder_resolving_to_750k_never_migrated(
-        self, tmp_path, monkeypatch
-    ):
+    def test_env_placeholder_resolving_to_750k_never_migrated(self, tmp_path, monkeypatch):
         """Review-round-1 reproduction #2: substitution happens before the
         migration, but the UNSUBSTITUTED text is the authority — a ${VAR}
         is operator configuration, not the legacy shipped default."""
         monkeypatch.setenv("MAX_CTX_TEST", str(LEGACY_MAX_CONTEXT_CHARS))
         config_path = tmp_path / "config.yml"
         config_path.write_text(
-            "discord:\n  token: \"t\"\n"
+            'discord:\n  token: "t"\n'
             "openai_codex:\n  context_compression:\n"
             "    max_context_chars: ${MAX_CTX_TEST}\n"
         )
         cfg = load_config(config_path)
-        assert (
-            cfg.openai_codex.context_compression.max_context_chars
-            == LEGACY_MAX_CONTEXT_CHARS
-        )
+        assert cfg.openai_codex.context_compression.max_context_chars == LEGACY_MAX_CONTEXT_CHARS
         # File untouched — the placeholder survives.
         assert "${MAX_CTX_TEST}" in config_path.read_text()
-        assert json.loads(ceiling_marker_path(config_path).read_text())[
-            "reason"
-        ] == "not_applicable"
+        assert (
+            json.loads(ceiling_marker_path(config_path).read_text())["reason"] == "not_applicable"
+        )
 
 
 class TestNoResurrection:
@@ -171,28 +193,36 @@ class TestNoResurrection:
 
 
 class TestFailureHonesty:
-    def test_rewrite_failure_is_this_boot_only_and_retries(self, tmp_path, caplog):
+    def test_rewrite_failure_is_this_boot_only_and_retries(self, tmp_path, caplog, monkeypatch):
         config_path = tmp_path / "config.yml"
         config_path.write_text(_LEGACY_YAML)
-        os.chmod(tmp_path, 0o555)  # atomic writer cannot create its tempfile
-        try:
-            with caplog.at_level(logging.WARNING, logger="odin.config"):
-                data = _migrate(config_path)
-        finally:
-            os.chmod(tmp_path, 0o755)
+        import src.config.persistence as persistence
+
+        real_patch = persistence.patch_config_paths
+
+        def fail_patch(*args, **kwargs):
+            raise OSError("config rewrite blocked")
+
+        monkeypatch.setattr(persistence, "patch_config_paths", fail_patch)
+        with caplog.at_level(logging.WARNING, logger="odin.config"):
+            data = _migrate(config_path)
         # In-memory auto so behavior is consistent this boot…
         assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
         assert any("retries next boot" in r.getMessage() for r in caplog.records)
-        # …but NO completion recorded and the file untouched: the gate refires.
+        # …but no completion is durable and the file is untouched: the gate refires.
         assert not ceiling_marker_path(config_path).exists()
         assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in config_path.read_text()
 
+        monkeypatch.setattr(persistence, "patch_config_paths", real_patch)
         data2 = _migrate(config_path)
         assert data2["openai_codex"]["context_compression"]["max_context_chars"] is None
-        assert yaml.safe_load(config_path.read_text())["openai_codex"][
-            "context_compression"
-        ]["max_context_chars"] is None
-        assert ceiling_marker_path(config_path).exists()
+        assert (
+            yaml.safe_load(config_path.read_text())["openai_codex"]["context_compression"][
+                "max_context_chars"
+            ]
+            is None
+        )
+        assert json.loads(ceiling_marker_path(config_path).read_text())["state"] == "completed"
 
 
 class TestDegenerateInputs:
@@ -208,32 +238,58 @@ class TestDegenerateInputs:
             == LEGACY_MAX_CONTEXT_CHARS
         )
         assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in config_path.read_text()
-        assert json.loads(ceiling_marker_path(config_path).read_text())[
-            "reason"
-        ] == "not_applicable"
+        assert (
+            json.loads(ceiling_marker_path(config_path).read_text())["reason"] == "not_applicable"
+        )
 
-    def test_marker_write_failure_after_rewrite_self_heals(self, tmp_path, caplog):
-        """Rewrite lands but the completion record cannot be written: the next
-        boot takes the vacuous branch (the file no longer says 750000) and
-        heals the marker."""
+    @pytest.mark.parametrize(
+        "original_raw",
+        [
+            "",  # empty document
+            "openai_codex: scalar\n",  # non-mapping hierarchy
+            (
+                "openai_codex:\n  context_compression:\n"
+                "    max_context_chars:\n      nested: value\n"
+            ),  # mapping rather than scalar leaf
+        ],
+    )
+    def test_non_scalar_or_missing_lexical_shapes_complete_vacuously(self, tmp_path, original_raw):
+        path = tmp_path / str(abs(hash(original_raw))) / "config.yml"
+        path.parent.mkdir()
+        path.write_text("discord:\n  token: t\n")
+        data = {}
+        apply_legacy_ceiling_migration(data, path, original_raw)
+        assert json.loads(ceiling_marker_path(path).read_text())["reason"] == "not_applicable"
+
+    def test_marker_write_failure_after_rewrite_self_heals(self, tmp_path, caplog, monkeypatch):
+        """The rewrite removes ambiguity; vacuous completion heals next boot."""
         config_path = tmp_path / "config.yml"
         config_path.write_text(_LEGACY_YAML)
-        (tmp_path / "data").write_text("not a directory")  # blocks mkdir
+        import src.config.migrations as migrations
+
+        real_write = migrations._atomic_write_marker
+
+        def fail_write(marker, record):
+            raise OSError("completion blocked")
+
+        monkeypatch.setattr(migrations, "_atomic_write_marker", fail_write)
         with caplog.at_level(logging.WARNING, logger="odin.config"):
             data = _migrate(config_path)
         assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
-        assert yaml.safe_load(config_path.read_text())["openai_codex"][
-            "context_compression"
-        ]["max_context_chars"] is None
-        assert any(
-            "Could not record ceiling-migration completion" in r.getMessage()
-            for r in caplog.records
+        assert (
+            yaml.safe_load(config_path.read_text())["openai_codex"]["context_compression"][
+                "max_context_chars"
+            ]
+            is None
         )
-        (tmp_path / "data").unlink()
+        assert not ceiling_marker_path(config_path).exists()
+        assert any("completion retries next boot" in r.getMessage() for r in caplog.records)
+
+        monkeypatch.setattr(migrations, "_atomic_write_marker", real_write)
         _migrate(config_path)
-        assert json.loads(ceiling_marker_path(config_path).read_text())[
-            "reason"
-        ] == "not_applicable"
+        record = json.loads(ceiling_marker_path(config_path).read_text())
+        assert record["state"] == "completed"
+        assert record["reason"] == "not_applicable"
 
 
 class TestPackagedSymlink:
@@ -255,9 +311,12 @@ class TestPackagedSymlink:
         apply_legacy_ceiling_migration(data, link, original)
 
         assert link.is_symlink()  # the link survives
-        assert yaml.safe_load(real.read_text())["openai_codex"][
-            "context_compression"
-        ]["max_context_chars"] is None
+        assert (
+            yaml.safe_load(real.read_text())["openai_codex"]["context_compression"][
+                "max_context_chars"
+            ]
+            is None
+        )
         assert ceiling_marker_path(link) == opt / "data" / "context_ceiling_migration.json"
         assert (opt / "data" / "context_ceiling_migration.json").is_file()
         assert not (etc / "data").exists()
@@ -272,9 +331,12 @@ class TestLoadConfigIntegration:
         cc = cfg.openai_codex.context_compression
         assert cc.max_context_chars is None
         assert cc.resolved_max_context_chars == LEGACY_MAX_CONTEXT_CHARS
-        assert yaml.safe_load(config_path.read_text())["openai_codex"][
-            "context_compression"
-        ]["max_context_chars"] is None
+        assert (
+            yaml.safe_load(config_path.read_text())["openai_codex"]["context_compression"][
+                "max_context_chars"
+            ]
+            is None
+        )
 
         # A deliberate explicit set of the SAME literal value now persists:
         # the one-time gate, not eternal coercion.
@@ -288,7 +350,345 @@ class TestLoadConfigIntegration:
             path=config_path,
         )
         cfg2 = load_config(config_path)
+        assert cfg2.openai_codex.context_compression.max_context_chars == LEGACY_MAX_CONTEXT_CHARS
+
+
+class TestLexicalLiteralGate:
+    def test_only_shipped_plain_decimal_scalar_is_rewritten(self, tmp_path):
+        forms = {
+            "750000": True,
+            "750000.0": False,
+            "0xB71B0": False,
+            "750_000": False,
+            "+750000": False,
+            "!!int 750000": False,
+            "'750000'": False,
+            '"750000"': False,
+        }
+        for index, (value, migrates) in enumerate(forms.items()):
+            path = tmp_path / str(index) / "config.yml"
+            path.parent.mkdir()
+            path.write_text(
+                f"openai_codex:\n  context_compression:\n    max_context_chars: {value}\n"
+            )
+            before = path.read_text()
+            data = _migrate(path)
+            if migrates:
+                assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+                assert (
+                    yaml.safe_load(path.read_text())["openai_codex"]["context_compression"][
+                        "max_context_chars"
+                    ]
+                    is None
+                )
+            else:
+                assert path.read_text() == before
+
+
+class TestCompletionRecordProvenance:
+    @pytest.mark.parametrize("kind", ["empty", "corrupt", "directory"])
+    def test_invalid_marker_never_counts_as_completion_or_gets_overwritten(self, tmp_path, kind):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir()
+        if kind == "empty":
+            marker.write_text("")
+        elif kind == "corrupt":
+            marker.write_text("{broken")
+        else:
+            marker.mkdir()
+        with pytest.raises(MigrationCompletionError):
+            _migrate(path)
+        assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in path.read_text()
+        if kind == "empty":
+            assert marker.read_text() == ""
+        elif kind == "corrupt":
+            assert marker.read_text() == "{broken"
+        else:
+            assert marker.is_dir()
+
+    def test_unknown_record_fails_closed_without_overwrite(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir(parents=True)
+        raw = '{"version": 99, "migration": "future"}\n'
+        marker.write_text(raw)
+        with pytest.raises(MigrationCompletionError):
+            _migrate(path)
+        assert marker.read_text() == raw
+        assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in path.read_text()
+
+    def test_round1_legacy_marker_does_not_suppress_rewrite(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text(
+            json.dumps(
+                {
+                    "migration": "legacy_max_context_chars_to_auto",
+                    "legacy_value": LEGACY_MAX_CONTEXT_CHARS,
+                    "migrated_at": datetime.now(UTC).isoformat(),
+                }
+            )
+        )
+        _migrate(path)
         assert (
-            cfg2.openai_codex.context_compression.max_context_chars
+            yaml.safe_load(path.read_text())["openai_codex"]["context_compression"][
+                "max_context_chars"
+            ]
+            is None
+        )
+        assert json.loads(marker.read_text())["version"] == 2
+
+    def test_round1_operator_marker_preserves_and_upgrades(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text(
+            json.dumps(
+                {
+                    "migration": "legacy_max_context_chars_to_auto",
+                    "operator_saved": True,
+                    "saved_at": datetime.now(UTC).isoformat(),
+                }
+            )
+        )
+        data = _migrate(path)
+        assert (
+            data["openai_codex"]["context_compression"]["max_context_chars"]
             == LEGACY_MAX_CONTEXT_CHARS
         )
+        record = json.loads(marker.read_text())
+        assert record["version"] == 2
+        assert record["reason"] == "prior_operator_saved"
+
+    def test_preversioned_round2_completion_is_validated_then_upgraded(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text(
+            json.dumps(
+                {
+                    "migration": "legacy_max_context_chars_to_auto",
+                    "reason": "not_applicable",
+                    "completed_at": datetime.now(UTC).isoformat(),
+                }
+            )
+        )
+        data = _migrate(path)
+        assert (
+            data["openai_codex"]["context_compression"]["max_context_chars"]
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+        assert json.loads(marker.read_text())["version"] == 2
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            [],
+            {
+                "version": 2,
+                "migration": "legacy_max_context_chars_to_auto",
+                "state": "completed",
+                "reason": "not_applicable",
+                "completed_at": 123,
+            },
+            {
+                "version": 2,
+                "migration": "legacy_max_context_chars_to_auto",
+                "state": "completed",
+                "reason": "not_applicable",
+                "completed_at": "not-a-date",
+            },
+            {
+                "version": 2,
+                "migration": "legacy_max_context_chars_to_auto",
+                "state": "completed",
+                "reason": [],
+                "completed_at": datetime.now(UTC).isoformat(),
+            },
+            {
+                "migration": "legacy_max_context_chars_to_auto",
+                "reason": {},
+                "completed_at": datetime.now(UTC).isoformat(),
+            },
+        ],
+    )
+    def test_malformed_record_fields_are_unknown(self, tmp_path, record):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text(json.dumps(record))
+        with pytest.raises(MigrationCompletionError):
+            _migrate(path)
+
+    def test_unreadable_marker_is_not_completion(self, tmp_path, monkeypatch):
+        path = tmp_path / "config.yml"
+        path.write_text(_LEGACY_YAML)
+        marker = ceiling_marker_path(path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text("placeholder")
+        real_read_text = type(marker).read_text
+
+        def unreadable(self, *args, **kwargs):
+            if self == marker:
+                raise OSError("unreadable")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(type(marker), "read_text", unreadable)
+        with pytest.raises(MigrationCompletionError):
+            _migrate(path)
+
+
+class TestVacuousFailureSequence:
+    def test_blocked_vacuous_record_prevents_later_750k_erasure(self, tmp_path):
+        """Exact round-2 blocker: failure must stop this boot truthfully."""
+        path = tmp_path / "config.yml"
+        path.write_text("openai_codex:\n  context_compression:\n    max_context_chars: null\n")
+        (tmp_path / "data").write_text("blocks marker directory")
+        with pytest.raises(MigrationCompletionError):
+            _migrate(path)
+        assert "max_context_chars: null" in path.read_text()
+
+        # No boot may have continued and handed control to an operator.  Once
+        # persistence is repaired, the original null completes vacuously; only
+        # then is a later literal 750000 unambiguously intentional.
+        (tmp_path / "data").unlink()
+        _migrate(path)
+        path.write_text(_LEGACY_YAML)
+        data = _migrate(path)
+        assert (
+            data["openai_codex"]["context_compression"]["max_context_chars"]
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+        assert f"max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}" in path.read_text()
+
+    def test_load_config_reports_truthful_vacuous_completion_failure(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text(
+            'discord:\n  token: "t"\n'
+            "openai_codex:\n  context_compression:\n"
+            "    max_context_chars: null\n"
+        )
+        (tmp_path / "data").write_text("blocks marker directory")
+        with pytest.raises(SystemExit, match="Configuration migration failed"):
+            load_config(path)
+
+
+class TestAtomicMarkerPersistence:
+    def test_marker_replace_is_fsynced_and_mode_0600(self, tmp_path, monkeypatch):
+        marker = tmp_path / "data" / "marker.json"
+        import src.config.migrations as migrations
+
+        calls = []
+        real_fsync = os.fsync
+        real_replace = os.replace
+
+        def spy_fsync(fd):
+            calls.append("fsync")
+            return real_fsync(fd)
+
+        def spy_replace(source, destination):
+            calls.append("replace")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(migrations.os, "fsync", spy_fsync)
+        monkeypatch.setattr(migrations.os, "replace", spy_replace)
+        _atomic_write_marker(marker, {"ok": True})
+        assert calls[0] == "fsync"
+        assert "replace" in calls
+        assert marker.stat().st_mode & 0o777 == 0o600
+        assert not list(marker.parent.glob("*.tmp"))
+
+
+class TestAtomicMarkerFailures:
+    def test_replace_failure_cleans_temporary_file(self, tmp_path, monkeypatch):
+        marker = tmp_path / "data" / "marker.json"
+        import src.config.migrations as migrations
+
+        def fail_replace(*args, **kwargs):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(migrations.os, "replace", fail_replace)
+        with pytest.raises(OSError, match="replace failed"):
+            _atomic_write_marker(marker, {"ok": True})
+        assert not marker.exists()
+        assert not list(marker.parent.glob("*.tmp"))
+
+
+class TestRemainingMigrationBranches:
+    def test_required_marker_write_error_is_truthful(self, tmp_path, monkeypatch):
+        path = tmp_path / "config.yml"
+        path.write_text("discord:\n  token: t\n")
+        import src.config.migrations as migrations
+
+        def fail_write(*args, **kwargs):
+            raise OSError("marker blocked")
+
+        monkeypatch.setattr(migrations, "_atomic_write_marker", fail_write)
+        with pytest.raises(MigrationCompletionError, match="configuration was left unchanged"):
+            _migrate(path)
+
+    def test_runtime_auto_tolerates_missing_or_non_mapping_sections(self):
+        import src.config.migrations as migrations
+
+        missing = {}
+        migrations._set_runtime_auto(missing)
+        assert missing == {}
+
+        non_mapping = {"openai_codex": {"context_compression": "disabled"}}
+        migrations._set_runtime_auto(non_mapping)
+        assert non_mapping["openai_codex"]["context_compression"] == "disabled"
+
+    def test_open_temp_stream_is_closed_and_removed_on_write_failure(self, tmp_path, monkeypatch):
+        marker = tmp_path / "marker.json"
+        import src.config.migrations as migrations
+
+        class BrokenStream:
+            closed = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return None
+
+            def write(self, value):
+                raise OSError("write failed")
+
+            def close(self):
+                self.closed = True
+
+        broken = BrokenStream()
+        monkeypatch.setattr(migrations.os, "fdopen", lambda *args, **kwargs: broken)
+        with pytest.raises(OSError, match="write failed"):
+            _atomic_write_marker(marker, {"ok": True})
+        assert broken.closed is True
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_fd_is_closed_and_temp_removed_when_fdopen_fails(self, tmp_path, monkeypatch):
+        marker = tmp_path / "marker.json"
+        import src.config.migrations as migrations
+
+        closed = []
+        real_close = os.close
+
+        def fail_fdopen(*args, **kwargs):
+            raise OSError("fdopen failed")
+
+        def spy_close(fd):
+            closed.append(fd)
+            return real_close(fd)
+
+        monkeypatch.setattr(migrations.os, "fdopen", fail_fdopen)
+        monkeypatch.setattr(migrations.os, "close", spy_close)
+        with pytest.raises(OSError, match="fdopen failed"):
+            _atomic_write_marker(marker, {"ok": True})
+        assert closed
+        assert not list(tmp_path.glob("*.tmp"))

--- a/tests/test_config_ceiling_migration.py
+++ b/tests/test_config_ceiling_migration.py
@@ -1,0 +1,197 @@
+"""Legacy soft-compaction-ceiling migration (campaign phase 1).
+
+Pins the provenance-gated contract: only the EXACT legacy default is ever
+reinterpreted, one WARNING at migration time, marker-stable INFO thereafter,
+deliberate persistence clears provenance, and failures degrade to this-boot
+interpretation without crashing the loader.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import yaml
+
+from src.config.migrations import (
+    apply_legacy_ceiling_migration,
+    ceiling_marker_path,
+    record_ceiling_operator_provenance,
+)
+from src.config.persistence import patch_config_paths
+from src.config.schema import LEGACY_MAX_CONTEXT_CHARS, load_config
+
+
+def _legacy_data() -> dict:
+    return {
+        "openai_codex": {
+            "context_compression": {
+                "enabled": True,
+                "max_context_chars": LEGACY_MAX_CONTEXT_CHARS,
+                "keep_recent_iterations": 30,
+            }
+        }
+    }
+
+
+class TestApplyMigration:
+    def test_legacy_default_becomes_auto_and_marker_recorded(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        data = _legacy_data()
+        with caplog.at_level(logging.INFO, logger="odin.config"):
+            apply_legacy_ceiling_migration(data, config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+        marker = ceiling_marker_path(config_path)
+        assert marker.is_file()
+        recorded = json.loads(marker.read_text())
+        assert recorded["legacy_value"] == LEGACY_MAX_CONTEXT_CHARS
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+    def test_marker_present_keeps_auto_at_info_level(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        marker = ceiling_marker_path(config_path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text("{}")
+        before = marker.read_text()
+        data = _legacy_data()
+        with caplog.at_level(logging.INFO, logger="odin.config"):
+            apply_legacy_ceiling_migration(data, config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+        # Subsequent boots reinterpret at INFO — never silent, never a second
+        # WARNING, marker untouched.
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert [r for r in caplog.records if r.levelno == logging.INFO]
+        assert marker.read_text() == before
+
+    def test_non_legacy_values_untouched_and_no_marker(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        for value in (LEGACY_MAX_CONTEXT_CHARS + 1, 1, None):
+            data = _legacy_data()
+            data["openai_codex"]["context_compression"]["max_context_chars"] = value
+            apply_legacy_ceiling_migration(data, config_path)
+            assert (
+                data["openai_codex"]["context_compression"]["max_context_chars"]
+                == value
+            )
+        assert not ceiling_marker_path(config_path).exists()
+
+    def test_absent_sections_are_noops(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        for data in ({}, {"openai_codex": None}, {"openai_codex": {}},
+                     {"openai_codex": {"context_compression": None}}):
+            apply_legacy_ceiling_migration(data, config_path)  # must not raise
+        assert not ceiling_marker_path(config_path).exists()
+
+    def test_marker_write_failure_still_interprets_auto(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        # Occupy the data-dir path with a FILE so mkdir(parents=True) fails.
+        (tmp_path / "data").write_text("not a directory")
+        data = _legacy_data()
+        with caplog.at_level(logging.WARNING, logger="odin.config"):
+            apply_legacy_ceiling_migration(data, config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+        assert any("retries next boot" in r.getMessage() for r in caplog.records)
+
+
+class TestOperatorProvenance:
+    def test_operator_stamp_makes_legacy_value_verbatim(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        record_ceiling_operator_provenance(config_path)
+        marker = ceiling_marker_path(config_path)
+        assert json.loads(marker.read_text())["operator_saved"] is True
+        data = _legacy_data()
+        apply_legacy_ceiling_migration(data, config_path)
+        # Operator provenance: the literal legacy value is honored verbatim.
+        assert (
+            data["openai_codex"]["context_compression"]["max_context_chars"]
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+
+    def test_corrupt_marker_fails_toward_auto(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("x: 1")
+        marker = ceiling_marker_path(config_path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text("not json {")
+        data = _legacy_data()
+        apply_legacy_ceiling_migration(data, config_path)
+        assert data["openai_codex"]["context_compression"]["max_context_chars"] is None
+
+    def test_persisting_compression_section_stamps_provenance(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(
+            "openai_codex:\n  context_compression:\n    max_context_chars: 750000\n"
+        )
+        marker = ceiling_marker_path(config_path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text("{}")  # legacy provenance until a deliberate save
+        patch_config_paths(
+            [
+                (
+                    ("openai_codex", "context_compression", "max_context_chars"),
+                    LEGACY_MAX_CONTEXT_CHARS,
+                )
+            ],
+            path=config_path,
+        )
+        assert json.loads(marker.read_text())["operator_saved"] is True
+        persisted = yaml.safe_load(config_path.read_text())
+        assert (
+            persisted["openai_codex"]["context_compression"]["max_context_chars"]
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+
+    def test_unrelated_persistence_does_not_stamp(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text("openai_codex:\n  model: gpt-5.5\n")
+        marker = ceiling_marker_path(config_path)
+        marker.parent.mkdir(parents=True)
+        marker.write_text("{}")
+        patch_config_paths(
+            [(("openai_codex", "model"), "gpt-5.6-sol")], path=config_path
+        )
+        assert json.loads(marker.read_text()) == {}
+
+
+class TestLoadConfigIntegration:
+    def test_load_config_migrates_then_honors_operator_750k(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(
+            "discord:\n"
+            '  token: "t"\n'
+            "openai_codex:\n"
+            "  context_compression:\n"
+            "    enabled: true\n"
+            f"    max_context_chars: {LEGACY_MAX_CONTEXT_CHARS}\n"
+            "    keep_recent_iterations: 30\n"
+        )
+        with caplog.at_level(logging.INFO, logger="odin.config"):
+            cfg = load_config(config_path)
+        cc = cfg.openai_codex.context_compression
+        assert cc.max_context_chars is None
+        assert cc.resolved_max_context_chars == LEGACY_MAX_CONTEXT_CHARS
+        assert ceiling_marker_path(config_path).is_file()
+
+        # An operator save of the section clears provenance; the SAME literal
+        # value now loads verbatim — the one-time gate, not eternal coercion.
+        patch_config_paths(
+            [
+                (
+                    ("openai_codex", "context_compression", "max_context_chars"),
+                    LEGACY_MAX_CONTEXT_CHARS,
+                )
+            ],
+            path=config_path,
+        )
+        cfg2 = load_config(config_path)
+        assert (
+            cfg2.openai_codex.context_compression.max_context_chars
+            == LEGACY_MAX_CONTEXT_CHARS
+        )

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,310 @@
+"""Contract battery for the per-model context-budget kernel (campaign phase 1).
+
+Covers the pure resolver (src/llm/context_budget.py), the schema-owned
+registry/canonicalizer, and the new configuration fields. The settled
+numbers here are the plan-of-record examples — a formula change that moves
+any of them is a design change, not a refactor.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from src.config.schema import (
+    CODEX_MODEL_INPUT_BUDGETS,
+    CODEX_UNKNOWN_MODEL_INPUT_BUDGET,
+    CONTEXT_BUDGET_OVERRIDE_MAX,
+    CONTEXT_BUDGET_OVERRIDE_MIN,
+    LEGACY_MAX_CONTEXT_CHARS,
+    ContextCompressionConfig,
+    OpenAICodexConfig,
+    canonical_codex_model,
+    input_budget_floor_for_model,
+)
+from src.llm.context_budget import (
+    FIXED_ENVELOPE_RESERVE_TOKENS,
+    LEGACY_UTILIZATION_FLOOR_TOKENS,
+    RESCUE_CEILING_CHARS,
+    resolve_context_budget,
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonicalizer + registry
+# ---------------------------------------------------------------------------
+class TestCanonicalizer:
+    def test_trims_and_preserves_unknown_spelling(self):
+        assert canonical_codex_model("  gpt-5.6-sol ") == "gpt-5.6-sol"
+        # Unknown models pass through spelling-preserved — no case folding.
+        assert canonical_codex_model(" Some-Future-Model ") == "Some-Future-Model"
+
+    def test_alias_maps_before_lookup(self):
+        assert canonical_codex_model("codex-auto-review") == "gpt-5.6-luna"
+        assert (
+            input_budget_floor_for_model("codex-auto-review")
+            == CODEX_MODEL_INPUT_BUDGETS["gpt-5.6-luna"]
+        )
+
+    def test_none_and_empty(self):
+        assert canonical_codex_model(None) == ""
+        assert canonical_codex_model("   ") == ""
+        assert input_budget_floor_for_model(None) == CODEX_UNKNOWN_MODEL_INPUT_BUDGET
+
+    def test_alias_is_not_a_registry_row(self):
+        assert "codex-auto-review" not in CODEX_MODEL_INPUT_BUDGETS
+
+
+class TestRegistryFloors:
+    def test_floors_match_probe_evidence(self):
+        # A floor never exceeds its own accepted observation: only sol got
+        # the fine-refinement acceptances (921,601); its window-mates proved
+        # 917,506 (plan of record R2).
+        assert CODEX_MODEL_INPUT_BUDGETS == {
+            "gpt-5.6-sol": 921_601,
+            "gpt-5.6-terra": 917_506,
+            "gpt-5.6-luna": 917_506,
+            "gpt-5.4": 917_506,
+            "gpt-5.5": 270_001,
+            "gpt-5.4-mini": 262_146,
+            "gpt-5.3-codex-spark": 124_001,
+        }
+        assert CODEX_UNKNOWN_MODEL_INPUT_BUDGET == 272_000
+
+
+# ---------------------------------------------------------------------------
+# Resolver characterization — the settled plan-of-record numbers
+# ---------------------------------------------------------------------------
+class TestResolverDefaults:
+    def test_sol_at_defaults(self):
+        snap = resolve_context_budget("gpt-5.6-sol")
+        assert snap.base_budget == 921_601
+        assert snap.base_source == "floor"
+        assert snap.working_budget == 552_960
+        assert snap.compactable_tokens == 510_960
+        assert snap.primary_chars == 1_277_400
+        assert snap.ladder == (894_180, 400_000)
+
+    def test_terra_luna_54_at_defaults(self):
+        for model in ("gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"):
+            snap = resolve_context_budget(model)
+            assert snap.base_budget == 917_506
+            assert snap.working_budget == 550_503
+            assert snap.primary_chars == 1_271_257
+            assert snap.ladder == (889_879, 400_000)
+
+    def test_55_legacy_floor_keeps_full_target(self):
+        snap = resolve_context_budget("gpt-5.5")
+        # 60% of 270,001 is 162,000 — the 272K legacy floor wins, so the
+        # working budget stays the full budget and the derived target matches
+        # the pre-campaign per-model result exactly.
+        assert snap.working_budget == 270_001
+        assert snap.primary_chars == 570_002
+        assert snap.ladder == (399_001,)
+
+    def test_54_mini_at_defaults(self):
+        snap = resolve_context_budget("gpt-5.4-mini")
+        assert snap.working_budget == 262_146
+        assert snap.primary_chars == 550_365
+        assert snap.ladder == (385_255,)
+
+    def test_spark_not_lifted_by_legacy_floor(self):
+        snap = resolve_context_budget("gpt-5.3-codex-spark")
+        # min(budget, max(272K, …)) can never RAISE a small budget.
+        assert snap.working_budget == 124_001
+        assert snap.primary_chars == 205_002
+        assert snap.ladder == (143_501,)
+
+    def test_unknown_model_reproduces_precampaign_constants(self):
+        snap = resolve_context_budget("some-new-model")
+        assert snap.base_source == "unknown_default"
+        assert snap.working_budget == 272_000
+        # Today's shipped emergency targets were 575,000 / 400,000: the
+        # unknown-model primary is exactly the old first target and the
+        # rescue ceiling is exactly the old aggressive target.
+        assert snap.primary_chars == 575_000
+        assert snap.ladder == (402_500, 400_000)
+
+    def test_alias_resolves_identically_to_luna(self):
+        assert resolve_context_budget("codex-auto-review") == resolve_context_budget(
+            "gpt-5.6-luna"
+        )
+
+    def test_snapshot_is_frozen(self):
+        snap = resolve_context_budget("gpt-5.6-sol")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            snap.primary_chars = 1  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Overrides, clamps, utilization, ceiling
+# ---------------------------------------------------------------------------
+class TestResolverInputs:
+    def test_override_beats_floor(self):
+        snap = resolve_context_budget(
+            "gpt-5.5", overrides={"gpt-5.5": 400_000}
+        )
+        assert snap.base_budget == 400_000
+        assert snap.base_source == "override"
+        # 60% of 400,000 = 240,000 < 272,000 legacy floor → floor wins,
+        # capped by the budget itself.
+        assert snap.working_budget == 272_000
+
+    def test_override_for_unknown_model(self):
+        snap = resolve_context_budget("future-x", overrides={"future-x": 600_000})
+        assert snap.base_source == "override"
+        assert snap.working_budget == 360_000
+
+    def test_clamp_below_base_applies(self):
+        snap = resolve_context_budget("gpt-5.6-sol", observed_clamp=372_000)
+        assert snap.clamp_applied is True
+        assert snap.effective_budget == 372_000
+        # 60% of 372,000 = 223,200 → legacy floor 272,000 wins.
+        assert snap.working_budget == 272_000
+        assert snap.primary_chars == 575_000
+
+    def test_clamp_at_or_above_base_ignored(self):
+        for clamp in (921_601, 1_000_000):
+            snap = resolve_context_budget("gpt-5.6-sol", observed_clamp=clamp)
+            assert snap.clamp_applied is False
+            assert snap.effective_budget == 921_601
+
+    def test_utilization_100_uses_full_budget(self):
+        snap = resolve_context_budget("gpt-5.6-sol", utilization=100)
+        assert snap.working_budget == 921_601
+        assert snap.primary_chars == 2_199_002
+
+    def test_utilization_30_bites_only_large_budgets(self):
+        sol = resolve_context_budget("gpt-5.6-sol", utilization=30)
+        assert sol.working_budget == 276_480
+        five5 = resolve_context_budget("gpt-5.5", utilization=30)
+        assert five5.working_budget == 270_001  # legacy floor: unchanged
+
+    def test_explicit_ceiling_only_lowers(self):
+        lowered = resolve_context_budget("gpt-5.6-sol", max_context_chars=800_000)
+        assert lowered.ceiling_applied is True
+        assert lowered.primary_chars == 800_000
+        raised = resolve_context_budget("gpt-5.6-sol", max_context_chars=9_999_999)
+        assert raised.ceiling_applied is False
+        assert raised.primary_chars == 1_277_400
+
+    def test_ladder_derives_from_final_primary_after_ceiling(self):
+        # The R5-settled ordering rule: a low explicit ceiling must pull the
+        # rescue rungs down with it — never an emergency target above primary.
+        snap = resolve_context_budget("gpt-5.6-sol", max_context_chars=300_000)
+        assert snap.primary_chars == 300_000
+        assert snap.ladder == (210_000,)
+        assert all(rung <= snap.primary_chars for rung in snap.ladder)
+
+
+# ---------------------------------------------------------------------------
+# Totality — evidence clamps bypass override bounds by design
+# ---------------------------------------------------------------------------
+class TestResolverTotality:
+    @pytest.mark.parametrize("clamp", [0, 41_999, FIXED_ENVELOPE_RESERVE_TOKENS])
+    def test_clamp_at_or_below_envelope_yields_empty_ladder(self, clamp):
+        snap = resolve_context_budget("gpt-5.6-sol", observed_clamp=clamp)
+        assert snap.compactable_tokens == 0
+        assert snap.derived_chars == 0
+        assert snap.primary_chars == 0
+        assert snap.ladder == ()
+
+    def test_negative_clamp_never_goes_negative(self):
+        snap = resolve_context_budget("gpt-5.6-sol", observed_clamp=-5)
+        assert snap.compactable_tokens == 0
+        assert snap.derived_chars == 0
+        assert snap.ladder == ()
+
+    def test_clamp_at_override_minimum_boundary(self):
+        snap = resolve_context_budget(
+            "gpt-5.6-sol", observed_clamp=CONTEXT_BUDGET_OVERRIDE_MIN
+        )
+        # 50,192 − 42,000 = 8,192 tokens → 20,480 chars → single 14,336 rung.
+        assert snap.compactable_tokens == 8_192
+        assert snap.derived_chars == 20_480
+        assert snap.ladder == (14_336,)
+
+    def test_ladder_always_positive_monotonic_deduped(self):
+        for clamp in (None, 43_000, 50_192, 100_000, 372_000, 921_601):
+            for util in (30, 60, 100):
+                for ceiling in (None, 1, 100_000, 500_000, 5_000_000):
+                    snap = resolve_context_budget(
+                        "gpt-5.6-sol",
+                        observed_clamp=clamp,
+                        utilization=util,
+                        max_context_chars=ceiling,
+                    )
+                    assert all(rung > 0 for rung in snap.ladder)
+                    assert list(snap.ladder) == sorted(snap.ladder, reverse=True)
+                    assert len(set(snap.ladder)) == len(snap.ladder)
+                    if snap.ladder:
+                        # The dedupe guarantees this: a lone surviving rung is
+                        # one that already sat at or below the rescue ceiling.
+                        assert snap.ladder[-1] <= RESCUE_CEILING_CHARS
+                    assert all(r <= snap.primary_chars for r in snap.ladder)
+
+    def test_rescue_ceiling_never_enlarges(self):
+        # Models whose own rung is below 400K keep it (min semantics).
+        snap = resolve_context_budget("gpt-5.3-codex-spark")
+        assert snap.ladder == (143_501,)
+        assert LEGACY_UTILIZATION_FLOOR_TOKENS == 272_000
+
+
+# ---------------------------------------------------------------------------
+# Configuration surface
+# ---------------------------------------------------------------------------
+class TestBudgetConfig:
+    def test_override_keys_canonicalized_and_deduped(self):
+        cfg = OpenAICodexConfig(
+            context_budget_overrides={" codex-auto-review ": 900_000}
+        )
+        assert cfg.context_budget_overrides == {"gpt-5.6-luna": 900_000}
+        with pytest.raises(ValueError, match="duplicates"):
+            OpenAICodexConfig(
+                context_budget_overrides={
+                    "codex-auto-review": 900_000,
+                    "gpt-5.6-luna": 800_000,
+                }
+            )
+
+    @pytest.mark.parametrize(
+        "value", [0, CONTEXT_BUDGET_OVERRIDE_MIN - 1, CONTEXT_BUDGET_OVERRIDE_MAX + 1]
+    )
+    def test_override_bounds_enforced(self, value):
+        with pytest.raises(ValueError):
+            OpenAICodexConfig(context_budget_overrides={"gpt-5.5": value})
+
+    def test_override_bound_edges_accepted(self):
+        cfg = OpenAICodexConfig(
+            context_budget_overrides={
+                "gpt-5.5": CONTEXT_BUDGET_OVERRIDE_MIN,
+                "gpt-5.6-sol": CONTEXT_BUDGET_OVERRIDE_MAX,
+            }
+        )
+        assert cfg.context_budget_overrides["gpt-5.5"] == CONTEXT_BUDGET_OVERRIDE_MIN
+
+    def test_empty_override_key_rejected(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            OpenAICodexConfig(context_budget_overrides={"   ": 900_000})
+
+    @pytest.mark.parametrize("value", [29, 101, True])
+    def test_utilization_bounds(self, value):
+        with pytest.raises(ValueError):
+            OpenAICodexConfig(context_utilization=value)
+
+    def test_utilization_default_and_edges(self):
+        assert OpenAICodexConfig().context_utilization == 60
+        assert OpenAICodexConfig(context_utilization=30).context_utilization == 30
+        assert OpenAICodexConfig(context_utilization=100).context_utilization == 100
+
+    def test_ceiling_null_is_auto_and_positive_required(self):
+        assert ContextCompressionConfig().max_context_chars is None
+        assert (
+            ContextCompressionConfig().resolved_max_context_chars
+            == LEGACY_MAX_CONTEXT_CHARS
+        )
+        explicit = ContextCompressionConfig(max_context_chars=500_000)
+        assert explicit.resolved_max_context_chars == 500_000
+        with pytest.raises(ValueError):
+            ContextCompressionConfig(max_context_chars=0)

--- a/tests/test_context_compressor.py
+++ b/tests/test_context_compressor.py
@@ -712,7 +712,10 @@ class TestContextCompressionConfig:
         from src.config.schema import ContextCompressionConfig
         cfg = ContextCompressionConfig()
         assert cfg.enabled is True
-        assert cfg.max_context_chars == 750_000
+        # Auto (None) by default; consumers read the resolved accessor, which
+        # keeps the legacy ceiling until the per-model resolver is wired.
+        assert cfg.max_context_chars is None
+        assert cfg.resolved_max_context_chars == 750_000
         assert cfg.keep_recent_iterations == 30
 
     def test_custom_config(self):

--- a/tests/test_native_agents_tasks.py
+++ b/tests/test_native_agents_tasks.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from src.config.schema import ContextCompressionConfig
 from src.discord.background_task import MAX_STEPS
 from src.discord.native_tools.agents_tasks import (
     AgentTaskDeps,
@@ -308,7 +309,7 @@ class TestSpawnAgent:
         assert {tool["name"] for tool in tools} == {"spawn_agent", "run_command"}
 
     async def test_nested_with_parent_and_compressor(self):
-        cc = SimpleNamespace(max_context_chars=500000, keep_recent_iterations=20)
+        cc = ContextCompressionConfig(max_context_chars=500000, keep_recent_iterations=20)
         t = _tools(get_context_compressor=lambda: cc)
         t._agent_manager.spawn.return_value = "child-1"
         t._agent_manager._agents = {"parent-1": SimpleNamespace(depth=0)}

--- a/tests/test_spawn_loop_agents_config.py
+++ b/tests/test_spawn_loop_agents_config.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from src.config.schema import ContextCompressionConfig
 from tests.fakes import FakeChannel, FakeLLM, FakeMessage, make_bot
 
 
@@ -58,7 +59,10 @@ class TestSpawnLoopAgentsConfigPath:
         assert "AttributeError" not in result
         assert "agent-a" in result or "spawned" in result.lower()
         assert captured["context_compression_enabled"] is True
-        assert captured["max_context_chars"] == bot.context_compressor.max_context_chars
+        assert (
+            captured["max_context_chars"]
+            == bot.context_compressor.resolved_max_context_chars
+        )
         assert captured["keep_recent_iterations"] == bot.context_compressor.keep_recent_iterations
 
     async def test_defaults_used_when_compression_disabled(self):
@@ -74,7 +78,7 @@ class TestSpawnLoopAgentsConfigPath:
 
     async def test_compressor_values_forwarded_when_enabled(self):
         bot, captured = _bot_with_running_loop()
-        bot.context_compressor = SimpleNamespace(
+        bot.context_compressor = ContextCompressionConfig(
             enabled=True, max_context_chars=123456, keep_recent_iterations=7
         )
         await bot.agent_task_tools._handle_spawn_loop_agents(


### PR DESCRIPTION
Phase 1 of the context-budget campaign (plan of record R2, jointly settled). Targets the campaign branch — nothing here reaches master until the final integration PR.

## Content
- **Per-model input-budget registry** (`CODEX_MODEL_INPUT_BUDGETS`): known-safe usable input floors — each value is that model's own probe-accepted observation (sol 921,601; terra/luna/gpt-5.4 917,506; gpt-5.5 270,001; 5.4-mini 262,146; spark 124,001; unknown slugs 272,000). `canonical_codex_model()` is the single canonicalizer (trim, alias `codex-auto-review`→`gpt-5.6-luna`, spelling preserved) behind every lookup.
- **New config**: `openai_codex.context_budget_overrides` (canonical keys, duplicate-alias rejection, 50,192–2,000,000 bounds, bool-rejection) and `openai_codex.context_utilization` (30–100, default 60). Both classified **dormant** in the apply registry — truthful until phase 3 wires the resolver.
- **Pure total resolver** (`src/llm/context_budget.py`): override ?? floor ?? unknown-default → exact-evidence clamp → 60% utilization with the 272K legacy floor → 42K envelope reserve → exact integer arithmetic (×5//2, ×7//10 — no float drift) → positive, monotonic, deduplicated rescue ladder (0.7×final-primary, 400K rescue ceiling that never enlarges). Frozen per-generation snapshot dataclass. **No runtime consumer yet.**
- **Nullable global ceiling + one-time migration**: `max_context_chars` becomes `int|None` (null = auto). Consumers read `resolved_max_context_chars` (auto → legacy 750,000 until phase 3) — behavior byte-identical today, proven by the suite. The migration never rewrites config.yml (env placeholders/comments survive); a `data/`-side marker is a two-state provenance ledger: legacy-default 750,000 → auto with ONE warning + marker; marker-without-operator-stamp → auto at INFO; a deliberate save of the compression section stamps operator provenance so any post-save value — including 750,000 — loads verbatim forever. The save path stamps, never deletes (a bare deletion would make a still-materialized 750,000 look legacy again — caught by the round-trip test during development).

## Verification
- Suite: **9,309 passed / 5 skipped** (+52 new tests)
- Resolver characterization pinned at the plan-of-record numbers; totality boundary pins at clamp = 0 / 42,000 / 50,192; ladder invariants swept across clamp×utilization×ceiling grids
- Migration polarity round-trip: migrate → operator save of literal 750,000 → verbatim reload
- `ruff` clean · type-gate new=0 · apply-registry findings=0 (264 leaves) · coverage-gate findings=0 (both new files baselined at 95.65% / 100%)
- Registry census pin updated 262→264; test fakes upgraded from SimpleNamespace to the real `ContextCompressionConfig` contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHfEwTsEyuS8RUhwdoW66g