### PR TITLE
Context-budget campaign: out-of-the-box defaults mirror the reference deployment

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,21 +14,21 @@ openai_codex:
   enabled: true
   # ChatGPT-account Codex backend only supports the GPT-5 family
   # (gpt-4o et al return "model not supported" via this auth path).
-  model: gpt-5.5
+  model: gpt-5.6-sol
   # Reasoning effort sent with every main-provider request:
   # none | low | medium | high | xhigh | max (backend default: medium).
   # "max" is gpt-5.6-family only — config load rejects a known-incompatible
   # model/effort pair (e.g. gpt-5.5 + max) rather than 400 on every request.
-  reasoning_effort: medium
+  reasoning_effort: xhigh
   # Effort for spawned-agent iterations only. Unset/null = inherit
   # reasoning_effort ("none" is a real effort level, not inherit). Set to
   # "auto" to let the spawner choose the effort per spawn from the catalogue.
   # Read at call time — live changes reach in-flight agents next iteration.
-  agent_reasoning_effort: null
+  agent_reasoning_effort: auto
   # Model for spawned-agent iterations only. Unset/null = inherit model; a
   # specific model = fixed; "auto" = let the spawner choose per spawn.
   # Read at call time — live changes reach in-flight agents next iteration.
-  agent_model: null
+  agent_model: auto
   credentials_path: ./data/codex_auth.json
   # Streaming transport timeouts. request_timeout_seconds is a generous
   # whole-request backstop (long high-effort reasoning turns stream past
@@ -55,8 +55,8 @@ openai_codex:
   # automatic fallback to the primary model on error. It shares the main Codex
   # OAuth credentials; only the model differs. Editable live from the WebUI.
   auxiliary:
-    enabled: false
-    model: gpt-5.6-luna
+    enabled: true
+    model: gpt-5.6-terra
 
 ollama:
   enabled: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,10 +69,10 @@ tools:
 ```yaml
 openai_codex:
   enabled: true
-  model: gpt-5.5                 # ChatGPT subscription path
-  reasoning_effort: medium       # none | low | medium | high | xhigh | max
-  agent_reasoning_effort: null   # spawned agents; null = inherit, "auto" = per-spawn choice
-  agent_model: null              # spawned agents; null = inherit, "auto" = per-spawn choice
+  model: gpt-5.6-sol             # ChatGPT subscription path
+  reasoning_effort: xhigh        # none | low | medium | high | xhigh | max
+  agent_reasoning_effort: auto   # spawned agents; "auto" = per-spawn choice, null = inherit
+  agent_model: auto              # spawned agents; "auto" = per-spawn choice, null = inherit
   credentials_path: ./data/codex_auth.json
   request_timeout_seconds: 3600  # whole-request backstop; long reasoning turns stream past 10 min
   stream_stall_timeout_seconds: 180  # fail fast when no stream bytes arrive for this long
@@ -91,8 +91,8 @@ openai_codex:
   # (30-100). Never reduces budgets at or below 272K tokens.
   context_utilization: 60
   auxiliary:                     # cheaper model for background jobs
-    enabled: false
-    model: gpt-5.6-luna
+    enabled: true
+    model: gpt-5.6-terra
 ```
 
 A persisted `max_context_chars: 750000` from the pre-campaign default is

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -366,12 +366,13 @@ class AuxiliaryLLMConfig(BaseModel):
     differs. When ``enabled`` and a Codex provider is active, those four
     jobs route here; otherwise they use the primary model.
 
-    Default Luna: the Codex catalog positions it for the cheap extraction /
-    transformation tier that suits this workload.
+    Default Terra, enabled: the out-of-the-box configuration mirrors the
+    reference deployment — background jobs on the mid-tier model while the
+    primary handles conversation.
     """
 
-    enabled: bool = False
-    model: str = "gpt-5.6-luna"
+    enabled: bool = True
+    model: str = "gpt-5.6-terra"
 
 
 # "minimal" is deliberately absent: it sits in the Codex API's generic
@@ -531,19 +532,19 @@ class OpenAICodexConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     enabled: bool = False
-    model: str = "gpt-4o"
-    reasoning_effort: ReasoningEffort = "medium"
+    model: str = "gpt-5.6-sol"
+    reasoning_effort: ReasoningEffort = "xhigh"
     # Effort for SPAWNED-AGENT iterations only. None = inherit
     # reasoning_effort (the string "none" is a real effort level, not
     # inherit); "auto" = expose per-spawn effort selection to the spawner
     # ("auto" is policy, never sent to a provider). Read at call time, so
     # live changes reach in-flight agents on their next iteration.
-    agent_reasoning_effort: ReasoningEffort | Literal["auto"] | None = None
+    agent_reasoning_effort: ReasoningEffort | Literal["auto"] | None = "auto"
     # Model for SPAWNED-AGENT iterations only. None = inherit ``model``;
     # "auto" = expose per-spawn model selection to the spawner. Free string
     # like ``model`` otherwise (the WebUI dropdown is the constraint; an
     # unsupported value fails per-request). Read at call time.
-    agent_model: str | None = None
+    agent_model: str | None = "auto"
     credentials_path: str = "./data/codex_auth.json"
     # Streaming transport timeouts: a generous whole-request backstop (long
     # high-effort reasoning turns stream well past 10 minutes) plus a stall

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -27,7 +27,11 @@ _DEFAULT_CONFIG: dict[str, Any] = {
     },
     "openai_codex": {
         "enabled": True,
-        "model": "gpt-5.5",
+        # Matches the schema default (the reference-deployment primary): an
+        # explicit legacy value here would silently override it on the one
+        # supported first-boot path and pin fresh installs to a 272K-class
+        # budget instead of sol's floor.
+        "model": "gpt-5.6-sol",
         "credentials_path": "./data/codex_auth.json",
     },
     "context": {

--- a/tests/test_auxiliary_llm.py
+++ b/tests/test_auxiliary_llm.py
@@ -62,10 +62,10 @@ def _make_client(
 class TestAuxiliaryLLMConfig:
     def test_defaults(self):
         cfg = AuxiliaryLLMConfig()
-        assert cfg.enabled is False
-        # Default is Luna (v3.62.x): the Codex catalog's cheap extraction/
-        # classification tier; gpt-4o-mini is no longer in the catalog.
-        assert cfg.model == "gpt-5.6-luna"
+        # Enabled on Terra out of the box: defaults mirror the reference
+        # deployment (context-budget campaign defaults ruling).
+        assert cfg.enabled is True
+        assert cfg.model == "gpt-5.6-terra"
 
     def test_custom_values(self):
         cfg = AuxiliaryLLMConfig(enabled=True, model="gpt-3.5-turbo")
@@ -81,7 +81,7 @@ class TestAuxiliaryLLMConfig:
     def test_nested_in_openai_codex_config(self):
         cfg = OpenAICodexConfig()
         assert isinstance(cfg.auxiliary, AuxiliaryLLMConfig)
-        assert cfg.auxiliary.enabled is False
+        assert cfg.auxiliary.enabled is True
 
     def test_custom_nested(self):
         cfg = OpenAICodexConfig(

--- a/tests/test_config_schema_validators.py
+++ b/tests/test_config_schema_validators.py
@@ -168,9 +168,10 @@ class TestLoadConfig:
 
 
 class TestCodexReasoningEffort:
-    def test_default_is_medium(self):
+    def test_default_is_xhigh(self):
+        # Defaults mirror the reference deployment (defaults ruling).
         from src.config.schema import OpenAICodexConfig
-        assert OpenAICodexConfig().reasoning_effort == "medium"
+        assert OpenAICodexConfig().reasoning_effort == "xhigh"
 
     def test_all_enum_values_accepted(self):
         from src.config.schema import CODEX_REASONING_EFFORTS, OpenAICodexConfig
@@ -253,9 +254,11 @@ class TestAgentsTimeoutConfig:
 
 
 class TestAgentReasoningEffortConfig:
-    def test_default_is_inherit(self):
+    def test_default_is_auto(self):
+        # Defaults mirror the reference deployment: per-spawn Auto/Dynamic.
         from src.config.schema import OpenAICodexConfig
-        assert OpenAICodexConfig().agent_reasoning_effort is None
+        assert OpenAICodexConfig().agent_reasoning_effort == "auto"
+        assert OpenAICodexConfig(agent_reasoning_effort=None).agent_reasoning_effort is None
 
     def test_valid_values_accepted(self):
         from src.config.schema import CODEX_REASONING_EFFORTS, OpenAICodexConfig
@@ -279,9 +282,11 @@ class TestAgentReasoningEffortConfig:
 
 
 class TestAgentModelConfig:
-    def test_default_is_inherit(self):
+    def test_default_is_auto(self):
+        # Defaults mirror the reference deployment: per-spawn Auto/Dynamic.
         from src.config.schema import OpenAICodexConfig
-        assert OpenAICodexConfig().agent_model is None
+        assert OpenAICodexConfig().agent_model == "auto"
+        assert OpenAICodexConfig(agent_model=None).agent_model is None
 
     def test_value_round_trips(self):
         from src.config.schema import OpenAICodexConfig

--- a/tests/test_max_reasoning_effort.py
+++ b/tests/test_max_reasoning_effort.py
@@ -102,6 +102,7 @@ class TestLoadBoundary:
             OpenAICodexConfig(
                 model="gpt-5.5",
                 reasoning_effort="xhigh",
+                agent_model=None,  # explicit inherit (default is now "auto")
                 agent_reasoning_effort="max",
             )
 
@@ -112,6 +113,7 @@ class TestLoadBoundary:
                 model="gpt-5.6-sol",
                 reasoning_effort="max",
                 agent_model="gpt-5.5",
+                agent_reasoning_effort=None,  # explicit inherit (default is now "auto")
             )
 
     def test_auto_model_axis_exempt(self):

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -40,6 +40,24 @@ class TestBuildConfig:
         cfg["discord"]["token"] = "mutated"
         assert build_config()["discord"]["token"] != "mutated"
 
+    def test_generated_codex_defaults_match_reference_deployment(self):
+        """The scaffold is the one supported first-boot writer: an explicit
+        legacy value here silently overrides the schema defaults, so the
+        GENERATED and the PARSED codex default tuple are pinned together."""
+        from src.config.schema import OpenAICodexConfig
+
+        generated = build_config()["openai_codex"]
+        assert generated["model"] == "gpt-5.6-sol"
+        parsed = OpenAICodexConfig(**generated)
+        assert (
+            parsed.model,
+            parsed.reasoning_effort,
+            parsed.agent_model,
+            parsed.agent_reasoning_effort,
+            parsed.auxiliary.enabled,
+            parsed.auxiliary.model,
+        ) == ("gpt-5.6-sol", "xhigh", "auto", "auto", True, "gpt-5.6-terra")
+
 
 class TestBuildEnv:
     def test_contains_discord_token_line(self):

--- a/tests/test_web_api_llm_admin.py
+++ b/tests/test_web_api_llm_admin.py
@@ -144,7 +144,7 @@ class TestLlmStatus:
             body = await (await c.get("/api/llm/status")).json()
             assert body["codex"]["configured"] is True
             assert "max_tokens" not in body["codex"]
-            assert body["codex"]["reasoning_effort"] == "medium"
+            assert body["codex"]["reasoning_effort"] == "xhigh"
             assert body["codex"]["active_reasoning_effort"] is None  # object() has no attr
             assert body["ollama"]["configured"] is False
             assert body["active_model"] == "gpt-5.5"
@@ -156,8 +156,9 @@ class TestLlmStatus:
         bot.llm_gateway.ollama_client = None
         bot.llm_gateway.kimi_client = None
         bot.llm_gateway.active_client = None
+        bot.config.openai_codex.agent_reasoning_effort = None  # explicit inherit (default: "auto")
         async with TestClient(TestServer(app)) as c:
-            # inherit (default): effective mirrors the live client's effort
+            # inherit: effective mirrors the live client's effort
             body = await (await c.get("/api/llm/status")).json()
             assert body["codex"]["agent_reasoning_effort"] is None
             assert body["codex"]["effective_agent_reasoning_effort"] == "high"
@@ -231,6 +232,7 @@ class TestLlmStatus:
         bot.llm_gateway.ollama_client = None
         bot.llm_gateway.kimi_client = None
         bot.llm_gateway.active_client = None
+        bot.config.openai_codex.agent_model = None  # explicit inherit (default is "auto")
         async with TestClient(TestServer(app)) as c:
             body = await (await c.get("/api/llm/status")).json()
             assert body["codex"]["agent_model"] is None
@@ -477,7 +479,7 @@ class TestProviderConfig:
                 await c.put("/api/llm/codex/config", json={"reasoning_effort": "minimal"})
             ).status == 400
         # nothing mutated, nothing reloaded
-        assert bot.config.openai_codex.reasoning_effort == "medium"
+        assert bot.config.openai_codex.reasoning_effort == "xhigh"
         assert bot.config.openai_codex.model != "changed-model"
         bot.llm_gateway.reload_codex_inner.assert_not_awaited()
 
@@ -687,7 +689,7 @@ class TestProviderConfig:
             )
             assert r.status == 400
             assert "agent_reasoning_effort" in (await r.json())["error"]
-        assert bot.config.openai_codex.agent_reasoning_effort is None
+        assert bot.config.openai_codex.agent_reasoning_effort == "auto"
         assert bot.config.openai_codex.model != "changed-model"
         bot.llm_gateway.reload_codex_inner.assert_not_awaited()
 
@@ -1330,7 +1332,7 @@ class TestCodexMaxEffortPairValidation:
             assert "gpt-5.5" in data["error"] and "'max'" in data["error"]
             assert "max" not in data["allowed"] and "xhigh" in data["allowed"]
         # nothing mutated, nothing reloaded
-        assert bot.config.openai_codex.reasoning_effort == "medium"
+        assert bot.config.openai_codex.reasoning_effort == "xhigh"
         gw.reload_codex_inner.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1355,11 +1357,12 @@ class TestCodexMaxEffortPairValidation:
         _gw(bot)
         bot.config.openai_codex.model = "gpt-5.6-sol"
         bot.config.openai_codex.reasoning_effort = "max"
+        bot.config.openai_codex.agent_reasoning_effort = None  # explicit inherit (default: "auto")
         async with TestClient(TestServer(app)) as c:
             r = await c.put("/api/llm/codex/config", json={"agent_model": "gpt-5.5"})
             assert r.status == 400
             assert "agent settings" in (await r.json())["error"]
-        assert bot.config.openai_codex.agent_model is None
+        assert bot.config.openai_codex.agent_model == "auto"
 
     @pytest.mark.asyncio
     async def test_agent_effort_direction_rejected(self):
@@ -1369,7 +1372,7 @@ class TestCodexMaxEffortPairValidation:
         async with TestClient(TestServer(app)) as c:
             r = await c.put("/api/llm/codex/config", json={"agent_reasoning_effort": "max"})
             assert r.status == 400
-        assert bot.config.openai_codex.agent_reasoning_effort is None
+        assert bot.config.openai_codex.agent_reasoning_effort == "auto"
 
     @pytest.mark.asyncio
     async def test_combined_valid_switch_in_one_put_accepted(self):


### PR DESCRIPTION
Small campaign PR implementing the defaults ruling: fresh installs start where the reference deployment runs.

- `openai_codex.model`: `gpt-4o` (ancient schema default) → `gpt-5.6-sol`
- `reasoning_effort`: `medium` → `xhigh`
- `agent_model` / `agent_reasoning_effort`: `null` → `"auto"` (per-spawn Auto/Dynamic out of the box)
- `auxiliary`: disabled/luna → **enabled**/`gpt-5.6-terra`
- Template + docs aligned. Combined with phase 1, fresh installs get the full sol-class working set immediately.

Behavioral notes for review: the axis-default change flips `apply_agent_axis_policy` from static defs to per-spawn exposure for any config that omits the axes — 15 default-pinned tests were updated **by intent** (inherit-semantics tests now declare `None` explicitly; default-value assertions updated; PUT null/empty-mean-inherit contract tests untouched). `image.outer_model` deliberately not touched (pinned image-tool host, separate concern). UI form-default alignment deferred to phase 6 with the rest of the WebUI contract.

Gates: suite 9,336 passed / 5 skipped · ruff clean · type-gate new=0 · apply-registry findings=0 · coverage-gate findings=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHfEwTsEyuS8RUhwdoW66g