### PR TITLE
Context-budget campaign phase 2: provider truth — server usage echoes + opaque account keys

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -420,10 +420,10 @@
   "statements": 12
  },
  "src/llm/account_key.py": {
-  "covered": 59,
+  "covered": 99,
   "missing": 0,
   "percent": 100.0,
-  "statements": 59
+  "statements": 99
  },
  "src/llm/auxiliary.py": {
   "covered": 65,

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -419,6 +419,12 @@
   "percent": 100.0,
   "statements": 12
  },
+ "src/llm/account_key.py": {
+  "covered": 59,
+  "missing": 0,
+  "percent": 100.0,
+  "statements": 59
+ },
  "src/llm/auxiliary.py": {
   "covered": 65,
   "missing": 0,

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -420,10 +420,10 @@
   "statements": 12
  },
  "src/llm/account_key.py": {
-  "covered": 99,
+  "covered": 115,
   "missing": 0,
   "percent": 100.0,
-  "statements": 99
+  "statements": 115
  },
  "src/llm/auxiliary.py": {
   "covered": 65,

--- a/src/llm/account_key.py
+++ b/src/llm/account_key.py
@@ -6,17 +6,27 @@ identifiers must never be exposed or persisted in evidence, exceptions, or
 logs. This module derives a deterministic, non-reversible, installation-
 local key: HMAC-SHA256 of the stable non-secret account identifier (the
 ChatGPT account id — an identity label, never token material), keyed by a
-random per-installation secret generated on first use.
+random per-installation secret established on first use.
 
-Contract (plan of record R2 §10/§11):
+Contract (plan of record R2 §10/§11, hardened in PR #272 review round 1):
 
-- Same account + same installation ⇒ same key across restarts.
-- No stable account identity, or no establishable key material ⇒ ``None``,
-  and the attempt is disqualified from account-scoped clamps. Key trouble
-  degrades evidence, never requests.
-- The key file lives under the runtime ``data`` directory (0600, atomic
-  creation); it never leaves the installation, so keys from different
-  installs never correlate.
+- Same account + same installation ⇒ same key across restarts AND across
+  concurrent processes: first use runs an exclusive-winner protocol
+  (temp-file write + fsync, then an atomic hard-link publication that fails
+  if a winner already exists; losers read and use the winner's material, so
+  every process converges on the one durable secret).
+- Persisted material is accepted only on the exact generated shape: a
+  regular file (final-component symlinks refused), owned by this process's
+  uid, mode 0600, exactly 32 bytes. Anything else fails CLOSED — a warning,
+  ``None``, and the questionable material left untouched (replacing it
+  would silently decorrelate every previously recorded observation).
+- No stable account identity — including an identifier that cannot be
+  UTF-8 encoded, e.g. an unpaired surrogate smuggled through credentials
+  JSON — ⇒ ``None``, and the attempt is disqualified from account-scoped
+  evidence. Key trouble degrades evidence, never requests: the public
+  function is total and non-raising by construction.
+- The key file lives under the runtime ``data`` directory; it never leaves
+  the installation, so keys from different installs never correlate.
 """
 
 from __future__ import annotations
@@ -26,6 +36,7 @@ import hmac
 import logging
 import os
 import secrets
+import stat as stat_module
 import tempfile
 from hashlib import sha256
 from pathlib import Path
@@ -42,31 +53,75 @@ _KEY_HEX_LENGTH = 32
 _key_cache: dict[Path, bytes] = {}
 
 
-def _load_or_create_key(key_path: Path) -> bytes | None:
-    cached = _key_cache.get(key_path)
-    if cached is not None:
-        return cached
+def _read_established_key(key_path: Path) -> bytes | None:
+    """Read existing material under the strict generated-shape contract.
+
+    Returns the 32 key bytes, or ``None`` for both "missing" and "present
+    but refused" (each refusal logs its specific reason). Never modifies
+    the file: questionable material is evidence about the installation and
+    replacing it would decorrelate all prior observations.
+    """
     try:
-        material = key_path.read_bytes()
-        if len(material) >= _KEY_BYTES:
-            _key_cache[key_path] = material
-            return material
-        # Truncated/foreign content: refuse to MAC with weak material. Never
-        # overwrite it either — replacing the key would silently decorrelate
-        # every previously recorded observation.
-        log.warning(
-            "Account key material at %s is unusable (%d bytes); account-scoped "
-            "evidence is disabled until it is repaired or removed.",
-            key_path,
-            len(material),
-        )
-        return None
+        fd = os.open(key_path, os.O_RDONLY | os.O_NOFOLLOW)
     except FileNotFoundError:
-        pass
+        return None
+    except OSError as exc:
+        # ELOOP here means the final component is a symlink — refused.
+        log.warning("Refusing account key %s: %s", key_path, exc)
+        return None
+    try:
+        info = os.fstat(fd)
+        if not stat_module.S_ISREG(info.st_mode):
+            log.warning("Refusing account key %s: not a regular file", key_path)
+            return None
+        if info.st_uid != os.getuid():
+            log.warning("Refusing account key %s: not owned by this user", key_path)
+            return None
+        if stat_module.S_IMODE(info.st_mode) != 0o600:
+            log.warning(
+                "Refusing account key %s: mode %o is not 0600 — fix the "
+                "permissions to re-enable account-scoped evidence.",
+                key_path,
+                stat_module.S_IMODE(info.st_mode),
+            )
+            return None
+        material = os.read(fd, _KEY_BYTES + 1)
+        if len(material) != _KEY_BYTES:
+            log.warning(
+                "Refusing account key %s: %d bytes is not the generated "
+                "%d-byte shape.",
+                key_path,
+                len(material),
+                _KEY_BYTES,
+            )
+            return None
+        return material
     except OSError as exc:
         log.warning("Could not read account key %s: %s", key_path, exc)
         return None
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
 
+
+def _fsync_parent(key_path: Path) -> None:
+    """Best-effort directory fsync so the publication survives a crash."""
+    with contextlib.suppress(OSError):
+        directory_fd = os.open(key_path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+
+def _create_key(key_path: Path) -> bytes | None:
+    """Establish the installation key with an exclusive-winner protocol.
+
+    The complete material is written and fsynced to a private temp file,
+    then published with ``os.link`` — atomic and fail-if-exists, so exactly
+    one process wins. Losers converge by reading the winner's file. A crash
+    can only ever leave a stray temp file, never a partial key.
+    """
     material = secrets.token_bytes(_KEY_BYTES)
     try:
         key_path.parent.mkdir(parents=True, exist_ok=True)
@@ -80,11 +135,17 @@ def _load_or_create_key(key_path: Path) -> bytes | None:
                 stream.write(material)
                 stream.flush()
                 os.fsync(stream.fileno())
-            os.replace(temporary, key_path)
-        except BaseException:
+            try:
+                os.link(temporary, key_path)
+            except FileExistsError:
+                # Another process won the race: use ITS material so every
+                # process MACs with the one durable secret.
+                return _read_established_key(key_path)
+            _fsync_parent(key_path)
+            return material
+        finally:
             with contextlib.suppress(OSError):
                 temporary.unlink()
-            raise
     except OSError as exc:
         log.warning(
             "Could not create account key %s: %s — account-scoped evidence "
@@ -93,7 +154,17 @@ def _load_or_create_key(key_path: Path) -> bytes | None:
             exc,
         )
         return None
-    _key_cache[key_path] = material
+
+
+def _load_or_create_key(key_path: Path) -> bytes | None:
+    cached = _key_cache.get(key_path)
+    if cached is not None:
+        return cached
+    material = _read_established_key(key_path)
+    if material is None and not key_path.exists() and not key_path.is_symlink():
+        material = _create_key(key_path)
+    if material is not None:
+        _key_cache[key_path] = material
     return material
 
 
@@ -102,18 +173,32 @@ def opaque_account_key(
 ) -> str | None:
     """Derive the opaque key for ``account_id``; ``None`` disqualifies.
 
-    Total and non-raising: any failure to establish key material logs and
-    returns ``None`` — evidence is forfeited, the request is never affected.
-    ``key_path`` defaults to ``DEFAULT_KEY_PATH`` resolved at CALL time so
-    tests can repoint the module default (a def-time bound default would
-    ignore the monkeypatch and write into the working tree).
+    Total and non-raising: any failure to establish key material or to
+    normalize the identity logs and returns ``None`` — evidence is
+    forfeited, the request is never affected. ``key_path`` defaults to
+    ``DEFAULT_KEY_PATH`` resolved at CALL time so tests can repoint the
+    module default (a def-time bound default would ignore the monkeypatch
+    and write into the working tree).
     """
-    if not account_id or not str(account_id).strip():
+    try:
+        if not account_id or not str(account_id).strip():
+            return None
+        try:
+            identity = str(account_id).strip().encode("utf-8")
+        except UnicodeError:
+            # E.g. an unpaired surrogate accepted by json.loads: there is no
+            # stable canonical encoding, so there is no stable identity.
+            log.warning(
+                "Account identifier is not UTF-8 encodable; disqualifying "
+                "it from account-scoped evidence."
+            )
+            return None
+        material = _load_or_create_key(
+            Path(key_path) if key_path is not None else DEFAULT_KEY_PATH
+        )
+        if material is None:
+            return None
+        return hmac.new(material, identity, sha256).hexdigest()[:_KEY_HEX_LENGTH]
+    except Exception:  # noqa: BLE001 — the totality contract outranks specificity
+        log.exception("Account key derivation failed; evidence forfeited")
         return None
-    material = _load_or_create_key(
-        Path(key_path) if key_path is not None else DEFAULT_KEY_PATH
-    )
-    if material is None:
-        return None
-    digest = hmac.new(material, str(account_id).strip().encode("utf-8"), sha256)
-    return digest.hexdigest()[:_KEY_HEX_LENGTH]

--- a/src/llm/account_key.py
+++ b/src/llm/account_key.py
@@ -38,6 +38,7 @@ import os
 import secrets
 import stat as stat_module
 import tempfile
+from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 
@@ -53,30 +54,48 @@ _KEY_HEX_LENGTH = 32
 _key_cache: dict[Path, bytes] = {}
 
 
-def _read_established_key(key_path: Path) -> bytes | None:
+@dataclass(frozen=True)
+class _KeyReadResult:
+    """Result of a strict key read, preserving missing vs refused.
+
+    A missing path is the only state that permits an exclusive publication
+    attempt.  Refused material must never be replaced.
+    """
+
+    material: bytes | None
+    missing: bool = False
+
+
+def _read_established_key(key_path: Path) -> _KeyReadResult:
     """Read existing material under the strict generated-shape contract.
 
-    Returns the 32 key bytes, or ``None`` for both "missing" and "present
-    but refused" (each refusal logs its specific reason). Never modifies
-    the file: questionable material is evidence about the installation and
-    replacing it would decorrelate all prior observations.
+    Returns a result that distinguishes "missing" from "present but
+    refused".  That distinction is security-sensitive: only a witnessed
+    missing path may enter the exclusive publication protocol.  Never
+    modifies questionable material.
     """
     try:
-        fd = os.open(key_path, os.O_RDONLY | os.O_NOFOLLOW)
+        # O_NONBLOCK is required before inspecting the descriptor.  Opening
+        # a hostile FIFO read-only would otherwise block forever before the
+        # regular-file check had a chance to reject it.
+        fd = os.open(
+            key_path,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+        )
     except FileNotFoundError:
-        return None
+        return _KeyReadResult(material=None, missing=True)
     except OSError as exc:
         # ELOOP here means the final component is a symlink — refused.
         log.warning("Refusing account key %s: %s", key_path, exc)
-        return None
+        return _KeyReadResult(material=None)
     try:
         info = os.fstat(fd)
         if not stat_module.S_ISREG(info.st_mode):
             log.warning("Refusing account key %s: not a regular file", key_path)
-            return None
+            return _KeyReadResult(material=None)
         if info.st_uid != os.getuid():
             log.warning("Refusing account key %s: not owned by this user", key_path)
-            return None
+            return _KeyReadResult(material=None)
         if stat_module.S_IMODE(info.st_mode) != 0o600:
             log.warning(
                 "Refusing account key %s: mode %o is not 0600 — fix the "
@@ -84,8 +103,20 @@ def _read_established_key(key_path: Path) -> bytes | None:
                 key_path,
                 stat_module.S_IMODE(info.st_mode),
             )
-            return None
-        material = os.read(fd, _KEY_BYTES + 1)
+            return _KeyReadResult(material=None)
+        # Validate the opened object size before reading.  Asking read() for
+        # one sentinel byte is not sufficient: a short read from an
+        # oversized file could otherwise masquerade as the exact shape.
+        if info.st_size != _KEY_BYTES:
+            log.warning(
+                "Refusing account key %s: %d bytes is not the generated "
+                "%d-byte shape.",
+                key_path,
+                info.st_size,
+                _KEY_BYTES,
+            )
+            return _KeyReadResult(material=None)
+        material = os.read(fd, _KEY_BYTES)
         if len(material) != _KEY_BYTES:
             log.warning(
                 "Refusing account key %s: %d bytes is not the generated "
@@ -94,11 +125,11 @@ def _read_established_key(key_path: Path) -> bytes | None:
                 len(material),
                 _KEY_BYTES,
             )
-            return None
-        return material
+            return _KeyReadResult(material=None)
+        return _KeyReadResult(material=material)
     except OSError as exc:
         log.warning("Could not read account key %s: %s", key_path, exc)
-        return None
+        return _KeyReadResult(material=None)
     finally:
         with contextlib.suppress(OSError):
             os.close(fd)
@@ -129,9 +160,16 @@ def _create_key(key_path: Path) -> bytes | None:
             dir=key_path.parent, prefix=f".{key_path.name}.", suffix=".tmp"
         )
         temporary = Path(temporary_name)
+        # mkstemp gives this function ownership.  Ownership transfers only
+        # after fdopen returns successfully; every earlier failure must close
+        # the raw descriptor explicitly.
+        owned_fd = fd
+        owns_fd = True
         try:
-            os.fchmod(fd, 0o600)
-            with os.fdopen(fd, "wb") as stream:
+            os.fchmod(owned_fd, 0o600)
+            stream = os.fdopen(owned_fd, "wb")
+            owns_fd = False
+            with stream:
                 stream.write(material)
                 stream.flush()
                 os.fsync(stream.fileno())
@@ -140,10 +178,13 @@ def _create_key(key_path: Path) -> bytes | None:
             except FileExistsError:
                 # Another process won the race: use ITS material so every
                 # process MACs with the one durable secret.
-                return _read_established_key(key_path)
+                return _read_established_key(key_path).material
             _fsync_parent(key_path)
             return material
         finally:
+            if owns_fd:
+                with contextlib.suppress(OSError):
+                    os.close(owned_fd)
             with contextlib.suppress(OSError):
                 temporary.unlink()
     except OSError as exc:
@@ -160,8 +201,13 @@ def _load_or_create_key(key_path: Path) -> bytes | None:
     cached = _key_cache.get(key_path)
     if cached is not None:
         return cached
-    material = _read_established_key(key_path)
-    if material is None and not key_path.exists() and not key_path.is_symlink():
+    read_result = _read_established_key(key_path)
+    material = read_result.material
+    if read_result.missing:
+        # Do not re-check with exists(): existence is only a snapshot and
+        # creates an ENOENT-to-publication race.  Always enter the atomic
+        # fail-if-exists protocol after a witnessed miss; EEXIST adopts the
+        # winner, while refused existing material never reaches this branch.
         material = _create_key(key_path)
     if material is not None:
         _key_cache[key_path] = material

--- a/src/llm/account_key.py
+++ b/src/llm/account_key.py
@@ -1,0 +1,119 @@
+"""Opaque, installation-local account keys for provider evidence.
+
+The context-window observer correlates a rejection with its rescue
+acceptance only when both landed on the SAME account — but raw account
+identifiers must never be exposed or persisted in evidence, exceptions, or
+logs. This module derives a deterministic, non-reversible, installation-
+local key: HMAC-SHA256 of the stable non-secret account identifier (the
+ChatGPT account id — an identity label, never token material), keyed by a
+random per-installation secret generated on first use.
+
+Contract (plan of record R2 §10/§11):
+
+- Same account + same installation ⇒ same key across restarts.
+- No stable account identity, or no establishable key material ⇒ ``None``,
+  and the attempt is disqualified from account-scoped clamps. Key trouble
+  degrades evidence, never requests.
+- The key file lives under the runtime ``data`` directory (0600, atomic
+  creation); it never leaves the installation, so keys from different
+  installs never correlate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hmac
+import logging
+import os
+import secrets
+import tempfile
+from hashlib import sha256
+from pathlib import Path
+
+log = logging.getLogger("odin.llm")
+
+DEFAULT_KEY_PATH = Path("data") / "account_key.secret"
+
+_KEY_BYTES = 32
+#: Hex prefix length: 128 bits of a keyed MAC — far beyond collision concern
+#: for a handful of pool accounts, short enough to read in evidence files.
+_KEY_HEX_LENGTH = 32
+
+_key_cache: dict[Path, bytes] = {}
+
+
+def _load_or_create_key(key_path: Path) -> bytes | None:
+    cached = _key_cache.get(key_path)
+    if cached is not None:
+        return cached
+    try:
+        material = key_path.read_bytes()
+        if len(material) >= _KEY_BYTES:
+            _key_cache[key_path] = material
+            return material
+        # Truncated/foreign content: refuse to MAC with weak material. Never
+        # overwrite it either — replacing the key would silently decorrelate
+        # every previously recorded observation.
+        log.warning(
+            "Account key material at %s is unusable (%d bytes); account-scoped "
+            "evidence is disabled until it is repaired or removed.",
+            key_path,
+            len(material),
+        )
+        return None
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        log.warning("Could not read account key %s: %s", key_path, exc)
+        return None
+
+    material = secrets.token_bytes(_KEY_BYTES)
+    try:
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary_name = tempfile.mkstemp(
+            dir=key_path.parent, prefix=f".{key_path.name}.", suffix=".tmp"
+        )
+        temporary = Path(temporary_name)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(material)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, key_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                temporary.unlink()
+            raise
+    except OSError as exc:
+        log.warning(
+            "Could not create account key %s: %s — account-scoped evidence "
+            "is skipped this boot.",
+            key_path,
+            exc,
+        )
+        return None
+    _key_cache[key_path] = material
+    return material
+
+
+def opaque_account_key(
+    account_id: str | None, *, key_path: str | Path | None = None
+) -> str | None:
+    """Derive the opaque key for ``account_id``; ``None`` disqualifies.
+
+    Total and non-raising: any failure to establish key material logs and
+    returns ``None`` — evidence is forfeited, the request is never affected.
+    ``key_path`` defaults to ``DEFAULT_KEY_PATH`` resolved at CALL time so
+    tests can repoint the module default (a def-time bound default would
+    ignore the monkeypatch and write into the working tree).
+    """
+    if not account_id or not str(account_id).strip():
+        return None
+    material = _load_or_create_key(
+        Path(key_path) if key_path is not None else DEFAULT_KEY_PATH
+    )
+    if material is None:
+        return None
+    digest = hmac.new(material, str(account_id).strip().encode("utf-8"), sha256)
+    return digest.hexdigest()[:_KEY_HEX_LENGTH]

--- a/src/llm/errors.py
+++ b/src/llm/errors.py
@@ -49,12 +49,22 @@ class LLMError(RuntimeError):
         model: str | None = None,
         retry_after: float | None = None,
         code: str | None = None,
+        server_input_tokens: int | None = None,
+        account_key: str | None = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.model = model
         self.retry_after = retry_after
         self.code = code
+        # Provider-truth evidence (context-budget campaign phase 2): the
+        # server-authoritative input count from an authoritative failure
+        # event when present (never a client estimate), and the opaque
+        # installation-local key of the account that served the failing
+        # attempt (never a raw identifier). A rejection without
+        # authoritative usage is an occurrence, not a numeric bound.
+        self.server_input_tokens = server_input_tokens
+        self.account_key = account_key
 
 
 class LLMCapacityError(LLMError):

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -231,11 +231,15 @@ class CodexStreamError(RuntimeError):
         error_type: str | None = None,
         error_code: str | None = None,
         retry_after: float | None = None,
+        server_input_tokens: int | None = None,
     ) -> None:
         super().__init__(message)
         self.error_type = error_type
         self.error_code = error_code
         self.retry_after = retry_after
+        # Server-authoritative usage from the failure event, when the event
+        # carried one (strictly parsed; None otherwise — never an estimate).
+        self.server_input_tokens = server_input_tokens
 
     @property
     def is_capacity(self) -> bool:
@@ -243,6 +247,20 @@ class CodexStreamError(RuntimeError):
             self.error_type in _CAPACITY_ERROR_MARKERS
             or self.error_code in _CAPACITY_ERROR_MARKERS
         )
+
+
+def _server_input_tokens_from_usage(usage: object) -> int | None:
+    """Strictly parse the server's accepted-input count from a usage object.
+
+    Absent, malformed, boolean, negative, or non-integer ⇒ ``None``. The
+    observer never substitutes the client estimate for this value.
+    """
+    if not isinstance(usage, dict):
+        return None
+    value = usage.get("input_tokens")
+    if type(value) is not int or value < 0:
+        return None
+    return value
 
 
 def _stream_error_from_event(event_type: str, event: dict) -> CodexStreamError:
@@ -265,6 +283,10 @@ def _stream_error_from_event(event_type: str, event: dict) -> CodexStreamError:
     error_type = err.get("type")
     error_code = err.get("code")
     retry_after = err.get("retry_after")
+    # Authoritative usage rides the failure event's response object when the
+    # server provides one; strictly parsed, never estimated.
+    resp_obj = event.get("response")
+    usage = resp_obj.get("usage") if isinstance(resp_obj, dict) else None
     fields = _sanitized_error_fields({"error": err})
     detail = "; ".join(fields)[:400] if fields else "unstructured stream error event"
     return CodexStreamError(
@@ -272,6 +294,7 @@ def _stream_error_from_event(event_type: str, event: dict) -> CodexStreamError:
         error_type=error_type if isinstance(error_type, str) else None,
         error_code=error_code if isinstance(error_code, str) else None,
         retry_after=float(retry_after) if isinstance(retry_after, (int, float)) else None,
+        server_input_tokens=_server_input_tokens_from_usage(usage),
     )
 
 
@@ -805,11 +828,19 @@ class CodexChatClient:
                                 # agent overflow recovery keys on ``code``.
                                 # The client breaker counts infrastructure
                                 # health, not payload validity: untouched.
+                                from .account_key import opaque_account_key
+
                                 raise LLMRequestError(
                                     f"Codex stream failed: {e}",
                                     provider="codex",
                                     model=str(body.get("model") or self.model),
                                     code=e.error_code or e.error_type,
+                                    # Provider truth for the observer: the
+                                    # failure event's own usage (None unless
+                                    # the server sent one) and the opaque key
+                                    # of the account that served THIS attempt.
+                                    server_input_tokens=e.server_input_tokens,
+                                    account_key=opaque_account_key(account_id),
                                 ) from e
                             # response.failed / error event: the "200" turned
                             # out to be a failure mid-stream — retryable.
@@ -834,6 +865,13 @@ class CodexChatClient:
                             ) from e
                         if not result_is_empty(result):
                             self.breaker.record_success()
+                            if isinstance(result, LLMResponse):
+                                # Per-attempt account provenance: the pool may
+                                # rotate between attempts, so the stamp is the
+                                # account that served THIS successful attempt.
+                                from .account_key import opaque_account_key
+
+                                result.account_key = opaque_account_key(account_id)
                             return result
                         log.warning(
                             "Codex returned 200 with empty response (attempt %d/%d)",
@@ -998,6 +1036,7 @@ class CodexChatClient:
         """
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        server_input_tokens: int | None = None
         incomplete = False
 
         # Track in-progress function calls by output_index
@@ -1121,6 +1160,12 @@ class CodexChatClient:
             # Final response object — fallback
             elif event_type == "response.completed":
                 response_obj = event.get("response", {})
+                # Server-authoritative accepted input from the usage echo —
+                # strictly parsed; the client estimate is a separate field
+                # and is never substituted for this one.
+                server_input_tokens = _server_input_tokens_from_usage(
+                    response_obj.get("usage")
+                )
                 output = response_obj.get("output", [])
                 for item in output:
                     item_type = item.get("type", "")
@@ -1159,7 +1204,12 @@ class CodexChatClient:
             stop_reason = "incomplete"
         else:
             stop_reason = "end_turn"
-        return LLMResponse(text=text, tool_calls=tool_calls, stop_reason=stop_reason)
+        return LLMResponse(
+            text=text,
+            tool_calls=tool_calls,
+            stop_reason=stop_reason,
+            server_input_tokens=server_input_tokens,
+        )
 
     async def _read_stream(self, resp: aiohttp.ClientResponse) -> str:
         """Read SSE stream and extract text content."""

--- a/src/llm/types.py
+++ b/src/llm/types.py
@@ -44,6 +44,16 @@ class LLMResponse:
     provenance_provider: str = ""
     provenance_model: str = ""
     provenance_reasoning_effort: str | None = None
+    # Server-authoritative accepted input, parsed strictly from the provider's
+    # usage echo (absent/malformed ⇒ None). NEVER derived from the client
+    # estimate above — the observer refuses estimates; ``input_tokens`` keeps
+    # its historical estimate meaning untouched.
+    server_input_tokens: int | None = None
+    # Opaque installation-local key of the account that served THIS attempt
+    # (HMAC over the stable non-secret account id — never a raw identifier).
+    # None when no stable account identity or key material exists; such
+    # attempts are disqualified from account-scoped evidence.
+    account_key: str | None = None
 
     @property
     def is_tool_use(self) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,3 +257,16 @@ def _process_containment():
     os.environ.setdefault(JOB_TOKEN_ENV, DEFAULT_JOB_TOKEN)
     yield
     set_child_subreaper(previous)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_account_key_path(tmp_path, monkeypatch):
+    """Keep the opaque-account-key material out of the working tree.
+
+    Provider stamping derives keys via ``DEFAULT_KEY_PATH`` (resolved at
+    call time); without this, any test whose auth fake returns a real
+    account id would materialize ``data/account_key.secret`` in the repo.
+    """
+    monkeypatch.setattr(
+        "src.llm.account_key.DEFAULT_KEY_PATH", tmp_path / "account_key.secret"
+    )

--- a/tests/test_provider_truth.py
+++ b/tests/test_provider_truth.py
@@ -115,18 +115,13 @@ class TestOpaqueAccountKey:
         assert key is None
         assert any("account key" in r.getMessage().lower() for r in caplog.records)
 
-    def test_replace_failure_cleans_temp_and_degrades(self, tmp_path, caplog, monkeypatch):
+    def test_publication_failure_cleans_temp_and_degrades(self, tmp_path, caplog, monkeypatch):
         """A failure after the temp file exists must not leave debris or a key."""
-        import os as _os
 
-        real_replace = _os.replace
+        def failing_link(src, dst):
+            raise OSError("simulated link failure")
 
-        def failing_replace(src, dst):
-            if str(dst).endswith("k.secret"):
-                raise OSError("simulated replace failure")
-            return real_replace(src, dst)
-
-        monkeypatch.setattr("src.llm.account_key.os.replace", failing_replace)
+        monkeypatch.setattr("src.llm.account_key.os.link", failing_link)
         key_path = tmp_path / "k.secret"
         with caplog.at_level(logging.WARNING, logger="odin.llm"):
             key = opaque_account_key("acct-a", key_path=key_path)
@@ -138,11 +133,188 @@ class TestOpaqueAccountKey:
     def test_weak_material_refused_never_overwritten(self, tmp_path, caplog):
         key_path = tmp_path / "k.secret"
         key_path.write_bytes(b"short")
+        key_path.chmod(0o600)
         with caplog.at_level(logging.WARNING, logger="odin.llm"):
             key = opaque_account_key("acct-a", key_path=key_path)
         assert key is None
         # Replacing weak material would decorrelate all prior evidence.
         assert key_path.read_bytes() == b"short"
+
+
+class TestPersistedKeyContract:
+    """Round-1 blocker #3: only the exact generated shape is trusted."""
+
+    def _valid_key(self, tmp_path):
+        key_path = tmp_path / "k.secret"
+        first = opaque_account_key("acct-a", key_path=key_path)
+        assert first is not None
+        _key_cache.clear()
+        return key_path, first
+
+    def test_exact_32_bytes_accepted_but_not_33(self, tmp_path):
+        key_path, first = self._valid_key(tmp_path)
+        assert opaque_account_key("acct-a", key_path=key_path) == first
+        _key_cache.clear()
+        key_path.write_bytes(key_path.read_bytes() + b"x")
+        key_path.chmod(0o600)
+        assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert len(key_path.read_bytes()) == 33  # refused, never repaired
+
+    def test_group_readable_material_fails_closed_and_stays(self, tmp_path, caplog):
+        key_path, _ = self._valid_key(tmp_path)
+        key_path.chmod(0o644)
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o644  # untouched
+        assert any("not 0600" in r.getMessage() for r in caplog.records)
+
+    def test_symlink_final_component_refused(self, tmp_path):
+        real = tmp_path / "real.key"
+        opaque_account_key("acct-a", key_path=real)
+        _key_cache.clear()
+        link = tmp_path / "k.secret"
+        link.symlink_to(real)
+        assert opaque_account_key("acct-a", key_path=link) is None
+        assert link.is_symlink()  # never replaced or followed
+
+    def test_foreign_owner_refused(self, tmp_path, monkeypatch, caplog):
+        import os as _os
+
+        key_path, _ = self._valid_key(tmp_path)
+        real_uid = _os.getuid()
+        monkeypatch.setattr("src.llm.account_key.os.getuid", lambda: real_uid + 1)
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert any("not owned" in r.getMessage() for r in caplog.records)
+
+    def test_parent_directory_fsynced_on_establish(self, tmp_path, monkeypatch):
+        synced: list = []
+        monkeypatch.setattr(
+            "src.llm.account_key._fsync_parent", lambda p: synced.append(p)
+        )
+        key_path = tmp_path / "k.secret"
+        assert opaque_account_key("acct-a", key_path=key_path) is not None
+        assert synced == [key_path]
+
+    def test_fsync_parent_syncs_a_directory_fd(self, tmp_path, monkeypatch):
+        import os as _os
+
+        from src.llm.account_key import _fsync_parent
+
+        seen: list[int] = []
+        real_fsync = _os.fsync
+
+        def recording_fsync(fd):
+            seen.append(fd)
+            return real_fsync(fd)
+
+        monkeypatch.setattr("src.llm.account_key.os.fsync", recording_fsync)
+        (tmp_path / "k.secret").write_bytes(b"x")
+        _fsync_parent(tmp_path / "k.secret")
+        assert len(seen) == 1
+
+
+class TestKeyEdgeBranches:
+    def test_directory_at_key_path_refused(self, tmp_path, caplog):
+        key_path = tmp_path / "k.secret"
+        key_path.mkdir()
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert any("not a regular file" in r.getMessage() for r in caplog.records)
+
+    def test_read_oserror_degrades(self, tmp_path, monkeypatch, caplog):
+        key_path = tmp_path / "k.secret"
+        opaque_account_key("acct-a", key_path=key_path)
+        _key_cache.clear()
+
+        def failing_read(fd, n):
+            raise OSError("simulated read failure")
+
+        monkeypatch.setattr("src.llm.account_key.os.read", failing_read)
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert any("Could not read account key" in r.getMessage() for r in caplog.records)
+
+    def test_link_race_loser_converges_deterministically(self, tmp_path, monkeypatch):
+        """Single-process pin of the loser branch: publication finds a winner
+        already in place and adopts the winner's material."""
+        key_path = tmp_path / "k.secret"
+        winner = opaque_account_key("acct-a", key_path=key_path)
+        winner_material = key_path.read_bytes()
+        key_path.unlink()
+        _key_cache.clear()
+
+        def racing_link(src, dst):
+            # The "other process" wins between our temp write and publication.
+            key_path.write_bytes(winner_material)
+            key_path.chmod(0o600)
+            raise FileExistsError("winner already published")
+
+        monkeypatch.setattr("src.llm.account_key.os.link", racing_link)
+        assert opaque_account_key("acct-a", key_path=key_path) == winner
+        assert key_path.read_bytes() == winner_material  # winner untouched
+
+    def test_totality_net_catches_derivation_failure(self, tmp_path, monkeypatch, caplog):
+        def exploding_hmac(*args, **kwargs):
+            raise RuntimeError("simulated derivation failure")
+
+        monkeypatch.setattr("src.llm.account_key.hmac.new", exploding_hmac)
+        with caplog.at_level(logging.ERROR, logger="odin.llm"):
+            assert opaque_account_key("acct-a", key_path=tmp_path / "k.secret") is None
+        assert any("evidence forfeited" in r.getMessage() for r in caplog.records)
+
+
+class TestIdentityNormalization:
+    """Round-1 blocker #2: identities that cannot be UTF-8 encoded disqualify."""
+
+    def test_unpaired_surrogate_returns_none_without_raising(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            key = opaque_account_key(
+                "acct-\ud800", key_path=tmp_path / "k.secret"
+            )
+        assert key is None
+        assert not (tmp_path / "k.secret").exists()  # no material minted
+        assert any("not UTF-8" in r.getMessage() for r in caplog.records)
+
+
+def _concurrent_worker(path_str, barrier, queue):
+    from src.llm.account_key import opaque_account_key as derive
+
+    barrier.wait()
+    queue.put(derive("acct-a", key_path=path_str))
+
+
+class TestConcurrentFirstUse:
+    """Round-1 blocker #1: the exclusive-winner protocol converges."""
+
+    def test_eight_processes_one_key(self, tmp_path):
+        import multiprocessing as mp
+
+        ctx = mp.get_context("fork")
+        barrier = ctx.Barrier(8)
+        queue = ctx.Queue()
+        key_path = tmp_path / "k.secret"
+        workers = [
+            ctx.Process(
+                target=_concurrent_worker, args=(str(key_path), barrier, queue)
+            )
+            for _ in range(8)
+        ]
+        for worker in workers:
+            worker.start()
+        keys = [queue.get(timeout=30) for _ in range(8)]
+        for worker in workers:
+            worker.join(timeout=30)
+            assert worker.exitcode == 0
+        assert None not in keys
+        assert len(set(keys)) == 1
+        # A fresh process (simulated: cold cache) reads the same winner.
+        _key_cache.clear()
+        assert opaque_account_key("acct-a", key_path=key_path) == keys[0]
+        assert len(key_path.read_bytes()) == 32
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+        # No stray temp files survive the race.
+        assert list(tmp_path.glob(".k.secret.*")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +384,11 @@ class _AccountAuth(FakeSingleAuth):
         return "acct-uuid-1"
 
 
+class _SurrogateAuth(FakeSingleAuth):
+    def get_account_id(self):
+        return "acct-\ud800"  # unpaired surrogate: json.loads accepts these
+
+
 class TestSendWithRetriesStamping:
     async def test_success_carries_account_key_and_server_usage(
         self, tmp_path, monkeypatch
@@ -261,6 +438,45 @@ class TestSendWithRetriesStamping:
         )
         assert exc.model == "m"
         assert "acct-uuid-1" not in str(exc)
+
+    async def test_surrogate_identity_none_on_success_path(self, tmp_path, monkeypatch):
+        """Blocker #2 end-to-end: a healthy response is never replaced by
+        UnicodeEncodeError — the stamp degrades to None."""
+        monkeypatch.setattr(
+            "src.llm.account_key.DEFAULT_KEY_PATH", tmp_path / "k.secret"
+        )
+        client = _client(auth=_SurrogateAuth())
+        session = FakeSession([
+            FakeResp(200, sse_lines=_sse([
+                {"type": "response.output_text.delta", "delta": "ok"},
+                {"type": "response.completed",
+                 "response": {"output": [], "usage": {"input_tokens": 10}}},
+            ])),
+        ])
+        monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+        result = await client._stream_tool_request({"model": "m"})
+        assert result.text == "ok"
+        assert result.account_key is None
+
+    async def test_surrogate_identity_none_on_overflow_path(self, tmp_path, monkeypatch):
+        """Blocker #2 end-to-end: the intended structural overflow is raised,
+        not a UnicodeEncodeError from evidence stamping."""
+        monkeypatch.setattr(
+            "src.llm.account_key.DEFAULT_KEY_PATH", tmp_path / "k.secret"
+        )
+        client = _client(auth=_SurrogateAuth(), max_retries=1)
+        session = FakeSession([
+            FakeResp(200, sse_lines=_sse([
+                {"type": "response.failed",
+                 "response": {"error": {"type": "invalid_request_error",
+                                        "code": "context_length_exceeded"}}},
+            ], done=False)),
+        ])
+        monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+        with pytest.raises(LLMRequestError) as excinfo:
+            await client._stream_tool_request({"model": "m"})
+        assert excinfo.value.code == "context_length_exceeded"
+        assert excinfo.value.account_key is None
 
     async def test_missing_account_identity_stamps_none(self, monkeypatch):
         client = _client()  # FakeSingleAuth: account id None

--- a/tests/test_provider_truth.py
+++ b/tests/test_provider_truth.py
@@ -214,6 +214,12 @@ class TestPersistedKeyContract:
         assert len(seen) == 1
 
 
+def _fifo_worker(path_str, queue):
+    from src.llm.account_key import opaque_account_key as derive
+
+    queue.put(derive("acct-a", key_path=path_str))
+
+
 class TestKeyEdgeBranches:
     def test_directory_at_key_path_refused(self, tmp_path, caplog):
         key_path = tmp_path / "k.secret"
@@ -221,6 +227,208 @@ class TestKeyEdgeBranches:
         with caplog.at_level(logging.WARNING, logger="odin.llm"):
             assert opaque_account_key("acct-a", key_path=key_path) is None
         assert any("not a regular file" in r.getMessage() for r in caplog.records)
+
+    def test_fifo_refused_promptly_and_untouched(self, tmp_path):
+        """The open itself must not block before fstat can reject a FIFO."""
+        import multiprocessing as mp
+        import os
+
+        key_path = tmp_path / "k.secret"
+        os.mkfifo(key_path, 0o600)
+        ctx = mp.get_context("fork")
+        queue = ctx.Queue()
+        worker = ctx.Process(
+            target=_fifo_worker, args=(str(key_path), queue)
+        )
+        worker.start()
+        worker.join(timeout=2)
+        if worker.is_alive():
+            worker.terminate()
+            worker.join(timeout=5)
+            pytest.fail("account-key read blocked while opening a FIFO")
+        assert worker.exitcode == 0
+        assert queue.get(timeout=2) is None
+        assert stat.S_ISFIFO(key_path.lstat().st_mode)
+
+    def test_fchmod_failure_closes_owned_descriptor(
+        self, tmp_path, monkeypatch
+    ):
+        import errno
+        import os
+        import tempfile
+
+        captured: list[int] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def recording_mkstemp(*args, **kwargs):
+            fd, name = real_mkstemp(*args, **kwargs)
+            captured.append(fd)
+            return fd, name
+
+        def failing_fchmod(fd, mode):
+            raise OSError("simulated fchmod failure")
+
+        monkeypatch.setattr(
+            "src.llm.account_key.tempfile.mkstemp", recording_mkstemp
+        )
+        monkeypatch.setattr("src.llm.account_key.os.fchmod", failing_fchmod)
+        assert opaque_account_key(
+            "acct-a", key_path=tmp_path / "k.secret"
+        ) is None
+        assert len(captured) == 1
+        with pytest.raises(OSError) as excinfo:
+            os.fstat(captured[0])
+        assert excinfo.value.errno == errno.EBADF
+        assert list(tmp_path.glob(".k.secret.*")) == []
+
+    def test_fdopen_failure_closes_owned_descriptor(
+        self, tmp_path, monkeypatch
+    ):
+        import errno
+        import os
+        import tempfile
+
+        captured: list[int] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def recording_mkstemp(*args, **kwargs):
+            fd, name = real_mkstemp(*args, **kwargs)
+            captured.append(fd)
+            return fd, name
+
+        def failing_fdopen(fd, mode):
+            raise OSError("simulated fdopen failure")
+
+        monkeypatch.setattr(
+            "src.llm.account_key.tempfile.mkstemp", recording_mkstemp
+        )
+        monkeypatch.setattr("src.llm.account_key.os.fdopen", failing_fdopen)
+        assert opaque_account_key(
+            "acct-a", key_path=tmp_path / "k.secret"
+        ) is None
+        assert len(captured) == 1
+        with pytest.raises(OSError) as excinfo:
+            os.fstat(captured[0])
+        assert excinfo.value.errno == errno.EBADF
+        assert list(tmp_path.glob(".k.secret.*")) == []
+
+    def test_oversized_file_refused_before_short_read(
+        self, tmp_path, monkeypatch
+    ):
+        key_path = tmp_path / "k.secret"
+        original = b"x" * 33
+        key_path.write_bytes(original)
+        key_path.chmod(0o600)
+        reads: list[tuple[int, int]] = []
+
+        def deceptive_short_read(fd, count):
+            reads.append((fd, count))
+            return b"x" * 32
+
+        monkeypatch.setattr(
+            "src.llm.account_key.os.read", deceptive_short_read
+        )
+        assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert reads == []  # fstat size rejects it before any read
+        assert key_path.read_bytes() == original
+
+    def test_short_read_of_exact_size_file_is_refused(
+        self, tmp_path, monkeypatch
+    ):
+        key_path = tmp_path / "k.secret"
+        original = b"x" * 32
+        key_path.write_bytes(original)
+        key_path.chmod(0o600)
+
+        monkeypatch.setattr(
+            "src.llm.account_key.os.read", lambda fd, count: b"x" * 31
+        )
+        assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert key_path.read_bytes() == original
+
+    def test_enoent_then_publish_race_adopts_winner(
+        self, tmp_path, monkeypatch
+    ):
+        """A witnessed miss goes straight to fail-if-exists publication.
+
+        A winner appearing between ENOENT and os.link must be adopted; no
+        exists() snapshot may suppress or redirect the protocol.
+        """
+        import hmac
+        import os
+        from hashlib import sha256
+
+        key_path = tmp_path / "k.secret"
+        winner_material = b"w" * 32
+        real_open = os.open
+        real_link = os.link
+        first_key_open = True
+        publication_attempts: list[tuple[object, object]] = []
+
+        def missing_then_winner(path, flags, *args, **kwargs):
+            nonlocal first_key_open
+            if first_key_open and path == key_path:
+                first_key_open = False
+                # Model another process publishing immediately after this
+                # open observed ENOENT, but before our caller can perform any
+                # non-atomic exists() recheck.
+                key_path.write_bytes(winner_material)
+                key_path.chmod(0o600)
+                raise FileNotFoundError(str(key_path))
+            return real_open(path, flags, *args, **kwargs)
+
+        def recording_link(src, dst):
+            publication_attempts.append((src, dst))
+            return real_link(src, dst)
+
+        monkeypatch.setattr(
+            "src.llm.account_key.os.open", missing_then_winner
+        )
+        monkeypatch.setattr("src.llm.account_key.os.link", recording_link)
+        result = opaque_account_key("acct-a", key_path=key_path)
+        expected = hmac.new(
+            winner_material, b"acct-a", sha256
+        ).hexdigest()[:32]
+        assert result == expected
+        assert len(publication_attempts) == 1
+        assert publication_attempts[0][1] == key_path
+        assert key_path.read_bytes() == winner_material
+
+    def test_enoent_race_invalid_winner_is_refused_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        """EEXIST adoption applies the same strict shape validation."""
+        import os
+
+        key_path = tmp_path / "k.secret"
+        invalid_winner = b"invalid-race-winner"
+        real_open = os.open
+        real_link = os.link
+        first_key_open = True
+        publication_attempts: list[tuple[object, object]] = []
+
+        def missing_then_invalid_winner(path, flags, *args, **kwargs):
+            nonlocal first_key_open
+            if first_key_open and path == key_path:
+                first_key_open = False
+                key_path.write_bytes(invalid_winner)
+                key_path.chmod(0o600)
+                raise FileNotFoundError(str(key_path))
+            return real_open(path, flags, *args, **kwargs)
+
+        def recording_link(src, dst):
+            publication_attempts.append((src, dst))
+            return real_link(src, dst)
+
+        monkeypatch.setattr(
+            "src.llm.account_key.os.open", missing_then_invalid_winner
+        )
+        monkeypatch.setattr("src.llm.account_key.os.link", recording_link)
+        assert opaque_account_key("acct-a", key_path=key_path) is None
+        assert len(publication_attempts) == 1
+        assert publication_attempts[0][1] == key_path
+        assert key_path.read_bytes() == invalid_winner
+        assert list(tmp_path.glob(".k.secret.*")) == []
 
     def test_read_oserror_degrades(self, tmp_path, monkeypatch, caplog):
         key_path = tmp_path / "k.secret"

--- a/tests/test_provider_truth.py
+++ b/tests/test_provider_truth.py
@@ -1,0 +1,275 @@
+"""Provider truth plumbing (context-budget campaign phase 2).
+
+Pins the evidence contract: ``server_input_tokens`` parsed STRICTLY from
+the server's own usage echoes (success and failure events; never the client
+estimate), and an opaque installation-local account key stamped on both the
+successful response and the structural overflow exception — per attempt,
+never a raw identifier. Key trouble degrades evidence, never requests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import stat
+
+import pytest
+
+from src.llm.account_key import _key_cache, opaque_account_key
+from src.llm.errors import LLMRequestError
+from src.llm.openai_codex import (
+    _server_input_tokens_from_usage,
+    _stream_error_from_event,
+)
+from src.llm.types import LLMResponse
+from tests.test_codex_reliability import (
+    FakeResp,
+    FakeSession,
+    FakeSingleAuth,
+    _async_return,
+    _client,
+    _sse,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_key_cache():
+    _key_cache.clear()
+    yield
+    _key_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Strict usage parsing
+# ---------------------------------------------------------------------------
+class TestStrictUsageParse:
+    @pytest.mark.parametrize(
+        "usage",
+        [
+            None,
+            "not a dict",
+            {},
+            {"input_tokens": None},
+            {"input_tokens": "12345"},
+            {"input_tokens": 12.5},
+            {"input_tokens": -1},
+            {"input_tokens": True},  # bool is not evidence
+            {"output_tokens": 5},
+        ],
+    )
+    def test_rejects_everything_not_a_nonnegative_int(self, usage):
+        assert _server_input_tokens_from_usage(usage) is None
+
+    def test_accepts_exact_ints(self):
+        assert _server_input_tokens_from_usage({"input_tokens": 0}) == 0
+        assert _server_input_tokens_from_usage({"input_tokens": 921_601}) == 921_601
+
+
+# ---------------------------------------------------------------------------
+# Opaque account key
+# ---------------------------------------------------------------------------
+class TestOpaqueAccountKey:
+    def test_deterministic_and_stable_across_cache_reset(self, tmp_path):
+        key_path = tmp_path / "k.secret"
+        first = opaque_account_key("acct-a", key_path=key_path)
+        _key_cache.clear()  # simulate a process restart: re-read from disk
+        second = opaque_account_key("acct-a", key_path=key_path)
+        assert first is not None and first == second
+
+    def test_distinct_accounts_distinct_keys(self, tmp_path):
+        key_path = tmp_path / "k.secret"
+        a = opaque_account_key("acct-a", key_path=key_path)
+        b = opaque_account_key("acct-b", key_path=key_path)
+        assert a != b
+
+    def test_never_reversible_or_raw(self, tmp_path):
+        key_path = tmp_path / "k.secret"
+        account = "user-account-uuid-1234"
+        key = opaque_account_key(account, key_path=key_path)
+        assert key is not None
+        assert account not in key
+        assert key != account
+
+    def test_installations_never_correlate(self, tmp_path):
+        a = opaque_account_key("acct-a", key_path=tmp_path / "one.secret")
+        b = opaque_account_key("acct-a", key_path=tmp_path / "two.secret")
+        assert a != b
+
+    def test_missing_identity_disqualifies(self, tmp_path):
+        key_path = tmp_path / "k.secret"
+        assert opaque_account_key(None, key_path=key_path) is None
+        assert opaque_account_key("", key_path=key_path) is None
+        assert opaque_account_key("   ", key_path=key_path) is None
+        assert not key_path.exists()  # no identity ⇒ no key material created
+
+    def test_key_file_created_0600(self, tmp_path):
+        key_path = tmp_path / "k.secret"
+        opaque_account_key("acct-a", key_path=key_path)
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    def test_unwritable_directory_degrades_to_none(self, tmp_path, caplog):
+        blocked = tmp_path / "data"
+        blocked.write_text("not a directory")
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            key = opaque_account_key("acct-a", key_path=blocked / "k.secret")
+        assert key is None
+        assert any("account key" in r.getMessage().lower() for r in caplog.records)
+
+    def test_replace_failure_cleans_temp_and_degrades(self, tmp_path, caplog, monkeypatch):
+        """A failure after the temp file exists must not leave debris or a key."""
+        import os as _os
+
+        real_replace = _os.replace
+
+        def failing_replace(src, dst):
+            if str(dst).endswith("k.secret"):
+                raise OSError("simulated replace failure")
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("src.llm.account_key.os.replace", failing_replace)
+        key_path = tmp_path / "k.secret"
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            key = opaque_account_key("acct-a", key_path=key_path)
+        assert key is None
+        assert not key_path.exists()
+        assert list(tmp_path.glob(".k.secret.*")) == []  # temp cleaned up
+        assert any("Could not create account key" in r.getMessage() for r in caplog.records)
+
+    def test_weak_material_refused_never_overwritten(self, tmp_path, caplog):
+        key_path = tmp_path / "k.secret"
+        key_path.write_bytes(b"short")
+        with caplog.at_level(logging.WARNING, logger="odin.llm"):
+            key = opaque_account_key("acct-a", key_path=key_path)
+        assert key is None
+        # Replacing weak material would decorrelate all prior evidence.
+        assert key_path.read_bytes() == b"short"
+
+
+# ---------------------------------------------------------------------------
+# Stream-event evidence
+# ---------------------------------------------------------------------------
+class TestFailureEventUsage:
+    def test_failure_event_usage_parsed_when_present(self):
+        exc = _stream_error_from_event(
+            "response.failed",
+            {
+                "response": {
+                    "error": {"type": "invalid_request_error", "code": "context_length_exceeded"},
+                    "usage": {"input_tokens": 372_101},
+                }
+            },
+        )
+        assert exc.server_input_tokens == 372_101
+
+    def test_failure_event_without_usage_is_none(self):
+        exc = _stream_error_from_event(
+            "error",
+            {"error": {"type": "invalid_request_error", "code": "context_length_exceeded"}},
+        )
+        assert exc.server_input_tokens is None
+
+    def test_malformed_failure_usage_is_none(self):
+        exc = _stream_error_from_event(
+            "response.failed",
+            {
+                "response": {
+                    "error": {"code": "context_length_exceeded"},
+                    "usage": {"input_tokens": "372101"},
+                }
+            },
+        )
+        assert exc.server_input_tokens is None
+
+
+class TestCompletedEventUsage:
+    async def test_completed_usage_stamped_on_response(self):
+        client = _client()
+        resp = FakeResp(200, sse_lines=_sse([
+            {"type": "response.output_text.delta", "delta": "hello"},
+            {"type": "response.completed",
+             "response": {"output": [], "usage": {"input_tokens": 917_506}}},
+        ]))
+        result = await client._read_tool_stream(resp)
+        assert result.server_input_tokens == 917_506
+
+    async def test_absent_usage_stays_none_and_estimate_untouched(self):
+        client = _client()
+        resp = FakeResp(200, sse_lines=_sse([
+            {"type": "response.output_text.delta", "delta": "hello"},
+            {"type": "response.completed", "response": {"output": []}},
+        ]))
+        result = await client._read_tool_stream(resp)
+        assert result.server_input_tokens is None
+        # The estimate field is a separate concern with unchanged semantics.
+        assert result.input_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end stamping through the retry engine
+# ---------------------------------------------------------------------------
+class _AccountAuth(FakeSingleAuth):
+    def get_account_id(self):
+        return "acct-uuid-1"
+
+
+class TestSendWithRetriesStamping:
+    async def test_success_carries_account_key_and_server_usage(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "src.llm.account_key.DEFAULT_KEY_PATH", tmp_path / "k.secret"
+        )
+        client = _client(auth=_AccountAuth())
+        session = FakeSession([
+            FakeResp(200, sse_lines=_sse([
+                {"type": "response.output_text.delta", "delta": "ok"},
+                {"type": "response.completed",
+                 "response": {"output": [], "usage": {"input_tokens": 1234}}},
+            ])),
+        ])
+        monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+        result = await client._stream_tool_request({"model": "m"})
+        assert isinstance(result, LLMResponse)
+        assert result.server_input_tokens == 1234
+        expected = opaque_account_key("acct-uuid-1", key_path=tmp_path / "k.secret")
+        assert result.account_key == expected
+        assert "acct-uuid-1" not in json.dumps(result.account_key)
+
+    async def test_overflow_exception_carries_evidence(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "src.llm.account_key.DEFAULT_KEY_PATH", tmp_path / "k.secret"
+        )
+        client = _client(auth=_AccountAuth(), max_retries=1)
+        session = FakeSession([
+            FakeResp(200, sse_lines=_sse([
+                {"type": "response.failed",
+                 "response": {
+                     "error": {"type": "invalid_request_error",
+                               "code": "context_length_exceeded"},
+                     "usage": {"input_tokens": 922_000},
+                 }},
+            ], done=False)),
+        ])
+        monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+        with pytest.raises(LLMRequestError) as excinfo:
+            await client._stream_tool_request({"model": "m"})
+        exc = excinfo.value
+        assert exc.code == "context_length_exceeded"
+        assert exc.server_input_tokens == 922_000
+        assert exc.account_key == opaque_account_key(
+            "acct-uuid-1", key_path=tmp_path / "k.secret"
+        )
+        assert exc.model == "m"
+        assert "acct-uuid-1" not in str(exc)
+
+    async def test_missing_account_identity_stamps_none(self, monkeypatch):
+        client = _client()  # FakeSingleAuth: account id None
+        session = FakeSession([
+            FakeResp(200, sse_lines=_sse([
+                {"type": "response.output_text.delta", "delta": "ok"},
+                {"type": "response.completed", "response": {"output": []}},
+            ])),
+        ])
+        monkeypatch.setattr(client, "_get_session", lambda: _async_return(session))
+        result = await client._stream_tool_request({"model": "m"})
+        assert result.account_key is None


### PR DESCRIPTION
Phase 2 of the campaign (plan of record R2 §10): pure instrumentation, zero behavior change — the provider now reports what the server actually said.

## Content
- **`LLMResponse.server_input_tokens`**: parsed STRICTLY from the `response.completed` usage echo (absent/malformed/bool/negative/non-int ⇒ None). The historical `input_tokens` client estimate keeps its exact meaning — never relabeled, never substituted.
- **Overflow evidence**: the structural overflow exception (and the `LLMError` family) carries `server_input_tokens` from authoritative failure-event usage when present — a rejection without authoritative usage is an occurrence, not a numeric bound — plus existing model provenance.
- **`src/llm/account_key.py`**: opaque installation-local account keys — HMAC-SHA256 of the stable non-secret account id, keyed by a random 0600 key file under `data/` (atomic first-use creation). Same account + same install ⇒ same key across restarts; no identity/no material ⇒ None ⇒ disqualified from account-scoped evidence. Weak or foreign key material is refused but **never overwritten** (replacing it would decorrelate all prior observations). Key trouble degrades evidence, never requests.
- **Per-attempt stamping in `_send_with_retries`**: the account key rides both the successful `LLMResponse` and the overflow exception, stamped from the account that served *that attempt* (the pool may rotate between attempts — the observer's same-account clamp rule depends on this). Raw ids appear nowhere.
- **`tests/conftest.py`**: autouse fixture isolates key material to tmp_path for every test — an auth fake returning a real account id would otherwise materialize `data/account_key.secret` in the working tree.

## Verification
- Suite: **9,363 passed / 5 skipped** (+27 tests)
- Strict-parse matrix · key determinism/stability-across-restart/0600/degradation/temp-cleanup · failure-event usage parsing · completed-event stamping · end-to-end retry-engine stamping (success + overflow) · no-raw-id pins
- `account_key.py` at 100% coverage, baselined · ruff clean · type-gate new=0 · apply-registry findings=0 · coverage-gate findings=0 · lint-gate new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHfEwTsEyuS8RUhwdoW66g