### PR TITLE
Context-budget campaign phase 3: budget-policy activation & agent migration

### DIFF
--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -99,6 +99,7 @@ class LoopAgentBridge:
         context_compression_enabled: bool = False,
         max_context_chars: int = 750000,
         keep_recent_iterations: int = 30,
+        budget_snapshot_provider_factory=None,
     ) -> list[str]:
         """Spawn agents for a loop iteration.
 
@@ -202,6 +203,14 @@ class LoopAgentBridge:
                 context_compression_enabled=context_compression_enabled,
                 max_context_chars=max_context_chars,
                 keep_recent_iterations=keep_recent_iterations,
+                # Per-task like the iteration callback: each agent's budget
+                # follows ITS OWN effective model, so a mixed-model fleet
+                # compacts each member against the right window.
+                budget_snapshot_provider=(
+                    budget_snapshot_provider_factory(model_override)
+                    if budget_snapshot_provider_factory is not None
+                    else None
+                ),
             )
 
             if not agent_id.startswith("Error"):

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -42,24 +42,24 @@ TREE_MAX_AGENTS = 25             # hard ceiling on agents in one tree's lifetime
                                  # breadth x depth must never compound into a
                                  # geometric invoice, whatever config says
 
-# --- Agent context-overflow recovery (design settled with Odin, 2026-08-09) ---
-# Served context window on the Codex/ChatGPT path, probed 2026-08-09 from
-# /backend-api/codex/models: uniform 272K across sol/terra/luna/5.5 (luna
-# served 372K in July and was re-tiered since — treat as observation, not
-# spec). System prompt, response, and reasoning ride OUTSIDE agent.messages,
-# hence the reserve; the remainder converts at a deliberately DENSE
-# chars-per-token so a char measure can never overshoot real tokens on
-# scraped content. Private constants, never config: a raisable knob would
-# resurrect the overflow class this recovery exists to close.
-_SERVED_CONTEXT_WINDOW_TOKENS = 272_000
-_EMERGENCY_RESERVE_TOKENS = 42_000
-_EMERGENCY_CHARS_PER_TOKEN = 2.5
-_EMERGENCY_TARGET_CHARS = int(
-    (_SERVED_CONTEXT_WINDOW_TOKENS - _EMERGENCY_RESERVE_TOKENS)
-    * _EMERGENCY_CHARS_PER_TOKEN
-)
-_EMERGENCY_TARGET_CHARS_AGGRESSIVE = 400_000
-_EMERGENCY_TARGETS = (_EMERGENCY_TARGET_CHARS, _EMERGENCY_TARGET_CHARS_AGGRESSIVE)
+# --- Agent context-overflow recovery (design settled with Odin, 2026-08-09;
+# per-model budgets since the context-budget campaign, 2026-08-17) ---
+# Targets and rescue ladders come from the shared per-model resolver
+# (src/llm/context_budget.py): each logical generation resolves the
+# EFFECTIVE agent model's snapshot via the spawn-provided callback, so a
+# sol-class agent works a sol-class budget while gpt-5.5 keeps the proven
+# 272K-class math. When no provider is wired (legacy/direct construction,
+# non-codex paths) the unknown-model snapshot reproduces the pre-campaign
+# conservative behavior. The old private constants are gone: their
+# "never config" rationale was retired by this recovery machinery itself —
+# wrong-high is one rejected request plus an in-flight rescue, not a
+# terminal failure.
+
+
+def _fallback_budget_snapshot():
+    from ..llm.context_budget import resolve_context_budget
+
+    return resolve_context_budget(None)
 
 
 def _is_context_overflow(exc: BaseException) -> bool:
@@ -423,8 +423,16 @@ class AgentManager:
         context_compression_enabled: bool = False,
         max_context_chars: int = 750000,
         keep_recent_iterations: int = 30,
+        budget_snapshot_provider: Callable | None = None,
     ) -> str:
-        """Spawn a new agent. Returns agent_id on success, or 'Error: ...' string."""
+        """Spawn a new agent. Returns agent_id on success, or 'Error: ...' string.
+
+        ``budget_snapshot_provider`` resolves the effective agent model's
+        ContextBudgetSnapshot per logical generation (live config reaches the
+        NEXT iteration; the in-flight one keeps its snapshot). Absent, the
+        spawn-frozen ``max_context_chars`` and the unknown-model fallback
+        ladder preserve pre-campaign behavior.
+        """
         # Check the live per-channel admission limit. Existing agents are
         # never evicted when the setting falls; only subsequent spawns see it.
         configured_limit = (
@@ -575,6 +583,7 @@ class AgentManager:
                 context_compression_enabled=context_compression_enabled,
                 max_context_chars=max_context_chars,
                 keep_recent_iterations=keep_recent_iterations,
+                budget_snapshot_provider=budget_snapshot_provider,
             )
         )
         agent._task = task
@@ -959,6 +968,7 @@ async def _run_agent(
     context_compression_enabled: bool = False,
     max_context_chars: int = 750000,
     keep_recent_iterations: int = 30,
+    budget_snapshot_provider: Callable | None = None,
 ) -> None:
     """Execute an agent's tool loop until completion, error, or timeout.
 
@@ -1035,6 +1045,27 @@ async def _run_agent(
                 except asyncio.QueueEmpty:
                     break
 
+            # Per-generation budget snapshot: the effective agent model's
+            # targets, resolved fresh each iteration (live config and a live
+            # model change reach the NEXT generation; retries and rescue
+            # rungs inside one generation reuse this snapshot). Provider
+            # failure or absence falls back to the spawn-frozen soft value
+            # and the unknown-model ladder — pre-campaign behavior.
+            budget_snapshot = None
+            if budget_snapshot_provider is not None:
+                try:
+                    budget_snapshot = budget_snapshot_provider()
+                except Exception:
+                    log.exception(
+                        "agent budget snapshot provider failed (non-fatal); "
+                        "using fallback targets"
+                    )
+            soft_target_chars = (
+                budget_snapshot.primary_chars
+                if budget_snapshot is not None
+                else max_context_chars
+            )
+
             # Context compression: summarize older tool iterations when context grows too large
             if context_compression_enabled and iteration > 0:
                 try:
@@ -1042,10 +1073,10 @@ async def _run_agent(
                         compress_tool_context,
                         estimate_message_chars,
                     )
-                    if estimate_message_chars(agent.messages) > max_context_chars:
+                    if estimate_message_chars(agent.messages) > soft_target_chars:
                         agent.messages, saved = compress_tool_context(
                             agent.messages,
-                            max_context_chars=max_context_chars,
+                            max_context_chars=soft_target_chars,
                             keep_recent=keep_recent_iterations,
                         )
                         log.info(
@@ -1092,13 +1123,17 @@ async def _run_agent(
                         emergency_compress_for_window,
                         estimate_message_chars,
                     )
+                    # The latch is capability evidence; the snapshot's primary
+                    # is policy. Compact to whichever is LOWER — a live budget
+                    # drop must not be out-waited by a stale larger latch.
+                    latch_target = min(agent.context_char_ceiling, soft_target_chars)
                     if (
                         estimate_message_chars(agent.messages)
-                        > agent.context_char_ceiling
+                        > latch_target
                     ):
                         agent.messages, latch_report = emergency_compress_for_window(
                             agent.messages,
-                            target_chars=agent.context_char_ceiling,
+                            target_chars=latch_target,
                         )
                         latch_report["attempt"] = 0
                         latch_report["trigger"] = "latch"
@@ -1116,6 +1151,9 @@ async def _run_agent(
             # Call LLM with recovery support
             response = await _call_llm_with_recovery(
                 agent, iteration_callback, system_prompt, tools,
+                rescue_ladder=(
+                    budget_snapshot.ladder if budget_snapshot is not None else None
+                ),
             )
             if response is None:
                 # Terminal state already set by recovery logic
@@ -1321,6 +1359,7 @@ async def _call_llm_with_recovery(
     iteration_callback: IterationCallback,
     system_prompt: str,
     tools: list[dict],
+    rescue_ladder: tuple[int, ...] | None = None,
 ) -> dict | None:
     """Call the LLM for one agent iteration.
 
@@ -1334,6 +1373,11 @@ async def _call_llm_with_recovery(
 
     Returns the LLM response dict, or None if agent reached terminal state.
     """
+    # The rescue ladder is part of the generation's frozen snapshot; None
+    # (legacy/direct callers) resolves the unknown-model fallback so recovery
+    # always has positive rungs to try.
+    if rescue_ladder is None:
+        rescue_ladder = _fallback_budget_snapshot().ladder
     emergency_passes = 0
     # ONE monotonic deadline bounds the whole logical iteration — the initial
     # attempt, any emergency compaction, and every retry share it (Odin's
@@ -1393,7 +1437,7 @@ async def _call_llm_with_recovery(
                 return None
             if (
                 _is_context_overflow(exc)
-                and emergency_passes < len(_EMERGENCY_TARGETS)
+                and emergency_passes < len(rescue_ladder)
             ):
                 # Window overflow: deterministic for THIS payload, so a plain
                 # retry is doomed — but a smaller payload is not. Bound the
@@ -1404,7 +1448,7 @@ async def _call_llm_with_recovery(
                 # breaker/rotation machinery engaged. Bounded passes, no loop.
                 from ..llm.context_compressor import emergency_compress_for_window
 
-                target = _EMERGENCY_TARGETS[emergency_passes]
+                target = rescue_ladder[emergency_passes]
                 emergency_passes += 1
                 compressed, report = emergency_compress_for_window(
                     agent.messages, target_chars=target

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -14,6 +14,7 @@ from collections import deque
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Protocol
 
 from ..error_presentation import format_user_facing_error
 from ..llm.secret_scrubber import scrub_output_secrets
@@ -50,7 +51,7 @@ TREE_MAX_AGENTS = 25             # hard ceiling on agents in one tree's lifetime
 # sol-class agent works a sol-class budget while gpt-5.5 keeps the proven
 # 272K-class math. When no provider is wired (legacy/direct construction,
 # non-codex paths) the unknown-model snapshot reproduces the pre-campaign
-# conservative behavior. The old private constants are gone: their
+# conservative budget behavior. The old private constants are gone: their
 # "never config" rationale was retired by this recovery machinery itself —
 # wrong-high is one rejected request plus an in-flight rescue, not a
 # terminal failure.
@@ -255,12 +256,24 @@ class AgentStateMachine:
 
 
 # Callback types
-# iteration_callback: (messages, system_prompt, tools) → LLMResponse-like dict
-#   dict with keys: "text" (str), "tool_calls" (list[dict]), "stop_reason" (str)
-# (messages, system_prompt, tools, *, generation_state=...) -> response dict.
-# Callable[...] because the frozen-generation channel is keyword-only with a
-# default — a positional-only Callable spelling cannot express it.
-IterationCallback = Callable[..., Awaitable[dict]]
+class IterationCallback(Protocol):
+    """Required callback contract for one logical agent generation.
+
+    ``generation_state`` is a manager-owned, per-generation channel reused by
+    every physical attempt and emergency rescue retry. Three-argument
+    callbacks are no longer supported: silently omitting this channel would
+    make request identity and context-budget snapshots impossible to freeze.
+    """
+
+    def __call__(
+        self,
+        messages: list[dict],
+        sys_prompt: str,
+        tool_defs: list[dict],
+        *,
+        generation_state: dict,
+    ) -> Awaitable[dict]: ...
+
 
 # tool_executor_callback: (tool_name, tool_input) → result string
 ToolExecutorCallback = Callable[
@@ -431,7 +444,8 @@ class AgentManager:
         ContextBudgetSnapshot per logical generation (live config reaches the
         NEXT iteration; the in-flight one keeps its snapshot). Absent, the
         spawn-frozen ``max_context_chars`` and the unknown-model fallback
-        ladder preserve pre-campaign behavior.
+        ladder preserve pre-campaign budget behavior. The iteration callback
+        must implement the required ``generation_state=`` channel.
         """
         # Check the live per-channel admission limit. Existing agents are
         # never evicted when the setting falls; only subsequent spawns see it.
@@ -1374,11 +1388,17 @@ async def _call_llm_with_recovery(
     the agent's snapshotted iteration_timeout capped at remaining lifetime
     hard-bounds the callback INCLUDING any recovery waits.
 
+    Production callbacks always receive the manager-created state channel.
+    ``generation_state=None`` remains only a helper-level convenience for
+    direct recovery tests; it creates the channel, it does not revive the
+    retired three-argument callback contract.
+
     Returns the LLM response dict, or None if agent reached terminal state.
     """
-    # The rescue ladder is part of the generation's frozen snapshot; None
-    # (legacy/direct callers) resolves the unknown-model fallback so recovery
-    # always has positive rungs to try.
+    # The advisory rescue ladder is optional; an absent advisory source uses
+    # unknown-model math. Once the callback publishes an authoritative plan,
+    # its snapshot wins even when its ladder is empty (for example a zero
+    # observed clamp): empty means honest terminal failure, never fallback.
     if rescue_ladder is None:
         rescue_ladder = _fallback_budget_snapshot().ladder
     if generation_state is None:
@@ -1466,12 +1486,17 @@ async def _call_llm_with_recovery(
 
                 plan = generation_state.get("plan")
                 plan_snapshot = plan.get("snapshot") if isinstance(plan, dict) else None
-                plan_ladder = getattr(plan_snapshot, "ladder", None)
                 # The ladder of the request that ACTUALLY overflowed: the
                 # generation plan captured by the callback at send time.
-                # Spawn-provider advisory only when no plan exists
-                # (legacy/direct callers).
-                active_ladder = plan_ladder if plan_ladder else rescue_ladder
+                # Spawn-provider advisory only when no authoritative plan
+                # snapshot exists. An authoritative EMPTY (or malformed-
+                # missing) ladder is a real terminal outcome and must not
+                # silently widen through the unknown-model fallback.
+                active_ladder = (
+                    tuple(getattr(plan_snapshot, "ladder", ()) or ())
+                    if plan_snapshot is not None
+                    else rescue_ladder
+                )
                 if emergency_passes < len(active_ladder):
                     target = active_ladder[emergency_passes]
                     emergency_passes += 1

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -257,10 +257,10 @@ class AgentStateMachine:
 # Callback types
 # iteration_callback: (messages, system_prompt, tools) → LLMResponse-like dict
 #   dict with keys: "text" (str), "tool_calls" (list[dict]), "stop_reason" (str)
-IterationCallback = Callable[
-    [list[dict], str, list[dict]],
-    Awaitable[dict],
-]
+# (messages, system_prompt, tools, *, generation_state=...) -> response dict.
+# Callable[...] because the frozen-generation channel is keyword-only with a
+# default — a positional-only Callable spelling cannot express it.
+IterationCallback = Callable[..., Awaitable[dict]]
 
 # tool_executor_callback: (tool_name, tool_input) → result string
 ToolExecutorCallback = Callable[
@@ -1149,11 +1149,13 @@ async def _run_agent(
                     )
 
             # Call LLM with recovery support
+            generation_state: dict = {}
             response = await _call_llm_with_recovery(
                 agent, iteration_callback, system_prompt, tools,
                 rescue_ladder=(
                     budget_snapshot.ladder if budget_snapshot is not None else None
                 ),
+                generation_state=generation_state,
             )
             if response is None:
                 # Terminal state already set by recovery logic
@@ -1360,6 +1362,7 @@ async def _call_llm_with_recovery(
     system_prompt: str,
     tools: list[dict],
     rescue_ladder: tuple[int, ...] | None = None,
+    generation_state: dict | None = None,
 ) -> dict | None:
     """Call the LLM for one agent iteration.
 
@@ -1378,7 +1381,14 @@ async def _call_llm_with_recovery(
     # always has positive rungs to try.
     if rescue_ladder is None:
         rescue_ladder = _fallback_budget_snapshot().ladder
+    if generation_state is None:
+        generation_state = {}
     emergency_passes = 0
+    # Published only after a provider ACCEPTS the compacted payload: a local
+    # "fits" proves a character target was met, not that the server took it
+    # (R2: the latch comes from the size that actually received a successful
+    # response).
+    pending_ceiling: int | None = None
     # ONE monotonic deadline bounds the whole logical iteration — the initial
     # attempt, any emergency compaction, and every retry share it (Odin's
     # adversarial repro: per-attempt timeouts let one iteration consume ~3x
@@ -1411,10 +1421,19 @@ async def _call_llm_with_recovery(
             agent.ended_at = time.time()
             return None
         try:
-            return await asyncio.wait_for(
-                iteration_callback(agent.messages, system_prompt, tools),
+            response = await asyncio.wait_for(
+                iteration_callback(
+                    agent.messages,
+                    system_prompt,
+                    tools,
+                    generation_state=generation_state,
+                ),
                 timeout=attempt_budget,
             )
+            if pending_ceiling is not None:
+                # The rescue rung is now server-accepted evidence.
+                agent.context_char_ceiling = pending_ceiling
+            return response
         except TimeoutError:
             if _remaining_lifetime(agent) <= 0:
                 # The wait was lifetime-capped and the deadline has passed:
@@ -1435,10 +1454,7 @@ async def _call_llm_with_recovery(
                 # v3.59.0 rule: exhaustion is TIMEOUT, never FAILED).
                 _lifetime_timeout(agent)
                 return None
-            if (
-                _is_context_overflow(exc)
-                and emergency_passes < len(rescue_ladder)
-            ):
+            if _is_context_overflow(exc):
                 # Window overflow: deterministic for THIS payload, so a plain
                 # retry is doomed — but a smaller payload is not. Bound the
                 # entire message list (recent iterations by SIZE, single huge
@@ -1448,35 +1464,52 @@ async def _call_llm_with_recovery(
                 # breaker/rotation machinery engaged. Bounded passes, no loop.
                 from ..llm.context_compressor import emergency_compress_for_window
 
-                target = rescue_ladder[emergency_passes]
-                emergency_passes += 1
-                compressed, report = emergency_compress_for_window(
-                    agent.messages, target_chars=target
-                )
-                report["attempt"] = emergency_passes
-                report["trigger"] = "overflow"
-                agent.context_recoveries.append(report)
-                if report["fits"]:
-                    agent.messages = compressed
-                    # Latch: later iterations compact BEFORE sending once they
-                    # cross the size that just proved survivable.
-                    agent.context_char_ceiling = report["compressed_chars"]
-                    log.warning(
-                        "Agent %s context overflow: emergency pass %d "
-                        "compressed %d -> %d chars; retrying iteration",
+                plan = generation_state.get("plan")
+                plan_snapshot = plan.get("snapshot") if isinstance(plan, dict) else None
+                plan_ladder = getattr(plan_snapshot, "ladder", None)
+                # The ladder of the request that ACTUALLY overflowed: the
+                # generation plan captured by the callback at send time.
+                # Spawn-provider advisory only when no plan exists
+                # (legacy/direct callers).
+                active_ladder = plan_ladder if plan_ladder else rescue_ladder
+                if emergency_passes < len(active_ladder):
+                    target = active_ladder[emergency_passes]
+                    emergency_passes += 1
+                    compressed, report = emergency_compress_for_window(
+                        agent.messages, target_chars=target
+                    )
+                    report["attempt"] = emergency_passes
+                    report["trigger"] = "overflow"
+                    agent.context_recoveries.append(report)
+                    if report["fits"]:
+                        agent.messages = compressed
+                        # Latch candidate: held until the retry actually
+                        # succeeds (the provider is the authority on
+                        # survivable size).
+                        pending_ceiling = report["compressed_chars"]
+                        log.warning(
+                            "Agent %s context overflow: emergency pass %d "
+                            "compressed %d -> %d chars; retrying iteration",
+                            agent.id,
+                            emergency_passes,
+                            report["original_chars"],
+                            report["compressed_chars"],
+                        )
+                        continue
+                    log.error(
+                        "Agent %s context overflow: payload cannot be bounded "
+                        "under %d chars (prefix %d); failing",
+                        agent.id,
+                        target,
+                        report["prefix_chars"],
+                    )
+                else:
+                    log.error(
+                        "Agent %s context overflow: rescue ladder exhausted "
+                        "after %d passes; failing",
                         agent.id,
                         emergency_passes,
-                        report["original_chars"],
-                        report["compressed_chars"],
                     )
-                    continue
-                log.error(
-                    "Agent %s context overflow: payload cannot be bounded "
-                    "under %d chars (prefix %d); failing",
-                    agent.id,
-                    target,
-                    report["prefix_chars"],
-                )
             # Typed fast-fail (auth / malformed request / quota-exhausted
             # after rotation) or a programming defect: neither earns a
             # manager-level retry — transient classes were already retried

--- a/src/config/apply_registry.py
+++ b/src/config/apply_registry.py
@@ -1007,26 +1007,29 @@ FIELDS: dict[str, FieldSpec] = {
     "openai_codex.context_compression.max_context_chars": FieldSpec(
         apply_mode="restart",
         unit="characters",
-        description="Context size at which compression begins. Null means "
-        "auto: the per-model budget resolver derives the ceiling once wired "
-        "(context-budget campaign); until then auto equals the legacy "
-        "750,000. An explicit value only lowers the derived target.",
+        description="Explicit ceiling on the compaction target, in "
+        "characters. Null means auto: the per-model budget resolver derives "
+        "the target from the serving model's usable input budget. An "
+        "explicit value only lowers the derived target, never raises it.",
         restart_reason="The compressor holds the configuration object it was "
         "built with, which a save replaces rather than updates.",
     ),
     "openai_codex.context_budget_overrides": FieldSpec(
-        apply_mode="dormant",
+        apply_mode="live_for_new_work",
         unit="tokens",
-        description="Stored per-model usable-input-budget overrides; the "
-        "budget resolver that consumes them is not wired to any runtime "
-        "surface yet (context-budget campaign phase 3).",
+        description="Per-model usable-input-budget overrides, keyed by "
+        "canonical model. Read at each logical generation's budget "
+        "resolution: chat turns, agent iterations, and rescue ladders pick "
+        "up a save on their next generation; an in-flight generation keeps "
+        "its snapshot.",
     ),
     "openai_codex.context_utilization": FieldSpec(
-        apply_mode="dormant",
+        apply_mode="live_for_new_work",
         unit="percent",
-        description="Stored working-set utilization policy; the budget "
-        "resolver that consumes it is not wired to any runtime surface yet "
-        "(context-budget campaign phase 3).",
+        description="Working-set share of the effective budget that "
+        "compaction targets. Read at each logical generation's budget "
+        "resolution; never reduces budgets at or below 272K tokens, so a "
+        "change may have no effect on smaller models by design.",
     ),
     "openai_codex.context_compression.keep_recent_iterations": FieldSpec(
         apply_mode="restart",

--- a/src/config/apply_registry.py
+++ b/src/config/apply_registry.py
@@ -1015,7 +1015,7 @@ FIELDS: dict[str, FieldSpec] = {
         "built with, which a save replaces rather than updates.",
     ),
     "openai_codex.context_budget_overrides": FieldSpec(
-        apply_mode="live_for_new_work",
+        apply_mode="live_read",
         unit="tokens",
         description="Per-model usable-input-budget overrides, keyed by "
         "canonical model. Read at each logical generation's budget "
@@ -1024,7 +1024,7 @@ FIELDS: dict[str, FieldSpec] = {
         "its snapshot.",
     ),
     "openai_codex.context_utilization": FieldSpec(
-        apply_mode="live_for_new_work",
+        apply_mode="live_read",
         unit="percent",
         description="Working-set share of the effective budget that "
         "compaction targets. Read at each logical generation's budget "

--- a/src/discord/llm_gateway.py
+++ b/src/discord/llm_gateway.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any, NamedTuple
 
 from ..config.persistence import config_transaction
 from ..llm import CodexChatClient, KimiClient, OllamaClient
@@ -36,6 +37,25 @@ from ..llm.recovery import RecoveryPolicy
 from ..odin_log import get_logger
 
 log = get_logger("discord")
+
+
+class LLMServingIdentity(NamedTuple):
+    """Immutable identity for one uninterrupted logical generation.
+
+    Chat captures this once before soft compaction. Preflight, breaker
+    admission, and every physical transport attempt then describe the same
+    provider/client/model/effort even if live configuration reloads in place
+    while recovery is waiting.
+    """
+
+    provider: str
+    client: Any
+    model: str | None
+    reasoning_effort: str | None
+
+    @property
+    def is_codex(self) -> bool:
+        return self.provider == "codex" and self.client is not None
 
 
 @dataclass(frozen=True)
@@ -118,34 +138,64 @@ class LLMGateway:
 
     # ---------- provider resolution ----------------------------------------
 
+    def capture_serving_identity(self, config=None) -> LLMServingIdentity:
+        """Snapshot the client and request identity for one generation.
+
+        This is deliberately synchronous: one root-config read and no await
+        means a live provider switch cannot split provider selection from the
+        client/model/effort facts captured beside it. If a configured local
+        provider is absent, the established Codex fallback is named Codex too
+        so breaker and subsystem identities describe the client actually sent.
+        """
+        if config is None:
+            config = self.get_config()
+        provider_cfg = getattr(config, "llm_provider", None)
+        requested = provider_cfg.active_provider if provider_cfg else "codex"
+        provider: str
+        client: Any
+        if requested == "ollama" and self.ollama_client is not None:
+            provider, client = "ollama", self.ollama_client
+        elif requested == "kimi" and self.kimi_client is not None:
+            provider, client = "kimi", self.kimi_client
+        else:
+            provider, client = "codex", self.codex_client
+        return LLMServingIdentity(
+            provider=provider,
+            client=client,
+            model=getattr(client, "model", None) if client is not None else None,
+            reasoning_effort=(
+                getattr(client, "reasoning_effort", None)
+                if client is not None and hasattr(client, "reasoning_effort")
+                else None
+            ),
+        )
+
     @property
     def active_client(self):
         """Return whichever LLM provider is currently active."""
-        provider_cfg = getattr(self.get_config(), "llm_provider", None)
-        active = provider_cfg.active_provider if provider_cfg else "codex"
-        if active == "ollama" and self.ollama_client is not None:
-            return self.ollama_client
-        if active == "kimi" and self.kimi_client is not None:
-            return self.kimi_client
-        return self.codex_client
+        return self.capture_serving_identity().client
 
     def recovery_policy(self) -> RecoveryPolicy:
         """The live recovery policy (config-backed via wiring)."""
         return self._recovery_policy_source()
 
-    def capacity_breaker_for(self, model: str | None = None) -> ModelCapacityBreaker:
-        """Model-scoped capacity breaker for the active provider.
+    def capacity_breaker_for(
+        self,
+        model: str | None = None,
+        *,
+        provider: str | None = None,
+    ) -> ModelCapacityBreaker:
+        """Return the breaker for an effective request identity.
 
-        ``model`` must be the EFFECTIVE model of the request when the caller
-        overrides it (agents); defaults to the active client's model.
+        Chat supplies both values from its frozen serving identity. Callers
+        that omit either retain the legacy live-resolution behavior.
         """
-        provider_cfg = getattr(self.get_config(), "llm_provider", None)
-        active = provider_cfg.active_provider if provider_cfg else "codex"
-        effective = model
-        if not effective:
-            client = self.active_client
-            effective = getattr(client, "model", None) if client is not None else None
-        return self.model_breakers.for_model(active, str(effective or "unknown"))
+        if provider is None:
+            serving = self.capture_serving_identity()
+            provider = serving.provider
+            if not model:
+                model = serving.model
+        return self.model_breakers.for_model(str(provider or "codex"), str(model or "unknown"))
 
     def notify_generation_success(self, provider: str | None) -> None:
         """Success signal from a path that bypasses ``call_with_tools``
@@ -729,6 +779,7 @@ class LLMGateway:
         user_id: str = "",
         channel_id: str = "",
         tools_used: list[str] | None = None,
+        serving_identity: LLMServingIdentity | None = None,
         **kwargs,
     ):
         """Wrap chat_with_tools with cost / subsystem wiring.
@@ -740,14 +791,20 @@ class LLMGateway:
         async with self.provider_lock:
             if self.switching:
                 raise RuntimeError("LLM provider switch in progress — retry shortly")
-            client = self.active_client
+            # A supplied serving identity is authoritative even when its
+            # client is None; truthiness-based fallback would silently switch
+            # providers after capture.
+            serving = (
+                serving_identity
+                if serving_identity is not None
+                else self.capture_serving_identity()
+            )
+            client = serving.client
             if client is None:
                 raise RuntimeError("No LLM provider configured")
             self.inflight_requests += 1
-            provider_cfg = getattr(self.get_config(), "llm_provider", None)
-            active = provider_cfg.active_provider if provider_cfg else "codex"
 
-        guard_key = f"llm_{active}"
+        guard_key = f"llm_{serving.provider}"
         if self.subsystem_guard is not None:
             err = self.subsystem_guard.check(guard_key)
             if err:

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -165,6 +165,25 @@ def _spawn_pair_error(
     return effort_incompatibility_error(model_now, effort_now)
 
 
+def _generation_budget_snapshot(cfg, client, resolved_model, compressor):
+    """The frozen generation's budget snapshot, from the SAME identity capture
+    as the request (collision-gated: non-Codex clients get unknown-model
+    math regardless of what their model is named)."""
+    from ...llm.context_budget import snapshot_for_codex_config
+
+    if hasattr(client, "reasoning_effort"):
+        model_for_budget = resolved_model or getattr(client, "model", None)
+    else:
+        model_for_budget = None
+    return snapshot_for_codex_config(
+        model_for_budget,
+        getattr(cfg, "openai_codex", None),
+        max_context_chars=(
+            getattr(compressor, "max_context_chars", None) if compressor else None
+        ),
+    )
+
+
 def _make_budget_snapshot_provider(get_config, get_client, get_compressor, model_override):
     """Per-generation context-budget snapshot for a spawned agent.
 
@@ -186,8 +205,16 @@ def _make_budget_snapshot_provider(get_config, get_client, get_compressor, model
             cfg, client, model_override=model_override, effort_override=None
         )
         compressor = get_compressor()
+        # Provider identity gates the registry: a non-Codex client whose
+        # model happens to be NAMED like a Codex slug (an Ollama model tagged
+        # "gpt-5.6-sol") must get conservative unknown-model math, never a
+        # Codex capability floor.
+        if hasattr(client, "reasoning_effort"):
+            model_for_budget = resolved_model or getattr(client, "model", None)
+        else:
+            model_for_budget = None
         return snapshot_for_codex_config(
-            resolved_model or getattr(client, "model", None),
+            model_for_budget,
             getattr(cfg, "openai_codex", None),
             max_context_chars=(
                 getattr(compressor, "max_context_chars", None) if compressor else None
@@ -654,23 +681,40 @@ class AgentTaskTools:
             messages: list[dict],
             sys_prompt: str,
             tool_defs: list[dict],
+            generation_state: dict | None = None,
         ) -> dict:
-            # Resolve the client ONCE per call so the provider/model/effort
-            # stamp describes the client this request actually went to, and
-            # read the agent policy from live config at call time (a WebUI
-            # change reaches in-flight agents on their next iteration).
-            client = self._llm_gateway.active_client
-            agent_effort, resolved_model = _agent_llm_policy(
-                self._get_config(), client,
-                model_override=model_override, effort_override=effort_override,
-            )
+            # ONE capture per logical generation: client, model, effort, and
+            # budget snapshot are resolved together on the FIRST attempt and
+            # reused verbatim by every rescue retry (R2 frozen-generation
+            # identity — a live reload between attempts must never split the
+            # budget from the request it governs). Live config reaches the
+            # NEXT generation, which starts with a fresh state dict.
+            plan = generation_state.get("plan") if generation_state is not None else None
+            if plan is None:
+                client = self._llm_gateway.active_client
+                agent_effort, resolved_model = _agent_llm_policy(
+                    self._get_config(), client,
+                    model_override=model_override, effort_override=effort_override,
+                )
+                plan = {
+                    "client": client,
+                    "effort": agent_effort,
+                    "model": resolved_model,
+                    "snapshot": _generation_budget_snapshot(
+                        self._get_config(), client, resolved_model,
+                        self._get_context_compressor(),
+                    ),
+                }
+                if generation_state is not None:
+                    generation_state["plan"] = plan
+            client = plan["client"]
             resp = await self._agent_generate(
                 client,
                 messages=messages,
                 sys_prompt=sys_prompt,
                 tool_defs=tool_defs,
-                agent_effort=agent_effort,
-                resolved_model=resolved_model,
+                agent_effort=plan["effort"],
+                resolved_model=plan["model"],
             )
             return {
                 "text": resp.text,
@@ -999,19 +1043,36 @@ class AgentTaskTools:
         # model/effort override, so a fleet can mix models. Overrides are fixed
         # for the agent's life; None fields track live config at call time.
         def _make_iteration_cb(model_override, effort_override):
-            async def _iteration_cb(messages, sys, tool_defs):
-                client = self._llm_gateway.active_client
-                agent_effort, resolved_model = _agent_llm_policy(
-                    self._get_config(), client,
-                    model_override=model_override, effort_override=effort_override,
+            async def _iteration_cb(messages, sys, tool_defs, generation_state=None):
+                # Same frozen-generation capture as the direct spawn path.
+                plan = (
+                    generation_state.get("plan") if generation_state is not None else None
                 )
+                if plan is None:
+                    client = self._llm_gateway.active_client
+                    agent_effort, resolved_model = _agent_llm_policy(
+                        self._get_config(), client,
+                        model_override=model_override, effort_override=effort_override,
+                    )
+                    plan = {
+                        "client": client,
+                        "effort": agent_effort,
+                        "model": resolved_model,
+                        "snapshot": _generation_budget_snapshot(
+                            self._get_config(), client, resolved_model,
+                            self._get_context_compressor(),
+                        ),
+                    }
+                    if generation_state is not None:
+                        generation_state["plan"] = plan
+                client = plan["client"]
                 resp = await self._agent_generate(
                     client,
                     messages=messages,
                     sys_prompt=sys,
                     tool_defs=tool_defs,
-                    agent_effort=agent_effort,
-                    resolved_model=resolved_model,
+                    agent_effort=plan["effort"],
+                    resolved_model=plan["model"],
                 )
                 return {
                     "text": resp.text or "",

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -165,6 +165,38 @@ def _spawn_pair_error(
     return effort_incompatibility_error(model_now, effort_now)
 
 
+def _make_budget_snapshot_provider(get_config, get_client, get_compressor, model_override):
+    """Per-generation context-budget snapshot for a spawned agent.
+
+    Resolves the EFFECTIVE agent model exactly like the iteration callback
+    (override fixed for life; None tracks live config at call time) and
+    derives the budget snapshot the manager compacts against. Overrides and
+    utilization are live reads; the explicit character ceiling comes from the
+    boot-frozen compression object so its restart-bound classification stays
+    truthful. Total: any resolution failure surfaces in the manager as the
+    documented fallback, never as an agent failure.
+    """
+
+    def provider():
+        from ...llm.context_budget import snapshot_for_codex_config
+
+        cfg = get_config()
+        client = get_client()
+        _, resolved_model = _agent_llm_policy(
+            cfg, client, model_override=model_override, effort_override=None
+        )
+        compressor = get_compressor()
+        return snapshot_for_codex_config(
+            resolved_model or getattr(client, "model", None),
+            getattr(cfg, "openai_codex", None),
+            max_context_chars=(
+                getattr(compressor, "max_context_chars", None) if compressor else None
+            ),
+        )
+
+    return provider
+
+
 def _provenance_stamp(resp: object, client: object) -> dict:
     """Execution-provenance fields for an iteration record, from the response.
 
@@ -736,6 +768,12 @@ class AgentTaskTools:
             keep_recent_iterations=self._get_context_compressor().keep_recent_iterations
             if self._get_context_compressor()
             else 30,
+            budget_snapshot_provider=_make_budget_snapshot_provider(
+                self._get_config,
+                lambda: self._llm_gateway.active_client,
+                self._get_context_compressor,
+                model_override,
+            ),
         )
 
         if agent_id.startswith("Error"):
@@ -1030,6 +1068,12 @@ class AgentTaskTools:
             context_compression_enabled=bool(cc),
             max_context_chars=cc.resolved_max_context_chars if cc else 750000,
             keep_recent_iterations=cc.keep_recent_iterations if cc else 30,
+            budget_snapshot_provider_factory=lambda mo: _make_budget_snapshot_provider(
+                self._get_config,
+                lambda: self._llm_gateway.active_client,
+                self._get_context_compressor,
+                mo,
+            ),
         )
 
         # Format response

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -184,6 +184,61 @@ def _generation_budget_snapshot(cfg, client, resolved_model, compressor):
     )
 
 
+def _gateway_client_for_config(gateway, config):
+    """Resolve a gateway client against an already-read root config.
+
+    Production gateways accept that object for an atomic identity capture;
+    narrow test doubles retain their historical ``active_client`` shape.
+    """
+    capture = getattr(gateway, "capture_serving_identity", None)
+    if capture is not None:
+        return capture(config).client
+    return gateway.active_client
+
+
+def _capture_agent_generation_plan(
+    get_config,
+    get_client,
+    get_compressor,
+    *,
+    model_override: str | None,
+    effort_override: str | None,
+) -> dict:
+    """Capture one immutable agent-generation identity and budget plan.
+
+    The root configuration is read exactly once. Request policy and the
+    context-budget snapshot are therefore derived from the same config object,
+    rather than straddling a live config replacement. ``effort`` is the
+    resolved effective value for Codex-shaped clients; the ``None`` inherit
+    sentinel never enters a frozen Codex plan, where a later in-place client
+    mutation could otherwise change a rescue retry.
+    """
+    cfg = get_config()
+    client = get_client(cfg)
+    requested_effort, resolved_model = _agent_llm_policy(
+        cfg,
+        client,
+        model_override=model_override,
+        effort_override=effort_override,
+    )
+    effective_effort = requested_effort
+    if effective_effort is None and hasattr(client, "reasoning_effort"):
+        effective_effort = getattr(client, "reasoning_effort", None)
+    if effective_effort is None and hasattr(client, "reasoning_effort"):
+        raise ValueError("Codex client has no resolved reasoning effort")
+    return {
+        "client": client,
+        "effort": effective_effort,
+        "model": resolved_model,
+        "snapshot": _generation_budget_snapshot(
+            cfg,
+            client,
+            resolved_model,
+            get_compressor(),
+        ),
+    }
+
+
 def _make_budget_snapshot_provider(get_config, get_client, get_compressor, model_override):
     """Per-generation context-budget snapshot for a spawned agent.
 
@@ -557,7 +612,7 @@ class AgentTaskTools:
         messages: list[dict],
         sys_prompt: str,
         tool_defs: list[dict],
-        agent_effort,
+        agent_effort: str,
         resolved_model,
     ):
         """One agent LLM generation through the shared recovery policy.
@@ -577,11 +632,12 @@ class AgentTaskTools:
         # xhigh→max — could turn an approved gpt-5.5@xhigh into a rejected
         # gpt-5.5@max at request build). Live config still reaches agents on
         # their NEXT iteration, the contract these callbacks document.
-        effective_effort = (
-            agent_effort
-            if agent_effort is not None
-            else getattr(client, "reasoning_effort", None)
-        )
+        effective_effort = agent_effort
+        # The production callback contract always supplies a concrete resolved
+        # effort for Codex-shaped clients; accepting the inherit sentinel here
+        # would reintroduce live client reads on later physical retries.
+        if effective_effort is None and hasattr(client, "reasoning_effort"):
+            raise ValueError("agent generation plan has unresolved reasoning effort")
         # Pre-admission: validate the exact pair this generation will request
         # before touching the breaker — never wait out an open breaker's
         # deadline (or count a capacity failure) for a request that could not
@@ -681,7 +737,8 @@ class AgentTaskTools:
             messages: list[dict],
             sys_prompt: str,
             tool_defs: list[dict],
-            generation_state: dict | None = None,
+            *,
+            generation_state: dict,
         ) -> dict:
             # ONE capture per logical generation: client, model, effort, and
             # budget snapshot are resolved together on the FIRST attempt and
@@ -689,24 +746,16 @@ class AgentTaskTools:
             # identity — a live reload between attempts must never split the
             # budget from the request it governs). Live config reaches the
             # NEXT generation, which starts with a fresh state dict.
-            plan = generation_state.get("plan") if generation_state is not None else None
+            plan = generation_state.get("plan")
             if plan is None:
-                client = self._llm_gateway.active_client
-                agent_effort, resolved_model = _agent_llm_policy(
-                    self._get_config(), client,
-                    model_override=model_override, effort_override=effort_override,
+                plan = _capture_agent_generation_plan(
+                    self._get_config,
+                    lambda config: _gateway_client_for_config(self._llm_gateway, config),
+                    self._get_context_compressor,
+                    model_override=model_override,
+                    effort_override=effort_override,
                 )
-                plan = {
-                    "client": client,
-                    "effort": agent_effort,
-                    "model": resolved_model,
-                    "snapshot": _generation_budget_snapshot(
-                        self._get_config(), client, resolved_model,
-                        self._get_context_compressor(),
-                    ),
-                }
-                if generation_state is not None:
-                    generation_state["plan"] = plan
+                generation_state["plan"] = plan
             client = plan["client"]
             resp = await self._agent_generate(
                 client,
@@ -1043,28 +1092,18 @@ class AgentTaskTools:
         # model/effort override, so a fleet can mix models. Overrides are fixed
         # for the agent's life; None fields track live config at call time.
         def _make_iteration_cb(model_override, effort_override):
-            async def _iteration_cb(messages, sys, tool_defs, generation_state=None):
+            async def _iteration_cb(messages, sys, tool_defs, *, generation_state: dict):
                 # Same frozen-generation capture as the direct spawn path.
-                plan = (
-                    generation_state.get("plan") if generation_state is not None else None
-                )
+                plan = generation_state.get("plan")
                 if plan is None:
-                    client = self._llm_gateway.active_client
-                    agent_effort, resolved_model = _agent_llm_policy(
-                        self._get_config(), client,
-                        model_override=model_override, effort_override=effort_override,
+                    plan = _capture_agent_generation_plan(
+                        self._get_config,
+                        lambda config: _gateway_client_for_config(self._llm_gateway, config),
+                        self._get_context_compressor,
+                        model_override=model_override,
+                        effort_override=effort_override,
                     )
-                    plan = {
-                        "client": client,
-                        "effort": agent_effort,
-                        "model": resolved_model,
-                        "snapshot": _generation_budget_snapshot(
-                            self._get_config(), client, resolved_model,
-                            self._get_context_compressor(),
-                        ),
-                    }
-                    if generation_state is not None:
-                        generation_state["plan"] = plan
+                    generation_state["plan"] = plan
                 client = plan["client"]
                 resp = await self._agent_generate(
                     client,

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from .tool_catalog import ToolCatalog
     from .turn_recorder import TurnRecorder
 from .delivery import DISCORD_MAX_LEN, TOOL_STATUS_LABELS
+from .llm_gateway import LLMServingIdentity
 from .response_guards import (
     _CODE_HEDGING_RETRY_MSG,
     _CONTINUATION_MSG,
@@ -581,14 +582,15 @@ class ToolLoopRunner:
             if st._cancel.is_set():
                 return self._stopped(st, "iteration_start")
 
-            # ONE capture of this iteration's serving identity: the
-            # compaction threshold and the outgoing request describe the same
-            # client and model (a mid-iteration provider switch is the
-            # phase-4 chat-durability freeze; model identity is pinned here).
-            request_client = getattr(self._llm_gateway, "active_client", None)
-            self._maybe_compress(st, request_client)
+            # ONE capture of this uninterrupted generation's serving
+            # identity: soft compaction, preflight, breaker admission, and
+            # every physical retry all describe this exact client/model/effort.
+            # Durable suspend/resume persistence remains phase 4.
+            config = self._get_config()
+            serving = self._llm_gateway.capture_serving_identity(config)
+            self._maybe_compress(st, serving.client, config)
 
-            kind, val = await self._call_llm(st, request_client)
+            kind, val = await self._call_llm(st, serving_identity=serving)
             if kind == "done":
                 return val
             llm_resp = val
@@ -878,7 +880,12 @@ class ToolLoopRunner:
             False,
         )
 
-    def _maybe_compress(self, st: _ChatTurn, request_client: object = None) -> None:
+    def _maybe_compress(
+        self,
+        st: _ChatTurn,
+        request_client: object = None,
+        request_config: object = None,
+    ) -> None:
         """Context auto-compression — when accumulated tool iterations push
         the message list over the configured budget, summarise older
         iterations into a single text message and keep the most recent N
@@ -900,7 +907,7 @@ class ToolLoopRunner:
                 # Overrides/utilization are live config reads; the explicit
                 # ceiling stays on the boot-frozen compression object so its
                 # restart-bound classification remains truthful.
-                if request_client is None:
+                if request_client is None and request_config is None:
                     request_client = self._llm_gateway.active_client
                 if hasattr(request_client, "reasoning_effort"):
                     model_for_budget = getattr(request_client, "model", None)
@@ -908,7 +915,11 @@ class ToolLoopRunner:
                     model_for_budget = None
                 snapshot = snapshot_for_codex_config(
                     model_for_budget,
-                    getattr(self._get_config(), "openai_codex", None),
+                    getattr(
+                        request_config if request_config is not None else self._get_config(),
+                        "openai_codex",
+                        None,
+                    ),
                     max_context_chars=_cc.max_context_chars,
                 )
                 if estimate_message_chars(st.messages) > snapshot.primary_chars:
@@ -924,7 +935,13 @@ class ToolLoopRunner:
                     "context_compressor failed (non-fatal); continuing with full context"
                 )
 
-    async def _call_llm(self, st: _ChatTurn, request_client: object = None):
+    async def _call_llm(
+        self,
+        st: _ChatTurn,
+        request_client: object = None,
+        *,
+        serving_identity=None,
+    ):
         """Guarded LLM call with typing indicator and deadline-based recovery.
 
         Returns ("ok", llm_resp) or ("done", <run() return tuple>).
@@ -938,11 +955,39 @@ class ToolLoopRunner:
         interrupts any recovery wait immediately.
         """
         _channel_id = str(st.message.channel.id)
-        # Pre-admission: a known-incompatible live pair fails fast — never
-        # deadline-wait on (or count against) a breaker for a request that
-        # could not legally be sent.
-        preflight_incompatible_effort(self._llm_gateway.active_client)
-        breaker = self._llm_gateway.capacity_breaker_for()
+        if serving_identity is None:
+            capture = getattr(self._llm_gateway, "capture_serving_identity", None)
+            if capture is not None:
+                serving_identity = capture()
+            else:
+                # Compatibility for narrow test gateways; production always
+                # supplies the explicit capture from _run_chat_iterations.
+                client = request_client or getattr(self._llm_gateway, "active_client", None)
+                serving_identity = LLMServingIdentity(
+                    provider=(
+                        "codex"
+                        if client is None or hasattr(client, "reasoning_effort")
+                        else getattr(client, "provider_name", "unknown")
+                    ),
+                    client=client,
+                    model=getattr(client, "model", None) if client is not None else None,
+                    reasoning_effort=(
+                        getattr(client, "reasoning_effort", None)
+                        if client is not None and hasattr(client, "reasoning_effort")
+                        else None
+                    ),
+                )
+        request_client = serving_identity.client
+        # Pre-admission and breaker identity are frozen beside the client that
+        # every physical attempt will invoke.
+        preflight_incompatible_effort(
+            request_client,
+            model=serving_identity.model,
+            effort=serving_identity.reasoning_effort,
+        )
+        breaker = self._llm_gateway.capacity_breaker_for(
+            serving_identity.model, provider=serving_identity.provider
+        )
         policy = self._llm_gateway.recovery_policy()
 
         def _on_wait(wait: float, remaining: float, error: BaseException) -> None:
@@ -951,17 +996,15 @@ class ToolLoopRunner:
                 type(error).__name__, wait, remaining,
             )
 
-        # Pin the captured identity's MODEL onto the request: even if the
-        # active client is swapped mid-iteration, a Codex client serves the
-        # model the compaction threshold was derived for (non-Codex clients
-        # accept-and-ignore; full client freezing is phase-4 durability).
-        pinned_model = (
-            getattr(request_client, "model", None)
-            if request_client is not None
-            and hasattr(request_client, "reasoning_effort")
-            else None
-        )
-        pin_kwargs = {"model": pinned_model} if pinned_model else {}
+        # Pin both Codex request axes. The client object's attributes are
+        # live-reloadable in place, so merely retaining the object is not an
+        # identity freeze.
+        pin_kwargs = {}
+        if serving_identity.is_codex:
+            if serving_identity.model:
+                pin_kwargs["model"] = serving_identity.model
+            if serving_identity.reasoning_effort is not None:
+                pin_kwargs["reasoning_effort"] = serving_identity.reasoning_effort
 
         async def _attempt():
             return await self._llm_gateway.call_with_tools(
@@ -972,6 +1015,7 @@ class ToolLoopRunner:
                 user_id=st.user_id,
                 channel_id=_channel_id,
                 tools_used=st.tools_used_in_loop,
+                serving_identity=serving_identity,
             )
 
         # A resumed generation carries only its REMAINING budget (persisted

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -880,16 +880,28 @@ class ToolLoopRunner:
         iterations intact."""
         if self._get_context_compressor() is not None and st.iteration > 0:
             try:
+                from ..llm.context_budget import snapshot_for_codex_config
                 from ..llm.context_compressor import (
                     compress_tool_context,
                     estimate_message_chars,
                 )
 
                 _cc = self._get_context_compressor()
-                if estimate_message_chars(st.messages) > _cc.resolved_max_context_chars:
+                # The threshold follows the model serving THIS turn: a
+                # sol-class chat works a sol-class budget, an unknown or
+                # non-codex model keeps the conservative 272K-class math.
+                # Overrides/utilization are live config reads; the explicit
+                # ceiling stays on the boot-frozen compression object so its
+                # restart-bound classification remains truthful.
+                snapshot = snapshot_for_codex_config(
+                    getattr(self._llm_gateway.active_client, "model", None),
+                    getattr(self._get_config(), "openai_codex", None),
+                    max_context_chars=_cc.max_context_chars,
+                )
+                if estimate_message_chars(st.messages) > snapshot.primary_chars:
                     st.messages, _saved = compress_tool_context(
                         st.messages,
-                        max_context_chars=_cc.resolved_max_context_chars,
+                        max_context_chars=snapshot.primary_chars,
                         keep_recent=_cc.keep_recent_iterations,
                         stats=self._get_compression_stats(),
                     )

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -581,9 +581,14 @@ class ToolLoopRunner:
             if st._cancel.is_set():
                 return self._stopped(st, "iteration_start")
 
-            self._maybe_compress(st)
+            # ONE capture of this iteration's serving identity: the
+            # compaction threshold and the outgoing request describe the same
+            # client and model (a mid-iteration provider switch is the
+            # phase-4 chat-durability freeze; model identity is pinned here).
+            request_client = getattr(self._llm_gateway, "active_client", None)
+            self._maybe_compress(st, request_client)
 
-            kind, val = await self._call_llm(st)
+            kind, val = await self._call_llm(st, request_client)
             if kind == "done":
                 return val
             llm_resp = val
@@ -873,7 +878,7 @@ class ToolLoopRunner:
             False,
         )
 
-    def _maybe_compress(self, st: _ChatTurn) -> None:
+    def _maybe_compress(self, st: _ChatTurn, request_client: object = None) -> None:
         """Context auto-compression — when accumulated tool iterations push
         the message list over the configured budget, summarise older
         iterations into a single text message and keep the most recent N
@@ -887,14 +892,22 @@ class ToolLoopRunner:
                 )
 
                 _cc = self._get_context_compressor()
-                # The threshold follows the model serving THIS turn: a
-                # sol-class chat works a sol-class budget, an unknown or
-                # non-codex model keeps the conservative 272K-class math.
+                # The threshold follows the CAPTURED client serving this
+                # iteration (same capture the request uses): a sol-class chat
+                # works a sol-class budget. Provider identity gates the
+                # registry — a non-Codex client NAMED like a Codex slug gets
+                # conservative unknown-model math, never a Codex floor.
                 # Overrides/utilization are live config reads; the explicit
                 # ceiling stays on the boot-frozen compression object so its
                 # restart-bound classification remains truthful.
+                if request_client is None:
+                    request_client = self._llm_gateway.active_client
+                if hasattr(request_client, "reasoning_effort"):
+                    model_for_budget = getattr(request_client, "model", None)
+                else:
+                    model_for_budget = None
                 snapshot = snapshot_for_codex_config(
-                    getattr(self._llm_gateway.active_client, "model", None),
+                    model_for_budget,
                     getattr(self._get_config(), "openai_codex", None),
                     max_context_chars=_cc.max_context_chars,
                 )
@@ -911,7 +924,7 @@ class ToolLoopRunner:
                     "context_compressor failed (non-fatal); continuing with full context"
                 )
 
-    async def _call_llm(self, st: _ChatTurn):
+    async def _call_llm(self, st: _ChatTurn, request_client: object = None):
         """Guarded LLM call with typing indicator and deadline-based recovery.
 
         Returns ("ok", llm_resp) or ("done", <run() return tuple>).
@@ -938,11 +951,24 @@ class ToolLoopRunner:
                 type(error).__name__, wait, remaining,
             )
 
+        # Pin the captured identity's MODEL onto the request: even if the
+        # active client is swapped mid-iteration, a Codex client serves the
+        # model the compaction threshold was derived for (non-Codex clients
+        # accept-and-ignore; full client freezing is phase-4 durability).
+        pinned_model = (
+            getattr(request_client, "model", None)
+            if request_client is not None
+            and hasattr(request_client, "reasoning_effort")
+            else None
+        )
+        pin_kwargs = {"model": pinned_model} if pinned_model else {}
+
         async def _attempt():
             return await self._llm_gateway.call_with_tools(
                 messages=st.messages,
                 system=st.system_prompt,
                 tools=st.tools or [],
+                **pin_kwargs,
                 user_id=st.user_id,
                 channel_id=_channel_id,
                 tools_used=st.tools_used_in_loop,

--- a/src/llm/context_budget.py
+++ b/src/llm/context_budget.py
@@ -103,6 +103,29 @@ class ContextBudgetSnapshot:
     ladder: tuple[int, ...]
 
 
+def snapshot_for_codex_config(
+    model: str | None,
+    codex_config: object,
+    *,
+    max_context_chars: int | None,
+) -> ContextBudgetSnapshot:
+    """Resolve a snapshot from the live codex config section, getattr-safe.
+
+    ``overrides`` and ``utilization`` are read from ``codex_config`` at CALL
+    time — a live save reaches the next logical generation. The explicit
+    character ceiling is passed by the CALLER from wherever its truthful
+    lifetime lives (the boot-frozen compression object for chat, the
+    spawn-frozen value for agents) so the apply-registry classification of
+    ``max_context_chars`` stays honest: this helper never re-reads it live.
+    """
+    return resolve_context_budget(
+        model,
+        overrides=getattr(codex_config, "context_budget_overrides", None),
+        utilization=getattr(codex_config, "context_utilization", 60),
+        max_context_chars=max_context_chars,
+    )
+
+
 def resolve_context_budget(
     model: str | None,
     *,

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -98,7 +98,7 @@ class _Harness:
         self.calls: list[list[dict]] = []
         self.script = script
 
-    async def iteration_callback(self, messages, system_prompt, tools):
+    async def iteration_callback(self, messages, system_prompt, tools, generation_state=None):
         self.calls.append(copy.deepcopy(messages))
         return await self.script(len(self.calls), messages)
 
@@ -457,7 +457,7 @@ class TestAdversarialBlockers:
                 raise _overflow_error()
             return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
 
-        async def cb(messages, system_prompt, tools):
+        async def cb(messages, system_prompt, tools, generation_state=None):
             return {"text": "unused", "tool_calls": []}
 
         with patch("src.agents.manager.asyncio.wait_for", side_effect=fake_wait_for):
@@ -760,3 +760,97 @@ class TestRoundThreeAdversarialPins:
             and m["content"].startswith("[Emergency context compression")
             for m in out
         )
+
+class TestRound1BlockerPins:
+    """PR #273 review round-1 reproductions, pinned."""
+
+    async def test_latch_published_only_after_server_acceptance(self):
+        """Blocker #3: overflow → local fit → retry fails on a NON-overflow
+        error ⇒ the ceiling must NOT be published (a local fit is not
+        provider acceptance)."""
+        big = _messages(40, 30_000)
+
+        async def script(n, messages):
+            if n == 1:
+                messages.clear()
+                messages.extend(copy.deepcopy(big))
+                raise _overflow_error()
+            raise LLMTransportError("mid-retry transport death")
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        await _run_to_terminal(mgr, agent_id)
+        agent = mgr._agents[agent_id]
+        assert agent.state.name == "FAILED"
+        assert agent.context_char_ceiling is None
+        assert [r["trigger"] for r in agent.context_recoveries] == ["overflow"]
+
+    async def test_latch_published_after_successful_retry(self):
+        big = _messages(40, 30_000)
+
+        async def script(n, messages):
+            if n == 1:
+                messages.clear()
+                messages.extend(copy.deepcopy(big))
+                raise _overflow_error()
+            return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
+
+        h = _Harness(script)
+        mgr = AgentManager()
+        agent_id = h.spawn(mgr)
+        await _run_to_terminal(mgr, agent_id)
+        agent = mgr._agents[agent_id]
+        assert agent.context_char_ceiling is not None
+
+    async def test_rescue_ladder_comes_from_the_frozen_plan(self, monkeypatch):
+        """Blocker #1: the ladder of the request that ACTUALLY overflowed —
+        the generation plan's snapshot — governs rescue, not the spawn
+        provider's advisory (his repro: a sol advisory ladder attached to a
+        gpt-5.5 request)."""
+        from src.llm.context_budget import resolve_context_budget
+
+        plan_snapshot = resolve_context_budget("gpt-5.5")  # ladder (399001,)
+        targets: list[int] = []
+
+        import src.llm.context_compressor as cc_mod
+
+        real = cc_mod.emergency_compress_for_window
+
+        def recording(messages, *, target_chars, stats=None):
+            targets.append(target_chars)
+            return real(messages, target_chars=target_chars)
+
+        monkeypatch.setattr(
+            "src.llm.context_compressor.emergency_compress_for_window", recording
+        )
+
+        async def script_cb(messages, system_prompt, tools, generation_state=None):
+            if generation_state is not None and "plan" not in generation_state:
+                # The callback captures its frozen identity BEFORE sending —
+                # a 5.5 request whose overflow must rescue on 5.5's ladder.
+                generation_state["plan"] = {
+                    "client": object(),
+                    "effort": None,
+                    "model": "gpt-5.5",
+                    "snapshot": plan_snapshot,
+                }
+                raise _overflow_error()
+            return {"text": "DONE", "tool_calls": [], "stop_reason": "end_turn"}
+
+        from src.agents.manager import AgentInfo, _call_llm_with_recovery
+
+        agent = AgentInfo(
+            id="a-pin", label="t", goal="g", channel_id="c1",
+            requester_id="u1", requester_name="user",
+        )
+        agent.messages = _messages(40, 30_000)
+        agent.iteration_timeout = 50.0
+        sol_advisory = resolve_context_budget("gpt-5.6-sol").ladder  # (894180, 400000)
+        result = await _call_llm_with_recovery(
+            agent, script_cb, "sys", [], rescue_ladder=sol_advisory,
+            generation_state={},
+        )
+        assert result is not None
+        assert targets == [399_001]  # the PLAN's rung, not the sol advisory
+

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -16,9 +16,8 @@ import json
 import pytest
 
 from src.agents.manager import (
-    _EMERGENCY_TARGET_CHARS,
-    _EMERGENCY_TARGET_CHARS_AGGRESSIVE,
     AgentManager,
+    _fallback_budget_snapshot,
     _is_context_overflow,
 )
 from src.llm.context_compressor import (
@@ -26,6 +25,13 @@ from src.llm.context_compressor import (
     estimate_message_chars,
 )
 from src.llm.errors import LLMRequestError, LLMTransportError
+
+# The no-provider fallback ladder (unknown-model snapshot): what legacy and
+# non-codex spawn paths recover against. Rung names keep the old constants'
+# roles — first rescue target, then the rescue-ceiling rung.
+_FALLBACK_LADDER = _fallback_budget_snapshot().ladder
+_RUNG_PRIMARY = _FALLBACK_LADDER[0]
+_RUNG_AGGRESSIVE = _FALLBACK_LADDER[-1]
 
 
 def _overflow_error() -> LLMRequestError:
@@ -193,14 +199,14 @@ class TestOverflowRecovery:
         # and the SECOND saw a compressed payload under the primary target.
         assert len(h.calls) == 2
         retry_payload = h.calls[1]
-        assert estimate_message_chars(retry_payload) <= _EMERGENCY_TARGET_CHARS
+        assert estimate_message_chars(retry_payload) <= _RUNG_PRIMARY
         # Task preserved verbatim, newest iteration retained, pairing valid.
         assert retry_payload[0] == {"role": "user", "content": "TASK: research the thing"}
         assert "result-39" in json.dumps(retry_payload)
         assert _pairing_valid(retry_payload)
         # Latch set to the size that succeeded; recovery recorded.
         assert agent.context_char_ceiling is not None
-        assert agent.context_char_ceiling <= _EMERGENCY_TARGET_CHARS
+        assert agent.context_char_ceiling <= _RUNG_PRIMARY
         assert len(agent.context_recoveries) == 1
         r = agent.context_recoveries[0]
         assert r["trigger"] == "overflow" and r["attempt"] == 1 and r["fits"]
@@ -222,7 +228,7 @@ class TestOverflowRecovery:
         # Exactly two emergency passes, then the existing failure handling —
         # no loops.
         assert len(h.calls) == 3
-        assert estimate_message_chars(h.calls[2]) <= _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert estimate_message_chars(h.calls[2]) <= _RUNG_AGGRESSIVE
         assert agent.state.name == "FAILED"
         assert "context_length_exceeded" in (agent.error or "")
         assert [r["attempt"] for r in agent.context_recoveries] == [1, 2]
@@ -398,13 +404,11 @@ class TestAdversarialBlockers:
         """Odin's repro: the fixed summary reserve underestimates a large
         summary and the candidate misses target by a hair — the compressor
         must CONVERGE, never return the original oversized payload."""
-        from src.agents.manager import _EMERGENCY_TARGETS
-
         # Runtime-shaped: hundreds of small-but-real iterations whose
         # summaries alone exceed the old 2,000-char reserve.
         msgs = _messages(520, 1_400)
-        assert estimate_message_chars(msgs) > max(_EMERGENCY_TARGETS)
-        for target in _EMERGENCY_TARGETS:
+        assert estimate_message_chars(msgs) > max(_FALLBACK_LADDER)
+        for target in _FALLBACK_LADDER:
             out, report = emergency_compress_for_window(msgs, target_chars=target)
             assert report["fits"], (target, report)
             assert estimate_message_chars(out) <= target
@@ -644,11 +648,11 @@ class TestRoundThreeAdversarialPins:
         for i in range(300):
             msgs.extend(_iteration(i, 1_400))
         primary, first = emergency_compress_for_window(
-            msgs, target_chars=_EMERGENCY_TARGET_CHARS
+            msgs, target_chars=_RUNG_PRIMARY
         )
         assert first["fits"]
         first_size = estimate_message_chars(primary)
-        assert first_size > _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert first_size > _RUNG_AGGRESSIVE
         summaries = [
             m for m in primary
             if isinstance(m.get("content"), str)
@@ -661,10 +665,10 @@ class TestRoundThreeAdversarialPins:
         assert estimate_message_chars(prefix + summaries) > 400_000
 
         aggressive, second = emergency_compress_for_window(
-            primary, target_chars=_EMERGENCY_TARGET_CHARS_AGGRESSIVE
+            primary, target_chars=_RUNG_AGGRESSIVE
         )
         assert second["fits"], second
-        assert estimate_message_chars(aggressive) <= _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert estimate_message_chars(aggressive) <= _RUNG_AGGRESSIVE
         assert estimate_message_chars(aggressive) < first_size
         assert aggressive[0] == msgs[0]
         assert "tu_299" in json.dumps(aggressive)
@@ -688,7 +692,7 @@ class TestRoundThreeAdversarialPins:
             msgs.extend(_iteration(i, 1_400))
 
         out, report = emergency_compress_for_window(
-            msgs, target_chars=_EMERGENCY_TARGET_CHARS
+            msgs, target_chars=_RUNG_PRIMARY
         )
         assert report["fits"]
         assert out[:2] == [quoted, parent]
@@ -720,11 +724,11 @@ class TestRoundThreeAdversarialPins:
         assert estimate_message_chars(msgs) > 1_200_000
 
         out, report = emergency_compress_for_window(
-            msgs, target_chars=_EMERGENCY_TARGET_CHARS_AGGRESSIVE
+            msgs, target_chars=_RUNG_AGGRESSIVE
         )
         blob = json.dumps(out)
         assert report["fits"], report
-        assert estimate_message_chars(out) <= _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        assert estimate_message_chars(out) <= _RUNG_AGGRESSIVE
         assert report["iterations_kept"] >= 1
         assert all(f'"id": "bulk_{i}"' in blob for i in range(count))
         assert all(f'"tool_use_id": "bulk_{i}"' in blob for i in range(count))
@@ -735,7 +739,7 @@ class TestRoundThreeAdversarialPins:
         # characters at the 400K target.  The sole newest iteration is
         # compressible into that space, and no summary will exist.  Charging
         # the old hypothetical 2K reserve rejected this recoverable payload.
-        target = _EMERGENCY_TARGET_CHARS_AGGRESSIVE
+        target = _RUNG_AGGRESSIVE
         prefix_content = "P" * (398_500 - len("user"))
         prefix = [{"role": "user", "content": prefix_content}]
         assert estimate_message_chars(prefix) == 398_500

--- a/tests/test_agent_context_overflow.py
+++ b/tests/test_agent_context_overflow.py
@@ -854,3 +854,80 @@ class TestRound1BlockerPins:
         assert result is not None
         assert targets == [399_001]  # the PLAN's rung, not the sol advisory
 
+
+class TestRound2AuthoritativePlanPins:
+    async def test_authoritative_empty_ladder_fails_without_legacy_fallback(self, monkeypatch):
+        """A zero-clamp plan has no positive rescue rung. That is an honest
+        terminal result, not permission to widen back to unknown-model math."""
+        from src.agents.manager import AgentInfo, _call_llm_with_recovery
+        from src.llm.context_budget import resolve_context_budget
+
+        calls = 0
+        targets: list[int] = []
+
+        async def callback(messages, system, tools, *, generation_state):
+            nonlocal calls
+            calls += 1
+            if "plan" not in generation_state:
+                generation_state["plan"] = {
+                    "client": object(),
+                    "effort": "xhigh",
+                    "model": "gpt-5.6-sol",
+                    "snapshot": resolve_context_budget("gpt-5.6-sol", observed_clamp=0),
+                }
+            raise _overflow_error()
+
+        def should_not_compact(messages, *, target_chars, stats=None):
+            targets.append(target_chars)
+            raise AssertionError("empty authoritative ladder used fallback")
+
+        monkeypatch.setattr(
+            "src.llm.context_compressor.emergency_compress_for_window",
+            should_not_compact,
+        )
+        agent = AgentInfo(
+            id="zero",
+            label="z",
+            goal="g",
+            channel_id="c",
+            requester_id="u",
+            requester_name="user",
+        )
+        agent.messages = _messages(2, 1_000)
+        agent.iteration_timeout = 10
+        result = await _call_llm_with_recovery(
+            agent,
+            callback,
+            "sys",
+            [],
+            rescue_ladder=_fallback_budget_snapshot().ladder,
+            generation_state={},
+        )
+        assert result is None
+        assert calls == 1
+        assert targets == []
+        assert agent.state.name == "FAILED"
+
+    async def test_three_argument_callback_is_explicitly_unsupported(self):
+        """The manager contract requires the frozen-generation channel; a
+        legacy three-argument callback fails loudly rather than half-working."""
+        from src.agents.manager import AgentInfo, _call_llm_with_recovery
+
+        async def legacy_callback(messages, system, tools):
+            return {"text": "wrong", "tool_calls": [], "stop_reason": "end_turn"}
+
+        agent = AgentInfo(
+            id="legacy",
+            label="l",
+            goal="g",
+            channel_id="c",
+            requester_id="u",
+            requester_name="user",
+        )
+        agent.iteration_timeout = 10
+        result = await _call_llm_with_recovery(
+            agent, legacy_callback, "sys", [], generation_state={}
+        )
+        assert result is None
+        assert agent.state.name == "FAILED"
+        assert "LLM error" in agent.error

--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -483,7 +483,7 @@ class TestAgentManagerWithStates:
         mgr = AgentManager()
         kill_reached = asyncio.Event()
 
-        async def slow_iter(msgs, sys, tools):
+        async def slow_iter(msgs, sys, tools, generation_state=None):
             kill_reached.set()
             await asyncio.sleep(10)
             return {"text": "done", "tool_calls": [], "stop_reason": "end_turn"}
@@ -527,7 +527,7 @@ class TestAgentManagerWithStates:
         mgr = AgentManager()
         started = asyncio.Event()
 
-        async def slow_iter(msgs, sys, tools):
+        async def slow_iter(msgs, sys, tools, generation_state=None):
             started.set()
             await asyncio.sleep(10)
             return {"text": "done", "tool_calls": [], "stop_reason": "end_turn"}
@@ -588,7 +588,7 @@ class TestRunAgentLifecycle:
         agent.messages = [{"role": "user", "content": "test"}]
 
         call_count = 0
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -654,7 +654,7 @@ class TestRunAgentLifecycle:
         )
         agent.messages = [{"role": "user", "content": "test"}]
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             return {
                 "text": "working",
                 "tool_calls": [{"name": "read_file", "input": {}}],
@@ -679,7 +679,7 @@ class TestRunAgentLifecycle:
         )
         agent.messages = [{"role": "user", "content": "test"}]
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             raise asyncio.CancelledError()
 
         tool_cb = AsyncMock()
@@ -695,7 +695,7 @@ class TestRunAgentLifecycle:
         )
         agent.messages = [{"role": "user", "content": "test"}]
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             raise RuntimeError("something broke")
 
         tool_cb = AsyncMock()
@@ -757,7 +757,7 @@ class TestLLMRecovery:
         agent.transition(AgentState.EXECUTING)
 
         call_count = 0
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1108,7 +1108,7 @@ class TestAgentToolExecution:
         agent.messages = [{"role": "user", "content": "test"}]
 
         call_count = 0
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1139,7 +1139,7 @@ class TestAgentToolExecution:
         agent.messages = [{"role": "user", "content": "test"}]
 
         call_count = 0
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1201,7 +1201,7 @@ class TestLoopBridgeCompat:
         bridge = LoopAgentBridge(mgr)
 
         call_count = 0
-        async def slow_iter(msgs, sys, tools):
+        async def slow_iter(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1343,7 +1343,7 @@ class TestEdgeCases:
         agent.messages = [{"role": "user", "content": "test"}]
 
         call_count = 0
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1618,7 +1618,7 @@ class TestLifetimeEnforcement:
 
         calls = 0
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal calls
             calls += 1
             if calls == 1:
@@ -1655,7 +1655,7 @@ class TestTrajectoryStamps:
 
         calls = 0
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal calls
             calls += 1
             if calls == 1:

--- a/tests/test_agent_trajectory.py
+++ b/tests/test_agent_trajectory.py
@@ -476,7 +476,7 @@ class TestRunAgentTrajectory:
         )
         call_count = 0
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -523,7 +523,7 @@ class TestRunAgentTrajectory:
         )
         call_count = 0
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -554,7 +554,7 @@ class TestRunAgentTrajectory:
             channel_id="ch1", requester_id="u1", requester_name="D",
         )
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             raise RuntimeError("LLM down")
 
         await _run_agent(
@@ -711,7 +711,7 @@ class TestRunAgentTrajectory:
         )
         call_count = 0
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -739,7 +739,7 @@ class TestRunAgentTrajectory:
         )
         call_count = 0
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1079,7 +1079,7 @@ class TestEdgeCases:
             channel_id="ch1", requester_id="u1", requester_name="Max",
         )
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             return {
                 "text": "more work",
                 "tool_calls": [{"name": "run_command", "input": {"cmd": "echo hi"}}],
@@ -1108,7 +1108,7 @@ class TestEdgeCases:
             channel_id="ch1", requester_id="u1", requester_name="Cancel",
         )
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             raise asyncio.CancelledError()
 
         await _run_agent(
@@ -1130,7 +1130,7 @@ class TestEdgeCases:
         )
         call_count = 0
 
-        async def iter_cb(messages, prompt, tools):
+        async def iter_cb(messages, prompt, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/tests/test_context_budget_activation.py
+++ b/tests/test_context_budget_activation.py
@@ -9,10 +9,17 @@ no-provider fallback reproduces the pre-campaign conservative math.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 
 from src.agents.manager import _fallback_budget_snapshot
 from src.config.schema import ContextCompressionConfig, OpenAICodexConfig
-from src.discord.native_tools.agents_tasks import _make_budget_snapshot_provider
+from src.discord.llm_gateway import LLMGateway
+from src.discord.native_tools.agents_tasks import (
+    _capture_agent_generation_plan,
+    _make_budget_snapshot_provider,
+)
 from src.discord.tool_loop import ToolLoopRunner
 from src.llm.context_budget import snapshot_for_codex_config
 from src.llm.context_compressor import estimate_message_chars
@@ -201,3 +208,269 @@ class TestChatSoftThreshold:
         before = list(st.messages)
         _chat_runner("gpt-5.6-sol", ContextCompressionConfig())._maybe_compress(st)
         assert st.messages == before
+
+
+# ---------------------------------------------------------------------------
+# Round-2 blocker regression pins
+# ---------------------------------------------------------------------------
+class TestRound2GenerationIdentityPins:
+    async def test_agent_plan_freezes_effective_effort_before_in_place_mutation(self):
+        """The production live-reload shape mutates the SAME client object.
+        A frozen plan must contain xhigh, never the None inherit sentinel that
+        would re-read the now-max client during rescue."""
+        cfg = SimpleNamespace(
+            openai_codex=OpenAICodexConfig(
+                model="gpt-5.6-sol",
+                agent_model=None,
+                agent_reasoning_effort=None,
+            )
+        )
+        client = _codex_client("gpt-5.6-sol")
+        plan = _capture_agent_generation_plan(
+            lambda: cfg,
+            lambda _cfg: client,
+            lambda: ContextCompressionConfig(),
+            model_override=None,
+            effort_override=None,
+        )
+        assert plan["effort"] == "xhigh"
+        client.reasoning_effort = "max"
+        assert plan["client"] is client
+        assert plan["effort"] == "xhigh"
+
+    def test_agent_capture_reads_root_config_once(self):
+        configs = [
+            SimpleNamespace(
+                openai_codex=OpenAICodexConfig(
+                    model="gpt-5.6-sol",
+                    context_budget_overrides={"gpt-5.6-sol": 800_000},
+                )
+            ),
+            SimpleNamespace(
+                openai_codex=OpenAICodexConfig(
+                    model="gpt-5.5",
+                    context_budget_overrides={"gpt-5.6-sol": 270_001},
+                )
+            ),
+        ]
+        reads = 0
+
+        def get_config():
+            nonlocal reads
+            value = configs[min(reads, 1)]
+            reads += 1
+            return value
+
+        plan = _capture_agent_generation_plan(
+            get_config,
+            lambda _cfg: _codex_client("gpt-5.6-sol"),
+            lambda: ContextCompressionConfig(),
+            model_override=None,
+            effort_override=None,
+        )
+        assert reads == 1
+        assert plan["model"] == "gpt-5.6-sol"
+        assert plan["snapshot"].base_budget == 800_000
+
+    async def test_chat_capture_and_budget_share_one_root_config_read(self):
+        configs = [
+            SimpleNamespace(
+                llm_provider=SimpleNamespace(active_provider="codex"),
+                openai_codex=OpenAICodexConfig(
+                    model="gpt-5.6-sol",
+                    context_budget_overrides={"gpt-5.6-sol": 800_000},
+                ),
+            ),
+            SimpleNamespace(
+                llm_provider=SimpleNamespace(active_provider="codex"),
+                openai_codex=OpenAICodexConfig(
+                    model="gpt-5.5",
+                    context_budget_overrides={"gpt-5.6-sol": 270_001},
+                ),
+            ),
+        ]
+        reads = 0
+
+        def get_config():
+            nonlocal reads
+            value = configs[min(reads, 1)]
+            reads += 1
+            return value
+
+        client = _codex_client("gpt-5.6-sol")
+        gateway = LLMGateway(
+            get_config=get_config,
+            codex_client=client,
+            ollama_client=None,
+            kimi_client=None,
+            subsystem_guard=None,
+            auxiliary_llm_client=None,
+            cost_tracker=None,
+            sessions=SimpleNamespace(),
+            reflector=SimpleNamespace(),
+        )
+        from tests.test_typing_resilience import _make_runner, _stub_state
+
+        runner, _saved, _cleared = _make_runner()
+        runner._get_config = get_config
+        runner._llm_gateway = gateway
+        runner._judge_entry_stuck = AsyncMock(return_value=None)
+        captures = []
+        runner._maybe_compress = lambda st, client, config: captures.append((client, config))
+        done = ("done", False, False, [], False)
+        runner._call_llm = AsyncMock(return_value=("done", done))
+        assert await runner._run_chat_iterations(_stub_state()) == done
+        assert reads == 1
+        assert captures == [(client, configs[0])]
+        serving = runner._call_llm.await_args.kwargs["serving_identity"]
+        assert serving.model == "gpt-5.6-sol"
+
+    async def test_chat_physical_retries_keep_captured_identity(self):
+        from src.llm.errors import LLMTransportError
+        from src.llm.recovery import RecoveryPolicy
+        from tests.test_typing_resilience import FakeChannel, _make_runner, _stub_state
+
+        calls: list[tuple[object, str | None, str | None]] = []
+        configs = [SimpleNamespace(llm_provider=SimpleNamespace(active_provider="codex"))]
+
+        class Client:
+            model = "gpt-5.6-sol"
+            reasoning_effort = "xhigh"
+
+            async def chat_with_tools(self, *, model=None, reasoning_effort=None, **_kwargs):
+                calls.append((self, model, reasoning_effort))
+                if len(calls) == 1:
+                    self.model = "gpt-5.5"
+                    self.reasoning_effort = "max"
+                    configs[0] = SimpleNamespace(
+                        llm_provider=SimpleNamespace(active_provider="kimi")
+                    )
+                    raise LLMTransportError("retry")
+                return SimpleNamespace(text="ok", tool_calls=[])
+
+        client = Client()
+        gateway = LLMGateway(
+            get_config=lambda: configs[0],
+            codex_client=client,
+            ollama_client=None,
+            kimi_client=None,
+            subsystem_guard=None,
+            auxiliary_llm_client=None,
+            cost_tracker=None,
+            sessions=SimpleNamespace(),
+            reflector=SimpleNamespace(),
+            recovery_policy_source=lambda: RecoveryPolicy(
+                deadline_seconds=1,
+                backoff_base=0,
+                backoff_cap=0,
+            ),
+        )
+        serving = gateway.capture_serving_identity()
+        breaker = gateway.capacity_breaker_for(serving.model, provider=serving.provider)
+        runner, _saved, _cleared = _make_runner()
+        runner._llm_gateway = gateway
+        st = _stub_state(channel=FakeChannel())
+        kind, response = await runner._call_llm(st, serving_identity=serving)
+        assert kind == "ok" and response.text == "ok"
+        assert calls == [
+            (client, "gpt-5.6-sol", "xhigh"),
+            (client, "gpt-5.6-sol", "xhigh"),
+        ]
+        assert gateway.capacity_breaker_for("gpt-5.6-sol", provider="codex") is breaker
+        assert gateway.capacity_breaker_for("gpt-5.5", provider="kimi") is not breaker
+
+    async def test_gateway_call_uses_captured_provider_for_guard_and_client(self):
+        guards = []
+
+        class Guard:
+            def check(self, key):
+                guards.append(("check", key))
+                return None
+
+            def record_success(self, key):
+                guards.append(("success", key))
+
+            def record_failure(self, key, error):
+                guards.append(("failure", key))
+
+        class Client:
+            model = "gpt-5.6-sol"
+            reasoning_effort = "xhigh"
+
+            async def chat_with_tools(self, **_kwargs):
+                return SimpleNamespace(text="ok", input_tokens=0, output_tokens=0)
+
+        client = Client()
+        config = SimpleNamespace(llm_provider=SimpleNamespace(active_provider="codex"))
+        gateway = LLMGateway(
+            get_config=lambda: config,
+            codex_client=client,
+            ollama_client=None,
+            kimi_client=SimpleNamespace(model="kimi-live", reasoning_effort=None),
+            subsystem_guard=Guard(),
+            auxiliary_llm_client=None,
+            cost_tracker=None,
+            sessions=SimpleNamespace(),
+            reflector=SimpleNamespace(),
+        )
+        serving = gateway.capture_serving_identity()
+        config.llm_provider.active_provider = "kimi"
+        assert gateway.active_client is gateway.kimi_client
+        response = await gateway.call_with_tools(
+            messages=[], system="s", tools=[], serving_identity=serving
+        )
+        assert response.text == "ok"
+        assert guards == [("check", "llm_codex"), ("success", "llm_codex")]
+
+    async def test_chat_preflight_uses_captured_pair_before_open_breaker(self):
+        from src.llm.errors import LLMRequestError
+        from src.llm.recovery import RecoveryPolicy
+        from tests.test_typing_resilience import FakeChannel, _make_runner, _stub_state
+
+        calls = 0
+
+        class Client:
+            model = "gpt-5.5"
+            reasoning_effort = "xhigh"
+
+            async def chat_with_tools(self, **_kwargs):
+                nonlocal calls
+                calls += 1
+                return SimpleNamespace(text="wrong", tool_calls=[])
+
+        client = Client()
+        gateway = LLMGateway(
+            get_config=lambda: SimpleNamespace(
+                llm_provider=SimpleNamespace(active_provider="codex")
+            ),
+            codex_client=client,
+            ollama_client=None,
+            kimi_client=None,
+            subsystem_guard=None,
+            auxiliary_llm_client=None,
+            cost_tracker=None,
+            sessions=SimpleNamespace(),
+            reflector=SimpleNamespace(),
+            recovery_policy_source=lambda: RecoveryPolicy(deadline_seconds=0.1),
+        )
+        serving = gateway.capture_serving_identity()
+        breaker = gateway.capacity_breaker_for(serving.model, provider=serving.provider)
+        while breaker.snapshot()["state"] != "open":
+            breaker.record_generation_failure()
+        client.reasoning_effort = "max"  # live drift after capture
+        frozen = type(serving)(
+            provider=serving.provider,
+            client=serving.client,
+            model=serving.model,
+            reasoning_effort="max",
+        )
+        assert gateway.capacity_breaker_for(
+            frozen.model, provider=frozen.provider
+        ) is breaker
+        runner, _saved, _cleared = _make_runner()
+        runner._llm_gateway = gateway
+        st = _stub_state(channel=FakeChannel())
+        with pytest.raises(LLMRequestError):
+            await runner._call_llm(st, serving_identity=frozen)
+        assert calls == 0
+        assert breaker.snapshot()["state"] == "open"

--- a/tests/test_context_budget_activation.py
+++ b/tests/test_context_budget_activation.py
@@ -96,6 +96,18 @@ class TestAgentSnapshotProvider:
         assert snap.base_source == "unknown_default"
         assert snap.primary_chars == 575_000
 
+    def test_non_codex_collision_gets_unknown_math(self):
+        """Review blocker #2 pin (agents): an Ollama client named after a
+        Codex slug never inherits the Codex capability floor."""
+        config = SimpleNamespace(openai_codex=OpenAICodexConfig())
+        impostor = SimpleNamespace(model="gpt-5.6-sol")  # not codex-shaped
+        provider = _make_budget_snapshot_provider(
+            lambda: config, lambda: impostor, lambda: ContextCompressionConfig(), None
+        )
+        snap = provider()
+        assert snap.base_source == "unknown_default"
+        assert snap.primary_chars == 575_000
+
     def test_frozen_ceiling_comes_from_compressor_object(self):
         config = SimpleNamespace(openai_codex=OpenAICodexConfig())
         compressor = ContextCompressionConfig(max_context_chars=500_000)
@@ -110,12 +122,17 @@ class TestAgentSnapshotProvider:
 # ---------------------------------------------------------------------------
 # Chat soft threshold follows the serving model
 # ---------------------------------------------------------------------------
-def _chat_runner(model, compressor):
+def _chat_runner(model, compressor, *, codex_shaped=True):
     runner = ToolLoopRunner.__new__(ToolLoopRunner)
     runner._get_context_compressor = lambda: compressor
     runner._get_compression_stats = lambda: None
     runner._get_config = lambda: SimpleNamespace(openai_codex=OpenAICodexConfig())
-    runner._llm_gateway = SimpleNamespace(active_client=SimpleNamespace(model=model))
+    client = (
+        _CodexClient(model=model, reasoning_effort="xhigh")
+        if codex_shaped
+        else SimpleNamespace(model=model)
+    )
+    runner._llm_gateway = SimpleNamespace(active_client=client)
     return runner
 
 
@@ -168,6 +185,16 @@ class TestChatSoftThreshold:
             "gpt-5.6-sol", ContextCompressionConfig(max_context_chars=500_000)
         )._maybe_compress(st)
         assert estimate_message_chars(st.messages) < 600_000
+
+    def test_non_codex_client_named_like_codex_slug_gets_unknown_math(self):
+        """Review blocker #2 pin (chat): provider identity gates the registry.
+        A non-Codex client literally named gpt-5.6-sol compacts at the
+        conservative 575K unknown-model target, never sol's 1.277M floor."""
+        st = SimpleNamespace(iteration=3, messages=_bulk_messages(700_000))
+        _chat_runner(
+            "gpt-5.6-sol", ContextCompressionConfig(), codex_shaped=False
+        )._maybe_compress(st)
+        assert estimate_message_chars(st.messages) < 700_000
 
     def test_first_iteration_never_compresses(self):
         st = SimpleNamespace(iteration=0, messages=_bulk_messages(2_000_000))

--- a/tests/test_context_budget_activation.py
+++ b/tests/test_context_budget_activation.py
@@ -1,0 +1,176 @@
+"""Budget-policy activation (context-budget campaign phase 3).
+
+Pins the wiring that makes the per-model resolver real: agents resolve
+their EFFECTIVE model's snapshot per generation, chat's soft threshold
+follows the serving model, rescue ladders come from the snapshot, and the
+no-provider fallback reproduces the pre-campaign conservative math.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.agents.manager import _fallback_budget_snapshot
+from src.config.schema import ContextCompressionConfig, OpenAICodexConfig
+from src.discord.native_tools.agents_tasks import _make_budget_snapshot_provider
+from src.discord.tool_loop import ToolLoopRunner
+from src.llm.context_budget import snapshot_for_codex_config
+from src.llm.context_compressor import estimate_message_chars
+
+
+class _CodexClient(SimpleNamespace):
+    """Codex-shaped: has reasoning_effort, so agent policy resolves models."""
+
+
+def _codex_client(model="gpt-5.6-sol"):
+    return _CodexClient(model=model, reasoning_effort="xhigh")
+
+
+# ---------------------------------------------------------------------------
+# snapshot_for_codex_config
+# ---------------------------------------------------------------------------
+class TestSnapshotForCodexConfig:
+    def test_reads_live_policy_fields_and_passed_ceiling(self):
+        cfg = OpenAICodexConfig(
+            context_budget_overrides={"gpt-5.6-sol": 800_000},
+            context_utilization=100,
+        )
+        snap = snapshot_for_codex_config("gpt-5.6-sol", cfg, max_context_chars=1_000_000)
+        assert snap.base_budget == 800_000
+        assert snap.working_budget == 800_000  # utilization 100
+        assert snap.primary_chars == 1_000_000  # explicit ceiling lowers
+        assert snap.ceiling_applied is True
+
+    def test_getattr_safe_on_none_config(self):
+        snap = snapshot_for_codex_config("gpt-5.6-sol", None, max_context_chars=None)
+        assert snap.primary_chars == 1_277_400  # defaults: 60% utilization
+
+    def test_fallback_snapshot_is_unknown_model_math(self):
+        snap = _fallback_budget_snapshot()
+        assert snap.base_source == "unknown_default"
+        assert snap.primary_chars == 575_000
+        assert snap.ladder == (402_500, 400_000)
+
+
+# ---------------------------------------------------------------------------
+# Agent spawn-path provider
+# ---------------------------------------------------------------------------
+class TestAgentSnapshotProvider:
+    def test_inherit_tracks_live_model_next_generation(self):
+        config = SimpleNamespace(
+            openai_codex=OpenAICodexConfig(model="gpt-5.6-sol", agent_model=None)
+        )
+        client = _codex_client("gpt-5.6-sol")
+        compressor = ContextCompressionConfig()
+        provider = _make_budget_snapshot_provider(
+            lambda: config, lambda: client, lambda: compressor, None
+        )
+        assert provider().canonical_model == "gpt-5.6-sol"
+        assert provider().primary_chars == 1_277_400
+        # A live model change reaches the NEXT resolution.
+        config.openai_codex.model = "gpt-5.5"
+        client.model = "gpt-5.5"
+        after = provider()
+        assert after.canonical_model == "gpt-5.5"
+        assert after.primary_chars == 570_002
+
+    def test_fixed_override_wins_over_live_config(self):
+        config = SimpleNamespace(
+            openai_codex=OpenAICodexConfig(model="gpt-5.6-sol", agent_model=None)
+        )
+        provider = _make_budget_snapshot_provider(
+            lambda: config, lambda: _codex_client(), lambda: ContextCompressionConfig(),
+            "gpt-5.5",
+        )
+        snap = provider()
+        assert snap.canonical_model == "gpt-5.5"
+        assert snap.primary_chars == 570_002
+
+    def test_non_codex_client_uses_its_own_model_name(self):
+        config = SimpleNamespace(openai_codex=OpenAICodexConfig())
+        ollama = SimpleNamespace(model="qwen3:14b")  # no reasoning_effort attr
+        provider = _make_budget_snapshot_provider(
+            lambda: config, lambda: ollama, lambda: ContextCompressionConfig(), None
+        )
+        snap = provider()
+        assert snap.base_source == "unknown_default"
+        assert snap.primary_chars == 575_000
+
+    def test_frozen_ceiling_comes_from_compressor_object(self):
+        config = SimpleNamespace(openai_codex=OpenAICodexConfig())
+        compressor = ContextCompressionConfig(max_context_chars=500_000)
+        provider = _make_budget_snapshot_provider(
+            lambda: config, lambda: _codex_client(), lambda: compressor, None
+        )
+        snap = provider()
+        assert snap.primary_chars == 500_000
+        assert snap.ceiling_applied is True
+
+
+# ---------------------------------------------------------------------------
+# Chat soft threshold follows the serving model
+# ---------------------------------------------------------------------------
+def _chat_runner(model, compressor):
+    runner = ToolLoopRunner.__new__(ToolLoopRunner)
+    runner._get_context_compressor = lambda: compressor
+    runner._get_compression_stats = lambda: None
+    runner._get_config = lambda: SimpleNamespace(openai_codex=OpenAICodexConfig())
+    runner._llm_gateway = SimpleNamespace(active_client=SimpleNamespace(model=model))
+    return runner
+
+
+def _bulk_messages(char_target: int) -> list[dict]:
+    # A prefix plus enough structurally complete tool iterations to cross
+    # any threshold under test; sizes dominated by tool_result payloads.
+    messages: list[dict] = [{"role": "user", "content": "task"}]
+    # Small chunks so every fixture comfortably exceeds keep_recent=30
+    # iterations — the soft pass only summarizes OLDER-than-recent ones.
+    chunk = "y" * 12_000
+    while estimate_message_chars(messages) < char_target:
+        messages.append(
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": f"t{len(messages)}", "name": "read_file",
+                 "input": {"path": "x"}},
+            ]}
+        )
+        messages.append(
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": f"t{len(messages) - 1}",
+                 "content": chunk},
+            ]}
+        )
+    return messages
+
+
+class TestChatSoftThreshold:
+    def test_sol_headroom_no_compress_where_legacy_would_have(self):
+        """850K chars: over the legacy 750K, comfortably under sol's 1.277M —
+        the whole point of the campaign is that this stays uncompressed."""
+        st = SimpleNamespace(iteration=3, messages=_bulk_messages(850_000))
+        before = list(st.messages)
+        _chat_runner("gpt-5.6-sol", ContextCompressionConfig())._maybe_compress(st)
+        assert st.messages == before
+
+    def test_sol_compresses_past_model_threshold(self):
+        st = SimpleNamespace(iteration=3, messages=_bulk_messages(1_400_000))
+        _chat_runner("gpt-5.6-sol", ContextCompressionConfig())._maybe_compress(st)
+        assert estimate_message_chars(st.messages) < 1_400_000
+
+    def test_unknown_model_keeps_conservative_threshold(self):
+        st = SimpleNamespace(iteration=3, messages=_bulk_messages(700_000))
+        _chat_runner("some-local-model", ContextCompressionConfig())._maybe_compress(st)
+        # 700K > the 575K unknown-model target: compressed.
+        assert estimate_message_chars(st.messages) < 700_000
+
+    def test_explicit_ceiling_still_lowers(self):
+        st = SimpleNamespace(iteration=3, messages=_bulk_messages(600_000))
+        _chat_runner(
+            "gpt-5.6-sol", ContextCompressionConfig(max_context_chars=500_000)
+        )._maybe_compress(st)
+        assert estimate_message_chars(st.messages) < 600_000
+
+    def test_first_iteration_never_compresses(self):
+        st = SimpleNamespace(iteration=0, messages=_bulk_messages(2_000_000))
+        before = list(st.messages)
+        _chat_runner("gpt-5.6-sol", ContextCompressionConfig())._maybe_compress(st)
+        assert st.messages == before

--- a/tests/test_executor_integration_smoke.py
+++ b/tests/test_executor_integration_smoke.py
@@ -312,7 +312,7 @@ class TestProcessWithToolsEndToEnd:
         bot.llm_gateway.codex_client = MagicMock()
 
         # Codex returns a single tool call on iter 1, then a text response on iter 2.
-        async def fake_chat_with_tools(messages, system, tools):
+        async def fake_chat_with_tools(messages, system, tools, **kwargs):
             # Distinguish first call (no tool_result yet) from second
             has_tool_result = any(
                 isinstance(m.get("content"), list) and any(

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -310,6 +310,31 @@ class TestCallWithTools:
         cost.record.assert_called_once()
         assert gw.inflight_requests == 0  # decremented in finally
 
+    async def test_capacity_failure_marks_only_transient_degradation(self):
+        from src.llm.errors import LLMCapacityError
+
+        client = SimpleNamespace(
+            chat_with_tools=AsyncMock(side_effect=LLMCapacityError("full"))
+        )
+        guard = MagicMock()
+        guard.check.return_value = None
+        gw = _gw(codex=client, guard=guard)
+        with pytest.raises(LLMCapacityError):
+            await gw.call_with_tools(messages=[], system="s", tools=[])
+        guard.mark_degraded_transient.assert_called_once_with(
+            "llm_codex", "full", expires_in=120.0
+        )
+        guard.record_failure.assert_not_called()
+
+    def test_bypass_success_uses_response_provenance_or_noops(self):
+        guard = MagicMock()
+        gw = _gw(codex=object(), guard=guard)
+        gw.notify_generation_success(None)
+        guard.record_success.assert_not_called()
+        gw.notify_generation_success("codex")
+        guard.record_success.assert_called_once_with("llm_codex")
+        _gw(codex=object()).notify_generation_success("codex")
+
     async def test_failure_records_and_raises(self):
         client = SimpleNamespace(chat_with_tools=AsyncMock(side_effect=RuntimeError("api")))
         guard = MagicMock()
@@ -1184,3 +1209,52 @@ class TestAuxiliaryPlanEdges:
         result = await gw.reload_auxiliary(plan=plan)
         assert result["committed"] is False
         assert "no primary" in result["reason"]
+
+
+class TestServingIdentityFreeze:
+    def test_capture_reuses_supplied_config_and_fallback_identity(self):
+        cfg = _cfg("ollama")
+        codex = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        gw = _gw(cfg, codex=codex, ollama=None)
+        serving = gw.capture_serving_identity(cfg)
+        assert serving.provider == "codex"
+        assert serving.client is codex
+        assert serving.model == "gpt-5.6-sol"
+        assert serving.reasoning_effort == "xhigh"
+
+    def test_capture_covers_each_available_provider(self):
+        ollama = SimpleNamespace(model="qwen")
+        kimi = SimpleNamespace(model="kimi")
+        ollama_serving = _gw(_cfg("ollama"), codex=None, ollama=ollama).capture_serving_identity()
+        kimi_serving = _gw(_cfg("kimi"), codex=None, kimi=kimi).capture_serving_identity()
+        assert (ollama_serving.provider, ollama_serving.client) == ("ollama", ollama)
+        assert (kimi_serving.provider, kimi_serving.client) == ("kimi", kimi)
+        assert ollama_serving.reasoning_effort is None
+        assert kimi_serving.reasoning_effort is None
+
+    def test_codex_identity_is_provider_fact_not_attribute_collision(self):
+        from src.discord.llm_gateway import LLMServingIdentity
+
+        collision = SimpleNamespace(model="local", reasoning_effort="decorative")
+        assert not LLMServingIdentity("ollama", collision, "local", None).is_codex
+
+    async def test_explicit_empty_identity_never_re_resolves_live_provider(self):
+        from src.discord.llm_gateway import LLMServingIdentity
+
+        client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        gw = _gw(_cfg("codex"), codex=client)
+        with pytest.raises(RuntimeError, match="No LLM provider"):
+            await gw.call_with_tools(
+                messages=[],
+                system="s",
+                tools=[],
+                serving_identity=LLMServingIdentity("codex", None, None, None),
+            )
+
+    def test_breaker_defaults_from_one_serving_capture(self):
+        client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        gw = _gw(_cfg("codex"), codex=client)
+        assert gw.capacity_breaker_for() is gw.model_breakers.for_model("codex", "gpt-5.6-sol")
+        assert gw.capacity_breaker_for("explicit", provider="kimi") is gw.model_breakers.for_model(
+            "kimi", "explicit"
+        )

--- a/tests/test_max_reasoning_effort.py
+++ b/tests/test_max_reasoning_effort.py
@@ -255,7 +255,7 @@ class TestPreflightBeforeAdmission:
 
         runner._llm_gateway = SimpleNamespace(
             call_with_tools=_cwt,
-            capacity_breaker_for=lambda model=None: breaker,
+            capacity_breaker_for=lambda model=None, provider=None: breaker,
             recovery_policy=lambda: RecoveryPolicy(
                 deadline_seconds=0.3, backoff_base=0.01,
                 backoff_cap=0.02, retry_after_cap=0.05),
@@ -284,7 +284,7 @@ class TestAutonomousPreflightCompletion:
         runner, _saved, _cleared = _make_runner()
         registry = ModelBreakerRegistry()
         runner._llm_gateway = SimpleNamespace(
-            capacity_breaker_for=lambda model=None: registry.for_model("codex", "m"),
+            capacity_breaker_for=lambda model=None, provider=None: registry.for_model("codex", "m"),
             recovery_policy=lambda: RecoveryPolicy(
                 deadline_seconds=0.3, backoff_base=0.01,
                 backoff_cap=0.02, retry_after_cap=0.05),

--- a/tests/test_native_agents_tasks.py
+++ b/tests/test_native_agents_tasks.py
@@ -1109,3 +1109,56 @@ class TestAgentEffortSnapshot:
         # the mid-generation "max" (which would 400 against gpt-5.5)
         assert calls == ["xhigh", "xhigh"]
         assert resp.text == "ok"
+
+class TestFrozenGenerationIdentity:
+    """PR #273 round-1 blocker #1 pin: client/model/effort/budget come from
+    ONE capture and stay fixed across rescue retries of the same generation;
+    a live reload or client swap reaches only the NEXT generation."""
+
+    async def test_rescue_retry_reuses_the_first_attempt_plan(self):
+        from src.config.schema import OpenAICodexConfig
+
+        cfg = _cfg()
+        cfg.openai_codex = OpenAICodexConfig(
+            model="gpt-5.6-sol", agent_model=None, agent_reasoning_effort=None,
+        )
+        sol_client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        gateway = SimpleNamespace(active_client=sol_client)
+        t = _tools(get_config=lambda: cfg, llm_gateway=gateway)
+        t._agent_manager.spawn = MagicMock(return_value="agent-1")
+        t._agent_generate = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok", tool_calls=[], stop_reason="end_turn",
+                provenance_provider="codex", provenance_model="gpt-5.6-sol",
+                provenance_reasoning_effort="xhigh",
+            )
+        )
+        await t._handle_spawn_agent(_message(), {"label": "x", "goal": "g"})
+        cb = t._agent_manager.spawn.call_args.kwargs["iteration_callback"]
+
+        generation_state: dict = {}
+        await cb([], "sys", [], generation_state=generation_state)
+        plan = generation_state["plan"]
+        assert plan["client"] is sol_client
+        assert plan["model"] == "gpt-5.6-sol"
+        assert plan["snapshot"].primary_chars == 1_277_400
+
+        # Mid-generation reload: live config and the active client both flip
+        # to 5.5. The rescue retry MUST still use the frozen sol identity.
+        cfg.openai_codex.model = "gpt-5.5"
+        gateway.active_client = SimpleNamespace(
+            model="gpt-5.5", reasoning_effort="xhigh"
+        )
+        await cb([], "sys", [], generation_state=generation_state)
+        first = t._agent_generate.await_args_list[0]
+        second = t._agent_generate.await_args_list[1]
+        assert second.args[0] is sol_client  # same client object
+        assert second.kwargs["resolved_model"] == first.kwargs["resolved_model"]
+        assert generation_state["plan"] is plan  # nothing re-resolved
+
+        # A FRESH generation state (the next iteration) sees the new world.
+        fresh: dict = {}
+        await cb([], "sys", [], generation_state=fresh)
+        assert fresh["plan"]["model"] == "gpt-5.5"
+        assert fresh["plan"]["snapshot"].primary_chars == 570_002
+

--- a/tests/test_native_agents_tasks.py
+++ b/tests/test_native_agents_tasks.py
@@ -15,6 +15,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.config.schema import ContextCompressionConfig
 from src.discord.background_task import MAX_STEPS
 from src.discord.native_tools.agents_tasks import (
@@ -386,7 +388,7 @@ class TestAgentReasoningEffortCallback:
         t = self._spawned_callback("low", client)
         await t._handle_spawn_agent(_message(), {"label": "w", "goal": "g"})
         cb = t._agent_manager.spawn.call_args.kwargs["iteration_callback"]
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["reasoning_effort"] == "low"
         assert out["reasoning_effort"] == "low"
         assert out["provider"] == "codex"
@@ -397,7 +399,7 @@ class TestAgentReasoningEffortCallback:
         t = self._spawned_callback(None, client)
         await t._handle_spawn_agent(_message(), {"label": "w", "goal": "g"})
         cb = t._agent_manager.spawn.call_args.kwargs["iteration_callback"]
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         # Since the round-2 snapshot contract, the inherited effort is pinned
         # per generation and travels EXPLICITLY on the wire (preflight and the
         # outbound request must agree) — same effective request as the old
@@ -416,12 +418,12 @@ class TestAgentReasoningEffortCallback:
         t._agent_manager._agents = {}
         await t._handle_spawn_agent(_message(), {"label": "w", "goal": "g"})
         cb = t._agent_manager.spawn.call_args.kwargs["iteration_callback"]
-        await cb([{"role": "user", "content": "x"}], "sys", [])
+        await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         # inherit resolves to the client's own effort, snapshotted per
         # generation (round-2 contract) — explicit on the wire, not None
         assert client.captured["reasoning_effort"] == "high"
         cfg.openai_codex.agent_reasoning_effort = "xhigh"  # live WebUI change
-        await cb([{"role": "user", "content": "x"}], "sys", [])
+        await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["reasoning_effort"] == "xhigh"
 
     async def test_callback_stamps_none_for_effortless_provider(self):
@@ -447,7 +449,7 @@ class TestAgentReasoningEffortCallback:
         t = self._spawned_callback("low", client)
         await t._handle_spawn_agent(_message(), {"label": "w", "goal": "g"})
         cb = t._agent_manager.spawn.call_args.kwargs["iteration_callback"]
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert out["reasoning_effort"] is None
         assert out["provider"] == "ollama"
 
@@ -465,7 +467,7 @@ class TestAgentReasoningEffortCallback:
         await t._handle_spawn_loop_agents(
             _message(), {"loop_id": "L1", "tasks": [{"label": "x", "goal": "g"}]})
         cb = t._loop_agent_bridge.spawn_agents_for_loop.call_args.kwargs["iteration_callback"]
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["reasoning_effort"] == "medium"
         assert out["reasoning_effort"] == "medium"
 
@@ -495,7 +497,7 @@ class TestAgentModelCallback:
                                           agent_model="gpt-5.6-luna",
                                           model="gpt-5.6-sol"), client)
         cb = await self._callback(t)
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-luna"
         assert out["model"] == "gpt-5.6-luna"
 
@@ -509,7 +511,7 @@ class TestAgentModelCallback:
                                           agent_model=None,
                                           model="gpt-5.6-sol"), client)
         cb = await self._callback(t)
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-sol"
         assert out["model"] == "gpt-5.6-sol"
 
@@ -519,7 +521,7 @@ class TestAgentModelCallback:
                                           agent_model="   ",
                                           model="gpt-5.6-sol"), client)
         cb = await self._callback(t)
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-sol"
         assert out["model"] == "gpt-5.6-sol"
 
@@ -531,10 +533,10 @@ class TestAgentModelCallback:
                                     agent_model=None, model="gpt-5.6-sol")
         t = self._spawned(cfg_codex, client)
         cb = await self._callback(t)
-        out1 = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out1 = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-sol" == out1["model"]
         cfg_codex.agent_model = "gpt-5.6-luna"  # live WebUI change
-        out2 = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out2 = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-luna" == out2["model"]
 
     async def test_non_codex_provider_stamps_actual_model(self):
@@ -562,7 +564,7 @@ class TestAgentModelCallback:
                                           agent_model="gpt-5.6-luna",
                                           model="gpt-5.6-sol"), client)
         cb = await self._callback(t)
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] is None  # override not forwarded
         assert out["model"] == "qwen3"
 
@@ -591,7 +593,7 @@ class TestAgentModelCallback:
                                           agent_model="gpt-5.6-luna",
                                           model="gpt-5.6-sol"), client)
         cb = await self._callback(t)
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-luna"  # resolver → request
         assert out["model"] == "proof-from-response"       # response → stamp
         assert out["reasoning_effort"] == "low"
@@ -617,7 +619,7 @@ class TestAgentModelCallback:
                                           agent_model="gpt-5.6-luna",
                                           model="gpt-5.6-sol"), client)
         cb = await self._callback(t)
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert out["provider"] == ""
         assert out["model"] == ""
         assert out["reasoning_effort"] is None
@@ -637,7 +639,7 @@ class TestAgentModelCallback:
         await t._handle_spawn_loop_agents(
             _message(), {"loop_id": "L1", "tasks": [{"label": "x", "goal": "g"}]})
         cb = t._loop_agent_bridge.spawn_agents_for_loop.call_args.kwargs["iteration_callback"]
-        out = await cb([{"role": "user", "content": "x"}], "sys", [])
+        out = await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-luna"
         assert out["model"] == "gpt-5.6-luna"
 
@@ -698,7 +700,7 @@ class TestPerSpawnModelEffort:
         assert kwargs["reasoning_effort_override"] == "low"
         # and the iteration callback ASKS the client for luna@low, not sol@medium
         cb = kwargs["iteration_callback"]
-        await cb([{"role": "user", "content": "x"}], "sys", [])
+        await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-luna"
         assert client.captured["reasoning_effort"] == "low"
 
@@ -715,8 +717,8 @@ class TestPerSpawnModelEffort:
         assert kwargs["model_override"] is None
         assert kwargs["reasoning_effort_override"] is None
         cb = kwargs["iteration_callback"]
-        await cb([{"role": "user", "content": "x"}], "sys", [])
-        assert client.captured["model"] == "gpt-5.6-terra"   # agent_model
+        await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
+        assert client.captured["model"] == "gpt-5.6-terra"  # agent_model
         assert client.captured["reasoning_effort"] == "high"
 
     async def test_invalid_effort_rejects_without_spawning(self):
@@ -755,7 +757,7 @@ class TestPerSpawnModelEffort:
         factory = t._loop_agent_bridge.spawn_agents_for_loop.call_args.kwargs[
             "iteration_callback_factory"]
         cb = factory("gpt-5.6-luna", None)
-        await cb([{"role": "user", "content": "x"}], "sys", [])
+        await cb([{"role": "user", "content": "x"}], "sys", [], generation_state={})
         assert client.captured["model"] == "gpt-5.6-luna"
         # one bad effort rejects the WHOLE batch — nothing spawns
         t._loop_agent_bridge.spawn_agents_for_loop.reset_mock()
@@ -1015,8 +1017,6 @@ class TestAgentGeneratePreflight:
     must not move the breaker's failure count."""
 
     async def test_bad_pair_fails_fast_with_open_breaker(self):
-        import pytest
-
         from src.llm.errors import LLMRequestError
 
         client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="medium")
@@ -1040,11 +1040,8 @@ class TestAgentGeneratePreflight:
         assert breaker.snapshot()["failed_generations"] == failures_before
         assert breaker.snapshot()["state"] == "open"
 
-    async def test_inherited_client_effort_pair_fails_fast(self):
-        """agent_effort None inherits the client's live effort at preflight —
-        the drift shape: fixed gpt-5.5 model override + live effort now max."""
-        import pytest
-
+    async def test_resolved_client_effort_pair_fails_fast(self):
+        """The plan's resolved effort is validated at preflight for its fixed model."""
         from src.llm.errors import LLMRequestError
 
         client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="max")
@@ -1052,7 +1049,7 @@ class TestAgentGeneratePreflight:
         with pytest.raises(LLMRequestError):
             await t._agent_generate(
                 client, messages=[], sys_prompt="s", tool_defs=[],
-                agent_effort=None, resolved_model="gpt-5.5",
+                agent_effort="max", resolved_model="gpt-5.5",
             )
 
 
@@ -1074,12 +1071,89 @@ class TestSpawnPairNonCodexCollision:
         assert "spawned" in out
 
 
+class TestResolvedAgentEffortBoundary:
+    async def test_codex_generation_rejects_unresolved_effort_sentinel(self):
+        client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        t = _tools(llm_gateway=_fake_gateway(client))
+        with pytest.raises(ValueError, match="unresolved reasoning effort"):
+            await t._agent_generate(
+                client,
+                messages=[],
+                sys_prompt="s",
+                tool_defs=[],
+                agent_effort=None,
+                resolved_model="gpt-5.6-sol",
+            )
+
+    async def test_effortless_provider_may_carry_none(self):
+        client = SimpleNamespace(
+            model="local",
+            chat_with_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    text="ok", tool_calls=[], provenance_provider="ollama"
+                )
+            ),
+        )
+        t = _tools(llm_gateway=_fake_gateway(client))
+        response = await t._agent_generate(
+            client,
+            messages=[],
+            sys_prompt="s",
+            tool_defs=[],
+            agent_effort=None,
+            resolved_model=None,
+        )
+        assert response.text == "ok"
+        assert client.chat_with_tools.await_args.kwargs["reasoning_effort"] is None
+
+
 class TestAgentEffortSnapshot:
     """Review round 2 (High): the inherited agent effort is snapshotted ONCE
     per generation — preflight approves the SAME immutable value every
     attempt carries. A legal live effort change mid-generation (during an
     open-breaker or transport-retry wait) must not rewrite the outbound
     request; it reaches the agent on its next iteration."""
+
+    async def test_plan_capture_drives_attempt_after_in_place_client_mutation(self):
+        from src.config.schema import OpenAICodexConfig
+        from src.discord.native_tools.agents_tasks import _capture_agent_generation_plan
+
+        calls = []
+
+        class _Client:
+            model = "gpt-5.6-sol"
+            reasoning_effort = "xhigh"
+
+            async def chat_with_tools(self, *, reasoning_effort=None, model=None, **_kw):
+                calls.append((reasoning_effort, model))
+                return SimpleNamespace(
+                    text="ok", tool_calls=[], provenance_provider="codex"
+                )
+
+        client = _Client()
+        cfg = SimpleNamespace(
+            openai_codex=OpenAICodexConfig(
+                model="gpt-5.6-sol", agent_reasoning_effort=None
+            )
+        )
+        plan = _capture_agent_generation_plan(
+            lambda: cfg,
+            lambda _cfg: client,
+            lambda: ContextCompressionConfig(),
+            model_override=None,
+            effort_override=None,
+        )
+        client.reasoning_effort = "max"
+        t = _tools(llm_gateway=_fake_gateway(client))
+        await t._agent_generate(
+            plan["client"],
+            messages=[],
+            sys_prompt="s",
+            tool_defs=[],
+            agent_effort=plan["effort"],
+            resolved_model=plan["model"],
+        )
+        assert calls == [("xhigh", "gpt-5.6-sol")]
 
     async def test_attempts_carry_the_snapshot_across_retries(self):
         from src.llm.errors import LLMTransportError
@@ -1103,7 +1177,7 @@ class TestAgentEffortSnapshot:
         t = _tools(llm_gateway=_fake_gateway(client))
         resp = await t._agent_generate(
             client, messages=[], sys_prompt="s", tool_defs=[],
-            agent_effort=None, resolved_model="gpt-5.5",
+            agent_effort="xhigh", resolved_model="gpt-5.5",
         )
         # both attempts carried the PRE-CHANGE snapshot, never None and never
         # the mid-generation "max" (which would 400 against gpt-5.5)
@@ -1161,4 +1235,3 @@ class TestFrozenGenerationIdentity:
         await cb([], "sys", [], generation_state=fresh)
         assert fresh["plan"]["model"] == "gpt-5.5"
         assert fresh["plan"]["snapshot"].primary_chars == 570_002
-

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -701,7 +701,7 @@ class TestAgentPerIterationRecovery:
         iteration_count = 0
         recovery_values = []
 
-        async def mock_iteration_cb(messages, system_prompt, tools):
+        async def mock_iteration_cb(messages, system_prompt, tools, generation_state=None):
             nonlocal iteration_count
             iteration_count += 1
             recovery_values.append(agent.recovery_attempts)
@@ -738,7 +738,7 @@ class TestAgentPerIterationRecovery:
 
         call_count = 0
 
-        async def mock_iteration_cb(messages, system_prompt, tools):
+        async def mock_iteration_cb(messages, system_prompt, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/tests/test_tool_timeouts.py
+++ b/tests/test_tool_timeouts.py
@@ -222,7 +222,7 @@ class TestAgentPerToolTimeout:
         call_count = 0
         tool_timeouts_used = []
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -265,7 +265,7 @@ class TestAgentPerToolTimeout:
         call_count = 0
         tool_timeouts_used = []
 
-        async def iter_cb(msgs, sys, tools):
+        async def iter_cb(msgs, sys, tools, generation_state=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/tests/test_trajectory_completeness.py
+++ b/tests/test_trajectory_completeness.py
@@ -317,7 +317,9 @@ class _LoopIterClient:
         _registry = ModelBreakerRegistry()
         self._fake_gateway = SimpleNamespace(
             active_client=self.llm_client,
-            capacity_breaker_for=lambda model=None: _registry.for_model("codex", "m"),
+            capacity_breaker_for=lambda model=None, provider=None: _registry.for_model(
+                "codex", "m"
+            ),
             recovery_policy=RecoveryPolicy,
             notify_generation_success=lambda provider: None,
         )
@@ -524,5 +526,7 @@ class TestAgentSaverWiring:
         # P5c: body moved to native_tools/agents_tasks.py (host-based)
         from src.discord.native_tools.agents_tasks import AgentTaskTools
 
-        src = inspect.getsource(AgentTaskTools._handle_spawn_agent)
-        assert "trajectory_saver=self._agent_trajectory_saver" in src
+        assert (
+            "trajectory_saver=self._agent_trajectory_saver"
+            in inspect.getsource(AgentTaskTools._handle_spawn_agent)
+        )

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -270,7 +270,7 @@ def _wire(runner, st, call_llm):
         return st
 
     runner._prepare_chat_turn = _prep
-    runner._maybe_compress = lambda st: None
+    runner._maybe_compress = lambda st, request_client=None: None
     runner._call_llm = call_llm
 
 
@@ -279,7 +279,7 @@ class TestRunEscapeGuard:
         runner, saved, cleared = _make_runner()
         st = _stub_state()
 
-        async def _boom(_st):
+        async def _boom(_st, _request_client=None):
             raise RuntimeError(CF_HTML)
 
         _wire(runner, st, _boom)
@@ -296,7 +296,7 @@ class TestRunEscapeGuard:
         runner, saved, cleared = _make_runner()
         st = _stub_state()
 
-        async def _cancel(_st):
+        async def _cancel(_st, _request_client=None):
             raise asyncio.CancelledError()
 
         _wire(runner, st, _cancel)
@@ -312,7 +312,7 @@ class TestRunEscapeGuard:
         runner, _saved, cleared = _make_runner(recorder_save=_bad_save)
         st = _stub_state()
 
-        async def _boom(_st):
+        async def _boom(_st, _request_client=None):
             raise RuntimeError("original failure")
 
         _wire(runner, st, _boom)
@@ -327,7 +327,7 @@ class TestRunEscapeGuard:
         st = _stub_state()
         done = ("all good", False, False, [], False)
 
-        async def _done(_st):
+        async def _done(_st, _request_client=None):
             return ("done", done)
 
         _wire(runner, st, _done)

--- a/tests/test_typing_resilience.py
+++ b/tests/test_typing_resilience.py
@@ -238,7 +238,13 @@ def _make_runner(recorder_save=None):
         loop_manager=SimpleNamespace(),
         stuck_loop_tracker_cls=object,
     )
-    return ToolLoopRunner(deps), saved, cleared
+    runner = ToolLoopRunner(deps)
+    from src.discord.llm_gateway import LLMServingIdentity
+
+    runner._llm_gateway.capture_serving_identity = lambda config=None: LLMServingIdentity(
+        provider="codex", client=None, model=None, reasoning_effort=None
+    )
+    return runner, saved, cleared
 
 
 def _stub_state(channel=None):
@@ -270,7 +276,7 @@ def _wire(runner, st, call_llm):
         return st
 
     runner._prepare_chat_turn = _prep
-    runner._maybe_compress = lambda st, request_client=None: None
+    runner._maybe_compress = lambda st, request_client=None, request_config=None: None
     runner._call_llm = call_llm
 
 
@@ -279,7 +285,7 @@ class TestRunEscapeGuard:
         runner, saved, cleared = _make_runner()
         st = _stub_state()
 
-        async def _boom(_st, _request_client=None):
+        async def _boom(_st, _request_client=None, **_kwargs):
             raise RuntimeError(CF_HTML)
 
         _wire(runner, st, _boom)
@@ -296,7 +302,7 @@ class TestRunEscapeGuard:
         runner, saved, cleared = _make_runner()
         st = _stub_state()
 
-        async def _cancel(_st, _request_client=None):
+        async def _cancel(_st, _request_client=None, **_kwargs):
             raise asyncio.CancelledError()
 
         _wire(runner, st, _cancel)
@@ -312,7 +318,7 @@ class TestRunEscapeGuard:
         runner, _saved, cleared = _make_runner(recorder_save=_bad_save)
         st = _stub_state()
 
-        async def _boom(_st, _request_client=None):
+        async def _boom(_st, _request_client=None, **_kwargs):
             raise RuntimeError("original failure")
 
         _wire(runner, st, _boom)
@@ -327,7 +333,7 @@ class TestRunEscapeGuard:
         st = _stub_state()
         done = ("all good", False, False, [], False)
 
-        async def _done(_st, _request_client=None):
+        async def _done(_st, _request_client=None, **_kwargs):
             return ("done", done)
 
         _wire(runner, st, _done)
@@ -374,7 +380,7 @@ class TestCallSitesSurviveTypingFailure:
         registry = ModelBreakerRegistry()
         runner._llm_gateway = SimpleNamespace(
             call_with_tools=_cwt,
-            capacity_breaker_for=lambda model=None: registry.for_model("codex", "m"),
+            capacity_breaker_for=lambda model=None, provider=None: registry.for_model("codex", "m"),
             recovery_policy=RecoveryPolicy,
             # consumed by the pre-admission effort preflight (no-op for None)
             active_client=None,


### PR DESCRIPTION
Phase 3: the resolver goes live — every logical generation works its effective model's budget.

- Manager's private emergency constants deleted; per-generation `budget_snapshot_provider` (live config reaches the NEXT generation; a generation's retries/rescues reuse its snapshot); fallback = the unknown-model snapshot, i.e. the exact pre-campaign conservative math.
- Latch target = min(learned ceiling, live primary) — a silent budget drop is never out-waited by a stale latch.
- Per-task provider factory through the loop bridge: mixed-model fleets compact each member against its own window.
- Chat soft threshold follows the serving model (sol ≈1.277M chars at 60% utilization; unknown/non-codex models keep 575K).
- Ceiling truth split: explicit `max_context_chars` reads from the boot-frozen compression object (honest restart classification); overrides/utilization are live reads, registry flipped to `live_for_new_work`.
- Reviewer note: while writing this I caught an attribute typo (`llm_gateway` vs `_llm_gateway`) that the compression block's non-fatal catch would have swallowed — silently disabling chat compression with a green suite. The activation battery now pins the fire paths (including sol-headroom: 850K chars stays uncompressed where legacy 750K would have trimmed).

Gates: suite **9,349 passed / 5 skipped** (+12 activation tests) · ruff clean · type-gate new=0 · apply-registry findings=0 · coverage findings=0 · lint-gate new=0. v3.74.0 overflow suite updated by intent (fallback-ladder rungs replace the deleted constants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHfEwTsEyuS8RUhwdoW66g