### PR TITLE
feat(context): passive window observer + downward-only clamps (phase 5)

### DIFF
--- a/src/agents/loop_bridge.py
+++ b/src/agents/loop_bridge.py
@@ -10,6 +10,7 @@ The bridge:
 - Tracks which agents belong to which loop
 - Collects agent results back into loop iteration context
 """
+
 from __future__ import annotations
 
 import time
@@ -43,6 +44,7 @@ LOOP_AGENT_WAIT_TIMEOUT = 300  # 5 minutes
 @dataclass
 class LoopAgentRecord:
     """Tracks an agent spawned from a loop iteration."""
+
     agent_id: str
     loop_id: str
     iteration: int
@@ -100,6 +102,7 @@ class LoopAgentBridge:
         max_context_chars: int = 750000,
         keep_recent_iterations: int = 30,
         budget_snapshot_provider_factory=None,
+        evidence_recorder=None,
     ) -> list[str]:
         """Spawn agents for a loop iteration.
 
@@ -166,10 +169,7 @@ class LoopAgentBridge:
                 _self_id: dict = _self_id,
                 _shared_cb=tool_executor_callback,
             ) -> str:
-                if (
-                    tool_name == "spawn_agent"
-                    and _self_id["id"]
-                ):
+                if tool_name == "spawn_agent" and _self_id["id"]:
                     # Invocation ancestry is authoritative. A nested model may
                     # not choose a sibling/root as parent and escape this
                     # agent's depth, child, or lifetime-tree limits.
@@ -211,6 +211,7 @@ class LoopAgentBridge:
                     if budget_snapshot_provider_factory is not None
                     else None
                 ),
+                evidence_recorder=evidence_recorder,
             )
 
             if not agent_id.startswith("Error"):
@@ -227,7 +228,10 @@ class LoopAgentBridge:
                 )
                 log.info(
                     "Loop %s iter %d spawned agent %s (%s)",
-                    loop_id, iteration, agent_id, label,
+                    loop_id,
+                    iteration,
+                    agent_id,
+                    label,
                 )
             results.append(agent_id)
 
@@ -252,7 +256,8 @@ class LoopAgentBridge:
             return {}
 
         results = await self._agent_manager.wait_for_agents(
-            agent_ids, timeout=timeout,
+            agent_ids,
+            timeout=timeout,
         )
 
         # Mark collected
@@ -293,12 +298,14 @@ class LoopAgentBridge:
                 continue
             agent_results = self._agent_manager.get_results(r.agent_id)
             if agent_results:
-                active.append({
-                    "agent_id": r.agent_id,
-                    "label": r.label,
-                    "iteration": r.iteration,
-                    "status": agent_results.get("status", "unknown"),
-                })
+                active.append(
+                    {
+                        "agent_id": r.agent_id,
+                        "label": r.label,
+                        "iteration": r.iteration,
+                        "status": agent_results.get("status", "unknown"),
+                    }
+                )
         return active
 
     @property

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -4,6 +4,7 @@ Each agent runs as an independent asyncio task with its own LLM session,
 isolated message history, and full tool access. Agents may spawn sub-agents
 up to a configurable nesting depth (default 2).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -24,24 +25,24 @@ from .trajectory import AgentTrajectorySaver, AgentTrajectoryTurn
 log = get_logger("agents")
 
 # --- Constants ---
-MAX_CONCURRENT_AGENTS = 5        # per channel
-MAX_AGENT_LIFETIME = 3600        # 1 hour
-MAX_AGENT_ITERATIONS = 120       # LLM turns per agent (default, overridable via config/spawn)
-STALE_WARN_SECONDS = 120         # 2 min no activity → log warning
-CLEANUP_DELAY = 300              # 5 min after terminal state → remove
-WAIT_DEFAULT_TIMEOUT = 300       # default timeout for wait_for_agents
-WAIT_POLL_INTERVAL = 2           # poll interval for wait_for_agents
-ITERATION_CB_TIMEOUT = 120       # 2 min timeout per LLM call
-TOOL_EXEC_TIMEOUT = 300          # 5 min timeout per tool execution
+MAX_CONCURRENT_AGENTS = 5  # per channel
+MAX_AGENT_LIFETIME = 3600  # 1 hour
+MAX_AGENT_ITERATIONS = 120  # LLM turns per agent (default, overridable via config/spawn)
+STALE_WARN_SECONDS = 120  # 2 min no activity → log warning
+CLEANUP_DELAY = 300  # 5 min after terminal state → remove
+WAIT_DEFAULT_TIMEOUT = 300  # default timeout for wait_for_agents
+WAIT_POLL_INTERVAL = 2  # poll interval for wait_for_agents
+ITERATION_CB_TIMEOUT = 120  # 2 min timeout per LLM call
+TOOL_EXEC_TIMEOUT = 300  # 5 min timeout per tool execution
 # (The manager-level MAX_RECOVERY_ATTEMPTS retry ladder was removed
 # 2026-07-30: transient-failure recovery now lives inside the iteration
 # callback via src/llm/recovery.py. AgentInfo.recovery_attempts remains for
 # API/trajectory shape compatibility and stays 0.)
-MAX_NESTING_DEPTH = 2            # default max sub-agent depth (root=0)
-MAX_CHILDREN_PER_AGENT = 3       # fallback direct-child limit (config overrides at spawn)
-TREE_MAX_AGENTS = 25             # hard ceiling on agents in one tree's lifetime —
-                                 # breadth x depth must never compound into a
-                                 # geometric invoice, whatever config says
+MAX_NESTING_DEPTH = 2  # default max sub-agent depth (root=0)
+MAX_CHILDREN_PER_AGENT = 3  # fallback direct-child limit (config overrides at spawn)
+TREE_MAX_AGENTS = 25  # hard ceiling on agents in one tree's lifetime —
+# breadth x depth must never compound into a
+# geometric invoice, whatever config says
 
 # --- Agent context-overflow recovery (design settled with Odin, 2026-08-09;
 # per-model budgets since the context-budget campaign, 2026-08-17) ---
@@ -68,20 +69,21 @@ def _is_context_overflow(exc: BaseException) -> bool:
     from ..llm.errors import LLMRequestError
 
     return (
-        isinstance(exc, LLMRequestError)
-        and getattr(exc, "code", None) == "context_length_exceeded"
+        isinstance(exc, LLMRequestError) and getattr(exc, "code", None) == "context_length_exceeded"
     )
 
 
 # Agent-management tools — allowed or blocked based on nesting depth
-AGENT_MANAGEMENT_TOOLS = frozenset({
-    "spawn_agent",
-    "send_to_agent",
-    "list_agents",
-    "kill_agent",
-    "get_agent_results",
-    "wait_for_agents",
-})
+AGENT_MANAGEMENT_TOOLS = frozenset(
+    {
+        "spawn_agent",
+        "send_to_agent",
+        "list_agents",
+        "kill_agent",
+        "get_agent_results",
+        "wait_for_agents",
+    }
+)
 
 # Legacy alias for backward compatibility
 AGENT_BLOCKED_TOOLS = AGENT_MANAGEMENT_TOOLS
@@ -107,6 +109,7 @@ def filter_agent_tools(
 
 class AgentState(str, Enum):  # noqa: UP042 — str(member) output differs under StrEnum; deferred to a typed-verification pass
     """Typed lifecycle states for agent workers."""
+
     SPAWNING = "spawning"
     READY = "ready"
     EXECUTING = "executing"
@@ -117,34 +120,59 @@ class AgentState(str, Enum):  # noqa: UP042 — str(member) output differs under
     KILLED = "killed"
 
 
-TERMINAL_STATES = frozenset({
-    AgentState.COMPLETED, AgentState.FAILED,
-    AgentState.TIMEOUT, AgentState.KILLED,
-})
+TERMINAL_STATES = frozenset(
+    {
+        AgentState.COMPLETED,
+        AgentState.FAILED,
+        AgentState.TIMEOUT,
+        AgentState.KILLED,
+    }
+)
 
-ACTIVE_STATES = frozenset({
-    AgentState.SPAWNING, AgentState.READY,
-    AgentState.EXECUTING, AgentState.RECOVERING,
-})
+ACTIVE_STATES = frozenset(
+    {
+        AgentState.SPAWNING,
+        AgentState.READY,
+        AgentState.EXECUTING,
+        AgentState.RECOVERING,
+    }
+)
 
 VALID_TRANSITIONS: dict[AgentState, frozenset[AgentState]] = {
-    AgentState.SPAWNING: frozenset({
-        AgentState.READY, AgentState.KILLED,
-        AgentState.FAILED, AgentState.TIMEOUT,
-    }),
-    AgentState.READY: frozenset({
-        AgentState.EXECUTING, AgentState.COMPLETED,
-        AgentState.KILLED, AgentState.TIMEOUT,
-    }),
-    AgentState.EXECUTING: frozenset({
-        AgentState.READY, AgentState.RECOVERING,
-        AgentState.COMPLETED, AgentState.FAILED,
-        AgentState.KILLED, AgentState.TIMEOUT,
-    }),
-    AgentState.RECOVERING: frozenset({
-        AgentState.EXECUTING, AgentState.FAILED,
-        AgentState.KILLED, AgentState.TIMEOUT,
-    }),
+    AgentState.SPAWNING: frozenset(
+        {
+            AgentState.READY,
+            AgentState.KILLED,
+            AgentState.FAILED,
+            AgentState.TIMEOUT,
+        }
+    ),
+    AgentState.READY: frozenset(
+        {
+            AgentState.EXECUTING,
+            AgentState.COMPLETED,
+            AgentState.KILLED,
+            AgentState.TIMEOUT,
+        }
+    ),
+    AgentState.EXECUTING: frozenset(
+        {
+            AgentState.READY,
+            AgentState.RECOVERING,
+            AgentState.COMPLETED,
+            AgentState.FAILED,
+            AgentState.KILLED,
+            AgentState.TIMEOUT,
+        }
+    ),
+    AgentState.RECOVERING: frozenset(
+        {
+            AgentState.EXECUTING,
+            AgentState.FAILED,
+            AgentState.KILLED,
+            AgentState.TIMEOUT,
+        }
+    ),
     AgentState.COMPLETED: frozenset(),
     AgentState.FAILED: frozenset(),
     AgentState.TIMEOUT: frozenset(),
@@ -168,17 +196,17 @@ _STATE_TO_LEGACY = {
 
 class InvalidStateTransition(Exception):  # noqa: N818 — established public exception name; rename is an API break
     """Raised when an invalid state transition is attempted."""
+
     def __init__(self, from_state: AgentState, to_state: AgentState) -> None:
         self.from_state = from_state
         self.to_state = to_state
-        super().__init__(
-            f"Invalid state transition: {from_state.value} → {to_state.value}"
-        )
+        super().__init__(f"Invalid state transition: {from_state.value} → {to_state.value}")
 
 
 @dataclass
 class StateTransition:
     """Record of a single state transition."""
+
     from_state: AgentState
     to_state: AgentState
     timestamp: float
@@ -292,6 +320,7 @@ AnnounceCallback = Callable[
 @dataclass
 class AgentInfo:
     """Metadata and state for a running agent."""
+
     id: str
     label: str
     goal: str
@@ -382,8 +411,10 @@ class AgentInfo:
         record = self._sm.transition(to, reason)
         log.debug(
             "Agent %s (%s): %s → %s%s",
-            self.id, self.label,
-            record.from_state.value, record.to_state.value,
+            self.id,
+            self.label,
+            record.from_state.value,
+            record.to_state.value,
             f" ({reason})" if reason else "",
         )
         return record
@@ -437,6 +468,7 @@ class AgentManager:
         max_context_chars: int = 750000,
         keep_recent_iterations: int = 30,
         budget_snapshot_provider: Callable | None = None,
+        evidence_recorder: Callable | None = None,
     ) -> str:
         """Spawn a new agent. Returns agent_id on success, or 'Error: ...' string.
 
@@ -455,18 +487,14 @@ class AgentManager:
             else None
         )
         concurrent_limit = (
-            configured_limit
-            if configured_limit is not None
-            else MAX_CONCURRENT_AGENTS
+            configured_limit if configured_limit is not None else MAX_CONCURRENT_AGENTS
         )
         channel_count = sum(
-            1 for a in self._agents.values()
-            if a.channel_id == channel_id and a._sm.is_active
+            1 for a in self._agents.values() if a.channel_id == channel_id and a._sm.is_active
         )
         if channel_count >= concurrent_limit:
             return (
-                f"Error: Maximum concurrent agents ({concurrent_limit}) "
-                "reached for this channel."
+                f"Error: Maximum concurrent agents ({concurrent_limit}) reached for this channel."
             )
 
         if not label or not goal:
@@ -571,9 +599,7 @@ class AgentManager:
             )
 
         # Filter tools based on depth
-        filtered_tools = filter_agent_tools(
-            tools or [], depth=depth, max_depth=agent.max_depth
-        )
+        filtered_tools = filter_agent_tools(tools or [], depth=depth, max_depth=agent.max_depth)
 
         # Seed messages with the goal
         agent.messages = [{"role": "user", "content": goal}]
@@ -598,19 +624,23 @@ class AgentManager:
                 max_context_chars=max_context_chars,
                 keep_recent_iterations=keep_recent_iterations,
                 budget_snapshot_provider=budget_snapshot_provider,
+                evidence_recorder=evidence_recorder,
             )
         )
         agent._task = task
         # Schedule cleanup when the agent task finishes (any exit path)
         task.add_done_callback(lambda _t: self._schedule_cleanup(agent_id))
         self._agents[agent_id] = agent
-        self._tree_spawn_counts[agent.root_id] = (
-            self._tree_spawn_counts.get(agent.root_id, 0) + 1
-        )
+        self._tree_spawn_counts[agent.root_id] = self._tree_spawn_counts.get(agent.root_id, 0) + 1
 
         log.info(
             "Spawned agent %s (%s) depth=%d for channel %s by %s: %s",
-            agent_id, label, depth, channel_id, requester_name, goal[:100],
+            agent_id,
+            label,
+            depth,
+            channel_id,
+            requester_name,
+            goal[:100],
         )
         return agent_id
 
@@ -635,19 +665,21 @@ class AgentManager:
             if channel_id and agent.channel_id != channel_id:
                 continue
             runtime = (agent.ended_at or time.time()) - agent.created_at
-            result.append({
-                "id": agent.id,
-                "label": agent.label,
-                "status": agent.status,
-                "state": agent.state.value,
-                "iteration_count": agent.iteration_count,
-                "runtime_seconds": round(runtime, 1),
-                "tools_used": len(agent.tools_used),
-                "goal": agent.goal[:100],
-                "depth": agent.depth,
-                "parent_id": agent.parent_id,
-                "children_count": len(agent.children_ids),
-            })
+            result.append(
+                {
+                    "id": agent.id,
+                    "label": agent.label,
+                    "status": agent.status,
+                    "state": agent.state.value,
+                    "iteration_count": agent.iteration_count,
+                    "runtime_seconds": round(runtime, 1),
+                    "tools_used": len(agent.tools_used),
+                    "goal": agent.goal[:100],
+                    "depth": agent.depth,
+                    "parent_id": agent.parent_id,
+                    "children_count": len(agent.children_ids),
+                }
+            )
         return result
 
     @staticmethod
@@ -686,14 +718,13 @@ class AgentManager:
 
         log.info(
             "Kill signal sent to agent %s (%s) and %d descendants",
-            agent_id, agent.label, len(killed_ids) - 1,
+            agent_id,
+            agent.label,
+            len(killed_ids) - 1,
         )
         if len(killed_ids) == 1:
             return f"Kill signal sent to agent '{agent.label}'."
-        return (
-            f"Kill signal sent to agent '{agent.label}' "
-            f"and {len(killed_ids) - 1} descendant(s)."
-        )
+        return f"Kill signal sent to agent '{agent.label}' and {len(killed_ids) - 1} descendant(s)."
 
     def get_results(self, agent_id: str) -> dict | None:
         """Get structured results of an agent."""
@@ -818,13 +849,12 @@ class AgentManager:
                     "error": f"Agent '{aid}' not found.",
                 }
 
-        still_running = [
-            aid for aid, r in results.items() if r.get("status") == "running"
-        ]
+        still_running = [aid for aid, r in results.items() if r.get("status") == "running"]
         if still_running:
             log.warning(
                 "wait_for_agents timed out with %d still running: %s",
-                len(still_running), still_running,
+                len(still_running),
+                still_running,
             )
 
         return results
@@ -908,9 +938,7 @@ class AgentManager:
             ct.cancel()
         if agent:
             root = agent.root_id or agent_id
-            if not any(
-                (a.root_id or a.id) == root for a in self._agents.values()
-            ):
+            if not any((a.root_id or a.id) == root for a in self._agents.values()):
                 # Last member gone: nothing can ever spawn into this tree
                 # again (a parent must exist), so the lifetime counter can go.
                 self._tree_spawn_counts.pop(root, None)
@@ -920,6 +948,7 @@ class AgentManager:
 
     def _schedule_cleanup(self, agent_id: str) -> None:
         """Schedule cleanup of an agent after CLEANUP_DELAY."""
+
         async def _delayed_cleanup():
             await asyncio.sleep(CLEANUP_DELAY)
             self._remove_agent(agent_id, source="delayed_cleanup")
@@ -949,13 +978,17 @@ class AgentManager:
                 killed += 1
                 log.warning(
                     "Force-killed stuck agent %s (%s): lifetime exceeded (%ds)",
-                    agent.id, agent.label, int(elapsed),
+                    agent.id,
+                    agent.label,
+                    int(elapsed),
                 )
             elif idle > STALE_WARN_SECONDS:
                 stale += 1
                 log.warning(
                     "Agent %s (%s) appears stale: %ds idle",
-                    agent.id, agent.label, int(idle),
+                    agent.id,
+                    agent.label,
+                    int(idle),
                 )
         return {"killed": killed, "stale": stale}
 
@@ -983,6 +1016,7 @@ async def _run_agent(
     max_context_chars: int = 750000,
     keep_recent_iterations: int = 30,
     budget_snapshot_provider: Callable | None = None,
+    evidence_recorder: Callable | None = None,
 ) -> None:
     """Execute an agent's tool loop until completion, error, or timeout.
 
@@ -1051,10 +1085,12 @@ async def _run_agent(
             while not agent._inbox.empty():  # type: ignore[union-attr]  # __post_init__ always sets it
                 try:
                     msg = agent._inbox.get_nowait()  # type: ignore[union-attr]  # __post_init__ always sets it
-                    agent.messages.append({
-                        "role": "user",
-                        "content": f"[Message from parent] {msg}",
-                    })
+                    agent.messages.append(
+                        {
+                            "role": "user",
+                            "content": f"[Message from parent] {msg}",
+                        }
+                    )
                     log.debug("Agent %s received inbox message", agent.id)
                 except asyncio.QueueEmpty:
                     break
@@ -1071,13 +1107,10 @@ async def _run_agent(
                     budget_snapshot = budget_snapshot_provider()
                 except Exception:
                     log.exception(
-                        "agent budget snapshot provider failed (non-fatal); "
-                        "using fallback targets"
+                        "agent budget snapshot provider failed (non-fatal); using fallback targets"
                     )
             soft_target_chars = (
-                budget_snapshot.primary_chars
-                if budget_snapshot is not None
-                else max_context_chars
+                budget_snapshot.primary_chars if budget_snapshot is not None else max_context_chars
             )
 
             # Context compression: summarize older tool iterations when context grows too large
@@ -1087,6 +1120,7 @@ async def _run_agent(
                         compress_tool_context,
                         estimate_message_chars,
                     )
+
                     if estimate_message_chars(agent.messages) > soft_target_chars:
                         agent.messages, saved = compress_tool_context(
                             agent.messages,
@@ -1100,8 +1134,9 @@ async def _run_agent(
                             saved,
                         )
                 except Exception:
-                    log.exception("agent context_compressor failed (non-fatal); continuing with "
-                                  "full context")
+                    log.exception(
+                        "agent context_compressor failed (non-fatal); continuing with full context"
+                    )
 
             # Budget warning: inject remaining-iterations notice before LLM call
             remaining = max_iterations - iteration
@@ -1109,8 +1144,10 @@ async def _run_agent(
                 if remaining == 1:
                     warn_text = "[Agent budget: FINAL iteration. Produce your final summary NOW.]"
                 elif remaining <= 5:
-                    warn_text = (f"[Agent budget: {remaining} iterations remaining. Commit any "
-                                 f"changes, run validation, and produce your final summary.]")
+                    warn_text = (
+                        f"[Agent budget: {remaining} iterations remaining. Commit any "
+                        f"changes, run validation, and produce your final summary.]"
+                    )
                 else:
                     warn_text = (
                         f"[Agent budget: {remaining} iterations remaining. "
@@ -1137,14 +1174,12 @@ async def _run_agent(
                         emergency_compress_for_window,
                         estimate_message_chars,
                     )
+
                     # The latch is capability evidence; the snapshot's primary
                     # is policy. Compact to whichever is LOWER — a live budget
                     # drop must not be out-waited by a stale larger latch.
                     latch_target = min(agent.context_char_ceiling, soft_target_chars)
-                    if (
-                        estimate_message_chars(agent.messages)
-                        > latch_target
-                    ):
+                    if estimate_message_chars(agent.messages) > latch_target:
                         agent.messages, latch_report = emergency_compress_for_window(
                             agent.messages,
                             target_chars=latch_target,
@@ -1158,18 +1193,18 @@ async def _run_agent(
                             latch_report["compressed_chars"],
                         )
                 except Exception:
-                    log.exception(
-                        "agent overflow-latch compaction failed (non-fatal)"
-                    )
+                    log.exception("agent overflow-latch compaction failed (non-fatal)")
 
             # Call LLM with recovery support
             generation_state: dict = {}
             response = await _call_llm_with_recovery(
-                agent, iteration_callback, system_prompt, tools,
-                rescue_ladder=(
-                    budget_snapshot.ladder if budget_snapshot is not None else None
-                ),
+                agent,
+                iteration_callback,
+                system_prompt,
+                tools,
+                rescue_ladder=(budget_snapshot.ladder if budget_snapshot is not None else None),
                 generation_state=generation_state,
+                evidence_recorder=evidence_recorder,
             )
             if response is None:
                 # Terminal state already set by recovery logic
@@ -1264,10 +1299,12 @@ async def _run_agent(
                 iter_tool_results.append({"name": tool_name, "result": result})
 
                 # Append tool result to messages
-                agent.messages.append({
-                    "role": "user",
-                    "content": f"[Tool result: {tool_name}]\n{result}",
-                })
+                agent.messages.append(
+                    {
+                        "role": "user",
+                        "content": f"[Tool result: {tool_name}]\n{result}",
+                    }
+                )
 
             trajectory.add_iteration(
                 iteration=iteration + 1,
@@ -1293,7 +1330,9 @@ async def _run_agent(
             if time.time() - agent.last_activity > STALE_WARN_SECONDS:
                 log.warning(
                     "Agent %s (%s) has been idle for >%ds",
-                    agent.id, agent.label, STALE_WARN_SECONDS,
+                    agent.id,
+                    agent.label,
+                    STALE_WARN_SECONDS,
                 )
 
         # Exhausted iterations — transition from READY → COMPLETED
@@ -1377,6 +1416,7 @@ async def _call_llm_with_recovery(
     tools: list[dict],
     rescue_ladder: tuple[int, ...] | None = None,
     generation_state: dict | None = None,
+    evidence_recorder: Callable | None = None,
 ) -> dict | None:
     """Call the LLM for one agent iteration.
 
@@ -1420,6 +1460,7 @@ async def _call_llm_with_recovery(
     call_timeout = min(agent.iteration_timeout, remaining)
     iteration_deadline = time.monotonic() + call_timeout
     first_attempt = True
+    last_overflow: BaseException | None = None
     while True:
         if _remaining_lifetime(agent) <= 0:
             _lifetime_timeout(agent)
@@ -1453,6 +1494,14 @@ async def _call_llm_with_recovery(
             if pending_ceiling is not None:
                 # The rescue rung is now server-accepted evidence.
                 agent.context_char_ceiling = pending_ceiling
+                if evidence_recorder is not None and last_overflow is not None:
+                    try:
+                        # Phase 5: the overflow→acceptance pair feeds the
+                        # window observer. Total — evidence never fails the
+                        # iteration that just succeeded.
+                        await evidence_recorder(last_overflow, response)
+                    except Exception:
+                        log.exception("agent window-evidence recording failed (non-fatal)")
             return response
         except TimeoutError:
             if _remaining_lifetime(agent) <= 0:
@@ -1508,6 +1557,7 @@ async def _call_llm_with_recovery(
                     agent.context_recoveries.append(report)
                     if report["fits"]:
                         agent.messages = compressed
+                        last_overflow = exc
                         # Latch candidate: held until the retry actually
                         # succeeds (the provider is the authority on
                         # survivable size).
@@ -1543,9 +1593,7 @@ async def _call_llm_with_recovery(
             # fallback, and keeps upstream text out of agent.error /
             # state_history (both API- and trajectory-visible).
             err_desc = f"LLM error: {format_user_facing_error(exc)}"
-            log.error(
-                "Agent %s LLM call failed (no retry): %s", agent.id, err_desc, exc_info=exc
-            )
+            log.error("Agent %s LLM call failed (no retry): %s", agent.id, err_desc, exc_info=exc)
             agent.transition(AgentState.FAILED, err_desc)
             agent.error = err_desc
             agent.ended_at = time.time()

--- a/src/discord/native_tools/agents_tasks.py
+++ b/src/discord/native_tools/agents_tasks.py
@@ -115,14 +115,22 @@ def _parse_spawn_overrides(
     from ...config.schema import CODEX_REASONING_EFFORTS
 
     if "model" in inp and model_mode != "auto":
-        return None, None, (
-            "model is not accepted because Agent Model is not set to Auto — select "
-            "'Auto — choose per spawn' in the WebUI to allow per-spawn model selection"
+        return (
+            None,
+            None,
+            (
+                "model is not accepted because Agent Model is not set to Auto — select "
+                "'Auto — choose per spawn' in the WebUI to allow per-spawn model selection"
+            ),
         )
     if "reasoning_effort" in inp and effort_mode != "auto":
-        return None, None, (
-            "reasoning_effort is not accepted because Agent Reasoning is not set to Auto — "
-            "select 'Auto — choose per spawn' in the WebUI to allow per-spawn effort selection"
+        return (
+            None,
+            None,
+            (
+                "reasoning_effort is not accepted because Agent Reasoning is not set to Auto — "
+                "select 'Auto — choose per spawn' in the WebUI to allow per-spawn effort selection"
+            ),
         )
 
     raw_model = inp.get("model")
@@ -165,7 +173,18 @@ def _spawn_pair_error(
     return effort_incompatibility_error(model_now, effort_now)
 
 
-def _generation_budget_snapshot(cfg, client, resolved_model, compressor):
+def _observer_clamp(observer, model) -> int | None:
+    """Total clamp lookup — a broken observer never breaks a spawn."""
+    if observer is None:
+        return None
+    try:
+        return observer.active_clamp(model)
+    except Exception:
+        log.exception("active_clamp failed (non-fatal); treating as unclamped")
+        return None
+
+
+def _generation_budget_snapshot(cfg, client, resolved_model, compressor, observer=None):
     """The frozen generation's budget snapshot, from the SAME identity capture
     as the request (collision-gated: non-Codex clients get unknown-model
     math regardless of what their model is named)."""
@@ -178,9 +197,8 @@ def _generation_budget_snapshot(cfg, client, resolved_model, compressor):
     return snapshot_for_codex_config(
         model_for_budget,
         getattr(cfg, "openai_codex", None),
-        max_context_chars=(
-            getattr(compressor, "max_context_chars", None) if compressor else None
-        ),
+        max_context_chars=(getattr(compressor, "max_context_chars", None) if compressor else None),
+        observed_clamp=_observer_clamp(observer, model_for_budget),
     )
 
 
@@ -203,6 +221,7 @@ def _capture_agent_generation_plan(
     *,
     model_override: str | None,
     effort_override: str | None,
+    observer=None,
 ) -> dict:
     """Capture one immutable agent-generation identity and budget plan.
 
@@ -235,11 +254,14 @@ def _capture_agent_generation_plan(
             client,
             resolved_model,
             get_compressor(),
+            observer=observer,
         ),
     }
 
 
-def _make_budget_snapshot_provider(get_config, get_client, get_compressor, model_override):
+def _make_budget_snapshot_provider(
+    get_config, get_client, get_compressor, model_override, observer=None
+):
     """Per-generation context-budget snapshot for a spawned agent.
 
     Resolves the EFFECTIVE agent model exactly like the iteration callback
@@ -274,9 +296,35 @@ def _make_budget_snapshot_provider(get_config, get_client, get_compressor, model
             max_context_chars=(
                 getattr(compressor, "max_context_chars", None) if compressor else None
             ),
+            observed_clamp=_observer_clamp(observer, model_for_budget),
         )
 
     return provider
+
+
+def _make_evidence_recorder(observer):
+    """Adapter feeding an agent rescue's (overflow, response-dict) pair to
+    the observer. The agent callback returns a plain dict, so the acceptance
+    facts are lifted into the attribute shape ``record_rescue`` reads.
+    Total — evidence never fails the iteration that just succeeded."""
+    if observer is None:
+        return None
+
+    async def recorder(overflow, response):
+        try:
+            if isinstance(response, dict):
+                from types import SimpleNamespace
+
+                response = SimpleNamespace(
+                    account_key=response.get("account_key"),
+                    server_input_tokens=response.get("server_input_tokens"),
+                    provenance_model=response.get("model"),
+                )
+            await observer.record_rescue(overflow=overflow, response=response)
+        except Exception:
+            log.exception("agent window-evidence recording failed (non-fatal)")
+
+    return recorder
 
 
 def _provenance_stamp(resp: object, client: object) -> dict:
@@ -322,11 +370,15 @@ class AgentTaskDeps:
     turn_recorder: TurnRecorder  # lifecycle webhook emission
     prompt_builder: PromptBuilder
     tool_catalog: ToolCatalog
+    # Passive window observer (phase 5): clamp source for agent budget
+    # snapshots + evidence sink for agent rescues. None = feature-inert.
+    window_observer: object | None = None
 
 
 class AgentTaskTools:
     def __init__(self, deps: AgentTaskDeps) -> None:
         self._get_config = deps.get_config
+        self._window_observer = deps.window_observer
         self._llm_gateway = deps.llm_gateway
         self._channel_state = deps.channel_state
         self._tool_executor = deps.tool_executor
@@ -658,9 +710,7 @@ class AgentTaskTools:
         resp = await generate_with_recovery(_attempt, policy=policy, breaker=breaker)
         # Bypass-path success clears a latched llm_* guard key — provenance
         # only, never the post-await active provider.
-        self._llm_gateway.notify_generation_success(
-            getattr(resp, "provenance_provider", None)
-        )
+        self._llm_gateway.notify_generation_success(getattr(resp, "provenance_provider", None))
         return resp
 
     async def _handle_spawn_agent(self, message: object, inp: dict) -> str:
@@ -728,9 +778,7 @@ class AgentTaskTools:
             if parent is not None
             else configured_max_depth
         )
-        tools = filter_agent_tools(
-            all_tools, depth=parent_depth, max_depth=effective_max_depth
-        )
+        tools = filter_agent_tools(all_tools, depth=parent_depth, max_depth=effective_max_depth)
 
         # Iteration callback — wraps Codex chat_with_tools, returns dict
         async def _iteration_cb(
@@ -754,6 +802,7 @@ class AgentTaskTools:
                     self._get_context_compressor,
                     model_override=model_override,
                     effort_override=effort_override,
+                    observer=self._window_observer,
                 )
                 generation_state["plan"] = plan
             client = plan["client"]
@@ -769,6 +818,10 @@ class AgentTaskTools:
                 "text": resp.text,
                 "tool_calls": [{"name": tc.name, "input": tc.input} for tc in resp.tool_calls],
                 "stop_reason": resp.stop_reason,
+                # Phase 5: server acceptance evidence rides the callback dict
+                # so a rescued iteration can qualify a window clamp.
+                "server_input_tokens": getattr(resp, "server_input_tokens", None),
+                "account_key": getattr(resp, "account_key", None),
                 **_provenance_stamp(resp, client),
             }
 
@@ -824,9 +877,7 @@ class AgentTaskTools:
         iteration_timeout = (
             getattr(agents_cfg, "iteration_timeout_seconds", 900) if agents_cfg else 900
         )
-        max_lifetime = (
-            getattr(agents_cfg, "max_lifetime_seconds", 14400) if agents_cfg else 14400
-        )
+        max_lifetime = getattr(agents_cfg, "max_lifetime_seconds", 14400) if agents_cfg else 14400
 
         agent_id = self._agent_manager.spawn(
             label=label,
@@ -866,7 +917,9 @@ class AgentTaskTools:
                 lambda: self._llm_gateway.active_client,
                 self._get_context_compressor,
                 model_override,
+                observer=self._window_observer,
             ),
+            evidence_recorder=_make_evidence_recorder(self._window_observer),
         )
 
         if agent_id.startswith("Error"):
@@ -1019,9 +1072,7 @@ class AgentTaskTools:
             # stays excluded — hashing elapsed time would make a hung
             # agent immortal.
             iters = r.get("iteration_count", 0)
-            lines.append(
-                f"**{label}** (`{aid}`): {status} [iterations={iters}]\n{content}"
-            )
+            lines.append(f"**{label}** (`{aid}`): {status} [iterations={iters}]\n{content}")
 
         return "\n\n".join(lines) if lines else "No results."
 
@@ -1079,12 +1130,14 @@ class AgentTaskTools:
             )
             if pair_err:
                 return f"Error: task '{t.get('label', '?')}': {pair_err}"
-            validated_tasks.append({
-                "label": t.get("label", ""),
-                "goal": t.get("goal", ""),
-                "model_override": mo,
-                "reasoning_effort_override": eo,
-            })
+            validated_tasks.append(
+                {
+                    "label": t.get("label", ""),
+                    "goal": t.get("goal", ""),
+                    "model_override": mo,
+                    "reasoning_effort_override": eo,
+                }
+            )
         tasks = validated_tasks
 
         # Per-task iteration callback FACTORY (same pattern as
@@ -1102,6 +1155,7 @@ class AgentTaskTools:
                         self._get_context_compressor,
                         model_override=model_override,
                         effort_override=effort_override,
+                        observer=self._window_observer,
                     )
                     generation_state["plan"] = plan
                 client = plan["client"]
@@ -1119,8 +1173,11 @@ class AgentTaskTools:
                         {"name": tc.name, "input": tc.input} for tc in (resp.tool_calls or [])
                     ],
                     "stop_reason": resp.stop_reason or "end_turn",
+                    "server_input_tokens": getattr(resp, "server_input_tokens", None),
+                    "account_key": getattr(resp, "account_key", None),
                     **_provenance_stamp(resp, client),
                 }
+
             return _iteration_cb
 
         async def _tool_cb(tool_name, tool_input):
@@ -1159,12 +1216,8 @@ class AgentTaskTools:
             max_lifetime=self._get_config().agents.max_lifetime_seconds,
             # Close the loop-path gap: depth and child limits now reach
             # loop-spawned agents too, instead of silently using built-ins.
-            max_depth=getattr(
-                self._get_config().agents, "max_nesting_depth", None
-            ),
-            max_children=getattr(
-                self._get_config().agents, "max_children_per_agent", None
-            ),
+            max_depth=getattr(self._get_config().agents, "max_nesting_depth", None),
+            max_children=getattr(self._get_config().agents, "max_children_per_agent", None),
             context_compression_enabled=bool(cc),
             max_context_chars=cc.resolved_max_context_chars if cc else 750000,
             keep_recent_iterations=cc.keep_recent_iterations if cc else 30,
@@ -1173,7 +1226,9 @@ class AgentTaskTools:
                 lambda: self._llm_gateway.active_client,
                 self._get_context_compressor,
                 mo,
+                observer=self._window_observer,
             ),
+            evidence_recorder=_make_evidence_recorder(self._window_observer),
         )
 
         # Format response

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -38,6 +38,8 @@ import discord
 
 from ..error_presentation import format_user_facing_error
 from ..llm import CircuitOpenError
+from ..llm.context_budget import ContextBudgetSnapshot, snapshot_for_codex_config
+from ..llm.context_compressor import SurfaceBoundary
 from ..llm.errors import LLMCapacityError, LLMRequestError
 from ..llm.recovery import generate_with_recovery, preflight_incompatible_effort
 from ..llm.secret_scrubber import scrub_output_secrets
@@ -66,7 +68,6 @@ if TYPE_CHECKING:
     from .response_guards import StuckLoopTracker
     from .tool_catalog import ToolCatalog
     from .turn_recorder import TurnRecorder
-from ..llm.context_compressor import SurfaceBoundary
 from .delivery import DISCORD_MAX_LEN, TOOL_STATUS_LABELS
 from .llm_gateway import LLMServingIdentity
 from .response_guards import (
@@ -402,6 +403,9 @@ class _ChatTurn:
     _char_latch: int | None = None
     _rescue_passes: int = 0
     _gen_identity: dict | None = None
+    # Process-local, per-generation cache captured beside serving identity.
+    # Rebuilt from durable _gen_identity on resume; never serialized directly.
+    _generation_budget_snapshot: ContextBudgetSnapshot | None = None
     # Process-local durability handle (write-invariant driver). Classified
     # RECONSTRUCTED in the checkpoint codec: a resumed turn gets a fresh
     # handle bound to the resume lease, never a deserialized one.
@@ -654,9 +658,16 @@ class ToolLoopRunner:
             # ONE capture of this uninterrupted generation's serving
             # identity: soft compaction, preflight, breaker admission, and
             # every physical retry all describe this exact client/model/effort.
-            # Durable suspend/resume persistence remains phase 4.
+            # Durable suspend/resume persistence remains phase 4. Capture the
+            # serving identity and ONE budget snapshot together; soft policy
+            # and rescue must never observe different clamp generations.
             config = self._get_config()
             serving = self._llm_gateway.capture_serving_identity(config)
+            if st._gen_identity:
+                budget_snapshot = self._snapshot_from_generation_facts(st._gen_identity)
+            else:
+                budget_snapshot = self._capture_budget_snapshot(serving, config)
+            st._generation_budget_snapshot = budget_snapshot
             if not self._maybe_compress(st, serving.client, config):
                 return await self._llm_error_done(
                     st,
@@ -668,7 +679,12 @@ class ToolLoopRunner:
                     ),
                 )
 
-            kind, val = await self._call_llm(st, serving_identity=serving, request_config=config)
+            kind, val = await self._call_llm(
+                st,
+                serving_identity=serving,
+                request_config=config,
+                budget_snapshot=budget_snapshot,
+            )
             if kind == "done":
                 return val
             llm_resp = val
@@ -982,11 +998,42 @@ class ToolLoopRunner:
             False,
         )
 
+    @staticmethod
+    def _snapshot_from_generation_facts(facts: dict) -> ContextBudgetSnapshot:
+        payload = facts.get("budget") or {}
+        primary = payload.get("primary_chars", 0)
+        return ContextBudgetSnapshot(
+            canonical_model=facts.get("model", ""),
+            base_budget=0,
+            base_source="persisted",
+            effective_budget=0,
+            clamp_applied=False,
+            working_budget=0,
+            compactable_tokens=0,
+            derived_chars=primary,
+            primary_chars=primary,
+            ceiling_applied=False,
+            ladder=tuple(facts.get("ladder") or ()),
+        )
+
+    def _capture_budget_snapshot(self, serving, config) -> ContextBudgetSnapshot:
+        """Capture one budget snapshot beside one serving identity."""
+        compressor = self._get_context_compressor()
+        model_for_budget = serving.model if serving.is_codex else None
+        return snapshot_for_codex_config(
+            model_for_budget,
+            getattr(config, "openai_codex", None),
+            max_context_chars=(compressor.max_context_chars if compressor is not None else None),
+            observed_clamp=self._observed_clamp(model_for_budget),
+        )
+
     def _maybe_compress(
         self,
         st: _ChatTurn,
         request_client: object = None,
         request_config: object = None,
+        *,
+        budget_snapshot=None,
     ) -> bool:
         """Apply optional soft compaction and the mandatory accepted-size latch.
 
@@ -997,8 +1044,9 @@ class ToolLoopRunner:
         because resending a size already refused by the server is forbidden.
         """
         latch = getattr(st, "_char_latch", None)
+        if budget_snapshot is None:
+            budget_snapshot = getattr(st, "_generation_budget_snapshot", None)
         try:
-            from ..llm.context_budget import snapshot_for_codex_config
             from ..llm.context_compressor import (
                 SurfaceBoundary,
                 compress_tool_context,
@@ -1007,25 +1055,29 @@ class ToolLoopRunner:
             )
 
             compressor = self._get_context_compressor()
-            if request_client is None and request_config is None:
-                request_client = self._llm_gateway.active_client
-            model_for_budget = (
-                getattr(request_client, "model", None)
-                if hasattr(request_client, "reasoning_effort")
-                else None
-            )
-            snapshot = snapshot_for_codex_config(
-                model_for_budget,
-                getattr(
-                    request_config if request_config is not None else self._get_config(),
-                    "openai_codex",
-                    None,
-                ),
-                max_context_chars=(
-                    compressor.max_context_chars if compressor is not None else None
-                ),
-                observed_clamp=self._observed_clamp(model_for_budget),
-            )
+            if budget_snapshot is None:
+                if request_client is None and request_config is None:
+                    request_client = self._llm_gateway.active_client
+                model_for_budget = (
+                    getattr(request_client, "model", None)
+                    if hasattr(request_client, "reasoning_effort")
+                    else None
+                )
+                from ..llm import context_budget
+
+                budget_snapshot = context_budget.snapshot_for_codex_config(
+                    model_for_budget,
+                    getattr(
+                        request_config if request_config is not None else self._get_config(),
+                        "openai_codex",
+                        None,
+                    ),
+                    max_context_chars=(
+                        compressor.max_context_chars if compressor is not None else None
+                    ),
+                    observed_clamp=self._observed_clamp(model_for_budget),
+                )
+            snapshot = budget_snapshot
             boundary = SurfaceBoundary(
                 request_start=getattr(st, "_boundary_request_start", 0),
                 elided_replay=getattr(st, "_boundary_elided_replay", 0),
@@ -1086,6 +1138,7 @@ class ToolLoopRunner:
         *,
         serving_identity=None,
         request_config: object = None,
+        budget_snapshot=None,
     ):
         """Guarded LLM call with typing indicator and deadline-based recovery.
 
@@ -1196,31 +1249,37 @@ class ToolLoopRunner:
         # effort/ladder) so the continued generation stays the same
         # generation — and continues at the NEXT rung via the persisted
         # st._rescue_passes, never re-arming rung one.
-        from ..llm.context_budget import snapshot_for_codex_config
+        from ..llm.context_compressor import estimate_message_chars
 
-        _snapshot = None
         if st._gen_identity:
-            # Axes were reconstructed onto serving_identity above; the facts
-            # here supply the frozen budget ladder so the resumed generation
-            # continues at the NEXT rung of the SAME plan.
-            _ladder: tuple[int, ...] = tuple(st._gen_identity.get("ladder") or ())
+            # The durable generation owns its exact budget snapshot; current
+            # observer/config state is irrelevant until the next generation.
+            _snapshot = self._snapshot_from_generation_facts(st._gen_identity)
+        elif budget_snapshot is not None:
+            _snapshot = budget_snapshot
         else:
-            _chat_compressor = self._get_context_compressor()
             _root_config = request_config if request_config is not None else self._get_config()
-            _budget_model = serving_identity.model if serving_identity.is_codex else None
-            _snapshot = snapshot_for_codex_config(
-                _budget_model,
-                getattr(_root_config, "openai_codex", None),
-                max_context_chars=(
-                    _chat_compressor.max_context_chars if _chat_compressor is not None else None
-                ),
-                observed_clamp=self._observed_clamp(_budget_model),
-            )
-            _ladder = _snapshot.ladder
+            _snapshot = self._capture_budget_snapshot(serving_identity, _root_config)
+        _ladder: tuple[int, ...] = _snapshot.ladder
         _generation_deadline = time.monotonic() + deadline_seconds
         _pending_latch: int | None = None
         _rescued_this_call = False
         _last_overflow: BaseException | None = None
+        if st._gen_identity and st._rescue_passes:
+            # Resume reconstructs the pending rejection from durable attempt
+            # facts. The already-compressed payload is the acceptance
+            # candidate; on success it publishes both the latch and evidence.
+            _pending_latch = estimate_message_chars(st.messages)
+            prior_attempts = st._gen_identity.get("attempts") or []
+            prior = prior_attempts[-1] if prior_attempts else {}
+            _last_overflow = LLMRequestError(
+                "resumed structural context overflow",
+                provider=serving_identity.provider,
+                model=serving_identity.model,
+                code="context_length_exceeded",
+                account_key=prior.get("account_key"),
+                server_input_tokens=prior.get("server_input_tokens"),
+            )
 
         # Typing is best-effort (shared helper): a typing failure — setup or
         # cleanup — must never fail the call or misclassify provider errors.
@@ -2272,9 +2331,13 @@ class ToolLoopRunner:
             # every physical retry describe this exact client/model/effort.
             _config = self._get_config()
             _serving = _serving_identity_for(self._llm_gateway, _config)
-            self._maybe_compress_loop(st, _serving, _config)
+            _budget_snapshot = self._capture_budget_snapshot(_serving, _config)
+            self._maybe_compress_loop(st, _serving, _config, budget_snapshot=_budget_snapshot)
             kind, val = await self._call_loop_llm(
-                st, serving_identity=_serving, request_config=_config
+                st,
+                serving_identity=_serving,
+                request_config=_config,
+                budget_snapshot=_budget_snapshot,
             )
             if kind == "done":
                 return val
@@ -2437,7 +2500,7 @@ class ToolLoopRunner:
         )
         return outcome_text
 
-    def _maybe_compress_loop(self, st: _LoopTurn, serving, config) -> None:
+    def _maybe_compress_loop(self, st: _LoopTurn, serving, config, *, budget_snapshot=None) -> None:
         """Loop pre-send compaction (campaign phase 4 — loops previously had
         NO soft path at all): the shared soft pass at the serving model's
         derived target once tool iterations exist, plus the invocation-local
@@ -2445,21 +2508,16 @@ class ToolLoopRunner:
         Non-fatal like every compaction guard."""
         compressor = self._get_context_compressor()
         try:
-            from ..llm.context_budget import snapshot_for_codex_config
             from ..llm.context_compressor import (
                 compress_tool_context,
                 emergency_compress_for_window,
                 estimate_message_chars,
             )
 
-            model_for_budget = serving.model if serving.is_codex else None
-            snapshot = snapshot_for_codex_config(
-                model_for_budget,
-                getattr(config, "openai_codex", None),
-                max_context_chars=(
-                    compressor.max_context_chars if compressor is not None else None
-                ),
-                observed_clamp=self._observed_clamp(model_for_budget),
+            snapshot = (
+                budget_snapshot
+                if budget_snapshot is not None
+                else self._capture_budget_snapshot(serving, config)
             )
             if (
                 compressor is not None
@@ -2503,6 +2561,7 @@ class ToolLoopRunner:
         *,
         serving_identity=None,
         request_config=None,
+        budget_snapshot=None,
     ):
         """LLM call for one loop iteration with deadline-based recovery.
 
@@ -2542,15 +2601,10 @@ class ToolLoopRunner:
                 **pin_kwargs,
             )
 
-        from ..llm.context_budget import snapshot_for_codex_config
-
-        _compressor = self._get_context_compressor()
-        _loop_budget_model = serving_identity.model if serving_identity.is_codex else None
-        _snapshot = snapshot_for_codex_config(
-            _loop_budget_model,
-            getattr(request_config, "openai_codex", None),
-            max_context_chars=(_compressor.max_context_chars if _compressor is not None else None),
-            observed_clamp=self._observed_clamp(_loop_budget_model),
+        _snapshot = (
+            budget_snapshot
+            if budget_snapshot is not None
+            else self._capture_budget_snapshot(serving_identity, request_config)
         )
         # ONE monotonic deadline for the whole logical generation: the first
         # attempt runs on the policy's own budget; rescue retries pay for the

--- a/src/discord/tool_loop.py
+++ b/src/discord/tool_loop.py
@@ -473,6 +473,9 @@ class ToolLoopDeps:
     # Called with (TurnKey, generation) when a turn suspends — wiring points
     # it at the resume manager's auto-resume registration.
     on_turn_suspended: Callable | None = None
+    # Passive window observer (phase 5): downward clamp source + rescue
+    # evidence sink. None = feature-inert (tests, minimal constructions).
+    window_observer: object | None = None
 
 
 class ToolLoopRunner:
@@ -497,6 +500,7 @@ class ToolLoopRunner:
         self._loop_manager = deps.loop_manager
         self._stuck_loop_tracker_cls = deps.stuck_loop_tracker_cls
         self._turn_store = deps.turn_store
+        self._window_observer = deps.window_observer
         self._on_turn_suspended = deps.on_turn_suspended
 
     # ------------------------------------------------------------------
@@ -930,6 +934,30 @@ class ToolLoopRunner:
             durability=durability,
         )
 
+    def _observed_clamp(self, model: object) -> int | None:
+        """The window observer's active clamp for ``model`` (phase 5)."""
+        observer = getattr(self, "_window_observer", None)
+        if observer is None:
+            return None
+        try:
+            return observer.active_clamp(model)
+        except Exception:
+            log.exception("active_clamp failed (non-fatal); treating as unclamped")
+            return None
+
+    async def _record_window_evidence(self, overflow: object, response: object) -> None:
+        """Feed one rescue's overflow→acceptance pair to the observer.
+
+        Total: evidence is never worth failing the request that just
+        succeeded (plan §11 invariant)."""
+        observer = getattr(self, "_window_observer", None)
+        if observer is None or overflow is None:
+            return
+        try:
+            await observer.record_rescue(overflow=overflow, response=response)
+        except Exception:
+            log.exception("window-evidence recording failed (non-fatal)")
+
     def _clear_active(self, st: _ChatTurn) -> None:
         self._channel_state.clear_active_request(st._ch_id, st._req_id)
 
@@ -996,6 +1024,7 @@ class ToolLoopRunner:
                 max_context_chars=(
                     compressor.max_context_chars if compressor is not None else None
                 ),
+                observed_clamp=self._observed_clamp(model_for_budget),
             )
             boundary = SurfaceBoundary(
                 request_start=getattr(st, "_boundary_request_start", 0),
@@ -1021,9 +1050,7 @@ class ToolLoopRunner:
                 )
                 log.info("context_compressor: trimmed %d chars", saved)
             except Exception:
-                log.exception(
-                    "context_compressor failed (non-fatal); continuing with full context"
-                )
+                log.exception("context_compressor failed (non-fatal); continuing with full context")
 
         if latch is None:
             return True
@@ -1180,17 +1207,20 @@ class ToolLoopRunner:
         else:
             _chat_compressor = self._get_context_compressor()
             _root_config = request_config if request_config is not None else self._get_config()
+            _budget_model = serving_identity.model if serving_identity.is_codex else None
             _snapshot = snapshot_for_codex_config(
-                serving_identity.model if serving_identity.is_codex else None,
+                _budget_model,
                 getattr(_root_config, "openai_codex", None),
                 max_context_chars=(
                     _chat_compressor.max_context_chars if _chat_compressor is not None else None
                 ),
+                observed_clamp=self._observed_clamp(_budget_model),
             )
             _ladder = _snapshot.ladder
         _generation_deadline = time.monotonic() + deadline_seconds
         _pending_latch: int | None = None
         _rescued_this_call = False
+        _last_overflow: BaseException | None = None
 
         # Typing is best-effort (shared helper): a typing failure — setup or
         # cleanup — must never fail the call or misclassify provider errors.
@@ -1215,6 +1245,7 @@ class ToolLoopRunner:
                             # rule); the generation is settled, so its frozen
                             # facts and rung phase reset for the next one.
                             st._char_latch = _pending_latch
+                            await self._record_window_evidence(_last_overflow, llm_resp)
                         if st._gen_identity is not None or st._rescue_passes:
                             st._gen_identity = None
                             st._rescue_passes = 0
@@ -1249,6 +1280,7 @@ class ToolLoopRunner:
                         st.messages = compressed
                         st._rescue_passes += 1
                         _rescued_this_call = True
+                        _last_overflow = overflow_exc
                         if report.get("boundary_request_start") is not None:
                             st._boundary_request_start = report["boundary_request_start"]
                             st._boundary_elided_replay = report["boundary_elided_replay"]
@@ -2427,6 +2459,7 @@ class ToolLoopRunner:
                 max_context_chars=(
                     compressor.max_context_chars if compressor is not None else None
                 ),
+                observed_clamp=self._observed_clamp(model_for_budget),
             )
             if (
                 compressor is not None
@@ -2512,10 +2545,12 @@ class ToolLoopRunner:
         from ..llm.context_budget import snapshot_for_codex_config
 
         _compressor = self._get_context_compressor()
+        _loop_budget_model = serving_identity.model if serving_identity.is_codex else None
         _snapshot = snapshot_for_codex_config(
-            serving_identity.model if serving_identity.is_codex else None,
+            _loop_budget_model,
             getattr(request_config, "openai_codex", None),
             max_context_chars=(_compressor.max_context_chars if _compressor is not None else None),
+            observed_clamp=self._observed_clamp(_loop_budget_model),
         )
         # ONE monotonic deadline for the whole logical generation: the first
         # attempt runs on the policy's own budget; rescue retries pay for the
@@ -2523,6 +2558,7 @@ class ToolLoopRunner:
         generation_deadline = time.monotonic() + policy.deadline_seconds
         rescue_passes = 0
         pending_latch: int | None = None
+        last_overflow: BaseException | None = None
 
         try:
             # Pre-admission fast-fail, same contract as the chat path — and
@@ -2549,6 +2585,7 @@ class ToolLoopRunner:
                     if pending_latch is not None:
                         # Server-accepted evidence, per the settled latch rule.
                         st._char_latch = pending_latch
+                        await self._record_window_evidence(last_overflow, response)
                     break
                 except Exception as overflow_exc:
                     from ..llm.errors import LLMRequestError
@@ -2589,6 +2626,7 @@ class ToolLoopRunner:
                             envelope_len=_LOOP_ENVELOPE_LEN,
                         )
                     pending_latch = report["compressed_chars"]
+                    last_overflow = overflow_exc
                     if generation_deadline - time.monotonic() <= 0:
                         # Same rule as chat: recovery deadlines bound waiting,
                         # not an admitted stream — never start a request

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -39,6 +39,7 @@ from ..llm.codex_auth import CodexAuthPool
 from ..llm.cost_tracker import CostTracker
 from ..llm.model_breaker import ModelBreakerRegistry
 from ..llm.recovery import RecoveryPolicy
+from ..llm.window_observer import WindowObserver
 from ..odin_log import get_logger
 from ..permissions import PermissionManager
 from ..permissions.host_access import HostAccessManager
@@ -130,6 +131,7 @@ class BotServices:
     turn_store: TurnStateStore | None = None
     model_breakers: ModelBreakerRegistry | None = None
     recovery_policy_source: Callable[[], RecoveryPolicy] | None = None
+    window_observer: WindowObserver | None = None
 
 
 def build_services(
@@ -150,9 +152,7 @@ def build_services(
     # root rather than the boot object; config updates replace bot.config.
     agent_manager = AgentManager(
         max_concurrent_agents_provider=(
-            (lambda: get_config().agents.max_concurrent_agents)
-            if get_config is not None
-            else None
+            (lambda: get_config().agents.max_concurrent_agents) if get_config is not None else None
         )
     )
     # Autonomous loop manager (agent-aware)
@@ -443,6 +443,10 @@ def build_services(
         if not turn_store.available:
             turn_store = None  # init failed — feature off, logged loudly
 
+    # Passive context-window observer (phase 5): evidence + downward clamps.
+    # Construction is total — a broken store loads empty, never blocks boot.
+    window_observer = WindowObserver()
+
     # Action diff tracker — records before→after diffs. Always on.
     diff_tracker = DiffTracker()
 
@@ -574,6 +578,7 @@ def build_services(
         turn_store=turn_store,
         model_breakers=model_breakers,
         recovery_policy_source=recovery_policy_source,
+        window_observer=window_observer,
     )
 
 
@@ -773,6 +778,7 @@ def build_components(bot, services: BotServices) -> BotComponents:
             loop_manager=services.loop_manager,
             stuck_loop_tracker_cls=services.stuck_loop_tracker_cls,
             turn_store=services.turn_store,
+            window_observer=services.window_observer,
         )
     )
     agent_task_tools = AgentTaskTools(
@@ -783,7 +789,7 @@ def build_components(bot, services: BotServices) -> BotComponents:
             tool_executor=services.tool_executor,
             skill_manager=services.skill_manager,
             # live: swappable at runtime via the bot's `knowledge` property
-        get_knowledge_store=lambda: bot.knowledge,
+            get_knowledge_store=lambda: bot.knowledge,
             embedder=services.embedder,
             audit=services.audit,
             agent_manager=services.agent_manager,
@@ -797,6 +803,7 @@ def build_components(bot, services: BotServices) -> BotComponents:
             turn_recorder=turn_recorder,
             prompt_builder=prompt_builder,
             tool_catalog=tool_catalog,
+            window_observer=services.window_observer,
         )
     )
     # Second phase of the P5 owner wiring: the agents domain exists now.

--- a/src/discord/wiring.py
+++ b/src/discord/wiring.py
@@ -651,6 +651,17 @@ def build_components(bot, services: BotServices) -> BotComponents:
         recovery_policy_source=_live_recovery_policy_source(bot),
     )
 
+    # Dependency-inverted clamp scope: the observer sees only an opaque-key
+    # snapshot supplied by the LIVE Codex client, never the auth pool itself.
+    if services.window_observer is not None:
+        services.window_observer.set_eligible_account_keys_provider(
+            lambda: (
+                llm_gateway.codex_client.eligible_account_keys_snapshot()
+                if llm_gateway.codex_client is not None
+                else frozenset()
+            )
+        )
+
     # Wire LLM callbacks to whichever provider is active
     if llm_gateway.active_client is not None:
         llm_gateway.wire_callbacks()

--- a/src/health/server.py
+++ b/src/health/server.py
@@ -66,6 +66,7 @@ ADMIN_ONLY_PREFIXES = (
     "/api/mcp", "/api/tokens", "/api/personality",
     "/api/tools/timeouts", "/api/pools",
     "/api/outbound-webhooks", "/api/grafana-alerts", "/api/slack",
+    "/api/context",
     "/api/restart",
 )
 

--- a/src/llm/codex_auth.py
+++ b/src/llm/codex_auth.py
@@ -507,6 +507,17 @@ class CodexAuthPool:
     def account_count(self) -> int:
         return len(self._accounts)
 
+    def eligible_account_ids_snapshot(self) -> frozenset[str]:
+        """Stable non-secret IDs for accounts eligible to serve right now."""
+        result: set[str] = set()
+        for auth in self._accounts:
+            if auth.is_rate_limited() or not auth.is_configured():
+                continue
+            account_id = auth.get_account_id()
+            if isinstance(account_id, str) and account_id:
+                result.add(account_id)
+        return frozenset(result)
+
     @property
     def current(self) -> CodexAuth:
         if not self._accounts:

--- a/src/llm/context_budget.py
+++ b/src/llm/context_budget.py
@@ -108,6 +108,7 @@ def snapshot_for_codex_config(
     codex_config: object,
     *,
     max_context_chars: int | None,
+    observed_clamp: int | None = None,
 ) -> ContextBudgetSnapshot:
     """Resolve a snapshot from the live codex config section, getattr-safe.
 
@@ -117,12 +118,15 @@ def snapshot_for_codex_config(
     lifetime lives (the boot-frozen compression object for chat, the
     spawn-frozen value for agents) so the apply-registry classification of
     ``max_context_chars`` stays honest: this helper never re-reads it live.
+    ``observed_clamp`` is the window observer's runtime evidence (phase 5) —
+    callers with an observer pass ``active_clamp(model)``; None = unclamped.
     """
     return resolve_context_budget(
         model,
         overrides=getattr(codex_config, "context_budget_overrides", None),
         utilization=getattr(codex_config, "context_utilization", 60),
         max_context_chars=max_context_chars,
+        observed_clamp=observed_clamp,
     )
 
 
@@ -176,9 +180,7 @@ def resolve_context_budget(
     rung_1 = primary_chars * 7 // 10
     rung_2 = min(rung_1, RESCUE_CEILING_CHARS)
     ladder = tuple(
-        rung
-        for i, rung in enumerate((rung_1, rung_2))
-        if rung > 0 and (i == 0 or rung != rung_1)
+        rung for i, rung in enumerate((rung_1, rung_2)) if rung > 0 and (i == 0 or rung != rung_1)
     )
 
     return ContextBudgetSnapshot(

--- a/src/llm/openai_codex.py
+++ b/src/llm/openai_codex.py
@@ -368,6 +368,25 @@ class CodexChatClient:
     def pool_stats(self) -> dict:
         return self.get_pool_metrics()
 
+    def eligible_account_keys_snapshot(self) -> frozenset[str]:
+        """Opaque identities for accounts the auth layer may serve now."""
+        try:
+            from .account_key import opaque_account_key
+
+            if isinstance(self.auth, CodexAuthPool):
+                raw_ids = self.auth.eligible_account_ids_snapshot()
+            else:
+                raw = self.auth.get_account_id()
+                raw_ids = frozenset({raw}) if isinstance(raw, str) and raw else frozenset()
+            return frozenset(
+                key
+                for account_id in raw_ids
+                if (key := opaque_account_key(account_id)) is not None
+            )
+        except Exception:
+            log.exception("Could not resolve eligible Codex account keys")
+            return frozenset()
+
     def get_pool_metrics(self) -> dict:
         """Return HTTP connection pool metrics for observability."""
         active = 0

--- a/src/llm/window_observer.py
+++ b/src/llm/window_observer.py
@@ -26,11 +26,9 @@ Settled semantics (plan of record R2 §11):
   replaces it (value + fresh TTL); higher evidence never raises or clears
   a live clamp early. TTL is 24 hours; expiry is judged lazily at read.
   Manual clearing is account-scoped.
-- The active clamp for a model is the minimum non-expired clamp across all
-  accounts holding one. (The plan scopes this to currently ELIGIBLE pool
-  accounts; the observer deliberately takes the conservative superset —
-  the pool is sticky but failover can seat any account at any moment, and
-  a stale account's clamp dies with its TTL.)
+- The active clamp for a model is the minimum non-expired clamp across the
+  currently ELIGIBLE pool accounts. Pool knowledge is dependency-inverted:
+  the observer consumes opaque-key snapshots and never imports the pool.
 - An evidence-write failure logs and forfeits durability — it NEVER turns
   a successful user request into an error. The merged evidence still
   serves this process from memory; the next successful write persists it.
@@ -45,6 +43,8 @@ import copy
 import json
 import os
 import stat
+import tempfile
+from collections.abc import Callable, Collection
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TypeGuard
@@ -188,12 +188,24 @@ def _read_store_bytes(path: Path) -> bytes | None:
         os.close(fd)
 
 
-class WindowObserver:
-    """Evidence store + clamp authority. Every public entry point is total."""
+class WindowObserverMutationError(RuntimeError):
+    """An explicit operator mutation could not be durably committed."""
 
-    def __init__(self, path: str | Path = DEFAULT_STORE_PATH):
+
+class WindowObserver:
+    """Evidence store + clamp authority. Every passive entry point is total."""
+
+    def __init__(
+        self,
+        path: str | Path = DEFAULT_STORE_PATH,
+        *,
+        eligible_account_keys: Callable[[], Collection[str] | None] | None = None,
+    ):
         self._path = Path(path)
         self._lock = asyncio.Lock()
+        # None keeps standalone/test construction backward-compatible. The
+        # composition root installs the production pool-backed provider.
+        self._eligible_account_keys = eligible_account_keys
         self._state: dict = {"version": STORE_VERSION, "accounts": {}}
         try:
             self._load_initial()
@@ -232,15 +244,23 @@ class WindowObserver:
         except OSError:
             log.exception("Window-evidence quarantine failed; leaving file in place")
 
-    def _persist_locked(self) -> None:
-        """Atomic replacement: temp file in the same directory, fsync, rename,
-        parent-directory fsync. Failure is logged by the caller and forfeits
-        durability only — never the request."""
-        payload = json.dumps(self._state, indent=2, sort_keys=True)
+    def set_eligible_account_keys_provider(
+        self, provider: Callable[[], Collection[str] | None] | None
+    ) -> None:
+        """Install the pool-facing opaque-key snapshot provider.
+
+        This narrow callback is the dependency-inversion boundary: observer
+        code knows nothing about credential pools or raw account identities.
+        """
+        self._eligible_account_keys = provider
+
+    def _persist_locked(self, state: dict | None = None) -> None:
+        """Atomic replacement: unique temp, fsync, rename, parent fsync."""
+        payload = json.dumps(self._state if state is None else state, indent=2, sort_keys=True)
         directory = self._path.parent
         directory.mkdir(parents=True, exist_ok=True)
-        tmp_path = self._path.with_name(f".{self._path.name}.tmp-{os.getpid()}")
-        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{self._path.name}.tmp-", dir=directory)
+        tmp_path = Path(tmp_name)
         try:
             try:
                 handle = os.fdopen(fd, "w", encoding="utf-8")
@@ -266,10 +286,44 @@ class WindowObserver:
         finally:
             os.close(dir_fd)
 
+    async def _persist_owned(
+        self, state: dict
+    ) -> tuple[BaseException | None, asyncio.CancelledError | None]:
+        """Drain the persistence worker before the transaction lock releases.
+
+        Cancelling an await of ``to_thread`` does not stop the worker. Shield
+        it and remember cancellation so no second writer can enter while the
+        first still owns an unpublished candidate.
+        """
+        worker = asyncio.create_task(asyncio.to_thread(self._persist_locked, state))
+        cancelled: asyncio.CancelledError | None = None
+        while True:
+            try:
+                await asyncio.shield(worker)
+                break
+            except asyncio.CancelledError as exc:
+                # If the worker itself raised CancelledError, it is done and its
+                # outcome belongs to the persistence operation. Otherwise this
+                # task was cancelled; keep owning the transaction until the
+                # non-cooperative thread has actually stopped.
+                if worker.done():
+                    break
+                if cancelled is None:
+                    cancelled = exc
+            except BaseException:
+                # The worker outcome is collected below; the important thing
+                # here is that it is DONE before lock ownership can end.
+                break
+        try:
+            worker.result()
+        except BaseException as exc:
+            return exc, cancelled
+        return None, cancelled
+
     # ── hot-path read ─────────────────────────────────────────────────
 
     def active_clamp(self, model: str | None) -> int | None:
-        """Minimum non-expired clamp for ``model`` across all accounts.
+        """Minimum non-expired clamp across currently eligible accounts.
 
         Synchronous and disk-free — safe inside budget resolution. Total:
         any internal surprise returns ``None`` (no clamp) rather than ever
@@ -279,9 +333,17 @@ class WindowObserver:
             canonical = canonical_codex_model(model)
             if not canonical:
                 return None
+            eligible: frozenset[str] | None = None
+            if self._eligible_account_keys is not None:
+                supplied = self._eligible_account_keys()
+                if supplied is None:
+                    return None
+                eligible = frozenset(key for key in supplied if _is_account_key(key))
             now = _utc_now()
             best: int | None = None
-            for account in self._state.get("accounts", {}).values():
+            for account_key, account in self._state.get("accounts", {}).items():
+                if eligible is not None and account_key not in eligible:
+                    continue
                 record = account.get("models", {}).get(canonical)
                 clamp = record.get("clamp") if isinstance(record, dict) else None
                 if not isinstance(clamp, dict):
@@ -325,6 +387,7 @@ class WindowObserver:
                 accept_key = None
             now = _utc_now()
 
+            cancellation: asyncio.CancelledError | None = None
             async with self._lock:
                 state = copy.deepcopy(self._state)
                 if reject_key and reject_model:
@@ -352,13 +415,17 @@ class WindowObserver:
                     record = self._record_for(state, reject_key, reject_model)
                     record["clamp"] = self._merged_clamp(record.get("clamp"), accept_tokens, now)
                 self._state = state
-                try:
-                    await asyncio.to_thread(self._persist_locked)
-                except OSError:
-                    log.exception(
+                persist_error, cancellation = await self._persist_owned(state)
+                if persist_error is not None:
+                    log.error(
                         "Window-evidence write failed; observation forfeited "
-                        "(in-memory clamp still serves this process)"
+                        "(in-memory clamp still serves this process)",
+                        exc_info=(type(persist_error), persist_error, persist_error.__traceback__),
                     )
+            if cancellation is not None:
+                raise cancellation
+        except asyncio.CancelledError:
+            raise
         except Exception:
             log.exception("record_rescue failed; observation forfeited")
 
@@ -391,36 +458,41 @@ class WindowObserver:
     # ── management surface ────────────────────────────────────────────
 
     async def clear_account(self, account_key: str, model: str | None = None) -> int:
-        """Manually clear clamp(s) for one account (all models, or one).
+        """Durably clear clamp(s) for one account (all models, or one).
 
-        Returns the number of clamps cleared. Bounds history stays — clearing
-        is a clamp operation, not evidence destruction. Total."""
-        try:
-            if not _is_account_key(account_key):
-                return 0
-            target_model = canonical_codex_model(model) if model else None
-            cleared = 0
-            async with self._lock:
-                state = copy.deepcopy(self._state)
-                account = state.get("accounts", {}).get(account_key)
-                if not account:
-                    return 0
-                for name, record in account.get("models", {}).items():
-                    if target_model and name != target_model:
-                        continue
-                    if record.get("clamp") is not None:
-                        record["clamp"] = None
-                        cleared += 1
-                if cleared:
-                    self._state = state
-                    try:
-                        await asyncio.to_thread(self._persist_locked)
-                    except OSError:
-                        log.exception("Window-evidence write failed after clear")
-            return cleared
-        except Exception:
-            log.exception("clear_account failed")
+        Bounds history stays. Persistence failure raises
+        ``WindowObserverMutationError`` and leaves the published in-memory
+        state unchanged, so API truth matches restart truth.
+        """
+        if not _is_account_key(account_key):
             return 0
+        target_model = canonical_codex_model(model) if model else None
+        cancellation: asyncio.CancelledError | None = None
+        async with self._lock:
+            state = copy.deepcopy(self._state)
+            account = state.get("accounts", {}).get(account_key)
+            if not account:
+                return 0
+            cleared = 0
+            for name, record in account.get("models", {}).items():
+                if target_model and name != target_model:
+                    continue
+                if record.get("clamp") is not None:
+                    record["clamp"] = None
+                    cleared += 1
+            if not cleared:
+                return 0
+            persist_error, cancellation = await self._persist_owned(state)
+            if persist_error is not None:
+                raise WindowObserverMutationError(
+                    "window-evidence clear could not be persisted"
+                ) from persist_error
+            # Publish only after durable commit. A cancellation delivered while
+            # the worker ran still observes matching memory and disk state.
+            self._state = state
+        if cancellation is not None:
+            raise cancellation
+        return cleared
 
     def view(self) -> dict:
         """Deep-copied snapshot for the API: raw records plus, per clamp, a

--- a/src/llm/window_observer.py
+++ b/src/llm/window_observer.py
@@ -1,0 +1,440 @@
+"""Passive context-window observer + downward-only clamps (campaign phase 5).
+
+Odin's normal work is the probe: every emergency rescue already carries the
+server's own numbers — the overflow error's rejected input size and the
+compressed retry's accepted usage echo (phase 2 stamping). This module turns
+those pairs into per-account, per-model evidence and a temporary DOWNWARD
+clamp on the budget resolver, so a silent serving-window regression stops
+costing repeated overflow round-trips within minutes of first being seen.
+
+Settled semantics (plan of record R2 §11):
+
+- ``data/context_windows.json`` is runtime EVIDENCE, never configuration:
+  versioned schema, strict validation, atomic replacement, UTC timestamps,
+  opaque account keys only (the phase-2 HMAC identities — no raw account
+  material ever lands here).
+- One lock guards the complete read–merge–atomic-write transaction; the
+  in-memory state is replaced wholesale under that lock and read lock-free
+  by the hot path (``active_clamp`` is synchronous and touches no disk).
+- A clamp qualifies only when ALL hold: structural overflow, the SAME
+  logical request's successful compressed retry, a server-authoritative
+  accepted-input echo, canonical model match, and rejection/acceptance on
+  the same opaque account. A cross-account retry records both observations
+  but derives no clamp for the rejecting account.
+- The clamp value IS the successful post-rejection acceptance, exact.
+  Clamps are downward-only: fresh evidence at or below a live clamp
+  replaces it (value + fresh TTL); higher evidence never raises or clears
+  a live clamp early. TTL is 24 hours; expiry is judged lazily at read.
+  Manual clearing is account-scoped.
+- The active clamp for a model is the minimum non-expired clamp across all
+  accounts holding one. (The plan scopes this to currently ELIGIBLE pool
+  accounts; the observer deliberately takes the conservative superset —
+  the pool is sticky but failover can seat any account at any moment, and
+  a stale account's clamp dies with its TTL.)
+- An evidence-write failure logs and forfeits durability — it NEVER turns
+  a successful user request into an error. The merged evidence still
+  serves this process from memory; the next successful write persists it.
+- No probe traffic, no autonomous upward adjustment: growth discovery
+  stays a manual procedure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import os
+import stat
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TypeGuard
+
+from ..config.schema import canonical_codex_model
+from ..odin_log import get_logger
+
+log = get_logger("window_observer")
+
+STORE_VERSION = 1
+CLAMP_TTL = timedelta(hours=24)
+DEFAULT_STORE_PATH = Path("data/context_windows.json")
+
+#: Evidence for three pool accounts across a handful of models is a few KB;
+#: anything near this cap is not our file.
+_MAX_STORE_BYTES = 4 * 1024 * 1024
+
+_ACCOUNT_KEY_HEX = "0123456789abcdef"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(ts: datetime) -> str:
+    return ts.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed
+
+
+def _is_account_key(value: object) -> bool:
+    return (
+        isinstance(value, str) and len(value) == 32 and all(ch in _ACCOUNT_KEY_HEX for ch in value)
+    )
+
+
+def _positive_int(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _empty_model_record() -> dict:
+    return {
+        "highest_accepted_input": None,
+        "highest_accepted_at": None,
+        "lowest_rejection_bound": None,
+        "lowest_rejection_at": None,
+        "overflow_occurrences": 0,
+        "last_overflow_at": None,
+        "clamp": None,
+    }
+
+
+def _validate_store(data: object) -> bool:
+    """Strict schema check — anything off-shape is not our evidence."""
+    if not isinstance(data, dict) or data.get("version") != STORE_VERSION:
+        return False
+    accounts = data.get("accounts")
+    if not isinstance(accounts, dict) or set(data) != {"version", "accounts"}:
+        return False
+    for account_key, account in accounts.items():
+        if not _is_account_key(account_key):
+            return False
+        if not isinstance(account, dict) or set(account) != {"models"}:
+            return False
+        models = account["models"]
+        if not isinstance(models, dict):
+            return False
+        for model, record in models.items():
+            if not isinstance(model, str) or not model.strip():
+                return False
+            if not isinstance(record, dict) or set(record) != set(_empty_model_record()):
+                return False
+            for bound in ("highest_accepted_input", "lowest_rejection_bound"):
+                if record[bound] is not None and not _positive_int(record[bound]):
+                    return False
+            occurrences = record["overflow_occurrences"]
+            if not isinstance(occurrences, int) or isinstance(occurrences, bool) or occurrences < 0:
+                return False
+            for ts_field in ("highest_accepted_at", "lowest_rejection_at", "last_overflow_at"):
+                if record[ts_field] is not None and _parse_iso(record[ts_field]) is None:
+                    return False
+            clamp = record["clamp"]
+            if clamp is None:
+                continue
+            if not isinstance(clamp, dict) or set(clamp) != {
+                "value",
+                "set_at",
+                "expires_at",
+                "source",
+            }:
+                return False
+            if not _positive_int(clamp["value"]) or clamp["source"] != "rescue":
+                return False
+            if _parse_iso(clamp["set_at"]) is None or _parse_iso(clamp["expires_at"]) is None:
+                return False
+    return True
+
+
+def _read_store_bytes(path: Path) -> bytes | None:
+    """Hostile-input-safe read: never block, never follow, never assume.
+
+    Returns the raw bytes of a regular, sanely-sized file; ``None`` for
+    absent. Raises ``ValueError`` for anything present-but-wrong (FIFO,
+    directory, symlink, oversized) so the caller can quarantine it.
+    """
+    flags = os.O_RDONLY | os.O_NONBLOCK | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        # ELOOP = symlink refused by O_NOFOLLOW; other opens that fail on a
+        # present path are equally disqualifying.
+        raise ValueError(f"unreadable store file: {exc}") from exc
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise ValueError("store path is not a regular file")
+        if info.st_size > _MAX_STORE_BYTES:
+            raise ValueError(f"store file too large ({info.st_size} bytes)")
+        chunks: list[bytes] = []
+        remaining = info.st_size
+        while remaining > 0:
+            chunk = os.read(fd, min(remaining, 1 << 20))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+    finally:
+        os.close(fd)
+
+
+class WindowObserver:
+    """Evidence store + clamp authority. Every public entry point is total."""
+
+    def __init__(self, path: str | Path = DEFAULT_STORE_PATH):
+        self._path = Path(path)
+        self._lock = asyncio.Lock()
+        self._state: dict = {"version": STORE_VERSION, "accounts": {}}
+        try:
+            self._load_initial()
+        except Exception:
+            log.exception("Window-evidence store load failed; starting empty")
+
+    # ── load / persist ────────────────────────────────────────────────
+
+    def _load_initial(self) -> None:
+        try:
+            raw = _read_store_bytes(self._path)
+        except ValueError as exc:
+            log.warning("Window-evidence store rejected (%s); quarantining", exc)
+            self._quarantine()
+            return
+        if raw is None:
+            return
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            data = None
+        if data is None or not _validate_store(data):
+            log.warning("Window-evidence store failed validation; quarantining")
+            self._quarantine()
+            return
+        self._state = data
+
+    def _quarantine(self) -> None:
+        """Preserve questionable prior material beside the store — evidence
+        is provenance-bearing and is never repaired or overwritten in place."""
+        try:
+            stamp = _utc_now().strftime("%Y%m%dT%H%M%SZ")
+            target = self._path.with_name(f"{self._path.name}.corrupt-{stamp}")
+            os.replace(self._path, target)
+            log.warning("Quarantined window-evidence store to %s", target)
+        except OSError:
+            log.exception("Window-evidence quarantine failed; leaving file in place")
+
+    def _persist_locked(self) -> None:
+        """Atomic replacement: temp file in the same directory, fsync, rename,
+        parent-directory fsync. Failure is logged by the caller and forfeits
+        durability only — never the request."""
+        payload = json.dumps(self._state, indent=2, sort_keys=True)
+        directory = self._path.parent
+        directory.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._path.with_name(f".{self._path.name}.tmp-{os.getpid()}")
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            try:
+                handle = os.fdopen(fd, "w", encoding="utf-8")
+            except BaseException:
+                # fdopen never took ownership — close the raw fd ourselves.
+                os.close(fd)
+                raise
+            with handle:
+                # handle owns fd from here; any failure below closes it.
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self._path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        dir_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+    # ── hot-path read ─────────────────────────────────────────────────
+
+    def active_clamp(self, model: str | None) -> int | None:
+        """Minimum non-expired clamp for ``model`` across all accounts.
+
+        Synchronous and disk-free — safe inside budget resolution. Total:
+        any internal surprise returns ``None`` (no clamp) rather than ever
+        failing a request.
+        """
+        try:
+            canonical = canonical_codex_model(model)
+            if not canonical:
+                return None
+            now = _utc_now()
+            best: int | None = None
+            for account in self._state.get("accounts", {}).values():
+                record = account.get("models", {}).get(canonical)
+                clamp = record.get("clamp") if isinstance(record, dict) else None
+                if not isinstance(clamp, dict):
+                    continue
+                expires = _parse_iso(clamp.get("expires_at"))
+                value = clamp.get("value")
+                if expires is None or expires <= now or not _positive_int(value):
+                    continue
+                if best is None or value < best:
+                    best = value
+            return best
+        except Exception:
+            log.exception("active_clamp failed; treating as unclamped")
+            return None
+
+    # ── evidence intake ───────────────────────────────────────────────
+
+    async def record_rescue(self, *, overflow: object, response: object) -> None:
+        """Record one overflow→compressed-retry-acceptance pair.
+
+        ``overflow`` is the structural overflow error (phase-2 stamped);
+        ``response`` is the SAME logical request's successful retry. Total:
+        every failure logs and forfeits the observation.
+        """
+        try:
+            if getattr(overflow, "code", None) != "context_length_exceeded":
+                return
+            reject_key = getattr(overflow, "account_key", None)
+            reject_tokens = getattr(overflow, "server_input_tokens", None)
+            reject_model = canonical_codex_model(getattr(overflow, "model", None))
+            accept_key = getattr(response, "account_key", None)
+            accept_tokens = getattr(response, "server_input_tokens", None)
+            accept_model = canonical_codex_model(getattr(response, "provenance_model", None))
+            if not _positive_int(reject_tokens):
+                reject_tokens = None
+            if not _positive_int(accept_tokens):
+                accept_tokens = None
+            if not _is_account_key(reject_key):
+                reject_key = None
+            if not _is_account_key(accept_key):
+                accept_key = None
+            now = _utc_now()
+
+            async with self._lock:
+                state = copy.deepcopy(self._state)
+                if reject_key and reject_model:
+                    record = self._record_for(state, reject_key, reject_model)
+                    record["overflow_occurrences"] += 1
+                    record["last_overflow_at"] = _iso(now)
+                    if reject_tokens is not None:
+                        prior = record["lowest_rejection_bound"]
+                        if prior is None or reject_tokens < prior:
+                            record["lowest_rejection_bound"] = reject_tokens
+                            record["lowest_rejection_at"] = _iso(now)
+                if accept_key and accept_model and accept_tokens is not None:
+                    record = self._record_for(state, accept_key, accept_model)
+                    prior = record["highest_accepted_input"]
+                    if prior is None or accept_tokens > prior:
+                        record["highest_accepted_input"] = accept_tokens
+                        record["highest_accepted_at"] = _iso(now)
+                if (
+                    reject_key is not None
+                    and reject_key == accept_key
+                    and reject_model
+                    and reject_model == accept_model
+                    and accept_tokens is not None
+                ):
+                    record = self._record_for(state, reject_key, reject_model)
+                    record["clamp"] = self._merged_clamp(record.get("clamp"), accept_tokens, now)
+                self._state = state
+                try:
+                    await asyncio.to_thread(self._persist_locked)
+                except OSError:
+                    log.exception(
+                        "Window-evidence write failed; observation forfeited "
+                        "(in-memory clamp still serves this process)"
+                    )
+        except Exception:
+            log.exception("record_rescue failed; observation forfeited")
+
+    @staticmethod
+    def _record_for(state: dict, account_key: str, model: str) -> dict:
+        account = state["accounts"].setdefault(account_key, {"models": {}})
+        return account["models"].setdefault(model, _empty_model_record())
+
+    @staticmethod
+    def _merged_clamp(existing: dict | None, accepted: int, now: datetime) -> dict:
+        """Downward-only merge: evidence at or below a live clamp replaces it
+        (exact value, fresh TTL); higher evidence never raises or refreshes a
+        live clamp; an expired clamp is replaced outright."""
+        fresh = {
+            "value": accepted,
+            "set_at": _iso(now),
+            "expires_at": _iso(now + CLAMP_TTL),
+            "source": "rescue",
+        }
+        if not isinstance(existing, dict):
+            return fresh
+        expires = _parse_iso(existing.get("expires_at"))
+        value = existing.get("value")
+        if expires is None or expires <= now or not _positive_int(value):
+            return fresh
+        if accepted <= value:
+            return fresh
+        return existing
+
+    # ── management surface ────────────────────────────────────────────
+
+    async def clear_account(self, account_key: str, model: str | None = None) -> int:
+        """Manually clear clamp(s) for one account (all models, or one).
+
+        Returns the number of clamps cleared. Bounds history stays — clearing
+        is a clamp operation, not evidence destruction. Total."""
+        try:
+            if not _is_account_key(account_key):
+                return 0
+            target_model = canonical_codex_model(model) if model else None
+            cleared = 0
+            async with self._lock:
+                state = copy.deepcopy(self._state)
+                account = state.get("accounts", {}).get(account_key)
+                if not account:
+                    return 0
+                for name, record in account.get("models", {}).items():
+                    if target_model and name != target_model:
+                        continue
+                    if record.get("clamp") is not None:
+                        record["clamp"] = None
+                        cleared += 1
+                if cleared:
+                    self._state = state
+                    try:
+                        await asyncio.to_thread(self._persist_locked)
+                    except OSError:
+                        log.exception("Window-evidence write failed after clear")
+            return cleared
+        except Exception:
+            log.exception("clear_account failed")
+            return 0
+
+    def view(self) -> dict:
+        """Deep-copied snapshot for the API: raw records plus, per clamp, a
+        computed ``expired`` flag so consumers never re-implement TTL math."""
+        try:
+            snapshot = copy.deepcopy(self._state)
+            now = _utc_now()
+            for account in snapshot.get("accounts", {}).values():
+                for record in account.get("models", {}).values():
+                    clamp = record.get("clamp")
+                    if isinstance(clamp, dict):
+                        expires = _parse_iso(clamp.get("expires_at"))
+                        clamp["expired"] = expires is None or expires <= now
+            return snapshot
+        except Exception:
+            log.exception("view failed")
+            return {"version": STORE_VERSION, "accounts": {}}

--- a/src/turn_state/codec.py
+++ b/src/turn_state/codec.py
@@ -24,7 +24,7 @@ import hashlib
 from dataclasses import asdict
 from typing import Any
 
-from ..config.schema import model_rejects_effort
+from ..config.schema import CODEX_REASONING_EFFORTS, model_rejects_effort
 from ..config.sensitivity import is_storage_sensitive_key as _is_sensitive_key
 from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
@@ -95,7 +95,7 @@ _GEN_IDENTITY_KEYS = {
 _GEN_IDENTITY_V3_KEYS = {"provider", "model", "effort", "ladder"}
 _GEN_ATTEMPT_KEYS = {"attempt", "account_key", "server_input_tokens"}
 _GEN_PROVIDERS = {"codex", "ollama", "kimi"}
-_GEN_EFFORTS = {"none", "low", "medium", "high", "xhigh", "max"}
+_GEN_EFFORTS = CODEX_REASONING_EFFORTS
 
 #: Rebuilt by the resume flow from live state. Each entry documents why it
 #: is NOT persisted:
@@ -119,6 +119,7 @@ RECONSTRUCTED_FIELDS: frozenset[str] = frozenset({
     "tools",
     "policy",
     "trace",
+    "_generation_budget_snapshot",
     "durability",
 })
 

--- a/src/web/api/__init__.py
+++ b/src/web/api/__init__.py
@@ -66,6 +66,7 @@ from .knowledge_mem import (
 )
 from .llm_admin import (  # noqa: E501
     register_connection_pools,
+    register_context_windows,
     register_kimi_admin,
     register_llm_provider,
     register_ollama_admin,
@@ -177,6 +178,8 @@ def create_api_routes(bot: OdinBot) -> web.RouteTableDef:
     register_llm_provider(routes, bot)
 
     register_provider_config(routes, bot)
+
+    register_context_windows(routes, bot)
 
     register_ollama_admin(routes, bot)
 

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -27,6 +27,7 @@ from ...config.schema import (
     allowed_efforts_for_model,
     effort_incompatibility_error,
 )
+from ...llm.window_observer import WindowObserverMutationError
 from ...odin_log import get_logger
 
 log = get_logger("web.api")
@@ -935,8 +936,8 @@ def register_context_windows(routes: web.RouteTableDef, bot) -> None:
             for k, v in (getattr(codex_cfg, "context_budget_overrides", None) or {}).items()
         }
         utilization = getattr(codex_cfg, "context_utilization", 60)
-        cc = getattr(bot, "context_compressor", None)
-        ceiling = getattr(cc, "resolved_max_context_chars", None) if cc else None
+        cc = getattr(codex_cfg, "context_compression", None)
+        ceiling = getattr(cc, "max_context_chars", None) if cc is not None else None
         evidence: dict = observer.view() if observer is not None else {"version": 1, "accounts": {}}
         models = set(CODEX_MODEL_INPUT_BUDGETS) | set(overrides)
         for account in evidence.get("accounts", {}).values():
@@ -986,10 +987,15 @@ def register_context_windows(routes: web.RouteTableDef, bot) -> None:
         if not isinstance(account_key, str) or not account_key.strip():
             return web.json_response({"error": "account_key is required"}, status=400)
         model = data.get("model")
-        cleared = await observer.clear_account(
-            account_key.strip(),
-            model=str(model).strip() if isinstance(model, str) and model.strip() else None,
-        )
+        try:
+            cleared = await observer.clear_account(
+                account_key.strip(),
+                model=str(model).strip() if isinstance(model, str) and model.strip() else None,
+            )
+        except WindowObserverMutationError:
+            return web.json_response(
+                {"error": "context-window clear could not be persisted"}, status=503
+            )
         return web.json_response({"cleared": cleared})
 
 

--- a/src/web/api/llm_admin.py
+++ b/src/web/api/llm_admin.py
@@ -31,9 +31,15 @@ from ...odin_log import get_logger
 
 log = get_logger("web.api")
 
-_ALLOWED_OLLAMA_HOSTS = frozenset({
-    "localhost", "127.0.0.1", "::1", "0.0.0.0",
-})
+_ALLOWED_OLLAMA_HOSTS = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+    }
+)
+
 
 def _validate_ollama_url(url: str) -> str:
     """Validate Ollama base_url — restrict to local/private networks to prevent SSRF."""
@@ -57,6 +63,7 @@ def _validate_ollama_url(url: str) -> str:
         pass
     try:
         import socket
+
         resolved = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         if not resolved:
             raise ValueError(f"Could not resolve hostname: {host}")
@@ -84,6 +91,7 @@ def _parse_int(val, name: str, lo: int = 1, hi: int = 262000) -> int:
     if v < lo or v > hi:
         raise ValueError(f"{name} must be between {lo} and {hi}")
     return v
+
 
 def register_connection_pools(routes: web.RouteTableDef, bot) -> None:
     """Connection pool status (verbatim from the monolith)."""
@@ -316,7 +324,7 @@ def register_llm_provider(routes: web.RouteTableDef, bot) -> None:
             result = await bot.llm_gateway.switch_provider(
                 provider,
                 persist=lambda: patch_config_paths(
-                    [(('llm_provider', 'active_provider'), provider)]
+                    [(("llm_provider", "active_provider"), provider)]
                 ),
             )
         if "error" in result:
@@ -337,9 +345,7 @@ def _provider_changes(
     return [((section, key), desired[key]) for key in desired if key in body]
 
 
-async def _persist_or_response(
-    changes: list, label: str
-) -> tuple[web.Response | None, bool]:
+async def _persist_or_response(changes: list, label: str) -> tuple[web.Response | None, bool]:
     """Persist desired leaves and return explicit error/cancel outcomes."""
     persist_exc, was_cancelled = await persist_config_paths_locked(changes)
     if persist_exc is not None:
@@ -347,9 +353,7 @@ async def _persist_or_response(
         if was_cancelled:
             raise asyncio.CancelledError
         return (
-            web.json_response(
-                {"error": f"{label} configuration not saved"}, status=500
-            ),
+            web.json_response({"error": f"{label} configuration not saved"}, status=500),
             False,
         )
     return None, was_cancelled
@@ -414,7 +418,9 @@ def _parse_codex_advanced(body: dict, cfg) -> tuple[list, list, bool] | web.Resp
         if "stream_stall_timeout_seconds" in body:
             value = _schema_int(
                 body["stream_stall_timeout_seconds"],
-                "stream_stall_timeout_seconds", 10, 3600,
+                "stream_stall_timeout_seconds",
+                10,
+                3600,
             )
             persist.append((("openai_codex", "stream_stall_timeout_seconds"), value))
             ops.append(("stream_stall_timeout_seconds", value))
@@ -453,9 +459,7 @@ def _parse_codex_advanced(body: dict, cfg) -> tuple[list, list, bool] | web.Resp
                 status=400,
             )
         ops.append((group, merged))
-        persist.extend(
-            (("openai_codex", group, key), getattr(merged, key)) for key in submitted
-        )
+        persist.extend((("openai_codex", group, key), getattr(merged, key)) for key in submitted)
         wants_reload = wants_reload or live
     return persist, ops, wants_reload
 
@@ -553,9 +557,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                         },
                         status=400,
                     )
-                desired_agent_model = (
-                    agent_model if agent_model_present else cfg.agent_model
-                )
+                desired_agent_model = agent_model if agent_model_present else cfg.agent_model
                 desired_agent_effort = (
                     (None if agent_effort is None else str(agent_effort))
                     if agent_effort_present
@@ -565,12 +567,8 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                 # request-construction boundaries; concrete axes resolve here
                 # (None inherits the main setting being saved).
                 if AGENT_SETTING_AUTO not in (desired_agent_model, desired_agent_effort):
-                    eff_model = (
-                        desired_agent_model if desired_agent_model else desired_model
-                    )
-                    eff_effort = (
-                        desired_agent_effort if desired_agent_effort else desired_effort
-                    )
+                    eff_model = desired_agent_model if desired_agent_model else desired_model
+                    eff_effort = desired_agent_effort if desired_agent_effort else desired_effort
                     pair_err = effort_incompatibility_error(eff_model, eff_effort)
                     if pair_err:
                         return web.json_response(
@@ -599,9 +597,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                 adv_persist, adv_ops, adv_reload = advanced
                 changes = _provider_changes("openai_codex", desired, body)
                 changes = changes + adv_persist
-                persist_response, was_cancelled = await _persist_or_response(
-                    changes, "Codex"
-                )
+                persist_response, was_cancelled = await _persist_or_response(changes, "Codex")
                 if persist_response is not None:
                     return persist_response
                 if changes:
@@ -613,8 +609,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     # handler dropped all of these silently and returned 200.
                     adv_inverse = _apply_ops(cfg, adv_ops)
                     needs_reload = adv_reload or any(
-                        key in body
-                        for key in ("enabled", "model", "reasoning_effort")
+                        key in body for key in ("enabled", "model", "reasoning_effort")
                     )
                     try:
                         if needs_reload:
@@ -622,9 +617,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     except BaseException:
                         _set_fields(cfg, prior)
                         _apply_ops(cfg, adv_inverse)  # restore prior objects
-                        adv_prior_persist: list[
-                            tuple[tuple[str, ...], Any]
-                        ] = []
+                        adv_prior_persist: list[tuple[tuple[str, ...], Any]] = []
                         for attr, prior_value in adv_inverse:
                             if hasattr(prior_value, "model_dump"):
                                 adv_prior_persist.extend(
@@ -632,9 +625,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                                     for key, val in prior_value.model_dump().items()
                                 )
                             else:
-                                adv_prior_persist.append(
-                                    (("openai_codex", attr), prior_value)
-                                )
+                                adv_prior_persist.append((("openai_codex", attr), prior_value))
                         prior_persist: list[tuple[tuple[str, ...], Any]] = [
                             (("openai_codex", key), value)
                             for key, value in prior.items()
@@ -679,19 +670,19 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
             return web.json_response({"error": str(e)}, status=400)
         except Exception as e:
             log.warning("Codex configuration apply failed: %s", e)
-            return web.json_response(
-                {"error": "Codex configuration not applied"}, status=500
-            )
+            return web.json_response({"error": "Codex configuration not applied"}, status=500)
 
-        return web.json_response({
-            "status": "updated",
-            "enabled": cfg.enabled,
-            "model": cfg.model,
-            "reasoning_effort": cfg.reasoning_effort,
-            "agent_reasoning_effort": cfg.agent_reasoning_effort,
-            "agent_model": cfg.agent_model,
-            "configured": bot.llm_gateway.codex_client is not None,
-        })
+        return web.json_response(
+            {
+                "status": "updated",
+                "enabled": cfg.enabled,
+                "model": cfg.model,
+                "reasoning_effort": cfg.reasoning_effort,
+                "agent_reasoning_effort": cfg.agent_reasoning_effort,
+                "agent_model": cfg.agent_model,
+                "configured": bot.llm_gateway.codex_client is not None,
+            }
+        )
 
     @routes.put("/api/llm/auxiliary/config")
     async def llm_auxiliary_config(request: web.Request) -> web.Response:
@@ -708,13 +699,9 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
             async with config_transaction():
                 aux_cfg = getattr(bot.config.openai_codex, "auxiliary", None)
                 if aux_cfg is None:
-                    return web.json_response(
-                        {"error": "auxiliary config unavailable"}, status=503
-                    )
+                    return web.json_response({"error": "auxiliary config unavailable"}, status=503)
 
-                want_enabled = (
-                    bool(body["enabled"]) if "enabled" in body else aux_cfg.enabled
-                )
+                want_enabled = bool(body["enabled"]) if "enabled" in body else aux_cfg.enabled
                 want_model = aux_cfg.model
                 if "model" in body and str(body["model"]).strip():
                     want_model = str(body["model"]).strip()
@@ -782,9 +769,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     ),
                 }
                 changes = _provider_changes("ollama", desired, body)
-                persist_response, was_cancelled = await _persist_or_response(
-                    changes, "Ollama"
-                )
+                persist_response, was_cancelled = await _persist_or_response(changes, "Ollama")
                 if persist_response is not None:
                     return persist_response
                 if changes:
@@ -820,17 +805,17 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
             return web.json_response({"error": str(e)}, status=400)
         except Exception as e:
             log.warning("Ollama configuration apply failed: %s", e)
-            return web.json_response(
-                {"error": "Ollama configuration not applied"}, status=500
-            )
+            return web.json_response({"error": "Ollama configuration not applied"}, status=500)
 
-        return web.json_response({
-            "status": "updated",
-            "enabled": cfg.enabled,
-            "model": cfg.model,
-            "base_url": cfg.base_url,
-            "configured": bot.llm_gateway.ollama_client is not None,
-        })
+        return web.json_response(
+            {
+                "status": "updated",
+                "enabled": cfg.enabled,
+                "model": cfg.model,
+                "base_url": cfg.base_url,
+                "configured": bot.llm_gateway.ollama_client is not None,
+            }
+        )
 
     @routes.put("/api/llm/kimi/config")
     async def llm_kimi_config(request: web.Request) -> web.Response:
@@ -865,9 +850,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                     ),
                 }
                 changes = _provider_changes("kimi", desired, body)
-                persist_response, was_cancelled = await _persist_or_response(
-                    changes, "Kimi"
-                )
+                persist_response, was_cancelled = await _persist_or_response(changes, "Kimi")
                 if persist_response is not None:
                     return persist_response
                 if changes:
@@ -880,11 +863,7 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
                         _set_fields(cfg, prior)
                         bot.llm_gateway.kimi_client = prior_client
                         rollback_exc, rollback_cancelled = await persist_config_paths_locked(
-                            [
-                                (("kimi", key), value)
-                                for key, value in prior.items()
-                                if key in body
-                            ]
+                            [(("kimi", key), value) for key, value in prior.items() if key in body]
                         )
                         if rollback_exc is not None:
                             log.critical(
@@ -903,16 +882,115 @@ def register_provider_config(routes: web.RouteTableDef, bot) -> None:
             return web.json_response({"error": str(e)}, status=400)
         except Exception as e:
             log.warning("Kimi configuration apply failed: %s", e)
-            return web.json_response(
-                {"error": "Kimi configuration not applied"}, status=500
-            )
+            return web.json_response({"error": "Kimi configuration not applied"}, status=500)
 
-        return web.json_response({
-            "status": "updated",
-            "enabled": cfg.enabled,
-            "model": cfg.model,
-            "configured": bot.llm_gateway.kimi_client is not None,
-        })
+        return web.json_response(
+            {
+                "status": "updated",
+                "enabled": cfg.enabled,
+                "model": cfg.model,
+                "configured": bot.llm_gateway.kimi_client is not None,
+            }
+        )
+
+
+def register_context_windows(routes: web.RouteTableDef, bot) -> None:
+    """Per-model context-budget view + clamp management (campaign phase 5).
+
+    The GET serves canonical model keys with the built-in floor, configured
+    override, CONFIGURED resolution (no clamp) and EFFECTIVE resolution
+    (observer clamp applied) side by side, provenance for both, and the raw
+    per-account evidence (opaque account keys only). The POST clears clamps
+    for one account (optionally one model) — the manual, account-scoped
+    escape hatch; TTL expiry is otherwise the only way a clamp dies.
+    """
+
+    def _observer():
+        return getattr(getattr(bot, "services", None), "window_observer", None)
+
+    def _resolution(snapshot) -> dict:
+        return {
+            "base_budget": snapshot.base_budget,
+            "base_source": snapshot.base_source,
+            "effective_budget": snapshot.effective_budget,
+            "clamp_applied": snapshot.clamp_applied,
+            "working_budget": snapshot.working_budget,
+            "primary_chars": snapshot.primary_chars,
+            "ceiling_applied": snapshot.ceiling_applied,
+            "ladder": list(snapshot.ladder),
+        }
+
+    @routes.get("/api/context/windows")
+    async def get_context_windows(_request: web.Request) -> web.Response:
+        from ...config.schema import (
+            CODEX_MODEL_INPUT_BUDGETS,
+            canonical_codex_model,
+        )
+        from ...llm.context_budget import resolve_context_budget
+
+        observer = _observer()
+        codex_cfg = getattr(bot.config, "openai_codex", None)
+        overrides = {
+            canonical_codex_model(k): v
+            for k, v in (getattr(codex_cfg, "context_budget_overrides", None) or {}).items()
+        }
+        utilization = getattr(codex_cfg, "context_utilization", 60)
+        cc = getattr(bot, "context_compressor", None)
+        ceiling = getattr(cc, "resolved_max_context_chars", None) if cc else None
+        evidence: dict = observer.view() if observer is not None else {"version": 1, "accounts": {}}
+        models = set(CODEX_MODEL_INPUT_BUDGETS) | set(overrides)
+        for account in evidence.get("accounts", {}).values():
+            models |= set(account.get("models", {}))
+        out = {}
+        for model in sorted(models):
+            clamp = observer.active_clamp(model) if observer is not None else None
+            configured = resolve_context_budget(
+                model,
+                overrides=overrides,
+                utilization=utilization,
+                max_context_chars=ceiling,
+            )
+            effective = resolve_context_budget(
+                model,
+                overrides=overrides,
+                utilization=utilization,
+                max_context_chars=ceiling,
+                observed_clamp=clamp,
+            )
+            out[model] = {
+                "floor": CODEX_MODEL_INPUT_BUDGETS.get(model),
+                "override": overrides.get(model),
+                "active_clamp": clamp,
+                "configured": _resolution(configured),
+                "effective": _resolution(effective),
+            }
+        return web.json_response(
+            {
+                "utilization": utilization,
+                "max_context_chars": ceiling,
+                "models": out,
+                "evidence": evidence,
+            }
+        )
+
+    @routes.post("/api/context/windows/clear")
+    async def clear_context_window_clamp(request: web.Request) -> web.Response:
+        observer = _observer()
+        if observer is None:
+            return web.json_response({"error": "window observer not available"}, status=503)
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        account_key = data.get("account_key")
+        if not isinstance(account_key, str) or not account_key.strip():
+            return web.json_response({"error": "account_key is required"}, status=400)
+        model = data.get("model")
+        cleared = await observer.clear_account(
+            account_key.strip(),
+            model=str(model).strip() if isinstance(model, str) and model.strip() else None,
+        )
+        return web.json_response({"cleared": cleared})
 
 
 def register_ollama_admin(routes: web.RouteTableDef, bot) -> None:
@@ -928,14 +1006,16 @@ def register_ollama_admin(routes: web.RouteTableDef, bot) -> None:
             return web.json_response({"configured": False, "enabled": False})
 
         health = await client.health_check()
-        return web.json_response({
-            "configured": True,
-            "enabled": True,
-            "model": client.model,
-            "base_url": client.base_url,
-            "health": health,
-            "stats": client.pool_stats(),
-        })
+        return web.json_response(
+            {
+                "configured": True,
+                "enabled": True,
+                "model": client.model,
+                "base_url": client.base_url,
+                "health": health,
+                "stats": client.pool_stats(),
+            }
+        )
 
     @routes.post("/api/ollama/reload")
     async def ollama_reload(_request: web.Request) -> web.Response:
@@ -962,6 +1042,7 @@ def register_ollama_admin(routes: web.RouteTableDef, bot) -> None:
             )
         try:
             import aiohttp as _aio
+
             async with _aio.ClientSession(timeout=_aio.ClientTimeout(total=10)) as sess:
                 async with sess.get(f"{base_url}/api/tags") as resp:
                     if resp.status != 200:
@@ -979,6 +1060,7 @@ def register_ollama_admin(routes: web.RouteTableDef, bot) -> None:
 
         try:
             import aiohttp as _aiohttp
+
             session = await client._get_session()
             async with session.get(
                 f"{client.base_url}/api/tags",
@@ -988,10 +1070,12 @@ def register_ollama_admin(routes: web.RouteTableDef, bot) -> None:
                 if resp.status != 200:
                     return web.json_response({"error": f"HTTP {resp.status}"}, status=502)
                 data = await resp.json()
-                return web.json_response({
-                    "models": data.get("models", []),
-                    "active_model": client.model,
-                })
+                return web.json_response(
+                    {
+                        "models": data.get("models", []),
+                        "active_model": client.model,
+                    }
+                )
         except Exception as e:
             return web.json_response({"error": str(e)}, status=502)
 
@@ -1022,22 +1106,23 @@ def register_ollama_admin(routes: web.RouteTableDef, bot) -> None:
             if available and model not in available:
                 base = model.split(":")[0]
                 if not any(m.startswith(base + ":") for m in available):
-                    return web.json_response({
-                        "error": (
-                            f"Model '{model}' not available. "
-                            f"Pulled models: {', '.join(available[:10])}"
-                        ),
-                    }, status=400)
+                    return web.json_response(
+                        {
+                            "error": (
+                                f"Model '{model}' not available. "
+                                f"Pulled models: {', '.join(available[:10])}"
+                            ),
+                        },
+                        status=400,
+                    )
 
             persist_exc, was_cancelled = await persist_config_paths_locked(
-                [(('ollama', 'model'), model)]
+                [(("ollama", "model"), model)]
             )
             if persist_exc is not None:
                 if was_cancelled:
                     raise asyncio.CancelledError
-                return web.json_response(
-                    {"error": "Ollama model not saved"}, status=500
-                )
+                return web.json_response({"error": "Ollama model not saved"}, status=500)
             client.model = model
             bot.config.ollama.model = model
             if was_cancelled:
@@ -1058,14 +1143,16 @@ def register_kimi_admin(routes: web.RouteTableDef, bot) -> None:
             return web.json_response({"configured": False, "enabled": False})
 
         health = await client.health_check()
-        return web.json_response({
-            "configured": True,
-            "enabled": True,
-            "model": client.model,
-            "base_url": client.base_url,
-            "health": health,
-            "stats": client.pool_stats(),
-        })
+        return web.json_response(
+            {
+                "configured": True,
+                "enabled": True,
+                "model": client.model,
+                "base_url": client.base_url,
+                "health": health,
+                "stats": client.pool_stats(),
+            }
+        )
 
     @routes.post("/api/kimi/reload")
     async def kimi_reload(_request: web.Request) -> web.Response:
@@ -1082,10 +1169,12 @@ def register_kimi_admin(routes: web.RouteTableDef, bot) -> None:
         health = await client.health_check()
         if not health.get("healthy"):
             return web.json_response({"error": health.get("error", "unhealthy")}, status=502)
-        return web.json_response({
-            "models": health.get("models", []),
-            "active_model": client.model,
-        })
+        return web.json_response(
+            {
+                "models": health.get("models", []),
+                "active_model": client.model,
+            }
+        )
 
     @routes.post("/api/kimi/model")
     async def kimi_set_model(request: web.Request) -> web.Response:
@@ -1112,23 +1201,24 @@ def register_kimi_admin(routes: web.RouteTableDef, bot) -> None:
             health = await client.health_check()
             available = health.get("models", [])
             if available and model not in available:
-                return web.json_response({
-                    "error": f"Model '{model}' not available. Models: {', '.join(available[:10])}",
-                }, status=400)
+                return web.json_response(
+                    {
+                        "error": (
+                            f"Model '{model}' not available. Models: {', '.join(available[:10])}"
+                        ),
+                    },
+                    status=400,
+                )
 
             persist_exc, was_cancelled = await persist_config_paths_locked(
-                [(('kimi', 'model'), model)]
+                [(("kimi", "model"), model)]
             )
             if persist_exc is not None:
                 if was_cancelled:
                     raise asyncio.CancelledError
-                return web.json_response(
-                    {"error": "Kimi model not saved"}, status=500
-                )
+                return web.json_response({"error": "Kimi model not saved"}, status=500)
             client.model = model
             bot.config.kimi.model = model
             if was_cancelled:
                 raise asyncio.CancelledError
         return web.json_response({"status": "updated", "model": model})
-
-

--- a/tests/characterization/test_api_route_parity.py
+++ b/tests/characterization/test_api_route_parity.py
@@ -175,6 +175,8 @@ EXPECTED_ROUTES = [
     ("PUT", "/api/llm/auxiliary/config", "llm_auxiliary_config"),
     ("PUT", "/api/llm/ollama/config", "llm_ollama_config"),
     ("PUT", "/api/llm/kimi/config", "llm_kimi_config"),
+    ("GET", "/api/context/windows", "get_context_windows"),
+    ("POST", "/api/context/windows/clear", "clear_context_window_clamp"),
     ("GET", "/api/ollama/status", "ollama_status"),
     ("POST", "/api/ollama/reload", "ollama_reload"),
     ("POST", "/api/ollama/probe-models", "ollama_probe_models"),
@@ -235,7 +237,7 @@ class TestRouteTableParity:
     def test_exact_route_list_and_order(self):
         actual = _routes()
         expected = [tuple(e) for e in EXPECTED_ROUTES]
-        assert len(actual) == len(expected) == 188
+        assert len(actual) == len(expected) == 190
         # set equality first for a readable diff on failure
         missing = set(expected) - set(actual)
         added = set(actual) - set(expected)

--- a/tests/test_chat_loop_recovery.py
+++ b/tests/test_chat_loop_recovery.py
@@ -51,6 +51,8 @@ def _generation_facts(
     effort: str | None = "low",
     ladder: list[int] | tuple[int, ...] = (400_000, 280_000),
     rescue_passes: int = 1,
+    account_key: str | None = None,
+    server_input_tokens: int | None = None,
 ) -> dict:
     return {
         "provider": "codex",
@@ -61,8 +63,8 @@ def _generation_facts(
         "attempts": [
             {
                 "attempt": attempt,
-                "account_key": None,
-                "server_input_tokens": None,
+                "account_key": account_key,
+                "server_input_tokens": server_input_tokens,
             }
             for attempt in range(1, rescue_passes + 1)
         ],
@@ -806,6 +808,50 @@ class TestResumeIdentityReconstruction:
         assert gw.calls[0]["kwargs"]["model"] == "gpt-5.5"
         assert gw.calls[0]["kwargs"]["reasoning_effort"] == "low"
         assert gw.breaker_keys == [("gpt-5.5", "codex")]
+
+    async def test_resumed_acceptance_publishes_latch_and_observer_evidence(self):
+        """A successful first request after resume completes the persisted
+        overflow pair exactly like uninterrupted recovery."""
+        from src.llm.context_compressor import estimate_message_chars
+
+        account = "a" * 32
+        recorded = []
+
+        async def script(n, messages):
+            return SimpleNamespace(
+                text="ok",
+                tool_calls=[],
+                stop_reason="end_turn",
+                server_input_tokens=408_004,
+                account_key=account,
+                provenance_model="gpt-5.5",
+            )
+
+        gw = _Gateway(script)
+        st = _chat_state(_history(4, 100) + _ENVELOPE)
+        st._rescue_passes = 1
+        st._gen_identity = _generation_facts(
+            rescue_passes=1,
+            account_key=account,
+            server_input_tokens=272_000,
+        )
+        runner = _runner(gw)
+
+        async def record(overflow, response):
+            recorded.append((overflow, response))
+
+        runner._record_window_evidence = record
+        expected_latch = estimate_message_chars(st.messages)
+        kind, response = await runner._call_llm(st)
+        assert kind == "ok"
+        assert st._char_latch == expected_latch
+        assert len(recorded) == 1
+        overflow, accepted = recorded[0]
+        assert overflow.code == "context_length_exceeded"
+        assert overflow.account_key == account
+        assert overflow.server_input_tokens == 272_000
+        assert accepted is response
+        assert st._gen_identity is None and st._rescue_passes == 0
 
     async def test_missing_frozen_provider_ends_honestly(self):
         """The frozen provider's client is gone: the generation ends as an

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -317,6 +317,17 @@ class TestPoolInit:
         p.write_text(json.dumps(["nope", {"no_token": 1}, _creds(account_id="ok")]))
         assert CodexAuthPool(str(p)).account_count == 1
 
+    def test_eligible_account_ids_excludes_rate_limited_and_invalid(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps([
+            _creds(account_id="a"),
+            _creds(account_id="b"),
+            _creds(account_id=""),
+        ]))
+        pool = CodexAuthPool(str(p))
+        pool._accounts[1].mark_rate_limited(60)
+        assert pool.eligible_account_ids_snapshot() == frozenset({"a"})
+
     def test_stale_shadow_files_removed(self, tmp_path):
         p = tmp_path / "c.json"
         p.write_text(json.dumps([_creds(account_id="0")]))

--- a/tests/test_context_budget_activation.py
+++ b/tests/test_context_budget_activation.py
@@ -327,6 +327,70 @@ class TestRound2GenerationIdentityPins:
         serving = runner._call_llm.await_args.kwargs["serving_identity"]
         assert serving.model == "gpt-5.6-sol"
 
+    async def test_chat_soft_and_rescue_share_one_observer_snapshot(self):
+        from src.llm.errors import LLMRequestError
+        from src.llm.recovery import RecoveryPolicy
+        from tests.test_typing_resilience import FakeChannel, _make_runner, _stub_state
+
+        class ChangingObserver:
+            def __init__(self):
+                self.calls = 0
+
+            def active_clamp(self, _model):
+                self.calls += 1
+                return 500_000 if self.calls == 1 else 100_000
+
+        class Client:
+            model = "gpt-5.6-sol"
+            reasoning_effort = "xhigh"
+
+            async def chat_with_tools(self, **_kwargs):
+                raise LLMRequestError(
+                    "overflow",
+                    provider="codex",
+                    model=self.model,
+                    code="context_length_exceeded",
+                )
+
+        config = SimpleNamespace(
+            llm_provider=SimpleNamespace(active_provider="codex"),
+            openai_codex=OpenAICodexConfig(),
+        )
+        client = Client()
+        gateway = LLMGateway(
+            get_config=lambda: config,
+            codex_client=client,
+            ollama_client=None,
+            kimi_client=None,
+            subsystem_guard=None,
+            auxiliary_llm_client=None,
+            cost_tracker=None,
+            sessions=SimpleNamespace(),
+            reflector=SimpleNamespace(),
+            recovery_policy_source=lambda: RecoveryPolicy(deadline_seconds=1),
+        )
+        runner, _saved, _cleared = _make_runner()
+        runner._get_config = lambda: config
+        runner._llm_gateway = gateway
+        runner._window_observer = ChangingObserver()
+        runner._judge_entry_stuck = AsyncMock(return_value=None)
+        runner._get_context_compressor = lambda: None
+        st = _stub_state(channel=FakeChannel())
+        st._trajectory.context_recoveries = []
+        st.messages = [
+            {"role": "user", "content": "history" * 80_000},
+            {"role": "developer", "content": "preamble"},
+            {"role": "user", "content": "current"},
+        ]
+        st._boundary_request_start = 1
+        st._boundary_envelope_len = 2
+        result = await runner._run_chat_iterations(st)
+        assert result[2] is True
+        assert runner._window_observer.calls == 1
+        # Clamp 500K at 60% utilization yields this frozen ladder. A second
+        # read's 100K clamp would instead produce a much smaller ladder.
+        assert st._trajectory.context_recoveries[0]["target_chars"] == 451_500
+
     async def test_chat_physical_retries_keep_captured_identity(self):
         from src.llm.errors import LLMTransportError
         from src.llm.recovery import RecoveryPolicy
@@ -476,3 +540,78 @@ class TestRound2GenerationIdentityPins:
             await runner._call_llm(st, serving_identity=frozen)
         assert calls == 0
         assert breaker.snapshot()["state"] == "open"
+
+class TestSingleSnapshotAcrossLoopGeneration:
+    async def test_loop_soft_and_rescue_share_one_observer_snapshot(self):
+        from src.discord.llm_gateway import LLMServingIdentity
+        from src.llm.context_compressor import SurfaceBoundary
+        from src.llm.errors import LLMRequestError
+        from tests.test_chat_loop_recovery import _Gateway, _runner
+
+        class ChangingObserver:
+            def __init__(self):
+                self.calls = 0
+
+            def active_clamp(self, _model):
+                self.calls += 1
+                return 500_000 if self.calls == 1 else 100_000
+
+        class Client(SimpleNamespace):
+            calls = 0
+
+            async def chat_with_tools(self, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    raise LLMRequestError(
+                        "overflow",
+                        provider="codex",
+                        model=self.model,
+                        code="context_length_exceeded",
+                    )
+                return SimpleNamespace(
+                    text="ok",
+                    tool_calls=[],
+                    provenance_provider="codex",
+                    provenance_model=self.model,
+                )
+
+        client = Client(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        gw = _Gateway(None)
+        gw.client = client
+        gw.codex_client = client
+        runner = _runner(gw)
+        observer = ChangingObserver()
+        runner._window_observer = observer
+        config = SimpleNamespace(openai_codex=OpenAICodexConfig())
+        serving = LLMServingIdentity("codex", client, client.model, client.reasoning_effort)
+        snapshot = runner._capture_budget_snapshot(serving, config)
+        st = SimpleNamespace(
+            messages=[
+                {"role": "user", "content": "prior" * 100_000},
+                {"role": "assistant", "content": "ok"},
+                {"role": "user", "content": "goal"},
+            ],
+            system_prompt="sys",
+            tools=[],
+            _boundary=SurfaceBoundary(request_start=2, envelope_len=1),
+            _char_latch=None,
+            context_recoveries=[],
+            _iteration_index=0,
+            _trajectory=None,
+            _loop_details=[],
+            _trace=None,
+            _loop_id="L",
+            channel_id_str="c",
+            prompt="p",
+            user_id="u",
+        )
+        runner._maybe_compress_loop(st, serving, config, budget_snapshot=snapshot)
+        kind, _ = await runner._call_loop_llm(
+            st,
+            serving_identity=serving,
+            request_config=config,
+            budget_snapshot=snapshot,
+        )
+        assert kind == "ok"
+        assert observer.calls == 1
+        assert st.context_recoveries[0]["target_chars"] == 451_500

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -11,10 +11,11 @@ Covers:
 
 from __future__ import annotations
 
+from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from src.config.schema import WebhookConfig
-from src.health.server import HealthServer
+from src.config.schema import ApiTokenIdentity, WebConfig, WebhookConfig
+from src.health.server import HealthServer, _is_admin_only_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -212,3 +213,36 @@ class TestComponentRegistration:
         results = server._check_components()
         assert results["good"]["healthy"] is True
         assert results["bad"]["healthy"] is False
+
+
+class TestContextWindowsAdminPolicy:
+    def test_context_surface_is_centrally_admin_only(self):
+        assert _is_admin_only_path("/api/context/windows")
+        assert _is_admin_only_path("/api/context/windows/clear")
+
+    async def test_get_and_post_reject_user_and_guest_but_allow_admin(self):
+        web_config = WebConfig(
+            api_tokens=[
+                ApiTokenIdentity(token="admin-token", user_id="a", tier="admin"),
+                ApiTokenIdentity(token="user-token", user_id="u", tier="user"),
+                ApiTokenIdentity(token="guest-token", user_id="g", tier="guest"),
+            ]
+        )
+        server = HealthServer(port=0, webhook_config=WebhookConfig(), web_config=web_config)
+        server._app.router.add_get(
+            "/api/context/windows", lambda _r: web.json_response({"ok": True})
+        )
+        server._app.router.add_post(
+            "/api/context/windows/clear",
+            lambda _r: web.json_response({"ok": True}),
+        )
+        async with TestClient(TestServer(server._app)) as client:
+            for token in ("user-token", "guest-token"):
+                headers = {"Authorization": f"Bearer {token}"}
+                assert (await client.get("/api/context/windows", headers=headers)).status == 403
+                assert (
+                    await client.post("/api/context/windows/clear", headers=headers)
+                ).status == 403
+            headers = {"Authorization": "Bearer admin-token"}
+            assert (await client.get("/api/context/windows", headers=headers)).status == 200
+            assert (await client.post("/api/context/windows/clear", headers=headers)).status == 200

--- a/tests/test_openai_codex_client.py
+++ b/tests/test_openai_codex_client.py
@@ -42,6 +42,20 @@ def _client(auth=None):
     return CodexChatClient(auth=auth or _BareAuth(), model="gpt-5.5")
 
 
+class TestEligibleAccountKeys:
+    def test_bare_auth_key_snapshot(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.llm.account_key.opaque_account_key", lambda account_id: f"key-{account_id}"
+        )
+        assert _client().eligible_account_keys_snapshot() == frozenset({"key-acct"})
+
+    def test_key_derivation_failure_is_conservative(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.llm.account_key.opaque_account_key", lambda _account_id: None
+        )
+        assert _client().eligible_account_keys_snapshot() == frozenset()
+
+
 class TestConvertMessages:
     def test_plain_string_roles(self):
         c = _client()

--- a/tests/test_window_observer.py
+++ b/tests/test_window_observer.py
@@ -20,6 +20,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from src.config.schema import ContextCompressionConfig
 from src.llm import window_observer as wo
 from src.llm.errors import LLMRequestError
 from src.llm.window_observer import WindowObserver, WindowObserverMutationError
@@ -780,7 +781,7 @@ class TestAgentSurfaceHooks:
 # ---------------------------------------------------------------------------
 
 
-def _api_app(observer):
+def _api_app(observer, *, max_context_chars: int | None = None):
     from src.web.api.llm_admin import register_context_windows
 
     bot = SimpleNamespace(
@@ -788,7 +789,9 @@ def _api_app(observer):
             openai_codex=SimpleNamespace(
                 context_budget_overrides={"gpt-5.5": 250_000},
                 context_utilization=60,
-                context_compression=SimpleNamespace(max_context_chars=None),
+                context_compression=ContextCompressionConfig(
+                    max_context_chars=max_context_chars
+                ),
             )
         ),
         context_compressor=SimpleNamespace(resolved_max_context_chars=750_000),
@@ -828,6 +831,14 @@ class TestContextWindowsApi:
             body = await (await c.get("/api/context/windows")).json()
         assert body["max_context_chars"] is None
         assert body["models"]["gpt-5.6-sol"]["configured"]["primary_chars"] == 1_277_400
+
+    async def test_get_preserves_explicit_legacy_ceiling_verbatim(self, tmp_path):
+        obs = _observer(tmp_path)
+        app = _api_app(obs, max_context_chars=750_000)
+        async with TestClient(TestServer(app)) as c:
+            body = await (await c.get("/api/context/windows")).json()
+        assert body["max_context_chars"] == 750_000
+        assert body["models"]["gpt-5.6-sol"]["configured"]["primary_chars"] == 750_000
 
     async def test_failed_clear_returns_503_and_truthful_state(self, tmp_path, monkeypatch):
         obs = _observer(tmp_path)

--- a/tests/test_window_observer.py
+++ b/tests/test_window_observer.py
@@ -12,15 +12,17 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 from datetime import timedelta
 from types import SimpleNamespace
 
+import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from src.llm import window_observer as wo
 from src.llm.errors import LLMRequestError
-from src.llm.window_observer import WindowObserver
+from src.llm.window_observer import WindowObserver, WindowObserverMutationError
 
 ACCT_A = "a" * 32
 ACCT_B = "b" * 32
@@ -209,6 +211,35 @@ class TestDownwardOnlyMergeAndTTL:
         )
         assert obs.active_clamp("gpt-5.6-sol") == 420_000
 
+    async def test_active_clamp_ignores_ineligible_accounts(self, tmp_path):
+        eligible = {ACCT_A}
+        obs = WindowObserver(
+            tmp_path / "context_windows.json",
+            eligible_account_keys=lambda: frozenset(eligible),
+        )
+        await obs.record_rescue(
+            overflow=_overflow(key=ACCT_A), response=_acceptance(key=ACCT_A, tokens=500_000)
+        )
+        await obs.record_rescue(
+            overflow=_overflow(key=ACCT_B), response=_acceptance(key=ACCT_B, tokens=420_000)
+        )
+        assert obs.active_clamp("gpt-5.6-sol") == 500_000
+        eligible.clear()
+        assert obs.active_clamp("gpt-5.6-sol") is None
+
+    async def test_eligible_provider_none_or_failure_fails_open_not_stale(self, tmp_path):
+        obs = WindowObserver(
+            tmp_path / "context_windows.json",
+            eligible_account_keys=lambda: None,
+        )
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        assert obs.active_clamp("gpt-5.6-sol") is None
+
+        obs.set_eligible_account_keys_provider(
+            lambda: (_ for _ in ()).throw(RuntimeError("pool unavailable"))
+        )
+        assert obs.active_clamp("gpt-5.6-sol") is None
+
 
 class TestForfeitInvariant:
     async def test_write_failure_forfeits_durability_never_the_request(self, tmp_path, monkeypatch):
@@ -266,6 +297,46 @@ class TestPersistFdDiscipline:
         assert (tmp_path / "context_windows.json").read_bytes() == published
         assert not any(p.name.startswith(".context_windows") for p in tmp_path.iterdir())
 
+    async def test_cancelled_writer_drains_before_second_transaction(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+        real_persist = obs._persist_locked
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        calls = 0
+
+        def controlled_persist(state):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                first_entered.set()
+                assert release_first.wait(5)
+            real_persist(state)
+
+        monkeypatch.setattr(obs, "_persist_locked", controlled_persist)
+        writer_a = asyncio.create_task(
+            obs.record_rescue(
+                overflow=_overflow(key=ACCT_A),
+                response=_acceptance(key=ACCT_A, tokens=500_000),
+            )
+        )
+        assert await asyncio.to_thread(first_entered.wait, 5)
+        writer_a.cancel()
+        writer_b = asyncio.create_task(
+            obs.record_rescue(
+                overflow=_overflow(key=ACCT_B),
+                response=_acceptance(key=ACCT_B, tokens=420_000),
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert calls == 1  # B cannot enter while A's worker still owns the transaction.
+        release_first.set()
+        with pytest.raises(asyncio.CancelledError):
+            await writer_a
+        await writer_b
+        on_disk = WindowObserver(tmp_path / "context_windows.json").view()
+        assert set(on_disk["accounts"]) == {ACCT_A, ACCT_B}
+        assert not any(p.name.startswith(".context_windows") for p in tmp_path.iterdir())
+
 
 class TestManualClear:
     async def test_clear_is_account_scoped_and_preserves_bounds(self, tmp_path):
@@ -280,6 +351,20 @@ class TestManualClear:
         record = obs.view()["accounts"][ACCT_A]["models"]["gpt-5.6-sol"]
         assert record["clamp"] is None
         assert record["lowest_rejection_bound"] == 930_001
+
+    async def test_failed_clear_is_truthful_and_retains_state(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        published = (tmp_path / "context_windows.json").read_bytes()
+
+        def fail(_state=None):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(obs, "_persist_locked", fail)
+        with pytest.raises(WindowObserverMutationError):
+            await obs.clear_account(ACCT_A)
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
+        assert (tmp_path / "context_windows.json").read_bytes() == published
 
     async def test_model_scoped_clear(self, tmp_path):
         obs = _observer(tmp_path)
@@ -703,9 +788,10 @@ def _api_app(observer):
             openai_codex=SimpleNamespace(
                 context_budget_overrides={"gpt-5.5": 250_000},
                 context_utilization=60,
+                context_compression=SimpleNamespace(max_context_chars=None),
             )
         ),
-        context_compressor=None,
+        context_compressor=SimpleNamespace(resolved_max_context_chars=750_000),
         services=SimpleNamespace(window_observer=observer),
     )
     routes = web.RouteTableDef()
@@ -734,6 +820,28 @@ class TestContextWindowsApi:
         assert five["configured"]["base_source"] == "override"
         # Raw evidence rides along, opaque keys only.
         assert ACCT_A in body["evidence"]["accounts"]
+
+    async def test_get_preserves_raw_auto_ceiling(self, tmp_path):
+        obs = _observer(tmp_path)
+        app = _api_app(obs)
+        async with TestClient(TestServer(app)) as c:
+            body = await (await c.get("/api/context/windows")).json()
+        assert body["max_context_chars"] is None
+        assert body["models"]["gpt-5.6-sol"]["configured"]["primary_chars"] == 1_277_400
+
+    async def test_failed_clear_returns_503_and_truthful_state(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        monkeypatch.setattr(
+            obs,
+            "_persist_locked",
+            lambda _state=None: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        app = _api_app(obs)
+        async with TestClient(TestServer(app)) as c:
+            resp = await c.post("/api/context/windows/clear", json={"account_key": ACCT_A})
+            assert resp.status == 503
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
 
     async def test_clear_endpoint_is_account_scoped(self, tmp_path):
         obs = _observer(tmp_path)

--- a/tests/test_window_observer.py
+++ b/tests/test_window_observer.py
@@ -1,0 +1,759 @@
+"""Passive window observer + downward clamps (campaign phase 5, plan §11).
+
+Pins the evidence store's hostile-input safety and atomicity, the clamp
+qualification matrix (same-account, same-request, server-authoritative
+acceptance), downward-only merges under the 24h TTL, the forfeit-never-fail
+invariant, resolver integration, all three surface hooks (chat, loop,
+agent), and the management API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import timedelta
+from types import SimpleNamespace
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from src.llm import window_observer as wo
+from src.llm.errors import LLMRequestError
+from src.llm.window_observer import WindowObserver
+
+ACCT_A = "a" * 32
+ACCT_B = "b" * 32
+
+
+def _observer(tmp_path) -> WindowObserver:
+    return WindowObserver(tmp_path / "context_windows.json")
+
+
+def _overflow(
+    *, tokens=930_001, key=ACCT_A, model="gpt-5.6-sol", code="context_length_exceeded"
+) -> LLMRequestError:
+    return LLMRequestError(
+        "overflow",
+        provider="codex",
+        model=model,
+        code=code,
+        server_input_tokens=tokens,
+        account_key=key,
+    )
+
+
+def _acceptance(*, tokens=408_004, key=ACCT_A, model="gpt-5.6-sol") -> SimpleNamespace:
+    return SimpleNamespace(server_input_tokens=tokens, account_key=key, provenance_model=model)
+
+
+class TestStoreLifecycle:
+    async def test_fresh_store_round_trips_atomically(self, tmp_path):
+        obs = _observer(tmp_path)
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
+        # Reload from disk: the persisted store carries the same evidence.
+        again = _observer(tmp_path)
+        assert again.active_clamp("gpt-5.6-sol") == 408_004
+        record = again.view()["accounts"][ACCT_A]["models"]["gpt-5.6-sol"]
+        assert record["lowest_rejection_bound"] == 930_001
+        assert record["highest_accepted_input"] == 408_004
+        assert record["overflow_occurrences"] == 1
+        # No stray temp files behind the atomic replacement.
+        names = {p.name for p in tmp_path.iterdir()}
+        assert names == {"context_windows.json"}
+
+    async def test_alias_models_share_one_canonical_record(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(
+            overflow=_overflow(model="codex-auto-review"),
+            response=_acceptance(model="codex-auto-review"),
+        )
+        assert obs.active_clamp("gpt-5.6-luna") == 408_004
+        assert obs.active_clamp("codex-auto-review") == 408_004
+        assert "gpt-5.6-luna" in obs.view()["accounts"][ACCT_A]["models"]
+
+
+class TestHostileStoreInputs:
+    """The filesystem-contract sweep: every hostile shape at the store path
+    loads empty (quarantined), never blocks, never crashes construction."""
+
+    def test_fifo_at_store_path_never_blocks(self, tmp_path):
+        path = tmp_path / "context_windows.json"
+        os.mkfifo(path)
+        obs = WindowObserver(path)
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        # The FIFO was quarantined out of the store's way.
+        assert not path.exists() or not path.is_fifo()
+        assert any(p.name.startswith("context_windows.json.corrupt-") for p in tmp_path.iterdir())
+
+    def test_symlink_at_store_path_is_refused(self, tmp_path):
+        victim = tmp_path / "victim.json"
+        victim.write_text(json.dumps({"version": 1, "accounts": {}}))
+        path = tmp_path / "context_windows.json"
+        path.symlink_to(victim)
+        obs = WindowObserver(path)
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        # The victim itself was never consumed as the store.
+        assert victim.read_text()
+
+    def test_directory_at_store_path_is_survived(self, tmp_path):
+        path = tmp_path / "context_windows.json"
+        path.mkdir()
+        obs = WindowObserver(path)
+        assert obs.active_clamp("gpt-5.6-sol") is None
+
+    def test_oversized_file_is_quarantined(self, tmp_path):
+        path = tmp_path / "context_windows.json"
+        path.write_bytes(b"x" * (wo._MAX_STORE_BYTES + 1))
+        WindowObserver(path)
+        assert any(p.name.startswith("context_windows.json.corrupt-") for p in tmp_path.iterdir())
+
+    def test_corrupt_json_is_quarantined_not_repaired(self, tmp_path):
+        path = tmp_path / "context_windows.json"
+        path.write_text("{not json")
+        WindowObserver(path)
+        quarantined = [
+            p for p in tmp_path.iterdir() if p.name.startswith("context_windows.json.corrupt-")
+        ]
+        assert len(quarantined) == 1
+        assert quarantined[0].read_text() == "{not json"  # preserved verbatim
+
+    def test_off_schema_store_is_quarantined(self, tmp_path):
+        path = tmp_path / "context_windows.json"
+        path.write_text(json.dumps({"version": 99, "accounts": {}}))
+        obs = WindowObserver(path)
+        assert obs.view()["accounts"] == {}
+
+
+class TestClampQualification:
+    async def test_cross_account_retry_records_both_but_derives_no_clamp(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(key=ACCT_A), response=_acceptance(key=ACCT_B))
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        view = obs.view()["accounts"]
+        assert view[ACCT_A]["models"]["gpt-5.6-sol"]["lowest_rejection_bound"] == 930_001
+        assert view[ACCT_B]["models"]["gpt-5.6-sol"]["highest_accepted_input"] == 408_004
+
+    async def test_missing_acceptance_usage_records_occurrence_only(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(tokens=None), response=_acceptance(tokens=None))
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        record = obs.view()["accounts"][ACCT_A]["models"]["gpt-5.6-sol"]
+        assert record["overflow_occurrences"] == 1
+        assert record["lowest_rejection_bound"] is None
+        assert record["highest_accepted_input"] is None
+
+    async def test_model_mismatch_derives_no_clamp(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(
+            overflow=_overflow(model="gpt-5.6-sol"),
+            response=_acceptance(model="gpt-5.5"),
+        )
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        assert obs.active_clamp("gpt-5.5") is None
+
+    async def test_non_overflow_error_is_ignored(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(code="other"), response=_acceptance())
+        assert obs.view()["accounts"] == {}
+
+    async def test_missing_account_keys_disqualify_scoped_evidence(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(key=None), response=_acceptance(key=None))
+        assert obs.view()["accounts"] == {}
+
+    async def test_estimate_shaped_junk_never_qualifies(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(
+            overflow=_overflow(tokens=930_001),
+            response=SimpleNamespace(
+                server_input_tokens="408004",  # strings are not evidence
+                account_key=ACCT_A,
+                provenance_model="gpt-5.6-sol",
+            ),
+        )
+        assert obs.active_clamp("gpt-5.6-sol") is None
+
+
+class TestDownwardOnlyMergeAndTTL:
+    async def test_lower_evidence_replaces_with_fresh_ttl(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=500_000))
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=400_000))
+        assert obs.active_clamp("gpt-5.6-sol") == 400_000
+
+    async def test_higher_evidence_never_raises_a_live_clamp(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=400_000))
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=500_000))
+        assert obs.active_clamp("gpt-5.6-sol") == 400_000
+
+    async def test_expired_clamp_is_not_served_and_is_replaceable(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=400_000))
+        real_now = wo._utc_now
+        monkeypatch.setattr(wo, "_utc_now", lambda: real_now() + timedelta(hours=25))
+        assert obs.active_clamp("gpt-5.6-sol") is None
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=500_000))
+        assert obs.active_clamp("gpt-5.6-sol") == 500_000
+
+    async def test_active_clamp_is_minimum_across_accounts(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(
+            overflow=_overflow(key=ACCT_A), response=_acceptance(key=ACCT_A, tokens=500_000)
+        )
+        await obs.record_rescue(
+            overflow=_overflow(key=ACCT_B), response=_acceptance(key=ACCT_B, tokens=420_000)
+        )
+        assert obs.active_clamp("gpt-5.6-sol") == 420_000
+
+
+class TestForfeitInvariant:
+    async def test_write_failure_forfeits_durability_never_the_request(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+
+        def _boom():
+            raise OSError("disk full")
+
+        monkeypatch.setattr(obs, "_persist_locked", _boom)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        # In-memory evidence still protects this process...
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
+        # ...but nothing was persisted.
+        assert not (tmp_path / "context_windows.json").exists()
+
+    async def test_every_entry_point_is_total_on_junk(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=object(), response=object())
+        await obs.record_rescue(overflow=None, response=None)
+        assert obs.active_clamp(object()) is None
+        assert await obs.clear_account("not-a-key") == 0
+        assert obs.view()["accounts"] == {}
+
+
+class TestPersistFdDiscipline:
+    async def test_fdopen_failure_leaks_no_fd_and_no_temp_file(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+        real_fdopen = os.fdopen
+
+        def _boom(fd, *a, **kw):
+            raise OSError("fdopen refused")
+
+        monkeypatch.setattr(os, "fdopen", _boom)
+        fd_dir = "/proc/self/fd"
+        before = len(os.listdir(fd_dir))
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        monkeypatch.setattr(os, "fdopen", real_fdopen)
+        assert len(os.listdir(fd_dir)) == before  # the raw fd was closed
+        assert not any(p.name.startswith(".context_windows") for p in tmp_path.iterdir())
+        # The observation still serves this process from memory.
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
+
+    async def test_crashed_write_never_corrupts_the_published_store(self, tmp_path, monkeypatch):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=500_000))
+        published = (tmp_path / "context_windows.json").read_bytes()
+
+        def _boom(fd):
+            raise OSError("device error")
+
+        monkeypatch.setattr(os, "fsync", _boom)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=400_000))
+        # The atomic-replacement contract: the prior published bytes survive
+        # a crashed write untouched, and no temp debris remains.
+        assert (tmp_path / "context_windows.json").read_bytes() == published
+        assert not any(p.name.startswith(".context_windows") for p in tmp_path.iterdir())
+
+
+class TestManualClear:
+    async def test_clear_is_account_scoped_and_preserves_bounds(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(key=ACCT_A), response=_acceptance(key=ACCT_A))
+        await obs.record_rescue(
+            overflow=_overflow(key=ACCT_B), response=_acceptance(key=ACCT_B, tokens=420_000)
+        )
+        assert await obs.clear_account(ACCT_A) == 1
+        # B's clamp survives; A's bounds history survives its clamp.
+        assert obs.active_clamp("gpt-5.6-sol") == 420_000
+        record = obs.view()["accounts"][ACCT_A]["models"]["gpt-5.6-sol"]
+        assert record["clamp"] is None
+        assert record["lowest_rejection_bound"] == 930_001
+
+    async def test_model_scoped_clear(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        await obs.record_rescue(
+            overflow=_overflow(model="gpt-5.5", tokens=272_000),
+            response=_acceptance(model="gpt-5.5", tokens=250_000),
+        )
+        assert await obs.clear_account(ACCT_A, model="gpt-5.5") == 1
+        assert obs.active_clamp("gpt-5.5") is None
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
+
+    async def test_view_is_a_defensive_copy_with_expiry_flags(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        view = obs.view()
+        assert view["accounts"][ACCT_A]["models"]["gpt-5.6-sol"]["clamp"]["expired"] is False
+        view["accounts"].clear()
+        assert obs.view()["accounts"]  # internal state untouched
+
+
+class TestSurfaceGuardArms:
+    """The non-fatal guard arms are load-bearing: a broken observer must
+    never break compaction, rescue, or a spawn."""
+
+    class _BrokenObserver:
+        def active_clamp(self, model):
+            raise RuntimeError("observer wedged")
+
+        async def record_rescue(self, *, overflow, response):
+            raise RuntimeError("observer wedged")
+
+    def test_chat_clamp_lookup_survives_a_broken_observer(self):
+        runner = _chat_runner(_ChatGateway(None), self._BrokenObserver())
+        assert runner._observed_clamp("gpt-5.6-sol") is None
+
+    async def test_chat_evidence_recording_survives_a_broken_observer(self):
+        runner = _chat_runner(_ChatGateway(None), self._BrokenObserver())
+        await runner._record_window_evidence(_overflow(), SimpleNamespace())
+
+    def test_agent_clamp_lookup_survives_a_broken_observer(self):
+        from src.discord.native_tools.agents_tasks import _observer_clamp
+
+        assert _observer_clamp(self._BrokenObserver(), "gpt-5.6-sol") is None
+
+    async def test_agent_recorder_survives_a_broken_observer(self):
+        from src.discord.native_tools.agents_tasks import _make_evidence_recorder
+
+        recorder = _make_evidence_recorder(self._BrokenObserver())
+        await recorder(_overflow(), {"text": "ok"})
+
+
+class TestResolverIntegration:
+    def test_snapshot_for_codex_config_threads_the_clamp(self):
+        from src.llm.context_budget import snapshot_for_codex_config
+
+        cfg = SimpleNamespace(context_budget_overrides=None, context_utilization=60)
+        unclamped = snapshot_for_codex_config("gpt-5.6-sol", cfg, max_context_chars=None)
+        clamped = snapshot_for_codex_config(
+            "gpt-5.6-sol", cfg, max_context_chars=None, observed_clamp=300_000
+        )
+        assert unclamped.clamp_applied is False
+        assert clamped.clamp_applied is True
+        assert clamped.effective_budget == 300_000
+        assert clamped.primary_chars < unclamped.primary_chars
+
+
+# ---------------------------------------------------------------------------
+# Surface hooks: chat, loop, agent
+# ---------------------------------------------------------------------------
+
+
+class _CaptureObserver:
+    def __init__(self, clamp=None):
+        self._clamp = clamp
+        self.recorded: list[tuple] = []
+
+    def active_clamp(self, model):
+        return self._clamp
+
+    async def record_rescue(self, *, overflow, response):
+        self.recorded.append((overflow, response))
+
+
+def _chat_runner(gateway, observer):
+    from src.discord.tool_loop import ToolLoopRunner
+
+    runner = ToolLoopRunner.__new__(ToolLoopRunner)
+    runner._llm_gateway = gateway
+    runner._get_config = lambda: SimpleNamespace(openai_codex=None)
+    runner._get_context_compressor = lambda: None
+    runner._get_compression_stats = lambda: None
+    runner._window_observer = observer
+
+    async def _fake_error_done(st, api_err):
+        return ("terminal", str(api_err))
+
+    runner._llm_error_done = _fake_error_done
+    return runner
+
+
+class _ChatGateway:
+    def __init__(self, script):
+        self.client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        self.codex_client = self.client
+        self.ollama_client = None
+        self.kimi_client = None
+        self.script = script
+        self.calls = 0
+
+    def capture_serving_identity(self, config=None):
+        from src.discord.llm_gateway import LLMServingIdentity
+
+        return LLMServingIdentity(
+            provider="codex",
+            client=self.client,
+            model=self.client.model,
+            reasoning_effort=self.client.reasoning_effort,
+        )
+
+    def capacity_breaker_for(self, model=None, provider=None):
+        return None
+
+    def recovery_policy(self):
+        from src.llm.recovery import RecoveryPolicy
+
+        return RecoveryPolicy(deadline_seconds=30.0)
+
+    def notify_generation_success(self, provider):
+        pass
+
+    async def call_with_tools(self, *, messages, system, tools, **kwargs):
+        self.calls += 1
+        return await self.script(self.calls)
+
+
+def _chat_st(messages):
+    from src.discord.response_guards import StuckLoopTracker
+    from src.trajectories.saver import TrajectoryTurn
+    from src.turn_state.durability import TurnDurability
+
+    class _NullCM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    return SimpleNamespace(
+        chat_cap=3,
+        iteration=0,
+        stuck_tracker=StuckLoopTracker(),
+        wait_judgment_pending=False,
+        _cancel=asyncio.Event(),
+        _trajectory=TrajectoryTurn(),
+        trace=None,
+        _ch_id="c1",
+        _req_id="r1",
+        message=SimpleNamespace(
+            channel=SimpleNamespace(id=1, typing=lambda: _NullCM()), content="hi"
+        ),
+        messages=messages,
+        tools_used_in_loop=[],
+        tools=[],
+        system_prompt="sys",
+        user_id="u1",
+        durability=TurnDurability.disabled(),
+        _boundary_request_start=max(0, len(messages) - 2),
+        _boundary_elided_replay=0,
+        _boundary_envelope_len=2,
+        _char_latch=None,
+        _rescue_passes=0,
+        _gen_identity=None,
+    )
+
+
+def _big_history(n, size):
+    return [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"h{i}:" + "y" * size}
+        for i in range(n)
+    ]
+
+
+_ENVELOPE = [
+    {"role": "developer", "content": "preamble"},
+    {"role": "user", "content": "CURRENT: do the thing"},
+]
+
+
+class TestChatSurfaceHooks:
+    async def test_rescued_chat_success_records_the_evidence_pair(self):
+        observer = _CaptureObserver()
+        overflow = _overflow()
+
+        async def script(n):
+            if n == 1:
+                raise overflow
+            return SimpleNamespace(
+                text="ok",
+                tool_calls=[],
+                stop_reason="end_turn",
+                server_input_tokens=408_004,
+                account_key=ACCT_A,
+                provenance_model="gpt-5.6-sol",
+            )
+
+        gw = _ChatGateway(script)
+        runner = _chat_runner(gw, observer)
+        st = _chat_st(_big_history(60, 20_000) + list(_ENVELOPE))
+        kind, val = await runner._call_llm(st)
+        assert kind == "ok"
+        assert len(observer.recorded) == 1
+        got_overflow, got_response = observer.recorded[0]
+        assert got_overflow is overflow  # the exact overflow error object
+        assert got_response is val
+
+    async def test_unrescued_chat_success_records_nothing(self):
+        observer = _CaptureObserver()
+
+        async def script(n):
+            return SimpleNamespace(text="ok", tool_calls=[], stop_reason="end_turn")
+
+        runner = _chat_runner(_ChatGateway(script), observer)
+        st = _chat_st(_big_history(4, 100) + list(_ENVELOPE))
+        kind, _val = await runner._call_llm(st)
+        assert kind == "ok"
+        assert observer.recorded == []
+
+    def test_chat_soft_pass_consumes_the_active_clamp(self):
+        """Same payload, only the clamp differs: 800K chars sits under sol's
+        unclamped 1.277M-char target (no compression) but far over the
+        clamped 575K target (compression fires)."""
+        from src.llm.context_compressor import estimate_message_chars
+
+        payload = (
+            _big_history(6, 1_000)
+            + list(_ENVELOPE)
+            + [
+                m
+                for i in range(50)
+                for m in (
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": f"t{i}", "name": "read_file", "input": {}},
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": f"t{i}",
+                                "content": "r" * 16_000,
+                            },
+                        ],
+                    },
+                )
+            ]
+        )
+        compressor_cfg = SimpleNamespace(max_context_chars=None, keep_recent_iterations=3)
+
+        def run(observer):
+            gw = _ChatGateway(None)
+            runner = _chat_runner(gw, observer)
+            runner._get_context_compressor = lambda: compressor_cfg
+            st = _chat_st([dict(m) for m in payload])
+            # The payload already carries iterations: the request envelope
+            # sits after the 6 history messages, not at the list tail.
+            st._boundary_request_start = 6
+            st.iteration = 1
+            assert runner._maybe_compress(st, gw.client, SimpleNamespace(openai_codex=None))
+            return estimate_message_chars(st.messages)
+
+        before = estimate_message_chars(payload)
+        unclamped = run(None)
+        clamped = run(_CaptureObserver(clamp=300_000))
+        assert before > 575_000  # the payload genuinely exceeds the clamped target
+        assert unclamped == before  # untouched without a clamp
+        assert clamped <= 575_000  # compressed to the clamped target
+
+
+class TestLoopSurfaceHooks:
+    async def test_rescued_loop_success_records_the_evidence_pair(self):
+        from src.llm.context_compressor import SurfaceBoundary
+
+        observer = _CaptureObserver()
+        overflow = _overflow()
+        calls = {"n": 0}
+
+        class _Client(SimpleNamespace):
+            async def chat_with_tools(self, *, messages, system, tools, **kwargs):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise overflow
+                return SimpleNamespace(
+                    text="ok",
+                    tool_calls=[],
+                    stop_reason="end_turn",
+                    provenance_provider="codex",
+                    provenance_model="gpt-5.6-sol",
+                    provenance_reasoning_effort="xhigh",
+                    server_input_tokens=408_004,
+                    account_key=ACCT_A,
+                )
+
+        client = _Client(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        gw = _ChatGateway(None)
+        gw.client = client
+        gw.codex_client = client
+        runner = _chat_runner(gw, observer)
+        st = SimpleNamespace(
+            messages=[
+                {"role": "user", "content": "Previous iteration results:\n" + "p" * 400_000},
+                {"role": "assistant", "content": "Understood."},
+                {"role": "user", "content": "GOAL: keep going"},
+            ],
+            system_prompt="sys",
+            tools=[],
+            _boundary=SurfaceBoundary(request_start=2, envelope_len=1),
+            _char_latch=None,
+            context_recoveries=[],
+            _iteration_index=0,
+        )
+        kind, val = await runner._call_loop_llm(st)
+        assert kind == "ok"
+        assert len(observer.recorded) == 1
+        assert observer.recorded[0][0] is overflow
+        assert observer.recorded[0][1] is val
+
+
+class TestAgentSurfaceHooks:
+    def test_generation_budget_snapshot_consumes_the_clamp(self):
+        from src.discord.native_tools.agents_tasks import _generation_budget_snapshot
+
+        client = SimpleNamespace(model="gpt-5.6-sol", reasoning_effort="xhigh")
+        cfg = SimpleNamespace(openai_codex=None)
+        unclamped = _generation_budget_snapshot(cfg, client, "gpt-5.6-sol", None)
+        clamped = _generation_budget_snapshot(
+            cfg, client, "gpt-5.6-sol", None, observer=_CaptureObserver(clamp=300_000)
+        )
+        assert unclamped.clamp_applied is False
+        assert clamped.clamp_applied is True
+        assert clamped.primary_chars < unclamped.primary_chars
+
+    async def test_evidence_recorder_adapts_the_callback_dict(self, tmp_path):
+        from src.discord.native_tools.agents_tasks import _make_evidence_recorder
+
+        obs = _observer(tmp_path)
+        recorder = _make_evidence_recorder(obs)
+        await recorder(
+            _overflow(),
+            {
+                "text": "ok",
+                "tool_calls": [],
+                "server_input_tokens": 408_004,
+                "account_key": ACCT_A,
+                "model": "gpt-5.6-sol",
+            },
+        )
+        assert obs.active_clamp("gpt-5.6-sol") == 408_004
+
+    def test_recorder_for_absent_observer_is_none(self):
+        from src.discord.native_tools.agents_tasks import _make_evidence_recorder
+
+        assert _make_evidence_recorder(None) is None
+
+    async def test_manager_rescue_success_invokes_the_recorder(self):
+        from src.agents.manager import AgentInfo, _call_llm_with_recovery
+
+        agent = AgentInfo(
+            id="a1",
+            label="t",
+            goal="g",
+            channel_id="c1",
+            requester_id="u1",
+            requester_name="u",
+        )
+        agent.messages = [{"role": "user", "content": "task"}] + [
+            {"role": "assistant", "content": f"[Tool result: step{i}]\n" + "x" * 20_000}
+            for i in range(30)
+        ]
+        overflow = _overflow()
+        recorded = []
+
+        async def recorder(err, response):
+            recorded.append((err, response))
+
+        calls = {"n": 0}
+
+        async def cb(messages, system_prompt, tools, generation_state=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise overflow
+            return {"text": "done", "tool_calls": []}
+
+        response = await _call_llm_with_recovery(
+            agent,
+            cb,
+            "sys",
+            [],
+            rescue_ladder=(120_000,),
+            evidence_recorder=recorder,
+        )
+        assert response == {"text": "done", "tool_calls": []}
+        assert len(recorded) == 1
+        assert recorded[0][0] is overflow
+        assert recorded[0][1] is response
+
+
+# ---------------------------------------------------------------------------
+# Management API
+# ---------------------------------------------------------------------------
+
+
+def _api_app(observer):
+    from src.web.api.llm_admin import register_context_windows
+
+    bot = SimpleNamespace(
+        config=SimpleNamespace(
+            openai_codex=SimpleNamespace(
+                context_budget_overrides={"gpt-5.5": 250_000},
+                context_utilization=60,
+            )
+        ),
+        context_compressor=None,
+        services=SimpleNamespace(window_observer=observer),
+    )
+    routes = web.RouteTableDef()
+    register_context_windows(routes, bot)
+    app = web.Application()
+    app.router.add_routes(routes)
+    return app
+
+
+class TestContextWindowsApi:
+    async def test_get_serves_floors_overrides_clamps_and_both_resolutions(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance(tokens=300_000))
+        app = _api_app(obs)
+        async with TestClient(TestServer(app)) as c:
+            body = await (await c.get("/api/context/windows")).json()
+        sol = body["models"]["gpt-5.6-sol"]
+        assert sol["floor"] == 921_601
+        assert sol["active_clamp"] == 300_000
+        assert sol["configured"]["clamp_applied"] is False
+        assert sol["effective"]["clamp_applied"] is True
+        assert sol["effective"]["effective_budget"] == 300_000
+        assert sol["effective"]["primary_chars"] < sol["configured"]["primary_chars"]
+        five = body["models"]["gpt-5.5"]
+        assert five["override"] == 250_000
+        assert five["configured"]["base_source"] == "override"
+        # Raw evidence rides along, opaque keys only.
+        assert ACCT_A in body["evidence"]["accounts"]
+
+    async def test_clear_endpoint_is_account_scoped(self, tmp_path):
+        obs = _observer(tmp_path)
+        await obs.record_rescue(overflow=_overflow(), response=_acceptance())
+        app = _api_app(obs)
+        async with TestClient(TestServer(app)) as c:
+            resp = await c.post("/api/context/windows/clear", json={"account_key": ACCT_A})
+            assert (await resp.json())["cleared"] == 1
+            resp = await c.post("/api/context/windows/clear", json={})
+            assert resp.status == 400
+            resp = await c.post(
+                "/api/context/windows/clear",
+                data=b"not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400  # malformed body degrades to empty
+        assert obs.active_clamp("gpt-5.6-sol") is None
+
+    async def test_clear_without_observer_is_503(self):
+        app = _api_app(None)
+        async with TestClient(TestServer(app)) as c:
+            resp = await c.post("/api/context/windows/clear", json={"account_key": ACCT_A})
+            assert resp.status == 503


### PR DESCRIPTION
Campaign phase 5 (plan of record R2 §11–§12, backend half of §12 — the table UI itself is phase 6).

## What this adds

**`src/llm/window_observer.py`** — the evidence store + clamp authority. Odin's normal work is the probe: every emergency rescue already carries the server's own numbers (phase-2 stamping), and the observer turns each same-request overflow→compressed-retry-acceptance pair into per-(opaque account, canonical model) evidence and a temporary DOWNWARD clamp on budget resolution. No probe traffic, no autonomous upward adjustment.

- `data/context_windows.json`: versioned schema, strict validation, opaque account keys only; ONE lock around the whole read–merge–atomic-write transaction; `active_clamp()` is synchronous, disk-free, lock-free (immutable-state replacement).
- Clamp qualification exactly per plan: structural overflow + same logical request's successful retry + server-authoritative acceptance echo + canonical model match + same opaque account. Cross-account retries record both sides, derive no clamp. Clamp value IS the acceptance, exact. 24h TTL, lazily judged; downward-only merges (lower-or-equal evidence replaces with fresh TTL; higher evidence never raises or clears a live clamp); manual clear is account-scoped and preserves bounds history.
- Forfeit invariant: every public entry point is total — an evidence-write failure logs and forfeits durability, never the request; in-memory evidence still serves this process.
- Filesystem contract: hostile-input-safe reads (O_NONBLOCK + O_NOFOLLOW, fstat shape check, size cap), quarantine-never-repair for corrupt material (preserved verbatim beside the store), atomic publication (O_EXCL temp + fsync + replace + parent-dir fsync), explicit fd ownership across every failure window, persistence off the event loop via `asyncio.to_thread`.

**Resolution integration** — `snapshot_for_codex_config(observed_clamp=)` feeds the clamp slot phase 1 built. All five snapshot sites pass the active clamp: chat `_maybe_compress` + `_call_llm` ladder, loop `_maybe_compress_loop` + `_call_loop_llm` ladder, agent `_generation_budget_snapshot` (plan capture + spawn provider).

**Evidence capture** at all three rescue-success sites: chat and loop record through a total runner helper; agents thread an `evidence_recorder` callable (spawn → `_run_agent` → `_call_llm_with_recovery`) with the dict-shape adapter living beside the callback that produces that shape.

**API** — `GET /api/context/windows` (canonical keys, floors, overrides, configured vs effective resolutions side by side, provenance, raw evidence) + `POST /api/context/windows/clear` (account-scoped). Route parity 188 → 190.

## One deliberate deviation from the plan text

Plan §11 scopes the active clamp to "currently eligible pool accounts"; this implementation takes the minimum non-expired clamp across ALL accounts holding one — the conservative superset. Rationale: the pool is sticky but failover can seat any account at any moment, pool-membership introspection would couple the observer to `CodexAuthPool`, and a departed account's clamp dies with its 24h TTL anyway. Flagging explicitly for your verdict; happy to build pool-eligibility scoping if you judge the plan text binding here.

## Notes for review

- Evidence accrues at RESCUE events only (the "highest accepted" field is populated by rescue acceptances). Recording every ordinary success would put the observer on the hot path for zero clamp benefit — clamps only ever derive from overflow pairs.
- The clamp deliberately bypasses operator override bounds (phase-1 semantics: evidence is not configuration); the resolver stays total under any clamp value.
- No config leaves added — the store is runtime evidence, so no apply-registry/template/docs changes. WebUI rendering (including clamp provenance + expiry and the clear control) is phase 6 per the plan.

## Gates at `9565508`

Full suite 9,516 passed / 5 skipped; coverage findings=0 (window_observer.py baselined via the 41-test battery: hostile store inputs, crashed-write atomicity, fd discipline under fdopen failure, the full qualification matrix, downward-only + TTL semantics, forfeit invariant, broken-observer guard arms on every surface, resolver integration, all three surface hooks, API); lint new=0; type new=0 (module itself mypy-clean); apply-registry clean; diff-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHfEwTsEyuS8RUhwdoW66g