### PR TITLE
P1: dual-era MCP client package (src/tools/mcp/)

### DIFF
--- a/docs/plans/mcp-wiring-plan.md
+++ b/docs/plans/mcp-wiring-plan.md
@@ -1,0 +1,157 @@
+# MCP Wiring Campaign — Plan of Record
+
+Status: campaign in progress on `feat/mcp-wiring`. **No MCP tool is exposed
+to any model until protocol (P1), lifecycle (P2), catalog/dispatch (P3), and
+persistence (P4) are all integrated** — publication stays impossible by
+construction until the final integration wiring lands.
+
+## Goal
+
+MCP servers manageable via the WebUI; standard/universal protocol
+acceptance; a connected server's tools appear as first-class tools. The
+honest v1 claim: **dual-era MCP core-tools interoperability** — supports
+current 2026 MCP and deployed legacy MCP for *tools* over stdio and
+Streamable HTTP, with static authentication. Not every optional feature or
+authorization mode (see Non-goals).
+
+## Publication invariant
+
+Four states: **Configured → Enabled → Connected → Published.** A tool is
+published iff:
+
+```text
+global enabled
+AND server enabled
+AND current config generation connected
+AND successful complete tools/list
+AND tool passed validation/provider compatibility
+```
+
+Disabled, removed, failed, disconnected, stale-generation, or blocked
+servers publish ZERO tools. Every state transition invalidates the tool
+catalog synchronously: **no model request assembled after the transition
+may contain the removed tool.** Over-limit servers are BLOCKED (publish
+nothing, report why) — the first N are never silently chosen.
+
+## Protocol matrix (normative — `src/tools/mcp/protocol.py` is its executable form)
+
+Supported protocol revisions, exact set, preference order newest-first:
+
+| Revision     | Era    | stdio | Streamable HTTP | Notes |
+|--------------|--------|-------|-----------------|-------|
+| `2026-07-28` | Modern | ✓     | ✓               | stateless; `server/discover`; per-request `_meta`; required `resultType`; `Mcp-Method`/`Mcp-Name` headers; `x-mcp-header` mirroring |
+| `2025-11-25` | Legacy | ✓     | ✓               | initialize handshake; optional sessions |
+| `2025-06-18` | Legacy | ✓     | ✓               | + `MCP-Protocol-Version` header |
+| `2025-03-26` | Legacy | ✓     | ✓               | + receive-side JSON-RPC batch arrays |
+| `2024-11-05` | Legacy | ✓     | ✗               | HTTP shape was the deprecated HTTP+SSE dual endpoint — out of scope |
+
+An unknown counteroffer or advertised version is never accepted.
+
+**Era detection** (a property of the server; re-probed on every connect):
+
+- stdio: probe `server/discover` with the preferred modern version.
+  `DiscoverResult` ⇒ modern-era evidence → version selection. Recognized
+  modern error (`-32020`/`-32021`/`-32022`) ⇒ modern → selection from its
+  advertised list. Any other error or bounded timeout ⇒ legacy `initialize`
+  fallback. Fallback is never keyed to one error code.
+- HTTP: the same probe as a POST. Only an **HTTP 400 with an
+  empty/unrecognized body** (or a plain method-not-found for the probe)
+  falls back to legacy. `401`/`403`/`429`/`5xx`/network failures establish
+  NO era — the connect fails retryable.
+- Modern version selection: validate `supportedVersions`, intersect with
+  the exact modern allowlist, choose deterministically. A modern-era server
+  advertising only legacy revisions is **modern-incompatible** (honest
+  error) — never modern metadata under a legacy version, never an
+  `initialize` fallback after modern-era evidence.
+
+**resultType:** required under a negotiated `2026-07-28` — `complete`
+passes; `input_required` is an explicit unsupported outcome (MRTR deferred),
+never replayed; missing/unknown = protocol violation. Treat-missing-as-
+complete applies only to negotiated-legacy responses.
+
+**Sessions (legacy Streamable HTTP): OPTIONAL.** Echo `Mcp-Session-Id`,
+apply 404-session recovery, and DELETE on disconnect only when the server
+minted one.
+
+**Cancellation:** modern stdio and legacy (both transports) send
+`notifications/cancelled`; modern HTTP aborts that request's SSE response
+stream (closing a LEGACY SSE stream is explicitly not cancellation).
+`initialize` is never cancelled; late responses after cancellation are
+ignored.
+
+**Outcome classification (drives the durability contract):**
+
+| Condition | Outcome |
+|---|---|
+| result without `isError` | ok |
+| `isError: true` / JSON-RPC error / validation rejection / failure before the request was written / explicit session rejection | failed (definite) |
+| timeout / disconnect / stream loss after the request was written | **uncertain — never automatically replayed** |
+
+Automatic retries are permitted for discovery/listing only. Session
+recovery (re-initialize) is a lifecycle operation and never implies
+reissuing the interrupted `tools/call`.
+
+**Other client obligations:** `tools/list` pagination via `nextCursor`
+(bounded pages, duplicate-cursor detection; a partial listing is a failed
+listing); duplicate tool names = listing failure; `x-mcp-header` support is
+mandatory on modern HTTP (validation per spec; an invalid annotation
+excludes that tool); legacy server-initiated requests are answered `-32601`
+on the correct channel (never dropped — a dropped request hangs the
+server); `server/discover.instructions` and all server-authored text are
+untrusted (UI-only, escaped and bounded — never injected into the system
+prompt); tool descriptions published to the model are length-bounded and
+control-character-stripped.
+
+## Bounds
+
+40 published tools per server and globally (over-limit ⇒ blocked, resolved
+via per-server `tool_allowlist`); 1,024-char model-facing descriptions;
+32 KiB schema per tool / 256 KiB per server / depth 20 / 2,048 nodes;
+32 list pages / 128 discovered tools; 4 MiB wire-result ceiling before the
+standard 12 K model-facing result cap. Tool-list freshness: TTL-clamped
+polling (60 s–10 min, ±10 % jitter, exponential failure backoff to 30 min,
+single-flight, manual refresh; a failed refresh unpublishes).
+
+## Runtime safety
+
+stdio servers run in an owned process group with an allowlisted minimal
+environment (PATH/HOME/locale/TERM/TMPDIR/USER + configured `env`) — never
+the full service environment; stderr is drained continuously into a bounded
+ring; shutdown escalates stdin-close → SIGTERM(group) → SIGKILL(group) with
+a final descendant sweep. HTTP uses one cookie-isolated session per server,
+never follows redirects, and never lets configured headers override managed
+transport headers. All error text surfaced from servers is sanitized and
+bounded.
+
+## Phases
+
+- **P1** `src/tools/mcp/` client package: protocol core, both transports,
+  era detection, typed outcomes, bounds, fake-server test harness (both
+  transports × both eras). The legacy `src/tools/mcp_client.py` module and
+  its tests remain untouched dead code until P4 retires them.
+- **P2** wiring/lifecycle: always-constructed control plane (status/CRUD
+  work even when disabled — first-server bootstrap), async start from the
+  bot lifecycle, reconnect supervision, config-generation fencing, bounded
+  concurrent shutdown, health component.
+- **P3** catalog merge + one shared dynamic-dispatch seam consumed by the
+  chat loop, the autonomous/agent/scheduled loop path, and background
+  tasks; freshness at request assembly (including per-iteration agent
+  assembly); provider-safe published names; admin-only RBAC default; audit
+  metadata (server, original name, generation, negotiated version, outcome
+  class); secret-shaped argument scrubbing.
+- **P4** persistence + routes: validate → persist (config transaction) →
+  publish generation → unpublish superseded → reconcile; status route that
+  always works; separate reconnect and refresh-tools operations; global
+  enable mutation; secrets returned as key names only, mutated via
+  set/remove patch ops.
+- **P5** WebUI: dedicated Manage → MCP Servers panel (global switch, state
+  vocabulary Disabled/Connecting/Connected/Stale/Error/Blocked, searchable
+  tool lists, transport-aware editor, confirmations) + docs + config
+  template.
+
+## Non-goals (v1)
+
+OAuth (interactive authorization is unsupported — static headers only);
+MRTR/elicitation; sampling; roots; tasks extension; `subscriptions/listen`;
+resources and prompts; the deprecated HTTP+SSE transport; model-facing
+server CRUD tools (the WebUI is the only management surface).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pyyaml>=6.0",
     "ruamel.yaml>=0.18",
     "pydantic>=2.0",
+    "jsonschema>=4.23,<5",
     "croniter>=2.0.0",
     "fastembed>=0.8.0",
     "sqlite-vec>=0.1.0",
@@ -39,6 +40,7 @@ dev = [
     "types-aiofiles==25.1.0.20260518",
     "types-PyYAML==6.0.12.20260518",
     "types-croniter==6.2.3.20260704",
+    "types-jsonschema==4.26.0.20260518",
 ]
 
 [project.scripts]

--- a/src/tools/mcp/__init__.py
+++ b/src/tools/mcp/__init__.py
@@ -1,0 +1,31 @@
+"""MCP (Model Context Protocol) client package.
+
+Dual-era core-tools client: current stateless MCP (revision 2026-07-28) and
+deployed legacy MCP (2024-11-05 … 2025-11-25) for tools over stdio and
+Streamable HTTP, with static authentication. Plan of record:
+``docs/plans/mcp-wiring-plan.md``.
+
+Public surface: :class:`MCPManager` (control plane), the typed error
+hierarchy, and :class:`MCPToolOutcome` (typed tool-call results — never
+stringly errors).
+"""
+
+from .errors import (
+    MCPConfigError,
+    MCPConnectError,
+    MCPError,
+    MCPProtocolError,
+    MCPTimeoutError,
+)
+from .manager import MCPManager
+from .outcomes import MCPToolOutcome
+
+__all__ = [
+    "MCPConfigError",
+    "MCPConnectError",
+    "MCPError",
+    "MCPManager",
+    "MCPProtocolError",
+    "MCPTimeoutError",
+    "MCPToolOutcome",
+]

--- a/src/tools/mcp/client.py
+++ b/src/tools/mcp/client.py
@@ -33,7 +33,7 @@ from typing import Any
 
 from ...odin_log import get_logger
 from . import protocol as proto
-from .errors import MCPConnectError, MCPProtocolError, MCPTimeoutError
+from .errors import MCPConnectError, MCPError, MCPPreWriteError, MCPProtocolError, MCPTimeoutError
 from .outcomes import (
     OUTCOME_FAILED,
     OUTCOME_OK,
@@ -61,6 +61,21 @@ _CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
 def _clean_text(text: str, cap: int) -> str:
     return _CONTROL_CHARS_RE.sub("", str(text))[:cap]
+
+
+async def _finish_cancellation(send: Callable[[], Any]) -> None:
+    """Complete a bounded cancellation signal despite repeated cancellation."""
+    task = asyncio.create_task(send())
+    while not task.done():
+        current = asyncio.current_task()
+        if current is not None:
+            while current.cancelling():
+                current.uncancel()
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            pass
+    await task
 
 
 @dataclass(frozen=True)
@@ -124,6 +139,7 @@ class MCPServerConnection:
         self._ids = itertools.count(1)
         self._pending: dict[Any, asyncio.Future[dict]] = {}
         self._lost_reason: str | None = None
+        self._disconnect_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Connect
@@ -132,6 +148,10 @@ class MCPServerConnection:
     async def connect(self) -> None:
         if self.connected:
             return
+        if self._disconnect_task is not None:
+            if not self._disconnect_task.done():
+                raise MCPConnectError(f"{self.name}: disconnect is still in progress")
+            self._disconnect_task = None
         self.era = None
         self.negotiated_version = None
         self._lost_reason = None
@@ -144,18 +164,40 @@ class MCPServerConnection:
         self.connected = True
 
     async def disconnect(self) -> None:
+        """Teardown to completion even when the caller is cancelled."""
+        task = self._disconnect_task
+        if task is None:
+            task = asyncio.create_task(self._disconnect_inner(), name=f"mcp-disconnect-{self.name}")
+            self._disconnect_task = task
+        cancelled = False
+        while not task.done():
+            current = asyncio.current_task()
+            if current is not None:
+                while current.cancelling():
+                    current.uncancel()
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                cancelled = True
+        await task
+        if cancelled:
+            raise asyncio.CancelledError
+
+    async def _disconnect_inner(self) -> None:
         self.connected = False
         self._fail_pending(MCPConnectError(f"{self.name}: disconnected"))
         stdio, self._stdio = self._stdio, None
         http, self._http = self._http, None
-        if stdio is not None:
-            await stdio.shutdown()
-        if http is not None:
-            if self.era == proto.ERA_LEGACY and http.session_id:
+        try:
+            if stdio is not None:
+                await stdio.shutdown()
+            if http is not None and self.era == proto.ERA_LEGACY and http.session_id:
                 await http.delete_session(protocol_version=self.negotiated_version)
-            await http.close()
-        self.era = None
-        self.negotiated_version = None
+        finally:
+            if http is not None:
+                await http.close()
+            self.era = None
+            self.negotiated_version = None
 
     # -------------------------- stdio ---------------------------------
 
@@ -242,10 +284,15 @@ class MCPServerConnection:
         assert self._stdio is not None
         future: asyncio.Future[dict] = asyncio.get_running_loop().create_future()
         self._pending[req_id] = future
-        try:
+
+        async def exchange() -> dict:
+            assert self._stdio is not None
             await self._stdio.send(request)
+            return await future
+
+        try:
             try:
-                return await asyncio.wait_for(future, timeout=timeout)
+                return await asyncio.wait_for(exchange(), timeout=timeout)
             except TimeoutError:
                 raise MCPTimeoutError(
                     f"{self.name}: no reply to {request.get('method')} within {timeout}s"
@@ -325,9 +372,23 @@ class MCPServerConnection:
                 self.era = proto.ERA_MODERN
                 self.negotiated_version = selection.version
                 return True
-            return False  # plain JSON-RPC error for the probe ⇒ legacy
+            if err is not None and err.get("code") == proto.ERROR_METHOD_NOT_FOUND:
+                return False
+            raise MCPConnectError(f"{self.name}: probe returned an error that is not era evidence")
         if outcome.kind == RESULT_HTTP_ERROR:
-            err = self._first_error(outcome.messages)
+            matched = self._match_response(outcome.messages, probe_id)
+            err = proto.rpc_error(matched) if matched is not None else None
+            if (
+                outcome.status in (404, 405)
+                and err is not None
+                and err.get("code") == proto.ERROR_METHOD_NOT_FOUND
+            ):
+                return False
+            if outcome.status != 400:
+                raise MCPConnectError(
+                    f"{self.name}: probe failed with HTTP {outcome.status} — "
+                    "not era evidence (check authentication/endpoint)"
+                )
             if proto.is_recognized_modern_error(err):
                 assert err is not None
                 selection = proto.select_modern_version(proto.supported_versions_from_error(err))
@@ -336,18 +397,7 @@ class MCPServerConnection:
                 self.era = proto.ERA_MODERN
                 self.negotiated_version = selection.version
                 return True
-            if outcome.status == 400:
-                return False  # 400 with empty/unrecognized body ⇒ legacy
-            if outcome.status in (404, 405) and (
-                err is None or err.get("code") in (proto.ERROR_METHOD_NOT_FOUND, -32602)
-            ):
-                # server/discover is mandatory on modern servers — a plain
-                # method-not-found for the probe identifies a legacy server.
-                return False
-            raise MCPConnectError(
-                f"{self.name}: probe failed with HTTP {outcome.status} — "
-                "not era evidence (check authentication/endpoint)"
-            )
+            return False  # 400 with empty/unrecognized body is legacy evidence
         # 202/stream for a request-probe is out-of-contract.
         raise MCPConnectError(f"{self.name}: probe produced no usable reply")
 
@@ -411,14 +461,6 @@ class MCPServerConnection:
                 return msg
         return None
 
-    @staticmethod
-    def _first_error(messages: list[dict]) -> dict | None:
-        for msg in messages:
-            err = proto.rpc_error(msg)
-            if err is not None:
-                return err
-        return None
-
     # ------------------------------------------------------------------
     # Shared identity adoption
     # ------------------------------------------------------------------
@@ -426,6 +468,9 @@ class MCPServerConnection:
     def _adopt_modern(self, discover_result: Any) -> None:
         if not isinstance(discover_result, dict):
             raise MCPConnectError(f"{self.name}: malformed DiscoverResult")
+        result_type = proto.check_result_type(discover_result, era=proto.ERA_MODERN)
+        if not result_type.ok:
+            raise MCPConnectError(f"{self.name}: server/discover: {result_type.reason}")
         selection = proto.select_modern_version(discover_result.get("supportedVersions"))
         if selection.version is None:
             raise MCPConnectError(f"{self.name}: {selection.reason}")
@@ -517,9 +562,33 @@ class MCPServerConnection:
     # ------------------------------------------------------------------
 
     async def discover_tools(self) -> DiscoveryResult:
-        """Full paginated tools/list with validation. Raises on any protocol
-        violation — a partial or malformed listing is a FAILED listing;
-        callers never publish half a server."""
+        """Discover atomically, recovering a rejected legacy HTTP session once.
+
+        Discovery is retry-safe; tool calls are deliberately not. A session
+        rejection restarts the full paginated listing after a lifecycle-only
+        re-initialization, so no partial snapshot can escape.
+        """
+        try:
+            return await self._discover_tools_once()
+        except _SessionLostError:
+            if self.transport_kind != "http" or self.era != proto.ERA_LEGACY:
+                raise
+            await self._recover_legacy_http_session()
+            try:
+                return await self._discover_tools_once()
+            except _SessionLostError as exc:
+                self._on_transport_closed("server session repeatedly rejected during discovery")
+                raise MCPProtocolError(
+                    f"{self.name}: legacy HTTP session was rejected again during discovery"
+                ) from exc
+
+    async def _recover_legacy_http_session(self) -> None:
+        assert self._http is not None
+        self._http.session_id = None
+        await self._initialize_legacy_http()
+
+    async def _discover_tools_once(self) -> DiscoveryResult:
+        """One complete paginated listing; partial listings never return."""
         if not self.connected or self.era is None or self.negotiated_version is None:
             raise MCPConnectError(f"{self.name}: not connected")
         records: list[ToolRecord] = []
@@ -577,9 +646,9 @@ class MCPServerConnection:
             raise MCPProtocolError(f"{self.name}: tool entry without a name")
         name = raw["name"]
         description = _clean_text(str(raw.get("description", "")), proto.MAX_DESCRIPTION_CHARS)
-        schema = raw.get("inputSchema", {"type": "object", "properties": {}})
+        schema = raw.get("inputSchema")
         check = proto.validate_tool_schema(schema)
-        if not check.ok:
+        if not check.ok or not isinstance(schema, dict):
             return ToolRecord(
                 name=name,
                 description=description,
@@ -648,7 +717,8 @@ class MCPServerConnection:
         err = proto.rpc_error(reply)
         if err is not None:
             raise MCPProtocolError(
-                f"{self.name}: {method} failed: {_clean_text(str(err.get('message', err)), 200)}"
+                f"{self.name}: {method} failed: {_clean_text(str(err.get('message', err)), 200)}",
+                rpc_code=err.get("code"),
             )
         result = reply.get("result")
         if not isinstance(result, dict):
@@ -668,7 +738,9 @@ class MCPServerConnection:
         mcp_name: str | None,
         param_headers: dict[str, str] | None = None,
     ) -> dict:
-        assert self._http is not None and self.negotiated_version is not None
+        if self._http is None or not self._http.started:
+            raise MCPPreWriteError(f"{self.name}: HTTP transport is not available")
+        assert self.negotiated_version is not None
         collected: dict[str, dict | None] = {"response": None}
 
         def on_message(msg: dict) -> None:
@@ -703,7 +775,8 @@ class MCPServerConnection:
         if collected["response"] is not None:
             return collected["response"]
         if outcome.kind == RESULT_HTTP_ERROR:
-            err = self._first_error(outcome.messages)
+            matched = self._match_response(outcome.messages, req_id)
+            err = proto.rpc_error(matched) if matched is not None else None
             if outcome.status == 404 and self._http.session_id:
                 raise _SessionLostError(self.name)
             detail = (
@@ -754,13 +827,10 @@ class MCPServerConnection:
             if value is not None:
                 param_headers[hp.name] = value
         params = {"name": tool.name, "arguments": arguments}
-        wrote = False
         try:
             if self.transport_kind == "stdio":
-                wrote = True  # conservatively: the write may reach the wire
                 result = await self._call_stdio(params, budget)
             else:
-                wrote = True
                 result = await self._call_http(
                     params, budget, tool_name=tool.name, param_headers=param_headers
                 )
@@ -776,7 +846,7 @@ class MCPServerConnection:
                 "not executed. The server is reconnecting — retry explicitly "
                 "if still needed.",
             )
-        except _DefiniteCallError as e:
+        except (_DefiniteCallError, MCPPreWriteError) as e:
             return outcome(OUTCOME_FAILED, str(e))
         except TimeoutError:
             await self._cancel_in_flight()
@@ -796,15 +866,13 @@ class MCPServerConnection:
                 detail="timeout",
             )
         except (MCPConnectError, MCPProtocolError) as e:
-            if wrote:
-                return outcome(
-                    OUTCOME_UNCERTAIN,
-                    f"MCP tool '{tool.name}' on '{self.name}' failed after the "
-                    f"request was sent ({_clean_text(str(e), 200)}); whether it "
-                    "executed is UNKNOWN. It was not retried automatically.",
-                    detail="transport-loss",
-                )
-            return outcome(OUTCOME_FAILED, _clean_text(str(e), 400))
+            return outcome(
+                OUTCOME_UNCERTAIN,
+                f"MCP tool '{tool.name}' on '{self.name}' failed after the "
+                f"request may have been sent ({_clean_text(str(e), 200)}); whether it "
+                "executed is UNKNOWN. It was not retried automatically.",
+                detail="transport-loss",
+            )
         rt = proto.check_result_type(result, era=self.era)
         if rt.input_required:
             return outcome(
@@ -825,17 +893,45 @@ class MCPServerConnection:
         request = proto.build_request(
             req_id, "tools/call", params, era=self.era, version=self.negotiated_version
         )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + budget
+        future: asyncio.Future[dict] = loop.create_future()
+        self._pending[req_id] = future
+        written = False
         try:
-            reply = await self._stdio_roundtrip(req_id, request, budget)
+            if self._stdio is None:
+                raise MCPPreWriteError(f"{self.name}: stdio transport is not available")
+            await self._stdio.send(request, timeout=budget)
+            written = True
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise MCPTimeoutError(
+                    f"{self.name}: tools/call exhausted its {budget}s request budget"
+                )
+            try:
+                reply = await asyncio.wait_for(future, timeout=remaining)
+            except TimeoutError:
+                raise MCPTimeoutError(
+                    f"{self.name}: no reply to tools/call within {budget}s"
+                ) from None
         except MCPTimeoutError:
-            await self._send_cancelled(req_id)
+            if written:
+                await self._send_cancelled(req_id)
             raise
+        except asyncio.CancelledError:
+            if written:
+                await _finish_cancellation(lambda: self._send_cancelled(req_id))
+            raise
+        except MCPProtocolError as exc:
+            raise _DefiniteCallError(_clean_text(str(exc), 300)) from exc
+        finally:
+            self._pending.pop(req_id, None)
         err = proto.rpc_error(reply)
         if err is not None:
             raise _DefiniteCallError(f"MCP error: {_clean_text(str(err.get('message', err)), 300)}")
         result = reply.get("result")
         if not isinstance(result, dict):
-            raise MCPProtocolError(f"{self.name}: tools/call returned no result")
+            raise _DefiniteCallError(f"{self.name}: tools/call returned no result")
         return result
 
     async def _call_http(
@@ -848,9 +944,8 @@ class MCPServerConnection:
     ) -> dict:
         assert self.era is not None and self.negotiated_version is not None
         modern = self.era == proto.ERA_MODERN
-        attempts = 0
-        while True:
-            attempts += 1
+        current_headers = dict(param_headers)
+        for attempt in range(2):
             req_id = next(self._ids)
             request = proto.build_request(
                 req_id, "tools/call", params, era=self.era, version=self.negotiated_version
@@ -862,12 +957,9 @@ class MCPServerConnection:
                     budget,
                     mcp_method="tools/call",
                     mcp_name=proto.encode_header_value(tool_name) if modern else None,
-                    param_headers=param_headers,
+                    param_headers=current_headers,
                 )
             except TimeoutError:
-                # Aborting the POST/stream IS the modern cancel; legacy
-                # additionally requires an explicit cancellation
-                # notification (closing legacy SSE is NOT cancel).
                 if not modern:
                     await self._send_cancelled(req_id)
                 raise MCPTimeoutError(
@@ -875,24 +967,66 @@ class MCPServerConnection:
                     f"{budget:.0f}s; whether it executed is UNKNOWN. It was "
                     "not retried automatically."
                 ) from None
-            except MCPProtocolError as e:
-                header_mismatch = e.rpc_code == proto.ERROR_HEADER_MISMATCH
-                if modern and header_mismatch and attempts == 1:
-                    # Spec recovery: the rejection happened at validation —
-                    # the call did NOT execute. Re-listing is the caller's
-                    # concern; one immediate retry with the same headers
-                    # after re-encoding is permitted.
+            except asyncio.CancelledError:
+                if not modern:
+                    await _finish_cancellation(lambda: self._send_cancelled(req_id))
+                raise
+            except MCPProtocolError as exc:
+                header_mismatch = exc.rpc_code == proto.ERROR_HEADER_MISMATCH
+                if modern and header_mismatch and attempt == 0:
+                    try:
+                        current_headers = await self._refresh_call_headers(
+                            tool_name, params.get("arguments") or {}
+                        )
+                    except (MCPError, TimeoutError) as refresh_error:
+                        raise _DefiniteCallError(
+                            f"{self.name}: header metadata refresh failed: "
+                            f"{_clean_text(str(refresh_error), 240)}"
+                        ) from refresh_error
                     continue
-                raise _DefiniteCallError(_clean_text(str(e), 300)) from e
+                if exc.rpc_code is not None:
+                    raise _DefiniteCallError(_clean_text(str(exc), 300)) from exc
+                raise
             err = proto.rpc_error(reply)
             if err is not None:
+                if modern and err.get("code") == proto.ERROR_HEADER_MISMATCH and attempt == 0:
+                    try:
+                        current_headers = await self._refresh_call_headers(
+                            tool_name, params.get("arguments") or {}
+                        )
+                    except (MCPError, TimeoutError) as refresh_error:
+                        raise _DefiniteCallError(
+                            f"{self.name}: header metadata refresh failed: "
+                            f"{_clean_text(str(refresh_error), 240)}"
+                        ) from refresh_error
+                    continue
                 raise _DefiniteCallError(
                     f"MCP error: {_clean_text(str(err.get('message', err)), 300)}"
                 )
             result = reply.get("result")
             if not isinstance(result, dict):
-                raise MCPProtocolError(f"{self.name}: tools/call returned no result")
+                raise _DefiniteCallError(f"{self.name}: tools/call returned no result")
             return result
+        raise _DefiniteCallError(f"{self.name}: header mismatch recovery exhausted")
+
+    async def _refresh_call_headers(self, tool_name: str, arguments: dict) -> dict[str, str]:
+        """Re-list and derive mirrored headers from the current annotation set."""
+        discovery = await self.discover_tools()
+        refreshed = next((tool for tool in discovery.tools if tool.name == tool_name), None)
+        if refreshed is None:
+            raise _DefiniteCallError(
+                f"MCP tool '{tool_name}' disappeared while refreshing header metadata"
+            )
+        if refreshed.excluded:
+            raise _DefiniteCallError(
+                f"MCP tool '{tool_name}' became invalid: {refreshed.exclusion_reason}"
+            )
+        headers: dict[str, str] = {}
+        for param in refreshed.header_params:
+            value = proto.header_param_value(arguments, param)
+            if value is not None:
+                headers[param.name] = value
+        return headers
 
     async def _send_cancelled(self, req_id: Any) -> None:
         """notifications/cancelled — required for stdio (both eras) and for
@@ -902,12 +1036,15 @@ class MCPServerConnection:
         )
         try:
             if self.transport_kind == "stdio" and self._stdio is not None:
-                await self._stdio.send(note)
+                await self._stdio.send(note, timeout=1.0)
             elif self._http is not None and self.era == proto.ERA_LEGACY:
-                await self._http.post(
-                    note,
-                    protocol_version=self.negotiated_version,
-                    negotiated_version=self.negotiated_version,
+                await asyncio.wait_for(
+                    self._http.post(
+                        note,
+                        protocol_version=self.negotiated_version,
+                        negotiated_version=self.negotiated_version,
+                    ),
+                    timeout=1.0,
                 )
         except Exception:
             log.debug("MCP %s: failed to send cancellation", self.name, exc_info=True)
@@ -939,7 +1076,7 @@ class _DefiniteCallError(Exception):
     lost (JSON-RPC error, validation rejection, isError result)."""
 
 
-class _SessionLostError(Exception):
+class _SessionLostError(MCPProtocolError):
     """Internal: HTTP 404 on a session-bearing request — the server
     rejected the session; the request was not executed."""
 

--- a/src/tools/mcp/client.py
+++ b/src/tools/mcp/client.py
@@ -1,0 +1,984 @@
+"""Per-server MCP connection: era detection, negotiation, discovery, calls.
+
+Era detection (plan §2, spec-sanctioned):
+
+- stdio: probe ``server/discover`` with our preferred modern version.
+  ``DiscoverResult`` ⇒ modern-era evidence, then deterministic version
+  selection. A recognized modern error ⇒ modern (select from its advertised
+  list). ANY other error or a bounded timeout ⇒ legacy ``initialize``
+  fallback. The fallback is never keyed to one error code.
+- HTTP: the same probe as a POST; classification inspects both HTTP status
+  and JSON-RPC body. Only a 400 with an empty/unrecognized body (or a plain
+  method-not-found for the probe) falls back to legacy; 401/403/429/5xx and
+  network failures establish NO era — the connect fails retryable.
+
+Version rules: exact allowlists only, never an unknown counteroffer. A
+modern-era server advertising no mutually supported modern revision is
+modern-incompatible (honest connect error) — never grounds for sending
+modern metadata under a legacy version, never grounds for ``initialize``.
+
+Outcome rules: a ``tools/call`` ends ok / failed / uncertain
+(:mod:`.outcomes`); an uncertain call is NEVER automatically replayed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ...odin_log import get_logger
+from . import protocol as proto
+from .errors import MCPConnectError, MCPProtocolError, MCPTimeoutError
+from .outcomes import (
+    OUTCOME_FAILED,
+    OUTCOME_OK,
+    OUTCOME_UNCERTAIN,
+    MCPToolOutcome,
+)
+from .transport_http import (
+    RESULT_ACCEPTED,
+    RESULT_HTTP_ERROR,
+    RESULT_JSON,
+    HttpTransport,
+    PostOutcome,
+)
+from .transport_stdio import StdioTransport
+
+log = get_logger("mcp.client")
+
+_PROBE_TIMEOUT = 15.0
+_INIT_TIMEOUT = 15.0
+_LIST_TIMEOUT = 30.0
+_DEFAULT_CALL_TIMEOUT = 120.0
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+def _clean_text(text: str, cap: int) -> str:
+    return _CONTROL_CHARS_RE.sub("", str(text))[:cap]
+
+
+@dataclass(frozen=True)
+class ToolRecord:
+    """One discovered tool, validated. Excluded tools stay visible to
+    status/UI with their reason but are never published."""
+
+    name: str
+    description: str
+    input_schema: dict
+    output_schema: dict | None = None
+    header_params: tuple[proto.HeaderParam, ...] = ()
+    excluded: bool = False
+    exclusion_reason: str = ""
+
+
+@dataclass
+class DiscoveryResult:
+    tools: list[ToolRecord] = field(default_factory=list)
+    ttl_ms: int | None = None
+
+
+class MCPServerConnection:
+    """One configured MCP server: transport + era + negotiated state."""
+
+    def __init__(
+        self,
+        name: str,
+        transport: str,
+        *,
+        command: str = "",
+        args: list[str] | None = None,
+        url: str = "",
+        headers: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str = "",
+        timeout: float = _DEFAULT_CALL_TIMEOUT,
+        on_tools_list_changed: Callable[[], None] | None = None,
+        on_connection_lost: Callable[[str], None] | None = None,
+    ) -> None:
+        self.name = name
+        self.transport_kind = transport
+        self.command = command
+        self.args = list(args or [])
+        self.url = url
+        self.headers = dict(headers or {})
+        self.env = dict(env or {})
+        self.cwd = cwd
+        self.timeout = timeout
+        self._on_tools_list_changed = on_tools_list_changed
+        self._on_connection_lost = on_connection_lost
+
+        self.era: str | None = None
+        self.negotiated_version: str | None = None
+        self.server_info: dict[str, Any] = {}
+        self.instructions: str = ""  # UI-only; never prompt-injected
+        self.connected = False
+
+        self._stdio: StdioTransport | None = None
+        self._http: HttpTransport | None = None
+        self._ids = itertools.count(1)
+        self._pending: dict[Any, asyncio.Future[dict]] = {}
+        self._lost_reason: str | None = None
+
+    # ------------------------------------------------------------------
+    # Connect
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        if self.connected:
+            return
+        self.era = None
+        self.negotiated_version = None
+        self._lost_reason = None
+        if self.transport_kind == "stdio":
+            await self._connect_stdio()
+        elif self.transport_kind == "http":
+            await self._connect_http()
+        else:
+            raise MCPConnectError(f"{self.name}: unsupported transport {self.transport_kind!r}")
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+        self._fail_pending(MCPConnectError(f"{self.name}: disconnected"))
+        stdio, self._stdio = self._stdio, None
+        http, self._http = self._http, None
+        if stdio is not None:
+            await stdio.shutdown()
+        if http is not None:
+            if self.era == proto.ERA_LEGACY and http.session_id:
+                await http.delete_session(protocol_version=self.negotiated_version)
+            await http.close()
+        self.era = None
+        self.negotiated_version = None
+
+    # -------------------------- stdio ---------------------------------
+
+    async def _connect_stdio(self) -> None:
+        transport = StdioTransport(
+            self.name,
+            self.command,
+            self.args,
+            env=self.env,
+            cwd=self.cwd or None,
+            on_message=self._on_stdio_message,
+            on_closed=self._on_transport_closed,
+            negotiated_version=lambda: self.negotiated_version,
+        )
+        self._stdio = transport
+        try:
+            await transport.start()
+            probe_id = next(self._ids)
+            probe = proto.build_request(
+                probe_id,
+                "server/discover",
+                {},
+                era=proto.ERA_MODERN,
+                version=proto.MODERN_VERSIONS[0],
+            )
+            try:
+                reply = await self._stdio_roundtrip(probe_id, probe, _PROBE_TIMEOUT)
+            except MCPTimeoutError:
+                reply = None  # silence ⇒ legacy probe outcome
+            if reply is not None and "result" in reply:
+                self._adopt_modern(reply["result"])
+                return
+            err = proto.rpc_error(reply) if reply is not None else None
+            if proto.is_recognized_modern_error(err):
+                assert err is not None
+                selection = proto.select_modern_version(proto.supported_versions_from_error(err))
+                if selection.version is None:
+                    raise MCPConnectError(f"{self.name}: {selection.reason}")
+                self.era = proto.ERA_MODERN
+                self.negotiated_version = selection.version
+                return
+            # Any other error or timeout: legacy fallback.
+            await self._initialize_legacy_stdio()
+        except BaseException:
+            self._stdio = None
+            await transport.shutdown()
+            raise
+
+    async def _initialize_legacy_stdio(self) -> None:
+        req_id = next(self._ids)
+        request = proto.build_request(
+            req_id,
+            "initialize",
+            {
+                "protocolVersion": proto.LEGACY_VERSIONS_STDIO[0],
+                "capabilities": {},
+                "clientInfo": dict(proto.CLIENT_INFO),
+            },
+            era=proto.ERA_LEGACY,
+            version=proto.LEGACY_VERSIONS_STDIO[0],
+        )
+        reply = await self._stdio_roundtrip(req_id, request, _INIT_TIMEOUT)
+        err = proto.rpc_error(reply)
+        if err is not None:
+            raise MCPConnectError(
+                f"{self.name}: initialize failed: {_clean_text(str(err.get('message', err)), 200)}"
+            )
+        result = reply.get("result")
+        if not isinstance(result, dict):
+            raise MCPConnectError(f"{self.name}: initialize returned no result")
+        counteroffer = result.get("protocolVersion")
+        version = proto.select_legacy_version(str(counteroffer), transport="stdio")
+        if version is None:
+            raise MCPConnectError(
+                f"{self.name}: server negotiated unsupported protocol version {counteroffer!r}"
+            )
+        self.era = proto.ERA_LEGACY
+        self.negotiated_version = version
+        self._adopt_server_identity(result)
+        assert self._stdio is not None
+        await self._stdio.send(proto.build_notification("notifications/initialized"))
+
+    async def _stdio_roundtrip(self, req_id: Any, request: dict, timeout: float) -> dict:
+        assert self._stdio is not None
+        future: asyncio.Future[dict] = asyncio.get_running_loop().create_future()
+        self._pending[req_id] = future
+        try:
+            await self._stdio.send(request)
+            try:
+                return await asyncio.wait_for(future, timeout=timeout)
+            except TimeoutError:
+                raise MCPTimeoutError(
+                    f"{self.name}: no reply to {request.get('method')} within {timeout}s"
+                ) from None
+        finally:
+            self._pending.pop(req_id, None)
+
+    def _on_stdio_message(self, msg: dict) -> None:
+        kind = proto.message_kind(msg)
+        if kind == proto.KIND_RESPONSE:
+            future = self._pending.get(msg.get("id"))
+            if future is not None and not future.done():
+                future.set_result(msg)
+            else:
+                # Late response after timeout/cancellation: ignored by rule.
+                log.debug("MCP %s: dropping late/unknown response id=%r", self.name, msg.get("id"))
+        elif kind == proto.KIND_NOTIFICATION:
+            self._handle_notification(msg)
+        elif kind == proto.KIND_REQUEST:
+            self._handle_server_request(msg, channel="stdio")
+
+    # --------------------------- HTTP ----------------------------------
+
+    async def _connect_http(self) -> None:
+        transport = HttpTransport(
+            self.name,
+            self.url,
+            headers=self.headers,
+            stall_timeout=max(self.timeout, 30.0),
+        )
+        self._http = transport
+        try:
+            await transport.start()
+            probe_id = next(self._ids)
+            probe = proto.build_request(
+                probe_id,
+                "server/discover",
+                {},
+                era=proto.ERA_MODERN,
+                version=proto.MODERN_VERSIONS[0],
+            )
+            outcome = await asyncio.wait_for(
+                transport.post(
+                    probe,
+                    protocol_version=proto.MODERN_VERSIONS[0],
+                    mcp_method="server/discover",
+                    include_session=False,
+                ),
+                timeout=_PROBE_TIMEOUT,
+            )
+            if self._classify_http_probe(outcome, probe_id):
+                return  # modern adopted
+            await self._initialize_legacy_http()
+        except TimeoutError:
+            self._http = None
+            await transport.close()
+            raise MCPConnectError(f"{self.name}: probe timed out") from None
+        except BaseException:
+            self._http = None
+            await transport.close()
+            raise
+
+    def _classify_http_probe(self, outcome: PostOutcome, probe_id: Any) -> bool:
+        """True ⇒ modern era adopted. False ⇒ legacy fallback. Raises for
+        non-era-evidence failures (auth/capacity/transport)."""
+        response = self._match_response(outcome.messages, probe_id)
+        if outcome.kind == RESULT_JSON and response is not None:
+            if "result" in response:
+                self._adopt_modern(response["result"])
+                return True
+            err = proto.rpc_error(response)
+            if proto.is_recognized_modern_error(err):
+                assert err is not None
+                selection = proto.select_modern_version(proto.supported_versions_from_error(err))
+                if selection.version is None:
+                    raise MCPConnectError(f"{self.name}: {selection.reason}")
+                self.era = proto.ERA_MODERN
+                self.negotiated_version = selection.version
+                return True
+            return False  # plain JSON-RPC error for the probe ⇒ legacy
+        if outcome.kind == RESULT_HTTP_ERROR:
+            err = self._first_error(outcome.messages)
+            if proto.is_recognized_modern_error(err):
+                assert err is not None
+                selection = proto.select_modern_version(proto.supported_versions_from_error(err))
+                if selection.version is None:
+                    raise MCPConnectError(f"{self.name}: {selection.reason}")
+                self.era = proto.ERA_MODERN
+                self.negotiated_version = selection.version
+                return True
+            if outcome.status == 400:
+                return False  # 400 with empty/unrecognized body ⇒ legacy
+            if outcome.status in (404, 405) and (
+                err is None or err.get("code") in (proto.ERROR_METHOD_NOT_FOUND, -32602)
+            ):
+                # server/discover is mandatory on modern servers — a plain
+                # method-not-found for the probe identifies a legacy server.
+                return False
+            raise MCPConnectError(
+                f"{self.name}: probe failed with HTTP {outcome.status} — "
+                "not era evidence (check authentication/endpoint)"
+            )
+        # 202/stream for a request-probe is out-of-contract.
+        raise MCPConnectError(f"{self.name}: probe produced no usable reply")
+
+    async def _initialize_legacy_http(self) -> None:
+        assert self._http is not None
+        best = proto.LEGACY_VERSIONS_HTTP[0]
+        req_id = next(self._ids)
+        request = proto.build_request(
+            req_id,
+            "initialize",
+            {
+                "protocolVersion": best,
+                "capabilities": {},
+                "clientInfo": dict(proto.CLIENT_INFO),
+            },
+            era=proto.ERA_LEGACY,
+            version=best,
+        )
+        outcome = await asyncio.wait_for(
+            self._http.post(
+                request,
+                protocol_version=None,  # header only AFTER negotiation
+                include_session=False,
+                capture_session=True,
+            ),
+            timeout=_INIT_TIMEOUT,
+        )
+        response = self._collect_http_response(outcome, req_id)
+        err = proto.rpc_error(response) if response else None
+        if response is None or err is not None:
+            detail = _clean_text(str((err or {}).get("message", "no response")), 200)
+            raise MCPConnectError(f"{self.name}: initialize failed: {detail}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise MCPConnectError(f"{self.name}: initialize returned no result")
+        counteroffer = result.get("protocolVersion")
+        version = proto.select_legacy_version(str(counteroffer), transport="http")
+        if version is None:
+            raise MCPConnectError(
+                f"{self.name}: server negotiated unsupported protocol version {counteroffer!r}"
+            )
+        self.era = proto.ERA_LEGACY
+        self.negotiated_version = version
+        self._adopt_server_identity(result)
+        note = proto.build_notification("notifications/initialized")
+        await self._http.post(
+            note,
+            protocol_version=version,
+            negotiated_version=version,
+        )
+
+    def _collect_http_response(self, outcome: PostOutcome, req_id: Any) -> dict | None:
+        if outcome.kind not in (RESULT_JSON, RESULT_ACCEPTED):
+            return None
+        return self._match_response(outcome.messages, req_id)
+
+    @staticmethod
+    def _match_response(messages: list[dict], req_id: Any) -> dict | None:
+        for msg in messages:
+            if proto.message_kind(msg) == proto.KIND_RESPONSE and msg.get("id") == req_id:
+                return msg
+        return None
+
+    @staticmethod
+    def _first_error(messages: list[dict]) -> dict | None:
+        for msg in messages:
+            err = proto.rpc_error(msg)
+            if err is not None:
+                return err
+        return None
+
+    # ------------------------------------------------------------------
+    # Shared identity adoption
+    # ------------------------------------------------------------------
+
+    def _adopt_modern(self, discover_result: Any) -> None:
+        if not isinstance(discover_result, dict):
+            raise MCPConnectError(f"{self.name}: malformed DiscoverResult")
+        selection = proto.select_modern_version(discover_result.get("supportedVersions"))
+        if selection.version is None:
+            raise MCPConnectError(f"{self.name}: {selection.reason}")
+        self.era = proto.ERA_MODERN
+        self.negotiated_version = selection.version
+        meta = discover_result.get("_meta")
+        if isinstance(meta, dict):
+            info = meta.get(proto.META_SERVER_INFO)
+            if isinstance(info, dict):
+                self.server_info = info
+        instructions = discover_result.get("instructions")
+        if isinstance(instructions, str):
+            self.instructions = _clean_text(instructions, proto.MAX_INSTRUCTIONS_CHARS)
+
+    def _adopt_server_identity(self, init_result: dict) -> None:
+        info = init_result.get("serverInfo")
+        if isinstance(info, dict):
+            self.server_info = info
+        instructions = init_result.get("instructions")
+        if isinstance(instructions, str):
+            self.instructions = _clean_text(instructions, proto.MAX_INSTRUCTIONS_CHARS)
+
+    # ------------------------------------------------------------------
+    # Notifications / server-initiated requests
+    # ------------------------------------------------------------------
+
+    def _handle_notification(self, msg: dict) -> None:
+        method = msg.get("method", "")
+        if method == "notifications/tools/list_changed":
+            if self._on_tools_list_changed is not None:
+                try:
+                    self._on_tools_list_changed()
+                except Exception:
+                    log.exception("MCP %s: list_changed handler failed", self.name)
+        else:
+            log.debug("MCP %s: notification %s", self.name, method)
+
+    def _handle_server_request(self, msg: dict, *, channel: str) -> None:
+        """Legacy servers may initiate requests (sampling/roots/elicitation).
+        We support none of those capabilities: answer -32601 on the correct
+        channel instead of silently dropping (a dropped request hangs the
+        server). Modern servers cannot initiate requests — log and ignore."""
+        if self.era == proto.ERA_MODERN:
+            log.warning(
+                "MCP %s: modern server sent a request (%s) — ignored",
+                self.name,
+                msg.get("method"),
+            )
+            return
+        reply = proto.build_error_response(
+            msg.get("id"),
+            proto.ERROR_METHOD_NOT_FOUND,
+            f"client does not support {msg.get('method', 'this method')}",
+        )
+        asyncio.get_running_loop().create_task(self._send_reply(reply, channel))
+
+    async def _send_reply(self, reply: dict, channel: str) -> None:
+        try:
+            if channel == "stdio" and self._stdio is not None:
+                await self._stdio.send(reply)
+            elif self._http is not None:
+                await self._http.post(
+                    reply,
+                    protocol_version=self.negotiated_version,
+                    negotiated_version=self.negotiated_version,
+                )
+        except Exception:
+            log.debug("MCP %s: failed to deliver -32601 reply", self.name, exc_info=True)
+
+    def _on_transport_closed(self, reason: str) -> None:
+        was_connected = self.connected
+        self.connected = False
+        self._lost_reason = reason
+        self._fail_pending(MCPConnectError(f"{self.name}: {reason}"))
+        if was_connected and self._on_connection_lost is not None:
+            try:
+                self._on_connection_lost(reason)
+            except Exception:
+                log.exception("MCP %s: connection-lost handler failed", self.name)
+
+    def _fail_pending(self, exc: Exception) -> None:
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_exception(exc)
+        self._pending.clear()
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    async def discover_tools(self) -> DiscoveryResult:
+        """Full paginated tools/list with validation. Raises on any protocol
+        violation — a partial or malformed listing is a FAILED listing;
+        callers never publish half a server."""
+        if not self.connected or self.era is None or self.negotiated_version is None:
+            raise MCPConnectError(f"{self.name}: not connected")
+        records: list[ToolRecord] = []
+        seen_names: set[str] = set()
+        seen_cursors: set[str] = set()
+        schema_bytes_total = 0
+        ttl_ms: int | None = None
+        cursor: str | None = None
+        for page in range(proto.MAX_LIST_PAGES + 1):
+            if page == proto.MAX_LIST_PAGES:
+                raise MCPProtocolError(
+                    f"{self.name}: tools/list exceeded {proto.MAX_LIST_PAGES} pages"
+                )
+            params: dict[str, Any] = {}
+            if cursor is not None:
+                params["cursor"] = cursor
+            result = await self._request("tools/list", params, timeout=_LIST_TIMEOUT, mcp_name=None)
+            raw_tools = result.get("tools")
+            if not isinstance(raw_tools, list):
+                raise MCPProtocolError(f"{self.name}: tools/list returned no tool array")
+            if ttl_ms is None and isinstance(result.get("ttlMs"), int):
+                ttl_ms = result["ttlMs"]
+            for raw in raw_tools:
+                record = self._validate_tool(raw)
+                if record.name in seen_names:
+                    raise MCPProtocolError(
+                        f"{self.name}: duplicate tool name {record.name!r} in listing"
+                    )
+                seen_names.add(record.name)
+                if not record.excluded:
+                    schema_bytes_total += len(json.dumps(record.input_schema).encode("utf-8"))
+                    if schema_bytes_total > proto.MAX_SCHEMA_BYTES_PER_SERVER:
+                        raise MCPProtocolError(
+                            f"{self.name}: combined tool schemas exceed "
+                            f"{proto.MAX_SCHEMA_BYTES_PER_SERVER} bytes"
+                        )
+                records.append(record)
+                if len(records) > proto.MAX_DISCOVERED_TOOLS:
+                    raise MCPProtocolError(
+                        f"{self.name}: more than {proto.MAX_DISCOVERED_TOOLS} tools discovered"
+                    )
+            next_cursor = result.get("nextCursor")
+            if next_cursor is None or next_cursor == "":
+                break
+            if not isinstance(next_cursor, str):
+                raise MCPProtocolError(f"{self.name}: malformed nextCursor")
+            if next_cursor in seen_cursors:
+                raise MCPProtocolError(f"{self.name}: duplicate pagination cursor")
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+        return DiscoveryResult(tools=records, ttl_ms=ttl_ms)
+
+    def _validate_tool(self, raw: Any) -> ToolRecord:
+        if not isinstance(raw, dict) or not isinstance(raw.get("name"), str) or not raw["name"]:
+            raise MCPProtocolError(f"{self.name}: tool entry without a name")
+        name = raw["name"]
+        description = _clean_text(str(raw.get("description", "")), proto.MAX_DESCRIPTION_CHARS)
+        schema = raw.get("inputSchema", {"type": "object", "properties": {}})
+        check = proto.validate_tool_schema(schema)
+        if not check.ok:
+            return ToolRecord(
+                name=name,
+                description=description,
+                input_schema={},
+                excluded=True,
+                exclusion_reason=check.reason,
+            )
+        output_schema = raw.get("outputSchema")
+        if not isinstance(output_schema, dict):
+            output_schema = None
+        header_params: tuple[proto.HeaderParam, ...] = ()
+        if self.transport_kind == "http" and self.era == proto.ERA_MODERN:
+            hp = proto.extract_header_params(schema)
+            if not hp.ok:
+                # Spec: an invalid x-mcp-header annotation invalidates the
+                # tool — exclude it, keep the rest of the listing usable.
+                return ToolRecord(
+                    name=name,
+                    description=description,
+                    input_schema=schema,
+                    output_schema=output_schema,
+                    excluded=True,
+                    exclusion_reason=hp.reason,
+                )
+            header_params = hp.params
+        return ToolRecord(
+            name=name,
+            description=description,
+            input_schema=schema,
+            output_schema=output_schema,
+            header_params=header_params,
+        )
+
+    # ------------------------------------------------------------------
+    # Requests (era-shaped) and tool calls
+    # ------------------------------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        params: dict,
+        *,
+        timeout: float,
+        mcp_name: str | None,
+        param_headers: dict[str, str] | None = None,
+    ) -> dict:
+        """One request/response on the negotiated era. Returns the RESULT
+        object; raises typed errors otherwise. Retry-safe callers only
+        (discovery/listing) — tools/call goes through :meth:`call_tool`."""
+        assert self.era is not None and self.negotiated_version is not None
+        req_id = next(self._ids)
+        request = proto.build_request(
+            req_id, method, params, era=self.era, version=self.negotiated_version
+        )
+        if self.transport_kind == "stdio":
+            reply = await self._stdio_roundtrip(req_id, request, timeout)
+        else:
+            reply = await self._http_roundtrip(
+                req_id,
+                request,
+                timeout,
+                mcp_method=method,
+                mcp_name=mcp_name,
+                param_headers=param_headers,
+            )
+        err = proto.rpc_error(reply)
+        if err is not None:
+            raise MCPProtocolError(
+                f"{self.name}: {method} failed: {_clean_text(str(err.get('message', err)), 200)}"
+            )
+        result = reply.get("result")
+        if not isinstance(result, dict):
+            raise MCPProtocolError(f"{self.name}: {method} returned no result object")
+        rt = proto.check_result_type(result, era=self.era)
+        if not rt.ok:
+            raise MCPProtocolError(f"{self.name}: {method}: {rt.reason}")
+        return result
+
+    async def _http_roundtrip(
+        self,
+        req_id: Any,
+        request: dict,
+        timeout: float,
+        *,
+        mcp_method: str,
+        mcp_name: str | None,
+        param_headers: dict[str, str] | None = None,
+    ) -> dict:
+        assert self._http is not None and self.negotiated_version is not None
+        collected: dict[str, dict | None] = {"response": None}
+
+        def on_message(msg: dict) -> None:
+            kind = proto.message_kind(msg)
+            if kind == proto.KIND_RESPONSE and msg.get("id") == req_id:
+                collected["response"] = msg
+            elif kind == proto.KIND_NOTIFICATION:
+                self._handle_notification(msg)
+            elif kind == proto.KIND_REQUEST:
+                self._handle_server_request(msg, channel="http")
+
+        modern = self.era == proto.ERA_MODERN
+        outcome = await asyncio.wait_for(
+            self._http.post(
+                request,
+                protocol_version=self.negotiated_version,
+                mcp_method=mcp_method if modern else None,
+                mcp_name=mcp_name if modern else None,
+                param_headers=param_headers if modern else None,
+                negotiated_version=self.negotiated_version,
+                on_message=on_message,
+            ),
+            timeout=timeout,
+        )
+        if outcome.kind == RESULT_JSON:
+            response = self._match_response(outcome.messages, req_id)
+            for msg in outcome.messages:
+                if msg is not response:
+                    on_message(msg)
+            if response is not None:
+                return response
+        if collected["response"] is not None:
+            return collected["response"]
+        if outcome.kind == RESULT_HTTP_ERROR:
+            err = self._first_error(outcome.messages)
+            if outcome.status == 404 and self._http.session_id:
+                raise _SessionLostError(self.name)
+            detail = (
+                _clean_text(str(err.get("message", "")), 200) if err else f"HTTP {outcome.status}"
+            )
+            raise MCPProtocolError(
+                f"{self.name}: {mcp_method} rejected: {detail}",
+                rpc_code=err.get("code") if err else None,
+            )
+        raise MCPProtocolError(f"{self.name}: no response for {mcp_method}")
+
+    async def call_tool(
+        self,
+        tool: ToolRecord,
+        arguments: dict,
+        *,
+        timeout: float | None = None,
+        generation: int = 0,
+    ) -> MCPToolOutcome:
+        """Invoke one tool. Returns a typed outcome; never raises for
+        call-path failures. NEVER automatically replays: after the request
+        has been written, any ambiguity is ``uncertain``; an explicit
+        session rejection is a definite failure — and still not reissued."""
+        budget = timeout if timeout is not None else self.timeout
+        version = self.negotiated_version or ""
+
+        def outcome(status: str, text: str, detail: str = "") -> MCPToolOutcome:
+            return MCPToolOutcome(
+                status=status,
+                text=text,
+                server=self.name,
+                tool=tool.name,
+                negotiated_version=version,
+                generation=generation,
+                detail=detail,
+            )
+
+        if not self.connected or self.era is None:
+            return outcome(OUTCOME_FAILED, f"MCP server '{self.name}' is not connected")
+        if tool.excluded:
+            return outcome(
+                OUTCOME_FAILED,
+                f"MCP tool '{tool.name}' is excluded: {tool.exclusion_reason}",
+            )
+        param_headers: dict[str, str] = {}
+        for hp in tool.header_params:
+            value = proto.header_param_value(arguments, hp)
+            if value is not None:
+                param_headers[hp.name] = value
+        params = {"name": tool.name, "arguments": arguments}
+        wrote = False
+        try:
+            if self.transport_kind == "stdio":
+                wrote = True  # conservatively: the write may reach the wire
+                result = await self._call_stdio(params, budget)
+            else:
+                wrote = True
+                result = await self._call_http(
+                    params, budget, tool_name=tool.name, param_headers=param_headers
+                )
+        except _SessionLostError:
+            # Explicit session rejection: the server refused the request at
+            # session validation — definite failure, never silently
+            # reissued. Reconnect (a lifecycle operation) is the
+            # supervisor's job, triggered via the lost-connection path.
+            self._on_transport_closed("server session expired")
+            return outcome(
+                OUTCOME_FAILED,
+                f"MCP server '{self.name}' rejected the session; the call was "
+                "not executed. The server is reconnecting — retry explicitly "
+                "if still needed.",
+            )
+        except _DefiniteCallError as e:
+            return outcome(OUTCOME_FAILED, str(e))
+        except TimeoutError:
+            await self._cancel_in_flight()
+            return outcome(
+                OUTCOME_UNCERTAIN,
+                f"MCP tool '{tool.name}' on '{self.name}' timed out after "
+                f"{budget:.0f}s; whether it executed is UNKNOWN. It was not "
+                "retried automatically.",
+                detail="timeout",
+            )
+        except MCPTimeoutError:
+            return outcome(
+                OUTCOME_UNCERTAIN,
+                f"MCP tool '{tool.name}' on '{self.name}' timed out after "
+                f"{budget:.0f}s; whether it executed is UNKNOWN. It was not "
+                "retried automatically.",
+                detail="timeout",
+            )
+        except (MCPConnectError, MCPProtocolError) as e:
+            if wrote:
+                return outcome(
+                    OUTCOME_UNCERTAIN,
+                    f"MCP tool '{tool.name}' on '{self.name}' failed after the "
+                    f"request was sent ({_clean_text(str(e), 200)}); whether it "
+                    "executed is UNKNOWN. It was not retried automatically.",
+                    detail="transport-loss",
+                )
+            return outcome(OUTCOME_FAILED, _clean_text(str(e), 400))
+        rt = proto.check_result_type(result, era=self.era)
+        if rt.input_required:
+            return outcome(
+                OUTCOME_FAILED,
+                f"MCP tool '{tool.name}' requested additional input (MRTR), "
+                "which this client does not support.",
+            )
+        if not rt.ok:
+            return outcome(OUTCOME_FAILED, f"protocol violation: {rt.reason}")
+        text, is_error = _render_tool_result(result)
+        if is_error:
+            return outcome(OUTCOME_FAILED, text or "tool reported an error")
+        return outcome(OUTCOME_OK, text)
+
+    async def _call_stdio(self, params: dict, budget: float) -> dict:
+        assert self.era is not None and self.negotiated_version is not None
+        req_id = next(self._ids)
+        request = proto.build_request(
+            req_id, "tools/call", params, era=self.era, version=self.negotiated_version
+        )
+        try:
+            reply = await self._stdio_roundtrip(req_id, request, budget)
+        except MCPTimeoutError:
+            await self._send_cancelled(req_id)
+            raise
+        err = proto.rpc_error(reply)
+        if err is not None:
+            raise _DefiniteCallError(f"MCP error: {_clean_text(str(err.get('message', err)), 300)}")
+        result = reply.get("result")
+        if not isinstance(result, dict):
+            raise MCPProtocolError(f"{self.name}: tools/call returned no result")
+        return result
+
+    async def _call_http(
+        self,
+        params: dict,
+        budget: float,
+        *,
+        tool_name: str,
+        param_headers: dict[str, str],
+    ) -> dict:
+        assert self.era is not None and self.negotiated_version is not None
+        modern = self.era == proto.ERA_MODERN
+        attempts = 0
+        while True:
+            attempts += 1
+            req_id = next(self._ids)
+            request = proto.build_request(
+                req_id, "tools/call", params, era=self.era, version=self.negotiated_version
+            )
+            try:
+                reply = await self._http_roundtrip(
+                    req_id,
+                    request,
+                    budget,
+                    mcp_method="tools/call",
+                    mcp_name=proto.encode_header_value(tool_name) if modern else None,
+                    param_headers=param_headers,
+                )
+            except TimeoutError:
+                # Aborting the POST/stream IS the modern cancel; legacy
+                # additionally requires an explicit cancellation
+                # notification (closing legacy SSE is NOT cancel).
+                if not modern:
+                    await self._send_cancelled(req_id)
+                raise MCPTimeoutError(
+                    f"MCP tool '{tool_name}' on '{self.name}' timed out after "
+                    f"{budget:.0f}s; whether it executed is UNKNOWN. It was "
+                    "not retried automatically."
+                ) from None
+            except MCPProtocolError as e:
+                header_mismatch = e.rpc_code == proto.ERROR_HEADER_MISMATCH
+                if modern and header_mismatch and attempts == 1:
+                    # Spec recovery: the rejection happened at validation —
+                    # the call did NOT execute. Re-listing is the caller's
+                    # concern; one immediate retry with the same headers
+                    # after re-encoding is permitted.
+                    continue
+                raise _DefiniteCallError(_clean_text(str(e), 300)) from e
+            err = proto.rpc_error(reply)
+            if err is not None:
+                raise _DefiniteCallError(
+                    f"MCP error: {_clean_text(str(err.get('message', err)), 300)}"
+                )
+            result = reply.get("result")
+            if not isinstance(result, dict):
+                raise MCPProtocolError(f"{self.name}: tools/call returned no result")
+            return result
+
+    async def _send_cancelled(self, req_id: Any) -> None:
+        """notifications/cancelled — required for stdio (both eras) and for
+        LEGACY Streamable HTTP; never sent for initialize."""
+        note = proto.build_notification(
+            "notifications/cancelled", {"requestId": req_id, "reason": "timeout"}
+        )
+        try:
+            if self.transport_kind == "stdio" and self._stdio is not None:
+                await self._stdio.send(note)
+            elif self._http is not None and self.era == proto.ERA_LEGACY:
+                await self._http.post(
+                    note,
+                    protocol_version=self.negotiated_version,
+                    negotiated_version=self.negotiated_version,
+                )
+        except Exception:
+            log.debug("MCP %s: failed to send cancellation", self.name, exc_info=True)
+
+    async def _cancel_in_flight(self) -> None:
+        # stdio path sends notifications/cancelled at the call site (it
+        # knows the request id); nothing further to do here.
+        return
+
+    # ------------------------------------------------------------------
+
+    def status(self) -> dict[str, Any]:
+        stderr_tail = self._stdio.stderr_tail() if self._stdio is not None else ""
+        return {
+            "name": self.name,
+            "transport": self.transport_kind,
+            "connected": self.connected,
+            "era": self.era,
+            "negotiated_version": self.negotiated_version,
+            "server_info": dict(self.server_info),
+            "instructions": self.instructions,
+            "last_error": self._lost_reason or "",
+            "stderr_tail": stderr_tail,
+        }
+
+
+class _DefiniteCallError(Exception):
+    """Internal: a tools/call failure that is definitely NOT executed-and-
+    lost (JSON-RPC error, validation rejection, isError result)."""
+
+
+class _SessionLostError(Exception):
+    """Internal: HTTP 404 on a session-bearing request — the server
+    rejected the session; the request was not executed."""
+
+
+def _render_tool_result(result: dict) -> tuple[str, bool]:
+    """Model-facing rendering of a tools/call result: text content joined;
+    structured content JSON-dumped when no text exists; binary content
+    described, never embedded."""
+    is_error = bool(result.get("isError", False))
+    texts: list[str] = []
+    content = result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                kind = item.get("type")
+                if kind == "text":
+                    texts.append(str(item.get("text", "")))
+                elif kind == "image":
+                    texts.append(f"[image: {item.get('mimeType', 'unknown')}]")
+                elif kind == "audio":
+                    texts.append(f"[audio: {item.get('mimeType', 'unknown')}]")
+                elif kind == "resource":
+                    resource = item.get("resource")
+                    uri = (
+                        resource.get("uri")
+                        if isinstance(resource, dict)
+                        else item.get("uri", "unknown")
+                    )
+                    texts.append(f"[resource: {uri}]")
+                else:
+                    texts.append(f"[{kind or 'unknown'} content]")
+            elif isinstance(item, str):
+                texts.append(item)
+    if not texts:
+        structured = result.get("structuredContent")
+        if structured is not None:
+            try:
+                texts.append(json.dumps(structured, indent=2)[: proto.WIRE_RESULT_CEILING])
+            except (TypeError, ValueError):
+                texts.append("[unrenderable structured content]")
+    text = "\n".join(t for t in texts if t) or "(no output)"
+    return text, is_error

--- a/src/tools/mcp/errors.py
+++ b/src/tools/mcp/errors.py
@@ -23,6 +23,10 @@ class MCPConnectError(MCPError):
     negotiation, or the initialize handshake. Retryable by reconnect."""
 
 
+class MCPPreWriteError(MCPConnectError):
+    """A tool request was rejected locally before any bytes could be written."""
+
+
 class MCPProtocolError(MCPError):
     """The server violated the negotiated protocol (malformed frame,
     oversized message, missing required fields, batch outside 2025-03-26,

--- a/src/tools/mcp/errors.py
+++ b/src/tools/mcp/errors.py
@@ -1,0 +1,40 @@
+"""Typed MCP error hierarchy.
+
+Every failure mode has a type; nothing in this package communicates failure
+through ambient strings. Dispatch layers translate these into user-facing
+tool results; the durability layer relies on the ok/failed/uncertain
+classification carried by :class:`~src.tools.mcp.outcomes.MCPToolOutcome`.
+"""
+
+from __future__ import annotations
+
+
+class MCPError(Exception):
+    """Base for every MCP client error."""
+
+
+class MCPConfigError(MCPError):
+    """A server configuration is structurally invalid (bad transport shape,
+    illegal header name, malformed env/cwd, limit violation)."""
+
+
+class MCPConnectError(MCPError):
+    """Connecting failed: transport launch, era detection, version
+    negotiation, or the initialize handshake. Retryable by reconnect."""
+
+
+class MCPProtocolError(MCPError):
+    """The server violated the negotiated protocol (malformed frame,
+    oversized message, missing required fields, batch outside 2025-03-26,
+    duplicate tool names, invalid pagination) — or rejected a request with a
+    JSON-RPC error, whose code rides on ``rpc_code`` so callers can react
+    structurally (never by matching error text)."""
+
+    def __init__(self, message: str, *, rpc_code: int | None = None) -> None:
+        super().__init__(message)
+        self.rpc_code = rpc_code
+
+
+class MCPTimeoutError(MCPError):
+    """A bounded operation exceeded its budget before the request was
+    written, or during connect/discovery where retry is safe."""

--- a/src/tools/mcp/manager.py
+++ b/src/tools/mcp/manager.py
@@ -22,6 +22,7 @@ its generation under the lock before touching published state.
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import random
 import re
@@ -222,25 +223,55 @@ class MCPManager:
         """Adopt the full desired state (boot / config reload). Validates
         every server; invalid entries are recorded in error state rather
         than discarded silently."""
+        desired_configs = {name: copy.deepcopy(config) for name, config in servers.items()}
+        retire: list[_ServerRuntime] = []
         async with self._lock:
-            self._global_enabled = bool(enabled)
-            for name, config in servers.items():
-                runtime = _ServerRuntime(config=dict(config), generation=self._next_gen())
+            previous_enabled = self._global_enabled
+            previous = self._servers
+            replacements: dict[str, _ServerRuntime] = {}
+            catalog_changed = False
+            for name, config in desired_configs.items():
+                old = previous.get(name)
+                reuse = (
+                    old is not None and old.config == config and previous_enabled == bool(enabled)
+                )
+                if reuse:
+                    assert old is not None
+                    replacements[name] = old
+                    continue
+                runtime = _ServerRuntime(config=config, generation=self._next_gen())
                 try:
                     _validate_server_config(name, runtime.config)
                 except MCPConfigError as e:
                     runtime.state = STATE_ERROR
                     runtime.last_error = str(e)
                     runtime.config_invalid = True
-                self._servers[name] = runtime
+                replacements[name] = runtime
+            for name, old in previous.items():
+                if replacements.get(name) is old:
+                    continue
+                old.generation = self._next_gen()
+                catalog_changed = catalog_changed or bool(old.published)
+                old.published = {}
+                retire.append(old)
+            self._global_enabled = bool(enabled)
+            self._servers = replacements
             self._rebuild_published_index_locked()
+            if catalog_changed:
+                self._notify_catalog_changed()
+        await asyncio.gather(*(self._retire_runtime(runtime) for runtime in retire))
+        if self._started and self._global_enabled:
+            await asyncio.gather(
+                *(self._reconcile_server(name) for name in list(self._servers)),
+                return_exceptions=True,
+            )
 
     async def add_server(self, name: str, config: dict[str, Any]) -> dict[str, Any]:
         _validate_server_config(name, config)
         async with self._lock:
             if name in self._servers:
                 raise MCPConfigError(f"server '{name}' already exists")
-            runtime = _ServerRuntime(config=dict(config), generation=self._next_gen())
+            runtime = _ServerRuntime(config=copy.deepcopy(config), generation=self._next_gen())
             self._servers[name] = runtime
         await self._reconcile_server(name)
         return self.get_status()
@@ -248,13 +279,14 @@ class MCPManager:
     async def update_server(self, name: str, config: dict[str, Any]) -> dict[str, Any]:
         _validate_server_config(name, config)
         async with self._lock:
-            runtime = self._servers.get(name)
-            if runtime is None:
+            old = self._servers.get(name)
+            if old is None:
                 raise MCPConfigError(f"server '{name}' not found")
-            runtime.config = dict(config)
-            runtime.generation = self._next_gen()
-            self._unpublish_locked(name, runtime, reason="configuration changed")
-        await self._teardown_connection(name)
+            old.generation = self._next_gen()
+            self._unpublish_locked(name, old, reason="configuration changed")
+            runtime = _ServerRuntime(config=copy.deepcopy(config), generation=self._next_gen())
+            self._servers[name] = runtime
+        await self._retire_runtime(old)
         await self._reconcile_server(name)
         return self.get_status()
 
@@ -265,22 +297,22 @@ class MCPManager:
                 raise MCPConfigError(f"server '{name}' not found")
             runtime.generation = self._next_gen()  # fences in-flight tasks
             self._unpublish_locked(name, runtime, reason="removed")
-        await self._stop_supervisor(runtime)
-        if runtime.connection is not None:
-            await runtime.connection.disconnect()
+        await self._retire_runtime(runtime)
 
     async def set_global_enabled(self, enabled: bool) -> None:
         """Off: synchronous unpublish, then teardown. On: async reconcile."""
+        runtimes: list[_ServerRuntime] = []
         async with self._lock:
             self._global_enabled = bool(enabled)
             if not enabled:
+                runtimes = list(self._servers.values())
                 for sname, runtime in self._servers.items():
                     runtime.generation = self._next_gen()
                     self._unpublish_locked(sname, runtime, reason="MCP globally disabled")
                     runtime.state = STATE_DISABLED
         if not enabled:
             await asyncio.gather(
-                *(self._teardown_connection(name) for name in list(self._servers)),
+                *(self._retire_runtime(runtime) for runtime in runtimes),
                 return_exceptions=True,
             )
         else:
@@ -305,28 +337,25 @@ class MCPManager:
     async def shutdown(self) -> None:
         """Concurrent, bounded teardown of everything."""
         self._stopping = True
-        runtimes = list(self._servers.values())
-        for runtime in runtimes:
-            runtime.generation = self._next_gen()
-        await asyncio.gather(*(self._stop_supervisor(r) for r in runtimes), return_exceptions=True)
-        await asyncio.gather(
-            *(r.connection.disconnect() for r in runtimes if r.connection is not None),
-            return_exceptions=True,
-        )
         async with self._lock:
+            runtimes = list(self._servers.values())
             for sname, runtime in self._servers.items():
+                runtime.generation = self._next_gen()
+                runtime.state = STATE_DISABLED
                 self._unpublish_locked(sname, runtime, reason="shutdown")
+        await asyncio.gather(*(self._retire_runtime(r) for r in runtimes), return_exceptions=True)
 
     async def reconnect_server(self, name: str) -> dict[str, Any]:
         """Manual reconnect: teardown + fresh connect now."""
         async with self._lock:
-            runtime = self._servers.get(name)
-            if runtime is None:
+            old = self._servers.get(name)
+            if old is None:
                 raise MCPConfigError(f"server '{name}' not found")
-            runtime.generation = self._next_gen()
-            runtime.backoff_idx = 0
-            self._unpublish_locked(name, runtime, reason="reconnecting")
-        await self._teardown_connection(name)
+            old.generation = self._next_gen()
+            self._unpublish_locked(name, old, reason="reconnecting")
+            runtime = _ServerRuntime(config=copy.deepcopy(old.config), generation=self._next_gen())
+            self._servers[name] = runtime
+        await self._retire_runtime(old)
         await self._reconcile_server(name)
         return self.get_status()
 
@@ -373,17 +402,15 @@ class MCPManager:
                 index[published_name] = (name, record)
         self._published_index = index
 
-    async def _teardown_connection(self, name: str) -> None:
-        runtime = self._servers.get(name)
-        if runtime is None:
-            return
+    async def _retire_runtime(self, runtime: _ServerRuntime) -> None:
+        """Stop one captured runtime by identity, never by a reused name."""
         await self._stop_supervisor(runtime)
         connection, runtime.connection = runtime.connection, None
         if connection is not None:
             try:
                 await connection.disconnect()
             except Exception:
-                log.exception("MCP %s: teardown error", name)
+                log.exception("MCP: retired runtime teardown error")
 
     async def _stop_supervisor(self, runtime: _ServerRuntime) -> None:
         task, runtime.supervisor = runtime.supervisor, None
@@ -407,7 +434,7 @@ class MCPManager:
                 if current is runtime:
                     self._unpublish_locked(name, runtime, reason="disabled")
                     runtime.state = STATE_DISABLED
-            await self._teardown_connection(name)
+            await self._retire_runtime(runtime)
             return
         if runtime.config_invalid:
             return  # structurally invalid config cannot be supervised
@@ -521,12 +548,17 @@ class MCPManager:
                 env=dict(config.get("env", {}) or {}),
                 cwd=config.get("cwd", ""),
                 timeout=float(config.get("timeout_seconds", 120)),
-                on_tools_list_changed=lambda: self._on_list_changed(name, generation),
-                on_connection_lost=lambda reason: self._on_lost(name, generation, reason),
+                on_tools_list_changed=lambda: self._on_list_changed(name, generation, connection),
+                on_connection_lost=lambda reason: self._on_lost(
+                    name, generation, connection, reason
+                ),
             )
             try:
                 await asyncio.wait_for(connection.connect(), timeout=_CONNECT_BUDGET_S)
                 discovery = await connection.discover_tools()
+            except asyncio.CancelledError:
+                await connection.disconnect()
+                raise
             except TimeoutError:
                 await connection.disconnect()
                 return await self._record_connect_failure(name, generation, "connect timed out")
@@ -674,26 +706,46 @@ class MCPManager:
                 return
             await self._publish(name, generation, connection, discovery)
 
-    def _on_list_changed(self, name: str, generation: int) -> None:
+    def _on_list_changed(self, name: str, generation: int, connection: MCPServerConnection) -> None:
         runtime = self._servers.get(name)
-        if runtime is not None and runtime.generation == generation:
+        if (
+            runtime is not None
+            and runtime.generation == generation
+            and runtime.connection is connection
+        ):
             runtime.wake.set()
 
-    def _on_lost(self, name: str, generation: int, reason: str) -> None:
+    def _on_lost(
+        self,
+        name: str,
+        generation: int,
+        connection: MCPServerConnection,
+        reason: str,
+    ) -> None:
+        """Fence loss synchronously before returning to the transport callback."""
         runtime = self._servers.get(name)
-        if runtime is None or runtime.generation != generation:
+        if (
+            runtime is None
+            or runtime.generation != generation
+            or runtime.connection is not connection
+        ):
             return
-        asyncio.get_running_loop().create_task(self._handle_lost(name, generation, reason))
-
-    async def _handle_lost(self, name: str, generation: int, reason: str) -> None:
-        async with self._lock:
-            runtime = self._servers.get(name)
-            if runtime is None or runtime.generation != generation:
-                return
-            runtime.state = STATE_ERROR
-            runtime.last_error = reason[:500]
-            self._unpublish_locked(name, runtime, reason=f"connection lost: {reason}")
+        runtime.state = STATE_ERROR
+        runtime.last_error = reason[:500]
+        runtime.connection = None
+        self._unpublish_locked(name, runtime, reason=f"connection lost: {reason}")
         runtime.wake.set()
+        asyncio.get_running_loop().create_task(
+            self._disconnect_lost_connection(connection),
+            name=f"mcp-retire-lost-{name}",
+        )
+
+    @staticmethod
+    async def _disconnect_lost_connection(connection: MCPServerConnection) -> None:
+        try:
+            await connection.disconnect()
+        except Exception:
+            log.exception("MCP: lost connection teardown failed")
 
     # ------------------------------------------------------------------
     # Execution

--- a/src/tools/mcp/manager.py
+++ b/src/tools/mcp/manager.py
@@ -1,0 +1,730 @@
+"""MCP control plane: desired state, supervision, publication.
+
+Always constructed (plan §4) — a globally disabled or empty installation
+still has a manager, so status/CRUD surfaces never 503 and the first server
+can always be added. Disabled means zero processes, zero HTTP sessions,
+zero published tools — not "the control plane vanished".
+
+Four states drive publication: Configured → Enabled → Connected → Published.
+A tool is published iff global enabled AND server enabled AND the CURRENT
+config generation connected AND a complete validated listing succeeded AND
+the tool passed validation/limits. Every transition invalidates the catalog
+synchronously via ``on_catalog_changed`` — no model request assembled after
+a transition may contain a removed tool.
+
+Concurrency: one reconciliation lock guards desired/published state; each
+server has a single-flight connect/refresh guard; every mutation advances a
+monotonic config generation, and a stale task (an old connect/refresh still
+running after an edit/disable/remove) can never republish — it re-checks
+its generation under the lock before touching published state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import random
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from ...odin_log import get_logger
+from . import protocol as proto
+from .client import DiscoveryResult, MCPServerConnection, ToolRecord
+from .errors import MCPConfigError, MCPError
+from .outcomes import OUTCOME_FAILED, MCPToolOutcome
+
+log = get_logger("mcp.manager")
+
+STATE_DISABLED = "disabled"
+STATE_CONNECTING = "connecting"
+STATE_CONNECTED = "connected"
+STATE_STALE = "stale"
+STATE_ERROR = "error"
+STATE_BLOCKED = "blocked"
+
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SAFE_TOOL_CHARS = re.compile(r"[^A-Za-z0-9_-]")
+_PUBLISHED_NAME_MAX = 64
+
+_REFRESH_MIN_S = 60.0
+_REFRESH_MAX_S = 600.0
+_REFRESH_DEFAULT_S = 600.0
+_BACKOFF_BASE_S = 5.0
+_BACKOFF_MAX_S = 1800.0
+_CONNECT_BUDGET_S = 20.0
+
+
+def make_published_name(server: str, tool: str) -> str:
+    """Deterministic provider-safe published name. MCP permits names model
+    providers reject; sanitize to ``[A-Za-z0-9_-]`` and bound to 64 chars.
+    When sanitization loses information or the name overflows, append an
+    8-hex digest of the ORIGINAL pair so distinct tools can never merge."""
+    safe_tool = _SAFE_TOOL_CHARS.sub("_", tool)
+    base = f"mcp_{server}_{safe_tool}"
+    if safe_tool == tool and len(base) <= _PUBLISHED_NAME_MAX:
+        return base
+    digest = hashlib.sha1(f"{server}/{tool}".encode()).hexdigest()[:8]
+    keep = _PUBLISHED_NAME_MAX - 9  # "_" + digest
+    return f"{base[:keep]}_{digest}"
+
+
+@dataclass
+class _ServerRuntime:
+    """Runtime companion of one configured server."""
+
+    config: dict[str, Any]
+    generation: int
+    state: str = STATE_DISABLED
+    connection: MCPServerConnection | None = None
+    discovered: list[ToolRecord] = field(default_factory=list)
+    published: dict[str, ToolRecord] = field(default_factory=dict)  # published name → record
+    ttl_ms: int | None = None
+    last_error: str = ""
+    blocked_reason: str = ""
+    config_invalid: bool = False
+    last_refresh_monotonic: float | None = None
+    supervisor: asyncio.Task | None = None
+    wake: asyncio.Event = field(default_factory=asyncio.Event)
+    flight: asyncio.Lock = field(default_factory=asyncio.Lock)
+    backoff_idx: int = 0
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.get("enabled", True))
+
+
+def _validate_server_config(name: str, config: dict[str, Any]) -> None:
+    if not _NAME_RE.match(name or ""):
+        raise MCPConfigError(
+            f"invalid server name {name!r}: letters, digits, underscores, no leading digit"
+        )
+    transport = config.get("transport", "stdio")
+    if transport not in ("stdio", "http"):
+        raise MCPConfigError(f"{name}: transport must be 'stdio' or 'http'")
+    if transport == "stdio" and not config.get("command"):
+        raise MCPConfigError(f"{name}: stdio transport requires 'command'")
+    if transport == "http":
+        url = config.get("url", "")
+        if not str(url).lower().startswith(("http://", "https://")):
+            raise MCPConfigError(f"{name}: http transport requires an http(s) 'url'")
+    for key in ("headers", "env"):
+        mapping = config.get(key) or {}
+        if not isinstance(mapping, dict):
+            raise MCPConfigError(f"{name}: {key} must be a mapping")
+        for k in mapping:
+            if not str(k).strip() or any(c in str(k) for c in "\r\n\0"):
+                raise MCPConfigError(f"{name}: illegal {key} key {k!r}")
+    allowlist = config.get("tool_allowlist") or []
+    if not isinstance(allowlist, list) or any(not isinstance(t, str) for t in allowlist):
+        raise MCPConfigError(f"{name}: tool_allowlist must be a list of tool names")
+    timeout = config.get("timeout_seconds", 120)
+    if not isinstance(timeout, (int, float)) or not (1 <= float(timeout) <= 3600):
+        raise MCPConfigError(f"{name}: timeout_seconds must be within 1–3600")
+
+
+class MCPManager:
+    """The control plane. Constructed synchronously with zero I/O; transports
+    exist only for globally-enabled, per-server-enabled configurations after
+    ``start()`` (or a mutation) reconciles them."""
+
+    def __init__(self, *, on_catalog_changed: Any | None = None) -> None:
+        self._servers: dict[str, _ServerRuntime] = {}
+        self._global_enabled = False
+        self._generation = 0
+        self._lock = asyncio.Lock()
+        self._on_catalog_changed = on_catalog_changed
+        self._published_index: dict[str, tuple[str, ToolRecord]] = {}
+        self._started = False
+        self._stopping = False
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def global_enabled(self) -> bool:
+        return self._global_enabled
+
+    @property
+    def server_names(self) -> list[str]:
+        return list(self._servers)
+
+    def has_tool(self, published_name: str) -> bool:
+        return published_name in self._published_index
+
+    def get_tool_definitions(self) -> list[dict]:
+        """Published tool definitions, catalog-shaped. Only CONNECTED
+        current-generation servers contribute; everything else is zero."""
+        defs: list[dict] = []
+        for name, runtime in self._servers.items():
+            if runtime.state != STATE_CONNECTED:
+                continue
+            for published_name, record in runtime.published.items():
+                defs.append(
+                    {
+                        "name": published_name,
+                        "description": f"[MCP:{name}] {record.description}"[
+                            : proto.MAX_DESCRIPTION_CHARS + 16
+                        ],
+                        "input_schema": record.input_schema,
+                    }
+                )
+        return defs
+
+    def get_status(self) -> dict[str, Any]:
+        servers = []
+        for name, runtime in self._servers.items():
+            conn_status = runtime.connection.status() if runtime.connection else {}
+            age = (
+                round(time.monotonic() - runtime.last_refresh_monotonic)
+                if runtime.last_refresh_monotonic is not None
+                else None
+            )
+            servers.append(
+                {
+                    "name": name,
+                    "transport": runtime.config.get("transport", "stdio"),
+                    "enabled": runtime.enabled,
+                    "state": runtime.state,
+                    "era": conn_status.get("era"),
+                    "negotiated_version": conn_status.get("negotiated_version"),
+                    "server_info": conn_status.get("server_info", {}),
+                    "instructions": conn_status.get("instructions", ""),
+                    "discovered_count": len(runtime.discovered),
+                    "published_count": len(runtime.published),
+                    "excluded_count": sum(1 for t in runtime.discovered if t.excluded),
+                    "published_tools": sorted(runtime.published),
+                    "original_tools": [t.name for t in runtime.discovered],
+                    "last_error": runtime.last_error,
+                    "blocked_reason": runtime.blocked_reason,
+                    "last_refresh_age_seconds": age,
+                    "stderr_tail": conn_status.get("stderr_tail", ""),
+                    "generation": runtime.generation,
+                }
+            )
+        return {
+            "enabled": self._global_enabled,
+            "server_count": len(self._servers),
+            "connected_count": sum(1 for r in self._servers.values() if r.state == STATE_CONNECTED),
+            "published_tool_count": len(self._published_index),
+            "servers": servers,
+        }
+
+    # ------------------------------------------------------------------
+    # Desired-state mutation (persistence is the caller's concern)
+    # ------------------------------------------------------------------
+
+    async def load_desired_state(
+        self, *, enabled: bool, servers: dict[str, dict[str, Any]]
+    ) -> None:
+        """Adopt the full desired state (boot / config reload). Validates
+        every server; invalid entries are recorded in error state rather
+        than discarded silently."""
+        async with self._lock:
+            self._global_enabled = bool(enabled)
+            for name, config in servers.items():
+                runtime = _ServerRuntime(config=dict(config), generation=self._next_gen())
+                try:
+                    _validate_server_config(name, runtime.config)
+                except MCPConfigError as e:
+                    runtime.state = STATE_ERROR
+                    runtime.last_error = str(e)
+                    runtime.config_invalid = True
+                self._servers[name] = runtime
+            self._rebuild_published_index_locked()
+
+    async def add_server(self, name: str, config: dict[str, Any]) -> dict[str, Any]:
+        _validate_server_config(name, config)
+        async with self._lock:
+            if name in self._servers:
+                raise MCPConfigError(f"server '{name}' already exists")
+            runtime = _ServerRuntime(config=dict(config), generation=self._next_gen())
+            self._servers[name] = runtime
+        await self._reconcile_server(name)
+        return self.get_status()
+
+    async def update_server(self, name: str, config: dict[str, Any]) -> dict[str, Any]:
+        _validate_server_config(name, config)
+        async with self._lock:
+            runtime = self._servers.get(name)
+            if runtime is None:
+                raise MCPConfigError(f"server '{name}' not found")
+            runtime.config = dict(config)
+            runtime.generation = self._next_gen()
+            self._unpublish_locked(name, runtime, reason="configuration changed")
+        await self._teardown_connection(name)
+        await self._reconcile_server(name)
+        return self.get_status()
+
+    async def remove_server(self, name: str) -> None:
+        async with self._lock:
+            runtime = self._servers.pop(name, None)
+            if runtime is None:
+                raise MCPConfigError(f"server '{name}' not found")
+            runtime.generation = self._next_gen()  # fences in-flight tasks
+            self._unpublish_locked(name, runtime, reason="removed")
+        await self._stop_supervisor(runtime)
+        if runtime.connection is not None:
+            await runtime.connection.disconnect()
+
+    async def set_global_enabled(self, enabled: bool) -> None:
+        """Off: synchronous unpublish, then teardown. On: async reconcile."""
+        async with self._lock:
+            self._global_enabled = bool(enabled)
+            if not enabled:
+                for sname, runtime in self._servers.items():
+                    runtime.generation = self._next_gen()
+                    self._unpublish_locked(sname, runtime, reason="MCP globally disabled")
+                    runtime.state = STATE_DISABLED
+        if not enabled:
+            await asyncio.gather(
+                *(self._teardown_connection(name) for name in list(self._servers)),
+                return_exceptions=True,
+            )
+        else:
+            await self.start()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Reconcile every enabled server (async supervisors; bounded
+        connects). Safe to call repeatedly."""
+        self._started = True
+        self._stopping = False
+        if not self._global_enabled:
+            return
+        await asyncio.gather(
+            *(self._reconcile_server(name) for name in list(self._servers)),
+            return_exceptions=True,
+        )
+
+    async def shutdown(self) -> None:
+        """Concurrent, bounded teardown of everything."""
+        self._stopping = True
+        runtimes = list(self._servers.values())
+        for runtime in runtimes:
+            runtime.generation = self._next_gen()
+        await asyncio.gather(*(self._stop_supervisor(r) for r in runtimes), return_exceptions=True)
+        await asyncio.gather(
+            *(r.connection.disconnect() for r in runtimes if r.connection is not None),
+            return_exceptions=True,
+        )
+        async with self._lock:
+            for sname, runtime in self._servers.items():
+                self._unpublish_locked(sname, runtime, reason="shutdown")
+
+    async def reconnect_server(self, name: str) -> dict[str, Any]:
+        """Manual reconnect: teardown + fresh connect now."""
+        async with self._lock:
+            runtime = self._servers.get(name)
+            if runtime is None:
+                raise MCPConfigError(f"server '{name}' not found")
+            runtime.generation = self._next_gen()
+            runtime.backoff_idx = 0
+            self._unpublish_locked(name, runtime, reason="reconnecting")
+        await self._teardown_connection(name)
+        await self._reconcile_server(name)
+        return self.get_status()
+
+    async def refresh_server_tools(self, name: str) -> dict[str, Any]:
+        """Manual tools refresh, bypassing the poll interval."""
+        runtime = self._servers.get(name)
+        if runtime is None:
+            raise MCPConfigError(f"server '{name}' not found")
+        await self._refresh_tools(name)
+        return self.get_status()
+
+    # ------------------------------------------------------------------
+    # Reconciliation internals
+    # ------------------------------------------------------------------
+
+    def _next_gen(self) -> int:
+        self._generation += 1
+        return self._generation
+
+    def _notify_catalog_changed(self) -> None:
+        if self._on_catalog_changed is not None:
+            try:
+                self._on_catalog_changed()
+            except Exception:
+                log.exception("MCP: catalog-changed callback failed")
+
+    def _unpublish_locked(self, name: str, runtime: _ServerRuntime, *, reason: str) -> None:
+        """Remove a server's tools from publication. Caller holds the lock.
+        Synchronous — by the time any mutation returns, the catalog is
+        already invalidated."""
+        had_tools = bool(runtime.published)
+        runtime.published = {}
+        self._rebuild_published_index_locked()
+        if had_tools:
+            log.info("MCP %s: unpublished (%s)", name, reason)
+            self._notify_catalog_changed()
+
+    def _rebuild_published_index_locked(self) -> None:
+        index: dict[str, tuple[str, ToolRecord]] = {}
+        for name, runtime in self._servers.items():
+            if runtime.state != STATE_CONNECTED:
+                continue
+            for published_name, record in runtime.published.items():
+                index[published_name] = (name, record)
+        self._published_index = index
+
+    async def _teardown_connection(self, name: str) -> None:
+        runtime = self._servers.get(name)
+        if runtime is None:
+            return
+        await self._stop_supervisor(runtime)
+        connection, runtime.connection = runtime.connection, None
+        if connection is not None:
+            try:
+                await connection.disconnect()
+            except Exception:
+                log.exception("MCP %s: teardown error", name)
+
+    async def _stop_supervisor(self, runtime: _ServerRuntime) -> None:
+        task, runtime.supervisor = runtime.supervisor, None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _reconcile_server(self, name: str) -> None:
+        """Ensure the server's runtime matches desired state: spawn (or
+        leave running) a supervisor for enabled servers under global enable;
+        mark others disabled."""
+        runtime = self._servers.get(name)
+        if runtime is None:
+            return
+        if not self._global_enabled or not runtime.enabled:
+            async with self._lock:
+                current = self._servers.get(name)
+                if current is runtime:
+                    self._unpublish_locked(name, runtime, reason="disabled")
+                    runtime.state = STATE_DISABLED
+            await self._teardown_connection(name)
+            return
+        if runtime.config_invalid:
+            return  # structurally invalid config cannot be supervised
+        if runtime.supervisor is None or runtime.supervisor.done():
+            first_attempt: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+            runtime.supervisor = asyncio.create_task(
+                self._supervise(name, runtime.generation, first_attempt=first_attempt),
+                name=f"mcp-supervise-{name}",
+            )
+            # Boot/mutation contract: wait out the FIRST bounded connect
+            # attempt (so callers can report connected: true|false), never
+            # the retries — the supervisor keeps working in the background.
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(first_attempt), timeout=_CONNECT_BUDGET_S + 15
+                )
+            except TimeoutError:
+                pass
+        else:
+            runtime.wake.set()
+
+    async def _supervise(
+        self,
+        name: str,
+        generation: int,
+        *,
+        first_attempt: asyncio.Future[bool] | None = None,
+    ) -> None:
+        """Per-server supervisor: connect (with jittered exponential backoff
+        on failure), then hold a refresh loop. Fenced by generation — the
+        moment desired state moves on, this task abandons without touching
+        published state. ``first_attempt`` resolves once the initial connect
+        attempt settles (either way)."""
+
+        def settle_first(value: bool) -> None:
+            if first_attempt is not None and not first_attempt.done():
+                first_attempt.set_result(value)
+
+        try:
+            while not self._stopping:
+                runtime = self._servers.get(name)
+                if runtime is None or runtime.generation != generation:
+                    return
+                if not self._global_enabled or not runtime.enabled:
+                    return
+                if (
+                    runtime.state not in (STATE_CONNECTED, STATE_BLOCKED)
+                    or runtime.connection is None
+                ):
+                    connected = await self._connect_once(name, generation)
+                    settle_first(connected)
+                    runtime = self._servers.get(name)
+                    if runtime is None or runtime.generation != generation:
+                        return
+                    if not connected:
+                        delay = self._backoff_delay(runtime)
+                        try:
+                            await asyncio.wait_for(runtime.wake.wait(), timeout=delay)
+                        except TimeoutError:
+                            pass
+                        runtime.wake.clear()
+                        continue
+                settle_first(True)
+                # Connected: wait out the refresh interval (or a wake), refresh.
+                delay = self._refresh_delay(runtime)
+                try:
+                    await asyncio.wait_for(runtime.wake.wait(), timeout=delay)
+                except TimeoutError:
+                    pass
+                runtime.wake.clear()
+                runtime = self._servers.get(name)
+                if runtime is None or runtime.generation != generation or self._stopping:
+                    return
+                if runtime.state in (STATE_CONNECTED, STATE_BLOCKED):
+                    # Blocked servers refresh too: a server-side listing change
+                    # (or an allowlist edit, which arrives as a new generation)
+                    # can resolve the block without a reconnect.
+                    await self._refresh_tools(name)
+        finally:
+            settle_first(False)
+
+    def _backoff_delay(self, runtime: _ServerRuntime) -> float:
+        delay = min(_BACKOFF_BASE_S * (2**runtime.backoff_idx), _BACKOFF_MAX_S)
+        runtime.backoff_idx = min(runtime.backoff_idx + 1, 12)
+        return delay * random.uniform(0.9, 1.1)
+
+    def _refresh_delay(self, runtime: _ServerRuntime) -> float:
+        if runtime.ttl_ms is not None and runtime.ttl_ms > 0:
+            base = min(max(runtime.ttl_ms / 1000.0, _REFRESH_MIN_S), _REFRESH_MAX_S)
+        else:
+            base = _REFRESH_DEFAULT_S
+        return base * random.uniform(0.9, 1.1)
+
+    async def _connect_once(self, name: str, generation: int) -> bool:
+        runtime = self._servers.get(name)
+        if runtime is None or runtime.generation != generation:
+            return False
+        async with runtime.flight:
+            runtime = self._servers.get(name)
+            if runtime is None or runtime.generation != generation:
+                return False
+            runtime.state = STATE_CONNECTING
+            config = runtime.config
+            connection = MCPServerConnection(
+                name,
+                config.get("transport", "stdio"),
+                command=config.get("command", ""),
+                args=list(config.get("args", []) or []),
+                url=config.get("url", ""),
+                headers=dict(config.get("headers", {}) or {}),
+                env=dict(config.get("env", {}) or {}),
+                cwd=config.get("cwd", ""),
+                timeout=float(config.get("timeout_seconds", 120)),
+                on_tools_list_changed=lambda: self._on_list_changed(name, generation),
+                on_connection_lost=lambda reason: self._on_lost(name, generation, reason),
+            )
+            try:
+                await asyncio.wait_for(connection.connect(), timeout=_CONNECT_BUDGET_S)
+                discovery = await connection.discover_tools()
+            except TimeoutError:
+                await connection.disconnect()
+                return await self._record_connect_failure(name, generation, "connect timed out")
+            except MCPError as e:
+                await connection.disconnect()
+                return await self._record_connect_failure(name, generation, str(e))
+            except Exception as e:
+                await connection.disconnect()
+                log.exception("MCP %s: unexpected connect failure", name)
+                return await self._record_connect_failure(
+                    name, generation, f"unexpected: {e.__class__.__name__}"
+                )
+            published = await self._publish(name, generation, connection, discovery)
+            if not published:
+                await connection.disconnect()
+            return published
+
+    async def _record_connect_failure(self, name: str, generation: int, reason: str) -> bool:
+        async with self._lock:
+            runtime = self._servers.get(name)
+            if runtime is None or runtime.generation != generation:
+                return False
+            runtime.state = STATE_ERROR
+            runtime.last_error = reason[:500]
+            runtime.connection = None
+            self._rebuild_published_index_locked()
+        log.warning("MCP %s: connect failed: %s", name, reason)
+        return False
+
+    async def _publish(
+        self,
+        name: str,
+        generation: int,
+        connection: MCPServerConnection,
+        discovery: DiscoveryResult,
+    ) -> bool:
+        """Validate limits and publish under the lock, fenced by generation.
+        Over-limit servers are BLOCKED — they publish nothing until the
+        admin narrows the allowlist; the first N are never silently chosen."""
+        async with self._lock:
+            runtime = self._servers.get(name)
+            if runtime is None or runtime.generation != generation:
+                return False  # stale task: never republish
+            allowlist = set(runtime.config.get("tool_allowlist") or [])
+            candidates = [
+                t
+                for t in discovery.tools
+                if not t.excluded and (not allowlist or t.name in allowlist)
+            ]
+            runtime.discovered = discovery.tools
+            runtime.ttl_ms = discovery.ttl_ms
+            runtime.last_refresh_monotonic = time.monotonic()
+            runtime.connection = connection
+            runtime.backoff_idx = 0
+            if len(candidates) > proto.MAX_PUBLISHED_TOOLS_PER_SERVER:
+                runtime.state = STATE_BLOCKED
+                runtime.published = {}
+                runtime.blocked_reason = (
+                    f"{len(candidates)} publishable tools exceed the per-server "
+                    f"limit of {proto.MAX_PUBLISHED_TOOLS_PER_SERVER}; narrow "
+                    "tool_allowlist to select the tools to publish"
+                )
+                runtime.last_error = runtime.blocked_reason
+                self._rebuild_published_index_locked()
+                self._notify_catalog_changed()
+                return True  # connection stays for status/UI; publishes zero
+            global_published = sum(
+                len(r.published)
+                for n, r in self._servers.items()
+                if n != name and r.state == STATE_CONNECTED
+            )
+            if global_published + len(candidates) > proto.MAX_PUBLISHED_TOOLS_GLOBAL:
+                runtime.state = STATE_BLOCKED
+                runtime.published = {}
+                runtime.blocked_reason = (
+                    f"publishing {len(candidates)} tools would exceed the "
+                    f"global MCP limit of {proto.MAX_PUBLISHED_TOOLS_GLOBAL} "
+                    f"({global_published} already published); narrow "
+                    "tool_allowlist"
+                )
+                runtime.last_error = runtime.blocked_reason
+                self._rebuild_published_index_locked()
+                self._notify_catalog_changed()
+                return True
+            published: dict[str, ToolRecord] = {}
+            collision = False
+            for record in candidates:
+                published_name = make_published_name(name, record.name)
+                if published_name in published or any(
+                    published_name in r.published for n, r in self._servers.items() if n != name
+                ):
+                    collision = True
+                    break
+                published[published_name] = record
+            if collision:
+                runtime.state = STATE_BLOCKED
+                runtime.published = {}
+                runtime.blocked_reason = (
+                    "published-name collision after provider-safe normalization"
+                )
+                runtime.last_error = runtime.blocked_reason
+                self._rebuild_published_index_locked()
+                self._notify_catalog_changed()
+                return True
+            runtime.state = STATE_CONNECTED
+            runtime.published = published
+            runtime.last_error = ""
+            runtime.blocked_reason = ""
+            self._rebuild_published_index_locked()
+        log.info(
+            "MCP %s: connected (%s tools published, %s discovered)",
+            name,
+            len(published),
+            len(discovery.tools),
+        )
+        self._notify_catalog_changed()
+        return True
+
+    async def _refresh_tools(self, name: str) -> None:
+        """Re-discover; a FAILED refresh unpublishes the active snapshot
+        until a successful refresh/reconnect. The stale list stays visible
+        as diagnostic data only."""
+        runtime = self._servers.get(name)
+        if runtime is None or runtime.connection is None:
+            return
+        generation = runtime.generation
+        async with runtime.flight:
+            runtime = self._servers.get(name)
+            if runtime is None or runtime.generation != generation:
+                return
+            connection = runtime.connection
+            if connection is None or not connection.connected:
+                return
+            try:
+                discovery = await connection.discover_tools()
+            except MCPError as e:
+                async with self._lock:
+                    runtime = self._servers.get(name)
+                    if runtime is None or runtime.generation != generation:
+                        return
+                    runtime.state = STATE_STALE
+                    runtime.last_error = f"tools refresh failed: {e}"[:500]
+                    self._unpublish_locked(name, runtime, reason="refresh failed")
+                runtime.wake.set()
+                return
+            await self._publish(name, generation, connection, discovery)
+
+    def _on_list_changed(self, name: str, generation: int) -> None:
+        runtime = self._servers.get(name)
+        if runtime is not None and runtime.generation == generation:
+            runtime.wake.set()
+
+    def _on_lost(self, name: str, generation: int, reason: str) -> None:
+        runtime = self._servers.get(name)
+        if runtime is None or runtime.generation != generation:
+            return
+        asyncio.get_running_loop().create_task(self._handle_lost(name, generation, reason))
+
+    async def _handle_lost(self, name: str, generation: int, reason: str) -> None:
+        async with self._lock:
+            runtime = self._servers.get(name)
+            if runtime is None or runtime.generation != generation:
+                return
+            runtime.state = STATE_ERROR
+            runtime.last_error = reason[:500]
+            self._unpublish_locked(name, runtime, reason=f"connection lost: {reason}")
+        runtime.wake.set()
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def execute(self, published_name: str, tool_input: dict) -> MCPToolOutcome:
+        """Dispatch one published tool. A stale call against a tool that is
+        no longer published fails here — typed, never a silent pass."""
+        entry = self._published_index.get(published_name)
+        if entry is None:
+            return MCPToolOutcome(
+                status=OUTCOME_FAILED,
+                text=(
+                    f"MCP tool '{published_name}' is not currently published "
+                    "(server disabled, disconnected, or tool removed)"
+                ),
+                server="",
+                tool=published_name,
+            )
+        server_name, record = entry
+        runtime = self._servers.get(server_name)
+        if runtime is None or runtime.state != STATE_CONNECTED or runtime.connection is None:
+            return MCPToolOutcome(
+                status=OUTCOME_FAILED,
+                text=f"MCP server '{server_name}' is not connected",
+                server=server_name,
+                tool=record.name,
+            )
+        return await runtime.connection.call_tool(
+            record,
+            dict(tool_input or {}),
+            timeout=float(runtime.config.get("timeout_seconds", 120)),
+            generation=runtime.generation,
+        )

--- a/src/tools/mcp/outcomes.py
+++ b/src/tools/mcp/outcomes.py
@@ -1,0 +1,54 @@
+"""Typed tool-call outcomes.
+
+A ``tools/call`` ends in exactly one of three states, and the distinction is
+load-bearing for the durability ledger (an uncertain external effect must
+never be recorded as success or silently replayed):
+
+- ``ok``        — the server returned a result without ``isError``.
+- ``failed``    — definite failure: server ``isError: true``, a JSON-RPC
+                  error, a validation failure, an explicit session
+                  rejection, or any failure BEFORE the request was written.
+- ``uncertain`` — the request was written and the outcome is unknowable
+                  (timeout, disconnect, stream loss after send). NEVER
+                  automatically replayed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+OUTCOME_OK = "ok"
+OUTCOME_FAILED = "failed"
+OUTCOME_UNCERTAIN = "uncertain"
+
+_VALID_STATUSES = frozenset({OUTCOME_OK, OUTCOME_FAILED, OUTCOME_UNCERTAIN})
+
+
+@dataclass(frozen=True)
+class MCPToolOutcome:
+    """Result of one MCP tool invocation, classified.
+
+    ``text`` is the model-facing rendering (already bounded by the caller's
+    caps). ``server``/``tool`` identify the ORIGINAL names; the published
+    (namespaced, provider-safe) name is dispatch-layer metadata.
+    """
+
+    status: str
+    text: str
+    server: str
+    tool: str
+    negotiated_version: str = ""
+    generation: int = 0
+    detail: str = field(default="", repr=False)
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(f"invalid outcome status: {self.status!r}")
+
+    @property
+    def ok(self) -> bool:
+        return self.status == OUTCOME_OK
+
+    @property
+    def uncertain(self) -> bool:
+        return self.status == OUTCOME_UNCERTAIN

--- a/src/tools/mcp/protocol.py
+++ b/src/tools/mcp/protocol.py
@@ -1,0 +1,489 @@
+"""Era-agnostic MCP protocol core: versions, eras, message model, bounds.
+
+The protocol matrix (docs/plans/mcp-wiring-plan.md) is normative; this module
+is its executable form. Two eras exist:
+
+- **Modern** (revision 2026-07-28): stateless; no initialize handshake; every
+  request carries ``_meta`` (protocolVersion / clientInfo /
+  clientCapabilities); ``server/discover`` is mandatory on servers; every
+  result carries a required ``resultType``.
+- **Legacy** (2024-11-05 … 2025-11-25): ``initialize`` → negotiated version →
+  ``notifications/initialized`` → operations. 2025-03-26 additionally permits
+  JSON-RPC batch arrays on the wire (receive side only for us).
+
+Nothing here does I/O.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+ERA_MODERN = "modern"
+ERA_LEGACY = "legacy"
+
+# Exact supported version sets, in preference order (newest first). An
+# unknown counteroffer is never accepted, even if it "looks newer".
+MODERN_VERSIONS: tuple[str, ...] = ("2026-07-28",)
+LEGACY_VERSIONS_STDIO: tuple[str, ...] = (
+    "2025-11-25",
+    "2025-06-18",
+    "2025-03-26",
+    "2024-11-05",
+)
+# 2024-11-05 over HTTP is the deprecated HTTP+SSE dual-endpoint transport,
+# which is out of scope — the legacy HTTP floor is 2025-03-26.
+LEGACY_VERSIONS_HTTP: tuple[str, ...] = (
+    "2025-11-25",
+    "2025-06-18",
+    "2025-03-26",
+)
+
+SUPPORTED_VERSIONS: frozenset[str] = frozenset(MODERN_VERSIONS) | frozenset(LEGACY_VERSIONS_STDIO)
+
+# The one legacy revision whose wire shape permits JSON-RPC batch arrays.
+BATCH_WIRE_VERSION = "2025-03-26"
+
+CLIENT_INFO: dict[str, str] = {"name": "odin", "version": "2.0.0"}
+
+META_PREFIX = "io.modelcontextprotocol/"
+META_PROTOCOL_VERSION = META_PREFIX + "protocolVersion"
+META_CLIENT_INFO = META_PREFIX + "clientInfo"
+META_CLIENT_CAPABILITIES = META_PREFIX + "clientCapabilities"
+META_SERVER_INFO = META_PREFIX + "serverInfo"
+
+# Recognized modern JSON-RPC error codes (2026-07-28 allocation).
+ERROR_HEADER_MISMATCH = -32020
+ERROR_MISSING_CLIENT_CAPABILITY = -32021
+ERROR_UNSUPPORTED_PROTOCOL_VERSION = -32022
+MODERN_ERROR_CODES: frozenset[int] = frozenset(
+    {
+        ERROR_HEADER_MISMATCH,
+        ERROR_MISSING_CLIENT_CAPABILITY,
+        ERROR_UNSUPPORTED_PROTOCOL_VERSION,
+    }
+)
+ERROR_METHOD_NOT_FOUND = -32601
+
+RESULT_TYPE_COMPLETE = "complete"
+RESULT_TYPE_INPUT_REQUIRED = "input_required"
+
+# ---------------------------------------------------------------------------
+# Bounds (plan §9). Wire-level bounds apply BEFORE parsing; model-facing caps
+# (description, published counts) are enforced at publication time.
+# ---------------------------------------------------------------------------
+WIRE_RESULT_CEILING = 4 * 1024 * 1024  # one JSON body / SSE data accumulation
+MAX_STDOUT_LINE_BYTES = WIRE_RESULT_CEILING
+MAX_SSE_EVENT_BYTES = WIRE_RESULT_CEILING
+MAX_STDERR_STORE_BYTES = 64 * 1024
+MAX_LIST_PAGES = 32
+MAX_DISCOVERED_TOOLS = 128
+MAX_PUBLISHED_TOOLS_PER_SERVER = 40
+MAX_PUBLISHED_TOOLS_GLOBAL = 40
+MAX_SCHEMA_BYTES_PER_TOOL = 32 * 1024
+MAX_SCHEMA_BYTES_PER_SERVER = 256 * 1024
+MAX_SCHEMA_DEPTH = 20
+MAX_SCHEMA_NODES = 2048
+MAX_DESCRIPTION_CHARS = 1024
+MAX_INSTRUCTIONS_CHARS = 4096  # UI-only display bound; never prompt-injected
+
+_JS_SAFE_INT_MAX = 2**53 - 1
+_JS_SAFE_INT_MIN = -(2**53) + 1
+
+
+def build_request_meta(version: str) -> dict[str, Any]:
+    """The ``_meta`` block every modern request carries."""
+    return {
+        META_PROTOCOL_VERSION: version,
+        META_CLIENT_INFO: dict(CLIENT_INFO),
+        META_CLIENT_CAPABILITIES: {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Message model
+# ---------------------------------------------------------------------------
+
+KIND_REQUEST = "request"
+KIND_RESPONSE = "response"
+KIND_NOTIFICATION = "notification"
+KIND_INVALID = "invalid"
+
+
+def message_kind(msg: Any) -> str:
+    """Classify one JSON-RPC message object."""
+    if not isinstance(msg, dict) or msg.get("jsonrpc") != "2.0":
+        return KIND_INVALID
+    has_id = "id" in msg and msg["id"] is not None
+    has_method = isinstance(msg.get("method"), str) and bool(msg.get("method"))
+    if has_method and has_id:
+        return KIND_REQUEST
+    if has_method:
+        return KIND_NOTIFICATION
+    if has_id and ("result" in msg or "error" in msg):
+        return KIND_RESPONSE
+    return KIND_INVALID
+
+
+def parse_wire_payload(raw: bytes | str, *, negotiated_version: str | None) -> list[dict]:
+    """Parse one wire payload (a stdout line or an HTTP/SSE body) into
+    messages.
+
+    A JSON array is a batch, legal on the receive side ONLY when the
+    negotiated version is 2025-03-26 (or negotiation has not completed yet,
+    where we must be tolerant enough to read the handshake reply). Every
+    other shape must be a single JSON object.
+    """
+    from .errors import MCPProtocolError
+
+    if isinstance(raw, bytes):
+        if len(raw) > WIRE_RESULT_CEILING:
+            raise MCPProtocolError(f"wire payload exceeds {WIRE_RESULT_CEILING} bytes")
+        raw = raw.decode("utf-8", errors="replace")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise MCPProtocolError(f"invalid JSON on the wire: {e}") from e
+
+    if isinstance(parsed, list):
+        if negotiated_version is not None and negotiated_version != BATCH_WIRE_VERSION:
+            raise MCPProtocolError(
+                "JSON-RPC batch received but the negotiated version "
+                f"{negotiated_version} does not permit batches"
+            )
+        if not parsed:
+            raise MCPProtocolError("empty JSON-RPC batch")
+        out: list[dict] = []
+        for item in parsed:
+            if message_kind(item) == KIND_INVALID:
+                raise MCPProtocolError("invalid message inside JSON-RPC batch")
+            out.append(item)
+        return out
+
+    if message_kind(parsed) == KIND_INVALID:
+        raise MCPProtocolError("invalid JSON-RPC message")
+    return [parsed]
+
+
+# ---------------------------------------------------------------------------
+# Modern error recognition and version selection
+# ---------------------------------------------------------------------------
+
+
+def rpc_error(msg: dict) -> dict | None:
+    """The ``error`` object of a response, if this is an error response."""
+    err = msg.get("error")
+    return err if isinstance(err, dict) else None
+
+
+def is_recognized_modern_error(err: dict | None) -> bool:
+    """A JSON-RPC error that only a modern (2026-07-28+) server emits."""
+    return err is not None and err.get("code") in MODERN_ERROR_CODES
+
+
+def supported_versions_from_error(err: dict) -> list[str]:
+    """The advertised ``supported`` list of an UnsupportedProtocolVersion
+    error, empty when absent/malformed."""
+    data = err.get("data")
+    if not isinstance(data, dict):
+        return []
+    supported = data.get("supported")
+    if not isinstance(supported, list):
+        return []
+    return [v for v in supported if isinstance(v, str)]
+
+
+@dataclass(frozen=True)
+class VersionSelection:
+    """Outcome of modern version selection against an advertised list."""
+
+    version: str | None
+    reason: str
+
+
+def select_modern_version(advertised: Any) -> VersionSelection:
+    """Deterministically select a modern version from a server-advertised
+    list, per the plan: validate the list, intersect with OUR exact modern
+    set, choose by our preference order.
+
+    A malformed, empty, or legacy-only list is **modern-incompatible** —
+    never grounds for sending modern metadata under a legacy version, and
+    never grounds for an ``initialize`` fallback (the server already proved
+    it is modern-era).
+    """
+    if not isinstance(advertised, list) or not advertised:
+        return VersionSelection(None, "server advertised no protocol versions")
+    versions = [v for v in advertised if isinstance(v, str)]
+    if len(versions) != len(advertised):
+        return VersionSelection(None, "server advertised a malformed version list")
+    for candidate in MODERN_VERSIONS:
+        if candidate in versions:
+            return VersionSelection(candidate, "selected")
+    return VersionSelection(
+        None,
+        "server is modern-era but advertises no mutually supported modern "
+        f"revision (advertised: {', '.join(versions[:8])})",
+    )
+
+
+def select_legacy_version(counteroffer: str, *, transport: str) -> str | None:
+    """Accept a legacy server's negotiated version only from our exact set
+    for that transport; unknown counteroffers are rejected."""
+    allowed = LEGACY_VERSIONS_STDIO if transport == "stdio" else LEGACY_VERSIONS_HTTP
+    return counteroffer if counteroffer in allowed else None
+
+
+# ---------------------------------------------------------------------------
+# resultType (modern-strict; legacy ignores the field entirely)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResultTypeCheck:
+    ok: bool
+    input_required: bool
+    reason: str
+
+
+def check_result_type(result: Any, *, era: str) -> ResultTypeCheck:
+    """Validate a result's ``resultType`` per era.
+
+    Modern: the field is REQUIRED. ``complete`` passes; ``input_required``
+    is an explicit unsupported/incomplete outcome (MRTR is deferred) that the
+    caller surfaces as a failure and never replays; missing or unknown
+    values are protocol violations. Legacy: the treat-missing-as-complete
+    rule applies — the field is ignored.
+    """
+    if not isinstance(result, dict):
+        return ResultTypeCheck(False, False, "result is not an object")
+    if era != ERA_MODERN:
+        return ResultTypeCheck(True, False, "")
+    rt = result.get("resultType")
+    if rt == RESULT_TYPE_COMPLETE:
+        return ResultTypeCheck(True, False, "")
+    if rt == RESULT_TYPE_INPUT_REQUIRED:
+        return ResultTypeCheck(
+            False,
+            True,
+            "server requested additional input (MRTR), which this client does not support",
+        )
+    if rt is None:
+        return ResultTypeCheck(False, False, "modern result missing required resultType")
+    return ResultTypeCheck(False, False, f"unknown resultType {rt!r}")
+
+
+# ---------------------------------------------------------------------------
+# Tool schema validation (bounded JSON Schema OBJECT — not a literal
+# root ``type: object``; composition/$ref may establish object semantics)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SchemaCheck:
+    ok: bool
+    reason: str
+    byte_size: int = 0
+
+
+def validate_tool_schema(schema: Any) -> SchemaCheck:
+    if not isinstance(schema, dict):
+        return SchemaCheck(False, "inputSchema is not a JSON Schema object")
+    try:
+        encoded = json.dumps(schema)
+    except (TypeError, ValueError):
+        return SchemaCheck(False, "inputSchema is not JSON-serializable")
+    size = len(encoded.encode("utf-8"))
+    if size > MAX_SCHEMA_BYTES_PER_TOOL:
+        return SchemaCheck(
+            False,
+            f"inputSchema exceeds {MAX_SCHEMA_BYTES_PER_TOOL} bytes",
+            size,
+        )
+    nodes = 0
+    stack: list[tuple[Any, int]] = [(schema, 1)]
+    while stack:
+        value, depth = stack.pop()
+        if depth > MAX_SCHEMA_DEPTH:
+            return SchemaCheck(False, f"inputSchema deeper than {MAX_SCHEMA_DEPTH}", size)
+        nodes += 1
+        if nodes > MAX_SCHEMA_NODES:
+            return SchemaCheck(False, f"inputSchema has more than {MAX_SCHEMA_NODES} nodes", size)
+        if isinstance(value, dict):
+            for child in value.values():
+                stack.append((child, depth + 1))
+        elif isinstance(value, list):
+            for child in value:
+                stack.append((child, depth + 1))
+    return SchemaCheck(True, "", size)
+
+
+# ---------------------------------------------------------------------------
+# x-mcp-header (modern Streamable HTTP — client support is MANDATORY)
+# ---------------------------------------------------------------------------
+
+_TCHAR_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_HEADER_SAFE_RE = re.compile(r"^[\x21-\x7e]([\x20\x09\x21-\x7e]*[\x21-\x7e])?$")
+_B64_SENTINEL_RE = re.compile(r"^=\?base64\?.*\?=$", re.DOTALL)
+
+_PRIMITIVE_HEADER_TYPES = frozenset({"string", "integer", "boolean"})
+
+
+@dataclass(frozen=True)
+class HeaderParam:
+    """One ``x-mcp-header`` annotation: mirror the value at ``path`` into
+    ``Mcp-Param-{name}``."""
+
+    name: str
+    path: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HeaderParamsCheck:
+    ok: bool
+    reason: str
+    params: tuple[HeaderParam, ...] = ()
+
+
+def extract_header_params(schema: dict) -> HeaderParamsCheck:
+    """Collect and validate every ``x-mcp-header`` annotation in a tool's
+    inputSchema.
+
+    Constraints (2026-07-28): non-empty RFC 9110 token; case-insensitively
+    unique; only on primitive string/integer/boolean properties (never
+    ``number``); only on properties statically reachable through chains of
+    ``properties`` keys (no array/composition/conditional keywords, no
+    ``$ref`` in the chain). ANY violation invalidates the WHOLE tool — the
+    caller excludes it from publication.
+    """
+    found: list[HeaderParam] = []
+    seen_lower: set[str] = set()
+
+    def visit(node: Any, path: tuple[str, ...]) -> str | None:
+        """Walk ONLY the statically reachable region: chains of
+        ``properties`` keys. Validates and collects annotations found
+        there."""
+        if not isinstance(node, dict):
+            return None
+        annotation = node.get("x-mcp-header")
+        if annotation is not None:
+            if not isinstance(annotation, str) or not annotation:
+                return "x-mcp-header value must be a non-empty string"
+            if not _TCHAR_RE.match(annotation):
+                return f"x-mcp-header value {annotation!r} is not a valid token"
+            if annotation.lower() in seen_lower:
+                return f"duplicate x-mcp-header value {annotation!r}"
+            prop_type = node.get("type")
+            if prop_type not in _PRIMITIVE_HEADER_TYPES:
+                return (
+                    "x-mcp-header only applies to string/integer/boolean "
+                    f"properties, got {prop_type!r}"
+                )
+            seen_lower.add(annotation.lower())
+            found.append(HeaderParam(annotation, path))
+        props = node.get("properties")
+        if isinstance(props, dict):
+            for key, child in props.items():
+                if not isinstance(key, str):
+                    continue
+                err = visit(child, path + (key,))
+                if err:
+                    return err
+        return None
+
+    def count_all_annotations(node: Any) -> int:
+        """Every annotation anywhere in the schema, reachable or not."""
+        total = 0
+        stack: list[Any] = [node]
+        while stack:
+            cur = stack.pop()
+            if isinstance(cur, dict):
+                if "x-mcp-header" in cur:
+                    total += 1
+                stack.extend(cur.values())
+            elif isinstance(cur, list):
+                stack.extend(cur)
+        return total
+
+    err = visit(schema, ())
+    if err is None and count_all_annotations(schema) != len(found):
+        # An annotation exists outside a pure `properties` chain (inside
+        # items/oneOf/anyOf/allOf/not/if/then/else/$ref targets/definitions/
+        # anything else). The spec invalidates the whole tool for ANY such
+        # placement, not only the named composition keywords.
+        err = "x-mcp-header on a property not statically reachable"
+    if err:
+        return HeaderParamsCheck(False, err)
+    return HeaderParamsCheck(True, "", tuple(found))
+
+
+def header_param_value(arguments: dict, param: HeaderParam) -> str | None:
+    """Read the instance value at the annotation's exact property path and
+    encode it; ``None`` when absent or null (header omitted)."""
+    cur: Any = arguments
+    for key in param.path:
+        if not isinstance(cur, dict) or key not in cur:
+            return None
+        cur = cur[key]
+    if cur is None:
+        return None
+    if isinstance(cur, bool):
+        text = "true" if cur else "false"
+    elif isinstance(cur, int):
+        if not (_JS_SAFE_INT_MIN <= cur <= _JS_SAFE_INT_MAX):
+            return None
+        text = str(cur)
+    elif isinstance(cur, str):
+        text = cur
+    else:
+        return None
+    return encode_header_value(text)
+
+
+def encode_header_value(value: str) -> str:
+    """RFC-safe header value: plain when already header-safe (and not
+    sentinel-shaped), else the Base64 sentinel ``=?base64?…?=`` form."""
+    if _HEADER_SAFE_RE.match(value) and not _B64_SENTINEL_RE.match(value):
+        return value
+    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
+    return f"=?base64?{encoded}?="
+
+
+# ---------------------------------------------------------------------------
+# Wire message builders
+# ---------------------------------------------------------------------------
+
+
+def build_request(
+    req_id: int | str,
+    method: str,
+    params: dict | None,
+    *,
+    era: str,
+    version: str,
+) -> dict:
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if era == ERA_MODERN:
+        merged = dict(params or {})
+        merged["_meta"] = build_request_meta(version)
+        body["params"] = merged
+    elif params is not None:
+        body["params"] = params
+    return body
+
+
+def build_notification(method: str, params: dict | None = None) -> dict:
+    body: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        body["params"] = params
+    return body
+
+
+def build_error_response(req_id: Any, code: int, message: str) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }

--- a/src/tools/mcp/protocol.py
+++ b/src/tools/mcp/protocol.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 
 import base64
 import json
+import math
 import re
 from dataclasses import dataclass
 from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
 
 ERA_MODERN = "modern"
 ERA_LEGACY = "legacy"
@@ -289,12 +293,19 @@ class SchemaCheck:
 
 
 def validate_tool_schema(schema: Any) -> SchemaCheck:
+    """Validate a bounded Draft 2020-12 schema that establishes object input.
+
+    Bounds are checked before metaschema validation so adversarial listings
+    cannot make the validator traverse unbounded input. Object semantics may
+    be established through local ``$ref`` or composition; a literal root
+    ``type: object`` is deliberately not required.
+    """
     if not isinstance(schema, dict):
         return SchemaCheck(False, "inputSchema is not a JSON Schema object")
     try:
-        encoded = json.dumps(schema)
+        encoded = json.dumps(schema, allow_nan=False)
     except (TypeError, ValueError):
-        return SchemaCheck(False, "inputSchema is not JSON-serializable")
+        return SchemaCheck(False, "inputSchema is not valid JSON")
     size = len(encoded.encode("utf-8"))
     if size > MAX_SCHEMA_BYTES_PER_TOOL:
         return SchemaCheck(
@@ -312,12 +323,75 @@ def validate_tool_schema(schema: Any) -> SchemaCheck:
         if nodes > MAX_SCHEMA_NODES:
             return SchemaCheck(False, f"inputSchema has more than {MAX_SCHEMA_NODES} nodes", size)
         if isinstance(value, dict):
-            for child in value.values():
-                stack.append((child, depth + 1))
+            if any(not isinstance(key, str) for key in value):
+                return SchemaCheck(False, "inputSchema object keys must be strings", size)
+            stack.extend((child, depth + 1) for child in value.values())
         elif isinstance(value, list):
-            for child in value:
-                stack.append((child, depth + 1))
+            stack.extend((child, depth + 1) for child in value)
+        elif isinstance(value, float) and not math.isfinite(value):
+            return SchemaCheck(False, "inputSchema contains a non-finite number", size)
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        detail = exc.message[:200] if exc.message else "invalid JSON Schema"
+        return SchemaCheck(False, f"inputSchema is invalid: {detail}", size)
+    if not _schema_establishes_object(schema, schema, set()):
+        return SchemaCheck(False, "inputSchema does not establish object input semantics", size)
     return SchemaCheck(True, "", size)
+
+
+def _schema_establishes_object(node: Any, root: dict, seen_refs: set[str]) -> bool:
+    """Conservative proof that every accepted instance is an object.
+
+    This intentionally does not attempt full satisfiability. It recognizes
+    the ordinary JSON Schema ways MCP tool schemas establish their object
+    input contract while rejecting ambiguous schemas that also accept scalar
+    or array arguments.
+    """
+    if not isinstance(node, dict):
+        return False
+    declared = node.get("type")
+    if declared == "object" or declared == ["object"]:
+        return True
+    const = node.get("const", object())
+    if isinstance(const, dict):
+        return True
+    enum = node.get("enum")
+    if isinstance(enum, list) and enum and all(isinstance(item, dict) for item in enum):
+        return True
+    ref = node.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#") and ref not in seen_refs:
+        target = _resolve_local_ref(root, ref)
+        if target is not None:
+            return _schema_establishes_object(target, root, seen_refs | {ref})
+    all_of = node.get("allOf")
+    if isinstance(all_of, list) and any(
+        _schema_establishes_object(branch, root, seen_refs) for branch in all_of
+    ):
+        return True
+    for keyword in ("anyOf", "oneOf"):
+        branches = node.get(keyword)
+        if (
+            isinstance(branches, list)
+            and branches
+            and all(_schema_establishes_object(branch, root, seen_refs) for branch in branches)
+        ):
+            return True
+    return False
+
+
+def _resolve_local_ref(root: dict, ref: str) -> Any | None:
+    if ref == "#":
+        return root
+    if not ref.startswith("#/"):
+        return None
+    current: Any = root
+    for raw_part in ref[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +432,8 @@ def extract_header_params(schema: dict) -> HeaderParamsCheck:
     ``$ref`` in the chain). ANY violation invalidates the WHOLE tool — the
     caller excludes it from publication.
     """
+    if "x-mcp-header" in schema:
+        return HeaderParamsCheck(False, "x-mcp-header is invalid at the schema root")
     found: list[HeaderParam] = []
     seen_lower: set[str] = set()
 

--- a/src/tools/mcp/transport_http.py
+++ b/src/tools/mcp/transport_http.py
@@ -1,0 +1,368 @@
+"""Streamable HTTP transport, both era shapes.
+
+- Legacy (2025-03-26 … 2025-11-25): sessions are OPTIONAL — when the server
+  mints an ``Mcp-Session-Id`` on the InitializeResult we echo it on every
+  subsequent request and DELETE it on disconnect; when it doesn't, no session
+  semantics apply at all. ``MCP-Protocol-Version`` is sent on every
+  post-negotiation request.
+- Modern (2026-07-28): stateless; every POST carries ``MCP-Protocol-Version``,
+  ``Mcp-Method``, ``Mcp-Name`` where a name exists, and mirrored
+  ``Mcp-Param-*`` headers for ``x-mcp-header`` annotations.
+
+Shared mechanics: every message is its own POST with
+``Accept: application/json, text/event-stream``; a request's reply is either
+one JSON object or an SSE stream scoped to that request (request-related
+notifications — and, legacy only, server-initiated requests — may precede
+the final response). Messages are dispatched to the caller MID-STREAM so a
+legacy server waiting on a reply to its own request cannot deadlock the
+stream. Redirects are never followed (a redirecting endpoint is a
+configuration error — configured credentials must never travel to another
+origin). One reused ClientSession per server, cookie-isolated.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+
+from ...odin_log import get_logger
+from .errors import MCPConnectError, MCPProtocolError
+from .protocol import (
+    MAX_SSE_EVENT_BYTES,
+    WIRE_RESULT_CEILING,
+    parse_wire_payload,
+)
+
+log = get_logger("mcp.http")
+
+_SOCK_CONNECT_TIMEOUT = 15
+_DEFAULT_STALL_TIMEOUT = 120
+
+# Headers the transport owns. Configured per-server headers and mirrored
+# Mcp-Param-* values must never override these (case-insensitive).
+_MANAGED_HEADERS = frozenset(
+    {
+        "host",
+        "content-length",
+        "content-type",
+        "accept",
+        "connection",
+        "transfer-encoding",
+        "mcp-protocol-version",
+        "mcp-session-id",
+        "mcp-method",
+        "mcp-name",
+    }
+)
+
+RESULT_JSON = "json"
+RESULT_ACCEPTED = "accepted"
+RESULT_HTTP_ERROR = "http_error"
+RESULT_STREAM_ENDED = "stream_ended"
+
+
+@dataclass
+class PostOutcome:
+    """What one POST produced.
+
+    ``json``:         ``messages`` holds the parsed body message(s).
+    ``accepted``:     2xx with no meaningful body (notification/response POST).
+    ``http_error``:   non-2xx; ``status`` + parsed ``messages`` (when the body
+                      was JSON-RPC) + a bounded ``body_snippet`` for sanitized
+                      diagnostics.
+    ``stream_ended``: an SSE reply ended; every message was already delivered
+                      mid-stream via ``on_message``.
+    """
+
+    kind: str
+    status: int = 0
+    messages: list[dict] = field(default_factory=list)
+    body_snippet: str = ""
+    session_id: str | None = None
+
+
+def _filter_configured_headers(configured: dict[str, str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, value in (configured or {}).items():
+        name = str(key)
+        lowered = name.lower()
+        if lowered in _MANAGED_HEADERS or lowered.startswith("mcp-param-"):
+            log.warning("MCP: dropping configured header %r (managed by transport)", name)
+            continue
+        out[name] = str(value)
+    return out
+
+
+class HttpTransport:
+    """One MCP server endpoint over Streamable HTTP."""
+
+    def __init__(
+        self,
+        server_name: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        stall_timeout: float = _DEFAULT_STALL_TIMEOUT,
+    ) -> None:
+        if not url or not url.lower().startswith(("http://", "https://")):
+            raise MCPConnectError(f"{server_name}: http transport requires an http(s) url")
+        self.server_name = server_name
+        self.url = url
+        self.configured_headers = _filter_configured_headers(headers or {})
+        self.stall_timeout = stall_timeout
+        self.session_id: str | None = None
+        self._session: aiohttp.ClientSession | None = None
+
+    async def start(self) -> None:
+        if self._session is not None:
+            return
+        self._session = aiohttp.ClientSession(
+            cookie_jar=aiohttp.DummyCookieJar(),
+            timeout=aiohttp.ClientTimeout(
+                total=None,
+                sock_connect=_SOCK_CONNECT_TIMEOUT,
+                sock_read=self.stall_timeout,
+            ),
+        )
+
+    async def close(self) -> None:
+        session, self._session = self._session, None
+        if session is not None:
+            try:
+                await session.close()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # POST
+    # ------------------------------------------------------------------
+
+    def _build_headers(
+        self,
+        *,
+        protocol_version: str | None,
+        mcp_method: str | None,
+        mcp_name: str | None,
+        param_headers: dict[str, str] | None,
+        include_session: bool,
+    ) -> dict[str, str]:
+        headers: dict[str, str] = dict(self.configured_headers)
+        headers["Content-Type"] = "application/json"
+        headers["Accept"] = "application/json, text/event-stream"
+        if protocol_version:
+            headers["MCP-Protocol-Version"] = protocol_version
+        if mcp_method:
+            headers["Mcp-Method"] = mcp_method
+        if mcp_name:
+            headers["Mcp-Name"] = mcp_name
+        if include_session and self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        for name, value in (param_headers or {}).items():
+            headers[f"Mcp-Param-{name}"] = value
+        return headers
+
+    async def post(
+        self,
+        body: dict[str, Any],
+        *,
+        protocol_version: str | None,
+        mcp_method: str | None = None,
+        mcp_name: str | None = None,
+        param_headers: dict[str, str] | None = None,
+        include_session: bool = True,
+        capture_session: bool = False,
+        negotiated_version: str | None = None,
+        on_message: Callable[[dict], None] | None = None,
+    ) -> PostOutcome:
+        """POST one JSON-RPC message and interpret the reply.
+
+        For SSE replies every message is delivered through ``on_message`` as
+        it arrives (mid-stream); the call returns once the stream ends.
+        Cancelling the awaiting task aborts the underlying request/stream —
+        which IS the modern cancellation signal.
+        """
+        if self._session is None:
+            raise MCPConnectError(f"{self.server_name}: transport not started")
+        headers = self._build_headers(
+            protocol_version=protocol_version,
+            mcp_method=mcp_method,
+            mcp_name=mcp_name,
+            param_headers=param_headers,
+            include_session=include_session,
+        )
+        try:
+            async with self._session.post(
+                self.url,
+                data=json.dumps(body, separators=(",", ":")).encode("utf-8"),
+                headers=headers,
+                allow_redirects=False,
+            ) as resp:
+                if 300 <= resp.status < 400:
+                    raise MCPConnectError(
+                        f"{self.server_name}: endpoint redirected "
+                        f"({resp.status}); redirects are not followed — "
+                        "configure the final URL"
+                    )
+                if capture_session:
+                    minted = resp.headers.get("Mcp-Session-Id")
+                    if minted:
+                        self.session_id = minted
+                content_type = (resp.content_type or "").lower()
+                if resp.status >= 400:
+                    return await self._read_error(resp, negotiated_version)
+                if resp.status in (202, 204):
+                    return PostOutcome(
+                        RESULT_ACCEPTED, status=resp.status, session_id=self.session_id
+                    )
+                if content_type == "text/event-stream":
+                    await self._consume_sse(resp, negotiated_version, on_message)
+                    return PostOutcome(
+                        RESULT_STREAM_ENDED, status=resp.status, session_id=self.session_id
+                    )
+                raw = await self._read_bounded(resp)
+                if not raw.strip():
+                    return PostOutcome(
+                        RESULT_ACCEPTED, status=resp.status, session_id=self.session_id
+                    )
+                messages = parse_wire_payload(raw, negotiated_version=negotiated_version)
+                return PostOutcome(
+                    RESULT_JSON,
+                    status=resp.status,
+                    messages=messages,
+                    session_id=self.session_id,
+                )
+        except aiohttp.ClientError as e:
+            raise MCPConnectError(
+                f"{self.server_name}: HTTP transport error: {e.__class__.__name__}"
+            ) from e
+
+    async def _read_bounded(self, resp: aiohttp.ClientResponse) -> bytes:
+        data = bytearray()
+        async for chunk in resp.content.iter_chunked(65536):
+            data.extend(chunk)
+            if len(data) > WIRE_RESULT_CEILING:
+                raise MCPProtocolError(
+                    f"{self.server_name}: response body exceeds {WIRE_RESULT_CEILING} bytes"
+                )
+        return bytes(data)
+
+    async def _read_error(
+        self, resp: aiohttp.ClientResponse, negotiated_version: str | None
+    ) -> PostOutcome:
+        """Non-2xx: parse a JSON-RPC error body when present; keep only a
+        bounded snippet otherwise (raw upstream bodies are never surfaced)."""
+        try:
+            raw = await self._read_bounded(resp)
+        except MCPProtocolError:
+            raw = b""
+        messages: list[dict] = []
+        snippet = ""
+        if raw.strip():
+            try:
+                messages = parse_wire_payload(raw, negotiated_version=negotiated_version)
+            except MCPProtocolError:
+                snippet = raw[:200].decode("utf-8", errors="replace")
+        return PostOutcome(
+            RESULT_HTTP_ERROR,
+            status=resp.status,
+            messages=messages,
+            body_snippet=snippet,
+            session_id=self.session_id,
+        )
+
+    # ------------------------------------------------------------------
+    # SSE
+    # ------------------------------------------------------------------
+
+    async def _consume_sse(
+        self,
+        resp: aiohttp.ClientResponse,
+        negotiated_version: str | None,
+        on_message: Callable[[dict], None] | None,
+    ) -> None:
+        """Incrementally parse one SSE stream, dispatching each JSON-RPC
+        message as it completes. Comment lines (``:`` prefix) are keep-alives
+        and ignored; event ``data:`` accumulation is bounded."""
+        data_lines: list[str] = []
+        data_bytes = 0
+        buffer = b""
+
+        def dispatch_event() -> None:
+            nonlocal data_lines, data_bytes
+            if not data_lines:
+                return
+            payload = "\n".join(data_lines)
+            data_lines = []
+            data_bytes = 0
+            try:
+                messages = parse_wire_payload(payload, negotiated_version=negotiated_version)
+            except MCPProtocolError as e:
+                log.warning("MCP %s: dropping SSE event: %s", self.server_name, e)
+                return
+            for msg in messages:
+                if on_message is not None:
+                    try:
+                        on_message(msg)
+                    except Exception:
+                        log.exception("MCP %s: SSE message handler failed", self.server_name)
+
+        async for chunk in resp.content.iter_chunked(16384):
+            buffer += chunk
+            if len(buffer) > MAX_SSE_EVENT_BYTES:
+                raise MCPProtocolError(
+                    f"{self.server_name}: SSE event exceeds {MAX_SSE_EVENT_BYTES} bytes"
+                )
+            while True:
+                for sep in (b"\r\n", b"\n", b"\r"):
+                    idx = buffer.find(sep)
+                    if idx != -1:
+                        line, buffer = buffer[:idx], buffer[idx + len(sep) :]
+                        break
+                else:
+                    break
+                text = line.decode("utf-8", errors="replace")
+                if not text:
+                    dispatch_event()
+                    continue
+                if text.startswith(":"):
+                    continue  # SSE comment / keep-alive
+                field_name, _, value = text.partition(":")
+                if value.startswith(" "):
+                    value = value[1:]
+                if field_name == "data":
+                    data_bytes += len(value)
+                    if data_bytes > MAX_SSE_EVENT_BYTES:
+                        raise MCPProtocolError(
+                            f"{self.server_name}: SSE data exceeds {MAX_SSE_EVENT_BYTES} bytes"
+                        )
+                    data_lines.append(value)
+                # event/id/retry fields carry no data we act on.
+        dispatch_event()
+
+    # ------------------------------------------------------------------
+    # Legacy session termination
+    # ------------------------------------------------------------------
+
+    async def delete_session(self, *, protocol_version: str | None) -> None:
+        """Legacy: explicitly terminate a server-minted session. 405 (server
+        does not allow client termination) is tolerated; only called when a
+        session id exists."""
+        if self._session is None or not self.session_id:
+            return
+        headers: dict[str, str] = dict(self.configured_headers)
+        headers["Mcp-Session-Id"] = self.session_id
+        if protocol_version:
+            headers["MCP-Protocol-Version"] = protocol_version
+        try:
+            async with self._session.delete(
+                self.url, headers=headers, allow_redirects=False
+            ) as resp:
+                await resp.read()
+        except aiohttp.ClientError:
+            pass
+        finally:
+            self.session_id = None

--- a/src/tools/mcp/transport_http.py
+++ b/src/tools/mcp/transport_http.py
@@ -22,6 +22,7 @@ origin). One reused ClientSession per server, cookie-isolated.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -41,6 +42,7 @@ log = get_logger("mcp.http")
 
 _SOCK_CONNECT_TIMEOUT = 15
 _DEFAULT_STALL_TIMEOUT = 120
+_SESSION_DELETE_TIMEOUT = 5.0
 
 # Headers the transport owns. Configured per-server headers and mirrored
 # Mcp-Param-* values must never override these (case-insensitive).
@@ -116,6 +118,10 @@ class HttpTransport:
         self.stall_timeout = stall_timeout
         self.session_id: str | None = None
         self._session: aiohttp.ClientSession | None = None
+
+    @property
+    def started(self) -> bool:
+        return self._session is not None and not self._session.closed
 
     async def start(self) -> None:
         if self._session is not None:
@@ -310,37 +316,53 @@ class HttpTransport:
                     except Exception:
                         log.exception("MCP %s: SSE message handler failed", self.server_name)
 
+        def pop_line(*, eof: bool = False) -> bytes | None:
+            nonlocal buffer
+            positions = [idx for marker in (b"\r", b"\n") if (idx := buffer.find(marker)) >= 0]
+            if not positions:
+                if eof and buffer:
+                    line, buffer = buffer, b""
+                    return line
+                return None
+            idx = min(positions)
+            if buffer[idx : idx + 1] == b"\r":
+                if idx + 1 == len(buffer) and not eof:
+                    return None  # CRLF may be split across chunks
+                width = 2 if buffer[idx + 1 : idx + 2] == b"\n" else 1
+            else:
+                width = 1
+            line, buffer = buffer[:idx], buffer[idx + width :]
+            return line
+
+        def consume_line(line: bytes) -> None:
+            nonlocal data_bytes
+            text = line.decode("utf-8", errors="replace")
+            if not text:
+                dispatch_event()
+                return
+            if text.startswith(":"):
+                return
+            field_name, _, value = text.partition(":")
+            if value.startswith(" "):
+                value = value[1:]
+            if field_name == "data":
+                data_bytes += len(value.encode("utf-8"))
+                if data_bytes > MAX_SSE_EVENT_BYTES:
+                    raise MCPProtocolError(
+                        f"{self.server_name}: SSE data exceeds {MAX_SSE_EVENT_BYTES} bytes"
+                    )
+                data_lines.append(value)
+
         async for chunk in resp.content.iter_chunked(16384):
             buffer += chunk
             if len(buffer) > MAX_SSE_EVENT_BYTES:
                 raise MCPProtocolError(
                     f"{self.server_name}: SSE event exceeds {MAX_SSE_EVENT_BYTES} bytes"
                 )
-            while True:
-                for sep in (b"\r\n", b"\n", b"\r"):
-                    idx = buffer.find(sep)
-                    if idx != -1:
-                        line, buffer = buffer[:idx], buffer[idx + len(sep) :]
-                        break
-                else:
-                    break
-                text = line.decode("utf-8", errors="replace")
-                if not text:
-                    dispatch_event()
-                    continue
-                if text.startswith(":"):
-                    continue  # SSE comment / keep-alive
-                field_name, _, value = text.partition(":")
-                if value.startswith(" "):
-                    value = value[1:]
-                if field_name == "data":
-                    data_bytes += len(value)
-                    if data_bytes > MAX_SSE_EVENT_BYTES:
-                        raise MCPProtocolError(
-                            f"{self.server_name}: SSE data exceeds {MAX_SSE_EVENT_BYTES} bytes"
-                        )
-                    data_lines.append(value)
-                # event/id/retry fields carry no data we act on.
+            while (line := pop_line()) is not None:
+                consume_line(line)
+        while (line := pop_line(eof=True)) is not None:
+            consume_line(line)
         dispatch_event()
 
     # ------------------------------------------------------------------
@@ -358,11 +380,12 @@ class HttpTransport:
         if protocol_version:
             headers["MCP-Protocol-Version"] = protocol_version
         try:
-            async with self._session.delete(
-                self.url, headers=headers, allow_redirects=False
-            ) as resp:
-                await resp.read()
-        except aiohttp.ClientError:
+            async with asyncio.timeout(_SESSION_DELETE_TIMEOUT):
+                async with self._session.delete(
+                    self.url, headers=headers, allow_redirects=False
+                ) as resp:
+                    await self._read_bounded(resp)
+        except (TimeoutError, aiohttp.ClientError, MCPProtocolError):
             pass
         finally:
             self.session_id = None

--- a/src/tools/mcp/transport_stdio.py
+++ b/src/tools/mcp/transport_stdio.py
@@ -1,0 +1,302 @@
+"""stdio transport: the MCP server runs as an owned subprocess.
+
+Framing: one JSON-RPC message per newline-delimited UTF-8 line on
+stdout/stdin. Lifecycle and safety rules (plan §3):
+
+- The child is launched in its OWN process group (session leader), with a
+  minimal allowlisted environment plus the server's configured ``env`` —
+  never Odin's full service environment, which carries credentials.
+- stdout lines are length-bounded before parsing.
+- stderr is drained CONTINUOUSLY into a bounded ring buffer (a verbose
+  server must never fill the pipe and deadlock) and surfaced for status/UI.
+- Shutdown escalates: stdin close → bounded wait → SIGTERM to the group →
+  bounded wait → SIGKILL to the group. Group signalling is guarded by the
+  same invariant as the executor's process-tree kills (v3.59.1): the pgid
+  must be > 1, equal to the child pid we spawned, and not our own group —
+  a broadcast kill must be impossible by construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import tempfile
+from collections import deque
+from collections.abc import Callable
+from typing import Any
+
+from ...odin_log import get_logger
+from .errors import MCPConnectError, MCPProtocolError
+from .protocol import (
+    MAX_STDERR_STORE_BYTES,
+    MAX_STDOUT_LINE_BYTES,
+    parse_wire_payload,
+)
+
+log = get_logger("mcp.stdio")
+
+# Minimal operational environment a spawned MCP server receives. Everything
+# else must be explicitly configured per server.
+_ENV_ALLOWLIST = ("PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR", "USER")
+
+_STDIN_CLOSE_GRACE = 3.0
+_TERM_GRACE = 4.0
+_KILL_GRACE = 3.0
+
+
+def build_child_env(configured: dict[str, str] | None) -> dict[str, str]:
+    """Allowlisted base environment + the server's configured env."""
+    env = {k: v for k in _ENV_ALLOWLIST if (v := os.environ.get(k)) is not None}
+    if configured:
+        for key, value in configured.items():
+            env[str(key)] = str(value)
+    return env
+
+
+class StdioTransport:
+    """Owns one MCP server subprocess and its message pump.
+
+    ``on_message`` receives every parsed JSON-RPC message dict from stdout.
+    ``on_closed`` fires exactly once when the pump stops (EOF, protocol
+    violation, or shutdown) with a human-readable reason.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        command: str,
+        args: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        on_message: Callable[[dict], None],
+        on_closed: Callable[[str], None],
+        negotiated_version: Callable[[], str | None],
+    ) -> None:
+        self.server_name = server_name
+        self.command = command
+        self.args = list(args)
+        self.env = dict(env or {})
+        self.cwd = cwd or None
+        self._on_message = on_message
+        self._on_closed = on_closed
+        self._negotiated_version = negotiated_version
+
+        self._process: asyncio.subprocess.Process | None = None
+        self._spawned_pgid: int | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
+        self._stderr_ring: deque[bytes] = deque()
+        self._stderr_bytes = 0
+        self._write_lock = asyncio.Lock()
+        self._closed_fired = False
+        self._closing = False
+
+    @property
+    def running(self) -> bool:
+        return self._process is not None and self._process.returncode is None
+
+    @property
+    def pid(self) -> int | None:
+        return self._process.pid if self._process else None
+
+    async def start(self) -> None:
+        if self._process is not None:
+            raise MCPConnectError(f"{self.server_name}: transport already started")
+        if not self.command:
+            raise MCPConnectError(f"{self.server_name}: stdio requires 'command'")
+        if self.cwd and not os.path.isdir(self.cwd):
+            raise MCPConnectError(f"{self.server_name}: cwd does not exist: {self.cwd}")
+        # Never inherit Odin's process cwd implicitly (the 2026-07-27
+        # relative-path hazard class): an unconfigured cwd runs the server
+        # from the temp dir, where a stray relative path can hurt nothing.
+        effective_cwd = self.cwd or tempfile.gettempdir()
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                self.command,
+                *self.args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=build_child_env(self.env),
+                cwd=effective_cwd,
+                start_new_session=True,  # own session ⇒ own process group
+                limit=MAX_STDOUT_LINE_BYTES + 1024,
+            )
+        except FileNotFoundError:
+            raise MCPConnectError(
+                f"{self.server_name}: command not found: {self.command}"
+            ) from None
+        except OSError as e:
+            raise MCPConnectError(f"{self.server_name}: failed to start: {e}") from e
+        try:
+            pgid = os.getpgid(self._process.pid)
+            self._spawned_pgid = pgid if pgid == self._process.pid else None
+        except OSError:
+            self._spawned_pgid = None
+        self._reader_task = asyncio.create_task(self._pump_stdout())
+        self._stderr_task = asyncio.create_task(self._pump_stderr())
+
+    async def send(self, message: dict[str, Any]) -> None:
+        proc = self._process
+        if proc is None or proc.stdin is None or proc.returncode is not None:
+            raise MCPConnectError(f"{self.server_name}: server process not running")
+        line = json.dumps(message, separators=(",", ":")) + "\n"
+        async with self._write_lock:
+            proc.stdin.write(line.encode("utf-8"))
+            await proc.stdin.drain()
+
+    # ------------------------------------------------------------------
+    # Pumps
+    # ------------------------------------------------------------------
+
+    async def _pump_stdout(self) -> None:
+        assert self._process and self._process.stdout
+        reason = "server closed its output stream"
+        try:
+            while True:
+                try:
+                    line = await self._process.stdout.readline()
+                except (ValueError, asyncio.LimitOverrunError):
+                    reason = f"stdout line exceeded {MAX_STDOUT_LINE_BYTES} bytes"
+                    break
+                if not line:
+                    break
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    messages = parse_wire_payload(
+                        stripped, negotiated_version=self._negotiated_version()
+                    )
+                except MCPProtocolError as e:
+                    log.warning("MCP %s: dropping stdout line: %s", self.server_name, e)
+                    continue
+                for msg in messages:
+                    try:
+                        self._on_message(msg)
+                    except Exception:
+                        log.exception("MCP %s: message handler failed", self.server_name)
+        except asyncio.CancelledError:
+            reason = "transport shut down"
+        except Exception as e:  # reader must never die silently
+            log.exception("MCP %s: stdout pump error", self.server_name)
+            reason = f"stdout pump error: {e.__class__.__name__}"
+        finally:
+            self._fire_closed(reason)
+
+    async def _pump_stderr(self) -> None:
+        assert self._process and self._process.stderr
+        try:
+            while True:
+                chunk = await self._process.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_ring.append(chunk)
+                self._stderr_bytes += len(chunk)
+                while self._stderr_bytes > MAX_STDERR_STORE_BYTES and self._stderr_ring:
+                    dropped = self._stderr_ring.popleft()
+                    self._stderr_bytes -= len(dropped)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            log.exception("MCP %s: stderr pump error", self.server_name)
+
+    def stderr_tail(self, max_chars: int = 4000) -> str:
+        """Bounded, decoded tail of the server's stderr (for status/UI)."""
+        data = b"".join(self._stderr_ring)
+        return data.decode("utf-8", errors="replace")[-max_chars:]
+
+    def _fire_closed(self, reason: str) -> None:
+        if self._closed_fired:
+            return
+        self._closed_fired = True
+        if self._closing:
+            reason = "transport shut down"
+        try:
+            self._on_closed(reason)
+        except Exception:
+            log.exception("MCP %s: on_closed handler failed", self.server_name)
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    def _owned_pgid(self) -> int | None:
+        """The child's process group, ONLY if it is safe to signal: pgid > 1,
+        the group is led by the pid we spawned (start_new_session guarantees
+        this while the leader lives), and it is not our own group. While ANY
+        member of the group survives, the pgid cannot be recycled — so the
+        value stays safe for the post-exit descendant sweep."""
+        pgid = self._spawned_pgid
+        if pgid is None or pgid <= 1 or pgid == os.getpgrp():
+            return None
+        return pgid
+
+    def _signal_group(self, sig: int) -> None:
+        proc = self._process
+        pgid = self._owned_pgid()
+        try:
+            if pgid is not None:
+                os.killpg(pgid, sig)
+            elif proc is not None and proc.returncode is None:
+                proc.send_signal(sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+
+    async def shutdown(self) -> None:
+        """stdin close → bounded wait → TERM group → bounded wait → KILL
+        group — then a final group SWEEP even when the leader exited
+        gracefully: a leader that honors EOF can still orphan descendants in
+        its group, and an unswept group leaks them (the v3.59.1 lesson).
+        Idempotent; never raises."""
+        self._closing = True
+        proc = self._process
+        if proc is None:
+            self._fire_closed("transport shut down")
+            return
+        try:
+            if proc.returncode is None and proc.stdin is not None:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=_STDIN_CLOSE_GRACE)
+                except TimeoutError:
+                    pass
+            if proc.returncode is None:
+                self._signal_group(signal.SIGTERM)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=_TERM_GRACE)
+                except TimeoutError:
+                    pass
+            if proc.returncode is None:
+                self._signal_group(signal.SIGKILL)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=_KILL_GRACE)
+                except TimeoutError:
+                    log.warning(
+                        "MCP %s: process %s survived SIGKILL grace",
+                        self.server_name,
+                        proc.pid,
+                    )
+            # Descendant sweep: the leader is gone (or wedged past KILL);
+            # TERM then KILL whatever remains of the owned group. ESRCH
+            # means the group is already empty — the common, silent case.
+            self._signal_group(signal.SIGTERM)
+            await asyncio.sleep(min(0.2, _TERM_GRACE))
+            self._signal_group(signal.SIGKILL)
+        finally:
+            for task in (self._reader_task, self._stderr_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    try:
+                        await task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+            self._reader_task = None
+            self._stderr_task = None
+            self._fire_closed("transport shut down")

--- a/src/tools/mcp/transport_stdio.py
+++ b/src/tools/mcp/transport_stdio.py
@@ -28,7 +28,7 @@ from collections.abc import Callable
 from typing import Any
 
 from ...odin_log import get_logger
-from .errors import MCPConnectError, MCPProtocolError
+from .errors import MCPConnectError, MCPPreWriteError, MCPProtocolError
 from .protocol import (
     MAX_STDERR_STORE_BYTES,
     MAX_STDOUT_LINE_BYTES,
@@ -44,6 +44,7 @@ _ENV_ALLOWLIST = ("PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR"
 _STDIN_CLOSE_GRACE = 3.0
 _TERM_GRACE = 4.0
 _KILL_GRACE = 3.0
+MAX_STDIN_FRAME_BYTES = 4 * 1024 * 1024
 
 
 def build_child_env(configured: dict[str, str] | None) -> dict[str, str]:
@@ -93,6 +94,7 @@ class StdioTransport:
         self._write_lock = asyncio.Lock()
         self._closed_fired = False
         self._closing = False
+        self._shutdown_task: asyncio.Task[None] | None = None
 
     @property
     def running(self) -> bool:
@@ -139,14 +141,30 @@ class StdioTransport:
         self._reader_task = asyncio.create_task(self._pump_stdout())
         self._stderr_task = asyncio.create_task(self._pump_stderr())
 
-    async def send(self, message: dict[str, Any]) -> None:
+    async def send(self, message: dict[str, Any], *, timeout: float | None = None) -> None:
+        """Write one bounded frame. When ``timeout`` is supplied it covers
+        waiting for the write lock and draining the child pipe."""
         proc = self._process
         if proc is None or proc.stdin is None or proc.returncode is not None:
             raise MCPConnectError(f"{self.server_name}: server process not running")
-        line = json.dumps(message, separators=(",", ":")) + "\n"
-        async with self._write_lock:
-            proc.stdin.write(line.encode("utf-8"))
-            await proc.stdin.drain()
+        frame = (json.dumps(message, separators=(",", ":")) + "\n").encode("utf-8")
+        if len(frame) > MAX_STDIN_FRAME_BYTES:
+            raise MCPProtocolError(
+                f"{self.server_name}: outbound frame exceeds {MAX_STDIN_FRAME_BYTES} bytes"
+            )
+
+        async def write() -> None:
+            async with self._write_lock:
+                current = self._process
+                if current is not proc or proc.stdin is None or proc.returncode is not None:
+                    raise MCPPreWriteError(f"{self.server_name}: server process not running")
+                proc.stdin.write(frame)
+                await proc.stdin.drain()
+
+        if timeout is None:
+            await write()
+        else:
+            await asyncio.wait_for(write(), timeout=timeout)
 
     # ------------------------------------------------------------------
     # Pumps
@@ -209,12 +227,10 @@ class StdioTransport:
         data = b"".join(self._stderr_ring)
         return data.decode("utf-8", errors="replace")[-max_chars:]
 
-    def _fire_closed(self, reason: str) -> None:
-        if self._closed_fired:
+    def _fire_closed(self, reason: str, *, final: bool = False) -> None:
+        if self._closed_fired or (self._closing and not final):
             return
         self._closed_fired = True
-        if self._closing:
-            reason = "transport shut down"
         try:
             self._on_closed(reason)
         except Exception:
@@ -247,16 +263,41 @@ class StdioTransport:
             pass
 
     async def shutdown(self) -> None:
-        """stdin close → bounded wait → TERM group → bounded wait → KILL
-        group — then a final group SWEEP even when the leader exited
-        gracefully: a leader that honors EOF can still orphan descendants in
-        its group, and an unswept group leaks them (the v3.59.1 lesson).
-        Idempotent; never raises."""
+        """Run teardown to completion even when the caller is cancelled.
+
+        The first caller owns one inner cleanup task. Every caller shields
+        that task; cancellation is re-raised only after the process group has
+        been terminated, descendants swept, pumps reaped, and the closed
+        callback fired.
+        """
         self._closing = True
+        task = self._shutdown_task
+        if task is None:
+            task = asyncio.create_task(
+                self._shutdown_inner(), name=f"mcp-stdio-shutdown-{self.server_name}"
+            )
+            self._shutdown_task = task
+        cancelled = False
+        while not task.done():
+            current = asyncio.current_task()
+            if current is not None:
+                while current.cancelling():
+                    current.uncancel()
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                cancelled = True
+        await task
+        if cancelled:
+            raise asyncio.CancelledError
+
+    async def _shutdown_inner(self) -> None:
+        """stdin close → TERM → KILL → descendant sweep; never raises."""
         proc = self._process
         if proc is None:
-            self._fire_closed("transport shut down")
+            self._fire_closed("transport shut down", final=True)
             return
+        final_reason = "transport shut down"
         try:
             if proc.returncode is None and proc.stdin is not None:
                 try:
@@ -278,17 +319,28 @@ class StdioTransport:
                 try:
                     await asyncio.wait_for(proc.wait(), timeout=_KILL_GRACE)
                 except TimeoutError:
+                    final_reason = "process survived SIGKILL grace"
                     log.warning(
                         "MCP %s: process %s survived SIGKILL grace",
                         self.server_name,
                         proc.pid,
                     )
-            # Descendant sweep: the leader is gone (or wedged past KILL);
-            # TERM then KILL whatever remains of the owned group. ESRCH
-            # means the group is already empty — the common, silent case.
             self._signal_group(signal.SIGTERM)
             await asyncio.sleep(min(0.2, _TERM_GRACE))
             self._signal_group(signal.SIGKILL)
+            deadline = asyncio.get_running_loop().time() + _KILL_GRACE
+            while True:
+                try:
+                    os.killpg(proc.pid, 0)
+                except (ProcessLookupError, PermissionError, OSError):
+                    break
+                if asyncio.get_running_loop().time() >= deadline:
+                    final_reason = "process group survived SIGKILL grace"
+                    log.warning("MCP %s: process group survived SIGKILL grace", self.server_name)
+                    break
+                await asyncio.sleep(0.02)
+        except Exception:
+            log.exception("MCP %s: shutdown cleanup failed", self.server_name)
         finally:
             for task in (self._reader_task, self._stderr_task):
                 if task is not None and not task.done():
@@ -299,4 +351,4 @@ class StdioTransport:
                         pass
             self._reader_task = None
             self._stderr_task = None
-            self._fire_closed("transport shut down")
+            self._fire_closed(final_reason, final=True)

--- a/tests/fakes/mcp_http.py
+++ b/tests/fakes/mcp_http.py
@@ -17,6 +17,14 @@ Modes (``make_app(mode)``):
   legacy-sse        legacy-stateless whose tools/call replies stream over
                     SSE and include a server-initiated request BEFORE the
                     final response (the client must answer -32601 via POST).
+  legacy-batch      2025-03-26 legacy; tools/list arrives as a receive-side batch.
+  modern-500-call    tools/call returns a bare HTTP 500 after accepting the POST.
+  modern-stall-call  tools/call stalls until the client request budget expires.
+  modern-missing-discover-result-type
+                    DiscoverResult omits mandatory modern resultType.
+  probe-200-internal probe returns HTTP 200 JSON-RPC -32603 (no era evidence).
+  probe-404-empty    probe returns an empty HTTP 404 (no era evidence).
+  probe-400-wrong-id probe returns HTTP 400 with a wrong-id modern marker.
   auth-401          every request → 401 (era must stay undetermined).
 
 ``state`` (returned alongside the app) records per-method call counts —
@@ -26,6 +34,7 @@ reply POSTed by the client for server-initiated requests.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -33,10 +42,9 @@ from aiohttp import web
 
 MODERN_VERSION = "2026-07-28"
 LEGACY_VERSION = "2025-06-18"
-SESSION_ID = "fake-session-0001"
 
 
-def _tool_defs(*, with_header_param: bool) -> list[dict]:
+def _tool_defs(*, with_header_param: bool, header_name: str = "Region") -> list[dict]:
     tools = [
         {
             "name": "echo",
@@ -60,7 +68,7 @@ def _tool_defs(*, with_header_param: bool) -> list[dict]:
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "region": {"type": "string", "x-mcp-header": "Region"},
+                        "region": {"type": "string", "x-mcp-header": header_name},
                         "query": {"type": "string"},
                     },
                 },
@@ -101,6 +109,17 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
         "session_deleted": False,
         "client_replies": [],
         "pushed": False,
+        "expire_once": False,
+        "header_name": "Region",
+        "discover_result_type": "complete",
+        "session_generation": 0,
+        "current_session_id": None,
+        "session_headers": [],
+        "cancelled": [],
+        "tool_effects": 0,
+        "reject_status": 400,
+        "reject_wrong_id": False,
+        "delete_mode": "normal",
     }
 
     def count(method: str) -> None:
@@ -121,6 +140,14 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
 
         count(str(method))
 
+        if method == "server/discover" and mode == "probe-200-internal":
+            return web.json_response(_rpc_error(msg_id, -32603, "Internal error"))
+        if method == "server/discover" and mode == "probe-404-empty":
+            return web.Response(status=404)
+        if method == "server/discover" and mode == "probe-400-wrong-id":
+            return web.json_response(
+                _rpc_error(msg_id + 1000, -32022, "Unsupported protocol version"), status=400
+            )
         if mode.startswith("modern"):
             return await _modern(request, body, method, msg_id, params)
         return await _legacy(request, body, method, msg_id, params)
@@ -129,6 +156,8 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
         request: web.Request, body: dict, method: str, msg_id: Any, params: dict
     ) -> web.StreamResponse:
         if message_is_notification(body):
+            if method == "notifications/cancelled":
+                state["cancelled"].append(params)
             return web.Response(status=202)
         header_version = request.headers.get("MCP-Protocol-Version")
         meta = params.get("_meta") or {}
@@ -153,32 +182,46 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
                 _rpc_error(msg_id, -32020, "Header mismatch: Mcp-Method"), status=400
             )
         if method == "server/discover":
-            return web.json_response(
-                _rpc_response(
-                    msg_id,
-                    {
-                        "resultType": "complete",
-                        "supportedVersions": [MODERN_VERSION],
-                        "capabilities": {"tools": {}},
-                        "_meta": {
-                            "io.modelcontextprotocol/serverInfo": {
-                                "name": "fake-modern-http",
-                                "version": "1.0",
-                            }
-                        },
-                    },
-                )
-            )
+            result = {
+                "supportedVersions": [MODERN_VERSION],
+                "capabilities": {"tools": {}},
+                "_meta": {
+                    "io.modelcontextprotocol/serverInfo": {
+                        "name": "fake-modern-http",
+                        "version": "1.0",
+                    }
+                },
+            }
+            if mode != "modern-missing-discover-result-type":
+                result["resultType"] = state["discover_result_type"]
+            return web.json_response(_rpc_response(msg_id, result))
         if method == "tools/list":
-            result = _result(mode, {"tools": _tool_defs(with_header_param=True), "ttlMs": 90000})
+            result = _result(
+                mode,
+                {
+                    "tools": _tool_defs(with_header_param=True, header_name=state["header_name"]),
+                    "ttlMs": 90000,
+                },
+            )
             return _reply(request, msg_id, result)
         if method == "tools/call":
             name = params.get("name", "")
+            if mode == "modern-500-call":
+                state["tool_effects"] += 1
+                return web.Response(status=500)
+            if mode == "modern-stall-call":
+                state["tool_effects"] += 1
+                await asyncio.sleep(60)
+                return web.Response(status=500)
             if state.get("reject_calls", 0) > 0:
                 state["reject_calls"] -= 1
                 return web.json_response(
-                    _rpc_error(msg_id, -32020, "Header mismatch: transient"),
-                    status=400,
+                    _rpc_error(
+                        msg_id + 1000 if state["reject_wrong_id"] else msg_id,
+                        -32020,
+                        "Header mismatch: transient",
+                    ),
+                    status=state["reject_status"],
                 )
             if request.headers.get("Mcp-Name") != name:
                 return web.json_response(
@@ -187,7 +230,7 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
             arguments = params.get("arguments") or {}
             if name == "region_tool":
                 region = arguments.get("region")
-                header = request.headers.get("Mcp-Param-Region")
+                header = request.headers.get(f"Mcp-Param-{state['header_name']}")
                 if region is not None and header != str(region):
                     return web.json_response(
                         _rpc_error(msg_id, -32020, "Header mismatch: Mcp-Param-Region"),
@@ -208,7 +251,7 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
     ) -> web.StreamResponse:
         session_mode = mode == "legacy-session"
         if method == "server/discover":
-            if mode == "legacy-stateless" or mode == "legacy-sse":
+            if mode in {"legacy-stateless", "legacy-sse"}:
                 return web.json_response(_rpc_error(msg_id, -32601, "Method not found"))
             return web.Response(status=400, text="")  # bare 400, empty body
         if method == "initialize":
@@ -216,28 +259,53 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
                 _rpc_response(
                     msg_id,
                     {
-                        "protocolVersion": LEGACY_VERSION,
+                        "protocolVersion": (
+                            "2025-03-26" if mode == "legacy-batch" else LEGACY_VERSION
+                        ),
                         "capabilities": {"tools": {"listChanged": True}},
                         "serverInfo": {"name": f"fake-{mode}", "version": "1.0"},
                     },
                 )
             )
             if session_mode:
-                response.headers["Mcp-Session-Id"] = SESSION_ID
+                state["session_generation"] += 1
+                minted = f"fake-session-{state['session_generation']:04d}"
+                state["current_session_id"] = minted
+                response.headers["Mcp-Session-Id"] = minted
             return response
         if session_mode:
             got = request.headers.get("Mcp-Session-Id")
-            if state["expired"]:
+            state["session_headers"].append((method, got))
+            if state["expired"] or state["expire_once"]:
+                state["expire_once"] = False
                 return web.json_response(_rpc_error(msg_id, -32000, "Session expired"), status=404)
-            if got != SESSION_ID:
+            if got != state["current_session_id"]:
                 return web.json_response(_rpc_error(msg_id, -32000, "Missing session"), status=400)
         if message_is_notification(body):
+            if method == "notifications/cancelled":
+                state["cancelled"].append(params)
             return web.Response(status=202)
         if method == "tools/list":
-            return _reply(request, msg_id, {"tools": _tool_defs(with_header_param=False)})
+            result = {"tools": _tool_defs(with_header_param=False)}
+            if mode == "legacy-batch":
+                return web.json_response(
+                    [
+                        _rpc_response(msg_id, result),
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "notifications/message",
+                            "params": {"level": "info", "data": "batched hello"},
+                        },
+                    ]
+                )
+            return _reply(request, msg_id, result)
         if method == "tools/call":
             name = params.get("name", "")
             arguments = params.get("arguments") or {}
+            if mode == "legacy-stall-call":
+                state["tool_effects"] += 1
+                await asyncio.sleep(60)
+                return web.Response(status=500)
             if mode == "legacy-sse" and not state["pushed"]:
                 state["pushed"] = True
                 messages = [
@@ -287,8 +355,12 @@ def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
         )
 
     async def delete_endpoint(request: web.Request) -> web.Response:
-        if request.headers.get("Mcp-Session-Id") == SESSION_ID:
+        if request.headers.get("Mcp-Session-Id") == state["current_session_id"]:
             state["session_deleted"] = True
+            if state["delete_mode"] == "oversized":
+                return web.Response(body=b"x" * (2 * 1024 * 1024 + 1))
+            if state["delete_mode"] == "stall":
+                await asyncio.sleep(60)
             return web.Response(status=200)
         return web.Response(status=405)
 

--- a/tests/fakes/mcp_http.py
+++ b/tests/fakes/mcp_http.py
@@ -1,0 +1,302 @@
+"""Fake Streamable HTTP MCP servers for tests (aiohttp app factories).
+
+Modes (``make_app(mode)``):
+  modern            2026-07-28: validates MCP-Protocol-Version, Mcp-Method,
+                    Mcp-Name and Mcp-Param-* header/body congruence
+                    (400 + -32020 on mismatch); server/discover; resultType
+                    on every result; serves an x-mcp-header annotated tool.
+  modern-sse        modern, but request replies arrive as SSE streams with a
+                    comment keep-alive and a progress notification first.
+  legacy-session    2025-06-18 initialize mints an Mcp-Session-Id; requests
+                    without it → 400; after ``state["expired"] = True`` →
+                    404; DELETE ends the session; probe gets a bare-400
+                    (empty body) so era detection must fall back.
+  legacy-stateless  like legacy-session but never mints a session; the
+                    probe gets HTTP 200 + JSON-RPC -32601 (the other
+                    legacy-detection shape).
+  legacy-sse        legacy-stateless whose tools/call replies stream over
+                    SSE and include a server-initiated request BEFORE the
+                    final response (the client must answer -32601 via POST).
+  auth-401          every request → 401 (era must stay undetermined).
+
+``state`` (returned alongside the app) records per-method call counts —
+``state["calls"]["tools/call"]`` pins never-reissued behavior — plus every
+reply POSTed by the client for server-initiated requests.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from aiohttp import web
+
+MODERN_VERSION = "2026-07-28"
+LEGACY_VERSION = "2025-06-18"
+SESSION_ID = "fake-session-0001"
+
+
+def _tool_defs(*, with_header_param: bool) -> list[dict]:
+    tools = [
+        {
+            "name": "echo",
+            "description": "Echo text back",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+            },
+        },
+        {
+            "name": "fail",
+            "description": "Always reports isError",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+    ]
+    if with_header_param:
+        tools.append(
+            {
+                "name": "region_tool",
+                "description": "Requires a mirrored Region header",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "region": {"type": "string", "x-mcp-header": "Region"},
+                        "query": {"type": "string"},
+                    },
+                },
+            }
+        )
+    return tools
+
+
+def _result(mode: str, payload: dict) -> dict:
+    if mode.startswith("modern"):
+        payload = dict(payload)
+        payload["resultType"] = "complete"
+    return payload
+
+
+def _rpc_response(msg_id: Any, result: dict) -> dict:
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def _rpc_error(msg_id: Any, code: int, message: str, data: dict | None = None) -> dict:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": msg_id, "error": err}
+
+
+def _sse_body(messages: list[dict]) -> str:
+    parts = [": keep-alive comment\n\n"]
+    for msg in messages:
+        parts.append(f"data: {json.dumps(msg)}\n\n")
+    return "".join(parts)
+
+
+def make_app(mode: str) -> tuple[web.Application, dict[str, Any]]:
+    state: dict[str, Any] = {
+        "calls": {},
+        "expired": False,
+        "session_deleted": False,
+        "client_replies": [],
+        "pushed": False,
+    }
+
+    def count(method: str) -> None:
+        state["calls"][method] = state["calls"].get(method, 0) + 1
+
+    async def endpoint(request: web.Request) -> web.StreamResponse:
+        if mode == "auth-401":
+            return web.json_response({"error": "unauthorized"}, status=401)
+        body = await request.json()
+        method = body.get("method")
+        msg_id = body.get("id")
+        params = body.get("params") or {}
+
+        # Client replies to server-initiated requests arrive as responses.
+        if method is None and msg_id is not None:
+            state["client_replies"].append(body)
+            return web.Response(status=202)
+
+        count(str(method))
+
+        if mode.startswith("modern"):
+            return await _modern(request, body, method, msg_id, params)
+        return await _legacy(request, body, method, msg_id, params)
+
+    async def _modern(
+        request: web.Request, body: dict, method: str, msg_id: Any, params: dict
+    ) -> web.StreamResponse:
+        if message_is_notification(body):
+            return web.Response(status=202)
+        header_version = request.headers.get("MCP-Protocol-Version")
+        meta = params.get("_meta") or {}
+        meta_version = meta.get("io.modelcontextprotocol/protocolVersion")
+        if header_version != meta_version or not header_version:
+            return web.json_response(
+                _rpc_error(msg_id, -32020, "Header mismatch: protocol version"),
+                status=400,
+            )
+        if header_version != MODERN_VERSION:
+            return web.json_response(
+                _rpc_error(
+                    msg_id,
+                    -32022,
+                    "Unsupported protocol version",
+                    {"supported": [MODERN_VERSION], "requested": header_version},
+                ),
+                status=400,
+            )
+        if request.headers.get("Mcp-Method") != method:
+            return web.json_response(
+                _rpc_error(msg_id, -32020, "Header mismatch: Mcp-Method"), status=400
+            )
+        if method == "server/discover":
+            return web.json_response(
+                _rpc_response(
+                    msg_id,
+                    {
+                        "resultType": "complete",
+                        "supportedVersions": [MODERN_VERSION],
+                        "capabilities": {"tools": {}},
+                        "_meta": {
+                            "io.modelcontextprotocol/serverInfo": {
+                                "name": "fake-modern-http",
+                                "version": "1.0",
+                            }
+                        },
+                    },
+                )
+            )
+        if method == "tools/list":
+            result = _result(mode, {"tools": _tool_defs(with_header_param=True), "ttlMs": 90000})
+            return _reply(request, msg_id, result)
+        if method == "tools/call":
+            name = params.get("name", "")
+            if state.get("reject_calls", 0) > 0:
+                state["reject_calls"] -= 1
+                return web.json_response(
+                    _rpc_error(msg_id, -32020, "Header mismatch: transient"),
+                    status=400,
+                )
+            if request.headers.get("Mcp-Name") != name:
+                return web.json_response(
+                    _rpc_error(msg_id, -32020, "Header mismatch: Mcp-Name"), status=400
+                )
+            arguments = params.get("arguments") or {}
+            if name == "region_tool":
+                region = arguments.get("region")
+                header = request.headers.get("Mcp-Param-Region")
+                if region is not None and header != str(region):
+                    return web.json_response(
+                        _rpc_error(msg_id, -32020, "Header mismatch: Mcp-Param-Region"),
+                        status=400,
+                    )
+                result = _result(
+                    mode,
+                    {"content": [{"type": "text", "text": f"region={region}"}]},
+                )
+                return _reply(request, msg_id, result)
+            return _reply(request, msg_id, _run_tool(name, arguments))
+        return web.json_response(
+            _rpc_error(msg_id, -32601, f"Method not found: {method}"), status=404
+        )
+
+    async def _legacy(
+        request: web.Request, body: dict, method: str, msg_id: Any, params: dict
+    ) -> web.StreamResponse:
+        session_mode = mode == "legacy-session"
+        if method == "server/discover":
+            if mode == "legacy-stateless" or mode == "legacy-sse":
+                return web.json_response(_rpc_error(msg_id, -32601, "Method not found"))
+            return web.Response(status=400, text="")  # bare 400, empty body
+        if method == "initialize":
+            response = web.json_response(
+                _rpc_response(
+                    msg_id,
+                    {
+                        "protocolVersion": LEGACY_VERSION,
+                        "capabilities": {"tools": {"listChanged": True}},
+                        "serverInfo": {"name": f"fake-{mode}", "version": "1.0"},
+                    },
+                )
+            )
+            if session_mode:
+                response.headers["Mcp-Session-Id"] = SESSION_ID
+            return response
+        if session_mode:
+            got = request.headers.get("Mcp-Session-Id")
+            if state["expired"]:
+                return web.json_response(_rpc_error(msg_id, -32000, "Session expired"), status=404)
+            if got != SESSION_ID:
+                return web.json_response(_rpc_error(msg_id, -32000, "Missing session"), status=400)
+        if message_is_notification(body):
+            return web.Response(status=202)
+        if method == "tools/list":
+            return _reply(request, msg_id, {"tools": _tool_defs(with_header_param=False)})
+        if method == "tools/call":
+            name = params.get("name", "")
+            arguments = params.get("arguments") or {}
+            if mode == "legacy-sse" and not state["pushed"]:
+                state["pushed"] = True
+                messages = [
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "srv-http-req-1",
+                        "method": "roots/list",
+                        "params": {},
+                    },
+                    _rpc_response(msg_id, _run_tool(name, arguments)),
+                ]
+                return web.Response(text=_sse_body(messages), content_type="text/event-stream")
+            return _reply(request, msg_id, _run_tool(name, arguments))
+        return web.json_response(_rpc_error(msg_id, -32601, "Method not found"))
+
+    def _reply(request: web.Request, msg_id: Any, result: dict) -> web.StreamResponse:
+        response_msg = _rpc_response(msg_id, result)
+        if mode.endswith("-sse"):
+            progress = {
+                "jsonrpc": "2.0",
+                "method": "notifications/progress",
+                "params": {"progress": 1},
+            }
+            return web.Response(
+                text=_sse_body([progress, response_msg]),
+                content_type="text/event-stream",
+            )
+        return web.json_response(response_msg)
+
+    def _run_tool(name: str, arguments: dict) -> dict:
+        if name == "echo":
+            return _result(
+                mode,
+                {"content": [{"type": "text", "text": f"echo: {arguments.get('text', '')}"}]},
+            )
+        if name == "fail":
+            return _result(
+                mode,
+                {
+                    "content": [{"type": "text", "text": "deliberate failure"}],
+                    "isError": True,
+                },
+            )
+        return _result(
+            mode,
+            {"content": [{"type": "text", "text": f"unknown tool {name}"}], "isError": True},
+        )
+
+    async def delete_endpoint(request: web.Request) -> web.Response:
+        if request.headers.get("Mcp-Session-Id") == SESSION_ID:
+            state["session_deleted"] = True
+            return web.Response(status=200)
+        return web.Response(status=405)
+
+    app = web.Application()
+    app.router.add_post("/mcp", endpoint)
+    app.router.add_delete("/mcp", delete_endpoint)
+    return app, state
+
+
+def message_is_notification(body: dict) -> bool:
+    return "method" in body and ("id" not in body or body.get("id") is None)

--- a/tests/fakes/mcp_stdio_server.py
+++ b/tests/fakes/mcp_stdio_server.py
@@ -15,12 +15,15 @@ Modes:
                     (exposed via the `pushy_reply` tool).
   legacy-unknown-version  counteroffers a version no client supports.
   modern-legacy-list      modern-era server advertising ONLY legacy versions.
-  modern-missing-result-type  modern server that omits resultType.
+  modern-missing-discover-result-type  modern server whose DiscoverResult omits resultType.
+  modern-missing-call-result-type  modern server whose tools/call result omits resultType.
   silent            never answers anything (probe/initialize time out).
   garbage           emits non-JSON noise, then behaves like `legacy`.
   dies-mid-call     exits abruptly during tools/call.
+  oversized-response emits a response line beyond the transport ceiling.
   stderr-flood      floods stderr forever while serving like `legacy`.
   hang-shutdown     ignores stdin EOF and SIGTERM (forces SIGKILL).
+  blocked-write     never reads stdin after startup (real pipe backpressure pin).
   grandchild        like `legacy`, but spawns a sleeping grandchild whose
                     pid is returned by the `child_pid` tool (process-group
                     teardown pin).
@@ -48,16 +51,29 @@ LEGACY_COUNTEROFFERS = {
     "legacy-oldest": "2024-11-05",
     "legacy-batch": "2025-03-26",
     "legacy-pushy": "2025-06-18",
+    "legacy-cancel": "2025-06-18",
     "legacy-unknown-version": "1999-01-01",
     "garbage": "2025-06-18",
     "dies-mid-call": "2025-06-18",
+    "oversized-response": "2025-06-18",
     "stderr-flood": "2025-06-18",
     "hang-shutdown": "2025-06-18",
     "grandchild": "2025-06-18",
+    "missing-schema": "2025-06-18",
 }
 
-STATE = {"initialized": False, "pushy_reply": None, "grandchild_pid": 0}
-_MODERN_MODES = {"modern", "modern-legacy-list", "modern-missing-result-type"}
+STATE = {
+    "initialized": False,
+    "pushy_reply": None,
+    "grandchild_pid": 0,
+    "cancelled_request_id": None,
+}
+_MODERN_MODES = {
+    "modern",
+    "modern-legacy-list",
+    "modern-missing-discover-result-type",
+    "modern-missing-call-result-type",
+}
 
 
 def send(obj) -> None:
@@ -66,7 +82,7 @@ def send(obj) -> None:
 
 
 def tool_defs() -> list[dict]:
-    return [
+    tools = [
         {
             "name": "echo",
             "description": "Echo text back",
@@ -108,12 +124,20 @@ def tool_defs() -> list[dict]:
             "description": "JSON of the reply the client sent to the pushed request",
             "inputSchema": {"type": "object", "properties": {}},
         },
+        {
+            "name": "cancelled_request_id",
+            "description": "Request id received in notifications/cancelled",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
     ]
+    if MODE == "missing-schema":
+        tools.append({"name": "missing_schema", "description": "omits inputSchema"})
+    return tools
 
 
 def text_result(text: str, *, is_error: bool = False) -> dict:
     result = {"content": [{"type": "text", "text": text}], "isError": is_error}
-    if MODE in _MODERN_MODES and MODE != "modern-missing-result-type":
+    if MODE in _MODERN_MODES and MODE != "modern-missing-call-result-type":
         result["resultType"] = "complete"
     return result
 
@@ -137,6 +161,8 @@ def run_tool(name: str, arguments: dict) -> dict:
         return text_result(str(STATE["grandchild_pid"]))
     if name == "pushy_reply":
         return text_result(json.dumps(STATE["pushy_reply"]))
+    if name == "cancelled_request_id":
+        return text_result(json.dumps(STATE["cancelled_request_id"]))
     return text_result(f"unknown tool {name}", is_error=True)
 
 
@@ -153,7 +179,7 @@ def handle(msg: dict) -> None:
         return
 
     if method == "server/discover":
-        if MODE == "modern":
+        if MODE in {"modern", "modern-missing-call-result-type"}:
             send(
                 {
                     "jsonrpc": "2.0",
@@ -184,7 +210,7 @@ def handle(msg: dict) -> None:
                     },
                 }
             )
-        elif MODE == "modern-missing-result-type":
+        elif MODE == "modern-missing-discover-result-type":
             send(
                 {
                     "jsonrpc": "2.0",
@@ -248,6 +274,7 @@ def handle(msg: dict) -> None:
         return
 
     if method == "notifications/cancelled":
+        STATE["cancelled_request_id"] = (msg.get("params") or {}).get("requestId")
         return
 
     if method == "tools/list":
@@ -276,6 +303,30 @@ def handle(msg: dict) -> None:
         name = params.get("name", "")
         if MODE == "dies-mid-call":
             os._exit(9)
+        if MODE == "legacy-cancel" and name == "sleepy":
+            seconds = float((params.get("arguments") or {}).get("seconds", 1))
+
+            def answer_later() -> None:
+                time.sleep(seconds)
+                send({"jsonrpc": "2.0", "id": msg_id, "result": text_result("awake")})
+
+            threading.Thread(target=answer_later, daemon=True).start()
+            return
+        if MODE == "oversized-response":
+            sys.stdout.write(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": msg_id,
+                        "result": {
+                            "content": [{"type": "text", "text": "x" * (4 * 1024 * 1024 + 65536)}]
+                        },
+                    }
+                )
+                + "\n"
+            )
+            sys.stdout.flush()
+            return
         result = run_tool(name, params.get("arguments") or {})
         send({"jsonrpc": "2.0", "id": msg_id, "result": result})
         return
@@ -291,6 +342,10 @@ def handle(msg: dict) -> None:
 
 
 def main() -> None:
+    if MODE == "blocked-write":
+        print("READY", flush=True)
+        while True:
+            time.sleep(60)
     if MODE == "hang-shutdown":
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
     if MODE == "grandchild":

--- a/tests/fakes/mcp_stdio_server.py
+++ b/tests/fakes/mcp_stdio_server.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Fake MCP stdio server for tests. Stdlib only; spawned as a subprocess.
+
+Usage: mcp_stdio_server.py MODE
+
+Modes:
+  modern            2026-07-28 server: server/discover, _meta-carrying
+                    requests, resultType on every result, ttlMs on listings.
+  legacy            2025-06-18 initialize-handshake server.
+  legacy-oldest     2024-11-05 counteroffer.
+  legacy-batch      2025-03-26 counteroffer; tools/list response arrives
+                    inside a JSON-RPC batch array with a notification.
+  legacy-pushy      legacy that sends a server-initiated sampling request
+                    right after initialized and records the client's reply
+                    (exposed via the `pushy_reply` tool).
+  legacy-unknown-version  counteroffers a version no client supports.
+  modern-legacy-list      modern-era server advertising ONLY legacy versions.
+  modern-missing-result-type  modern server that omits resultType.
+  silent            never answers anything (probe/initialize time out).
+  garbage           emits non-JSON noise, then behaves like `legacy`.
+  dies-mid-call     exits abruptly during tools/call.
+  stderr-flood      floods stderr forever while serving like `legacy`.
+  hang-shutdown     ignores stdin EOF and SIGTERM (forces SIGKILL).
+  grandchild        like `legacy`, but spawns a sleeping grandchild whose
+                    pid is returned by the `child_pid` tool (process-group
+                    teardown pin).
+
+Tools served (both eras): echo(text), fail(), env_keys(), sleepy(seconds).
+`legacy` emits notifications/tools/list_changed when echo is called with
+text == "trigger-list-changed".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+MODE = sys.argv[1] if len(sys.argv) > 1 else "legacy"
+
+MODERN_VERSION = "2026-07-28"
+LEGACY_COUNTEROFFERS = {
+    "legacy": "2025-06-18",
+    "legacy-oldest": "2024-11-05",
+    "legacy-batch": "2025-03-26",
+    "legacy-pushy": "2025-06-18",
+    "legacy-unknown-version": "1999-01-01",
+    "garbage": "2025-06-18",
+    "dies-mid-call": "2025-06-18",
+    "stderr-flood": "2025-06-18",
+    "hang-shutdown": "2025-06-18",
+    "grandchild": "2025-06-18",
+}
+
+STATE = {"initialized": False, "pushy_reply": None, "grandchild_pid": 0}
+_MODERN_MODES = {"modern", "modern-legacy-list", "modern-missing-result-type"}
+
+
+def send(obj) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def tool_defs() -> list[dict]:
+    return [
+        {
+            "name": "echo",
+            "description": "Echo text back",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+            },
+        },
+        {
+            "name": "fail",
+            "description": "Always reports isError",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "report_cwd",
+            "description": "The server process working directory",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "env_keys",
+            "description": "Sorted names of the environment variables visible",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "sleepy",
+            "description": "Sleep before answering",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"seconds": {"type": "number"}},
+            },
+        },
+        {
+            "name": "child_pid",
+            "description": "Pid of the spawned grandchild (0 when none)",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "pushy_reply",
+            "description": "JSON of the reply the client sent to the pushed request",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+    ]
+
+
+def text_result(text: str, *, is_error: bool = False) -> dict:
+    result = {"content": [{"type": "text", "text": text}], "isError": is_error}
+    if MODE in _MODERN_MODES and MODE != "modern-missing-result-type":
+        result["resultType"] = "complete"
+    return result
+
+
+def run_tool(name: str, arguments: dict) -> dict:
+    if name == "echo":
+        text = str(arguments.get("text", ""))
+        if text == "trigger-list-changed":
+            send({"jsonrpc": "2.0", "method": "notifications/tools/list_changed"})
+        return text_result(f"echo: {text}")
+    if name == "fail":
+        return text_result("deliberate failure", is_error=True)
+    if name == "report_cwd":
+        return text_result(os.getcwd())
+    if name == "env_keys":
+        return text_result(",".join(sorted(os.environ)))
+    if name == "sleepy":
+        time.sleep(float(arguments.get("seconds", 1)))
+        return text_result("awake")
+    if name == "child_pid":
+        return text_result(str(STATE["grandchild_pid"]))
+    if name == "pushy_reply":
+        return text_result(json.dumps(STATE["pushy_reply"]))
+    return text_result(f"unknown tool {name}", is_error=True)
+
+
+def handle(msg: dict) -> None:
+    method = msg.get("method")
+    msg_id = msg.get("id")
+
+    if method is None and msg_id is not None:
+        # A response from the client to a server-initiated request.
+        STATE["pushy_reply"] = msg
+        return
+
+    if MODE == "silent":
+        return
+
+    if method == "server/discover":
+        if MODE == "modern":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "resultType": "complete",
+                        "supportedVersions": [MODERN_VERSION],
+                        "capabilities": {"tools": {}},
+                        "_meta": {
+                            "io.modelcontextprotocol/serverInfo": {
+                                "name": "fake-modern",
+                                "version": "1.0",
+                            }
+                        },
+                        "instructions": "fake modern server",
+                    },
+                }
+            )
+        elif MODE == "modern-legacy-list":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "resultType": "complete",
+                        "supportedVersions": ["2025-11-25", "2025-06-18"],
+                        "capabilities": {"tools": {}},
+                    },
+                }
+            )
+        elif MODE == "modern-missing-result-type":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "supportedVersions": [MODERN_VERSION],
+                        "capabilities": {"tools": {}},
+                    },
+                }
+            )
+        else:
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {"code": -32601, "message": "Method not found"},
+                }
+            )
+        return
+
+    if method == "initialize":
+        if MODE in _MODERN_MODES:
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {
+                        "code": -32022,
+                        "message": "Unsupported protocol version",
+                        "data": {"supported": [MODERN_VERSION]},
+                    },
+                }
+            )
+            return
+        version = LEGACY_COUNTEROFFERS.get(MODE, "2025-06-18")
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "protocolVersion": version,
+                    "capabilities": {"tools": {"listChanged": True}},
+                    "serverInfo": {"name": f"fake-{MODE}", "version": "1.0"},
+                    "instructions": "fake legacy server",
+                },
+            }
+        )
+        return
+
+    if method == "notifications/initialized":
+        STATE["initialized"] = True
+        if MODE == "legacy-pushy":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "srv-req-1",
+                    "method": "sampling/createMessage",
+                    "params": {"messages": []},
+                }
+            )
+        return
+
+    if method == "notifications/cancelled":
+        return
+
+    if method == "tools/list":
+        result: dict = {"tools": tool_defs()}
+        if MODE in _MODERN_MODES:
+            result["resultType"] = "complete"
+            result["ttlMs"] = 120000
+            result["cacheScope"] = "private"
+        if MODE == "legacy-batch":
+            send(
+                [
+                    {"jsonrpc": "2.0", "id": msg_id, "result": result},
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "notifications/message",
+                        "params": {"level": "info", "data": "batched hello"},
+                    },
+                ]
+            )
+            return
+        send({"jsonrpc": "2.0", "id": msg_id, "result": result})
+        return
+
+    if method == "tools/call":
+        params = msg.get("params") or {}
+        name = params.get("name", "")
+        if MODE == "dies-mid-call":
+            os._exit(9)
+        result = run_tool(name, params.get("arguments") or {})
+        send({"jsonrpc": "2.0", "id": msg_id, "result": result})
+        return
+
+    if msg_id is not None:
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
+            }
+        )
+
+
+def main() -> None:
+    if MODE == "hang-shutdown":
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    if MODE == "grandchild":
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(600)"],
+        )
+        STATE["grandchild_pid"] = child.pid
+    if MODE == "stderr-flood":
+
+        def flood() -> None:
+            while True:
+                try:
+                    sys.stderr.write("noise " * 2000 + "\n")
+                    sys.stderr.flush()
+                except Exception:
+                    return
+
+        threading.Thread(target=flood, daemon=True).start()
+    if MODE == "garbage":
+        sys.stdout.write("this is not json\n")
+        sys.stdout.write("\x00\x01 binary-ish noise\n")
+        sys.stdout.flush()
+
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            handle(msg)
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"fake server error: {e}\n")
+
+    if MODE == "hang-shutdown":
+        # Ignore the EOF graceful-shutdown signal too.
+        while True:
+            time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_local_workspace.py
+++ b/tests/test_local_workspace.py
@@ -1944,6 +1944,11 @@ _CLASSIFIED_SPAWN_SITES: dict[str, str] = {
     "src/discord/native_tools/media.py": "argv-form ssh to a REMOTE host; local cwd is irrelevant",
     "src/tools/ssh_pool.py": "argv-form ssh control-socket management, no user command text",
     "src/tools/mcp_client.py": "operator-configured MCP server process, not a user command",
+    "src/tools/mcp/transport_stdio.py": (
+        "operator-configured MCP server process, not a user command; spawns "
+        "with an allowlisted env, an owned process group, and an explicit "
+        "validated cwd (never Odin's process cwd implicitly)"
+    ),
     "src/tools/skill_manager.py": "argv-form `pip install <specs>`, no user-supplied relative path",
     "src/tools/workspace.py": "`sudo -n install -d` provisioning the workspace itself",
     "src/web/api/self_update.py": "argv-form git/gh during self-update, inside the install",

--- a/tests/test_mcp_client_eras.py
+++ b/tests/test_mcp_client_eras.py
@@ -12,8 +12,10 @@ import pytest
 from aiohttp.test_utils import TestServer
 
 from src.tools.mcp import client as client_mod
-from src.tools.mcp.client import MCPServerConnection
-from src.tools.mcp.errors import MCPConnectError
+from src.tools.mcp import protocol as proto
+from src.tools.mcp.client import MCPServerConnection, ToolRecord
+from src.tools.mcp.errors import MCPConnectError, MCPProtocolError
+from src.tools.mcp.transport_http import HttpTransport
 from tests.fakes.mcp_http import make_app
 
 FAKE = str(Path(__file__).parent / "fakes" / "mcp_stdio_server.py")
@@ -47,6 +49,11 @@ class TestStdioEraDetection:
             assert "fake modern" in conn.instructions
         finally:
             await conn.disconnect()
+
+    async def test_modern_discover_missing_result_type_rejected(self):
+        conn = _stdio("modern-missing-discover-result-type")
+        with pytest.raises(MCPConnectError, match="server/discover.*resultType"):
+            await conn.connect()
 
     async def test_legacy_server_falls_back_to_initialize(self):
         conn = _stdio("legacy")
@@ -105,7 +112,7 @@ class TestStdioDiscoveryAndCalls:
         # The fake includes resultType on listings but OMITS it on tool-call
         # results: under a negotiated 2026-07-28 that is a protocol
         # violation and a definite failure — never treated as complete.
-        conn = _stdio("modern-missing-result-type")
+        conn = _stdio("modern-missing-call-result-type")
         await conn.connect()
         try:
             discovery = await conn.discover_tools()
@@ -205,6 +212,30 @@ class TestHttpEraDetection:
             assert conn.era == "modern"
             assert conn.negotiated_version == "2026-07-28"
             assert state["calls"]["server/discover"] == 1
+            assert "initialize" not in state["calls"]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_modern_http_unknown_discover_result_type_rejected(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("m-unknown-result", "http", url=url)
+        state["discover_result_type"] = "partial"
+        try:
+            with pytest.raises(MCPConnectError, match="unknown resultType"):
+                await conn.connect()
+            assert "initialize" not in state["calls"]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_modern_http_input_required_discover_rejected(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("m-input-result", "http", url=url)
+        state["discover_result_type"] = "input_required"
+        try:
+            with pytest.raises(MCPConnectError, match="does not support"):
+                await conn.connect()
             assert "initialize" not in state["calls"]
         finally:
             await conn.disconnect()
@@ -356,3 +387,264 @@ class TestHttpCallsAndStreams:
         finally:
             await conn.disconnect()
             await server.close()
+
+
+class TestHttpStrictEraEvidence:
+    @pytest.mark.parametrize("mode", ["probe-200-internal", "probe-404-empty"])
+    async def test_non_evidence_never_initializes(self, mode):
+        server, url, state = await _http_server(mode)
+        conn = MCPServerConnection(f"strict-{mode}", "http", url=url)
+        try:
+            with pytest.raises(MCPConnectError, match="not era evidence"):
+                await conn.connect()
+            assert "initialize" not in state["calls"]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_http_modern_discover_missing_result_type_rejected(self):
+        server, url, state = await _http_server("modern-missing-discover-result-type")
+        conn = MCPServerConnection("strict-result-type", "http", url=url)
+        try:
+            with pytest.raises(MCPConnectError, match="server/discover.*resultType"):
+                await conn.connect()
+            assert "initialize" not in state["calls"]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestHttpFailureModes:
+    async def test_bare_500_after_call_is_uncertain_never_reissued(self):
+        server, url, state = await _http_server("modern-500-call")
+        conn = MCPServerConnection("http500", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "accepted"})
+            assert outcome.uncertain
+            assert state["calls"]["tools/call"] == 1
+            assert state["tool_effects"] == 1
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_stalled_call_is_uncertain_never_reissued(self):
+        server, url, state = await _http_server("modern-stall-call")
+        conn = MCPServerConnection("httpstall", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "accepted"}, timeout=0.1)
+            assert outcome.uncertain
+            assert state["calls"]["tools/call"] == 1
+            assert state["tool_effects"] == 1
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_http_2025_03_26_receive_side_batch_listing(self):
+        server, url, state = await _http_server("legacy-batch")
+        conn = MCPServerConnection("httpbatch", "http", url=url)
+        try:
+            await conn.connect()
+            assert conn.negotiated_version == "2025-03-26"
+            discovery = await conn.discover_tools()
+            assert any(tool.name == "echo" for tool in discovery.tools)
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestSessionRefreshRecovery:
+    async def test_discovery_reinitializes_and_retries_once(self):
+        server, url, state = await _http_server("legacy-session")
+        conn = MCPServerConnection("refresh-session", "http", url=url)
+        try:
+            await conn.connect()
+            state["expire_once"] = True
+            before_initialize = state["calls"]["initialize"]
+            before_list = state["calls"].get("tools/list", 0)
+            discovery = await conn.discover_tools()
+            assert any(tool.name == "echo" for tool in discovery.tools)
+            assert state["calls"]["initialize"] == before_initialize + 1
+            assert state["calls"]["tools/list"] == before_list + 2
+            list_sessions = [
+                session for method, session in state["session_headers"] if method == "tools/list"
+            ]
+            assert len(list_sessions) == 2
+            assert list_sessions[0] != list_sessions[1]
+            assert list_sessions[1] == state["current_session_id"]
+            assert conn.connected
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestHttpErrorStatusEraEvidence:
+    @pytest.mark.parametrize("code", [-32601, -32022])
+    def test_http_5xx_body_never_establishes_era(self, code):
+        conn = MCPServerConnection("status-evidence", "http", url="http://example.invalid/mcp")
+        outcome = client_mod.PostOutcome(
+            client_mod.RESULT_HTTP_ERROR,
+            status=500,
+            messages=[
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {
+                        "code": code,
+                        "message": "not evidence",
+                        "data": {"supported": ["2026-07-28"]},
+                    },
+                }
+            ],
+        )
+        with pytest.raises(MCPConnectError, match="not era evidence"):
+            conn._classify_http_probe(outcome, 1)  # noqa: SLF001
+
+    async def test_repeated_session_rejection_marks_connection_lost(self):
+        server, url, state = await _http_server("legacy-session")
+        lost: list[str] = []
+        conn = MCPServerConnection(
+            "refresh-session-fails", "http", url=url, on_connection_lost=lost.append
+        )
+        try:
+            await conn.connect()
+            state["expired"] = True
+            with pytest.raises(MCPProtocolError, match="rejected again"):
+                await conn.discover_tools()
+            assert not conn.connected
+            assert lost and "session" in lost[0]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestCallerCancellationMatrix:
+    async def test_stdio_caller_cancel_sends_matching_notification(self):
+        conn = _stdio("legacy-cancel")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            sleepy = next(tool for tool in discovery.tools if tool.name == "sleepy")
+            probe = next(tool for tool in discovery.tools if tool.name == "cancelled_request_id")
+            task = asyncio.create_task(conn.call_tool(sleepy, {"seconds": 5}, timeout=30))
+            await asyncio.sleep(0.1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            for _ in range(20):
+                recorded = await conn.call_tool(probe, {})
+                if recorded.text != "null":
+                    break
+                await asyncio.sleep(0.05)
+            assert recorded.ok
+            assert json.loads(recorded.text) is not None
+        finally:
+            await conn.disconnect()
+
+    async def test_legacy_http_caller_cancel_sends_matching_notification(self):
+        server, url, state = await _http_server("legacy-stall-call")
+        conn = MCPServerConnection("legacy-cancel", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(tool for tool in discovery.tools if tool.name == "echo")
+            task = asyncio.create_task(conn.call_tool(echo, {"text": "side effect"}, timeout=30))
+            await asyncio.sleep(0.1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            for _ in range(20):
+                if state["cancelled"]:
+                    break
+                await asyncio.sleep(0.05)
+            assert state["tool_effects"] == 1
+            assert len(state["cancelled"]) == 1
+            assert state["cancelled"][0]["requestId"] is not None
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    def test_http_404_plain_method_not_found_is_legacy_evidence(self):
+        conn = MCPServerConnection(
+            "plain-method-not-found", "http", url="http://example.invalid/mcp"
+        )
+        outcome = client_mod.PostOutcome(
+            client_mod.RESULT_HTTP_ERROR,
+            status=404,
+            messages=[
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32601, "message": "Method not found"},
+                }
+            ],
+        )
+        assert conn._classify_http_probe(outcome, 1) is False  # noqa: SLF001
+
+
+class TestErrorCorrelationAndPrewrite:
+    async def test_wrong_id_modern_error_on_http_400_is_not_modern_evidence(self):
+        server, url, _state = await _http_server("probe-400-wrong-id")
+        conn = MCPServerConnection("wrong-id-probe", "http", url=url)
+        try:
+            await conn.connect()
+            assert conn.era == proto.ERA_LEGACY
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_wrong_id_header_mismatch_is_uncertain_and_never_replayed(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("wrong-id-call", "http", url=url)
+        try:
+            await conn.connect()
+            tool = next(item for item in (await conn.discover_tools()).tools if item.name == "echo")
+            before_list = state["calls"]["tools/list"]
+            state["reject_calls"] = 1
+            state["reject_wrong_id"] = True
+            outcome = await conn.call_tool(tool, {"text": "once"})
+            assert outcome.uncertain
+            assert state["calls"]["tools/call"] == 1
+            assert state["calls"]["tools/list"] == before_list
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_http_failure_before_post_is_definite(self):
+        conn = MCPServerConnection("prewrite-http", "http", url="http://example.invalid/mcp")
+        conn.connected = True
+        conn.era = proto.ERA_MODERN
+        conn.negotiated_version = proto.MODERN_VERSIONS[0]
+        conn._http = HttpTransport("prewrite-http", conn.url)  # noqa: SLF001
+        tool = ToolRecord("echo", "", {"type": "object"})
+        outcome = await conn.call_tool(tool, {})
+        assert outcome.status == "failed"
+        assert not outcome.uncertain
+        assert "not available" in outcome.text
+
+    async def test_missing_input_schema_is_excluded(self):
+        conn = _stdio("missing-schema")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            tool = next(item for item in discovery.tools if item.name == "missing_schema")
+            assert tool.excluded
+            assert "not a JSON Schema object" in tool.exclusion_reason
+        finally:
+            await conn.disconnect()
+
+    async def test_connection_object_can_reconnect_after_clean_disconnect(self):
+        conn = _stdio("legacy")
+        await conn.connect()
+        await conn.disconnect()
+        await conn.connect()
+        try:
+            assert conn.connected
+            assert (await conn.discover_tools()).tools
+        finally:
+            await conn.disconnect()

--- a/tests/test_mcp_client_eras.py
+++ b/tests/test_mcp_client_eras.py
@@ -1,0 +1,358 @@
+"""Era detection, negotiation, discovery, calls, and cancellation pins —
+against real stdio subprocess fakes and real aiohttp Streamable HTTP fakes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestServer
+
+from src.tools.mcp import client as client_mod
+from src.tools.mcp.client import MCPServerConnection
+from src.tools.mcp.errors import MCPConnectError
+from tests.fakes.mcp_http import make_app
+
+FAKE = str(Path(__file__).parent / "fakes" / "mcp_stdio_server.py")
+
+
+def _stdio(mode: str, **kwargs) -> MCPServerConnection:
+    return MCPServerConnection(
+        f"fake_{mode.replace('-', '_')}",
+        "stdio",
+        command=sys.executable,
+        args=[FAKE, mode],
+        **kwargs,
+    )
+
+
+async def _http_server(mode: str):
+    app, state = make_app(mode)
+    server = TestServer(app)
+    await server.start_server()
+    return server, str(server.make_url("/mcp")), state
+
+
+class TestStdioEraDetection:
+    async def test_modern_server_adopts_2026(self):
+        conn = _stdio("modern")
+        await conn.connect()
+        try:
+            assert conn.era == "modern"
+            assert conn.negotiated_version == "2026-07-28"
+            assert conn.server_info.get("name") == "fake-modern"
+            assert "fake modern" in conn.instructions
+        finally:
+            await conn.disconnect()
+
+    async def test_legacy_server_falls_back_to_initialize(self):
+        conn = _stdio("legacy")
+        await conn.connect()
+        try:
+            assert conn.era == "legacy"
+            assert conn.negotiated_version == "2025-06-18"
+            assert conn.server_info.get("name") == "fake-legacy"
+        finally:
+            await conn.disconnect()
+
+    async def test_oldest_legacy_accepted_on_stdio(self):
+        conn = _stdio("legacy-oldest")
+        await conn.connect()
+        try:
+            assert conn.negotiated_version == "2024-11-05"
+        finally:
+            await conn.disconnect()
+
+    async def test_unknown_counteroffer_rejected(self):
+        conn = _stdio("legacy-unknown-version")
+        with pytest.raises(MCPConnectError, match="unsupported protocol"):
+            await conn.connect()
+
+    async def test_modern_server_with_legacy_only_list_is_incompatible(self):
+        # Modern-era evidence + no mutually supported modern revision:
+        # honest error — NEVER an initialize fallback.
+        conn = _stdio("modern-legacy-list")
+        with pytest.raises(MCPConnectError, match="modern"):
+            await conn.connect()
+
+    async def test_silent_server_times_out_through_both_phases(self, monkeypatch):
+        monkeypatch.setattr(client_mod, "_PROBE_TIMEOUT", 0.4)
+        monkeypatch.setattr(client_mod, "_INIT_TIMEOUT", 0.4)
+        conn = _stdio("silent")
+        with pytest.raises((MCPConnectError, Exception)):
+            await conn.connect()
+        assert not conn.connected
+
+
+class TestStdioDiscoveryAndCalls:
+    async def test_modern_discovery_and_call(self):
+        conn = _stdio("modern")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            assert discovery.ttl_ms == 120000
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "hi"})
+            assert outcome.ok and "echo: hi" in outcome.text
+            assert outcome.negotiated_version == "2026-07-28"
+        finally:
+            await conn.disconnect()
+
+    async def test_modern_missing_result_type_is_definite_failure(self):
+        # The fake includes resultType on listings but OMITS it on tool-call
+        # results: under a negotiated 2026-07-28 that is a protocol
+        # violation and a definite failure — never treated as complete.
+        conn = _stdio("modern-missing-result-type")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "hi"})
+            assert outcome.status == "failed"
+            assert "resultType" in outcome.text
+        finally:
+            await conn.disconnect()
+
+    async def test_is_error_result_is_definite_failure(self):
+        conn = _stdio("legacy")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            fail = next(t for t in discovery.tools if t.name == "fail")
+            outcome = await conn.call_tool(fail, {})
+            assert outcome.status == "failed"
+            assert "deliberate failure" in outcome.text
+        finally:
+            await conn.disconnect()
+
+    async def test_timeout_is_uncertain_and_sends_cancelled(self):
+        conn = _stdio("legacy")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            sleepy = next(t for t in discovery.tools if t.name == "sleepy")
+            outcome = await conn.call_tool(sleepy, {"seconds": 10}, timeout=0.5)
+            assert outcome.uncertain
+            assert "UNKNOWN" in outcome.text
+            assert "not retried" in outcome.text
+        finally:
+            await conn.disconnect()
+
+    async def test_death_mid_call_is_uncertain(self):
+        conn = _stdio("dies-mid-call")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "boom"}, timeout=10)
+            assert outcome.uncertain
+        finally:
+            await conn.disconnect()
+
+    async def test_list_changed_notification_fires_callback(self):
+        changed = asyncio.Event()
+        conn = _stdio("legacy", on_tools_list_changed=changed.set)
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "trigger-list-changed"})
+            assert outcome.ok
+            await asyncio.wait_for(changed.wait(), timeout=5)
+        finally:
+            await conn.disconnect()
+
+
+class TestBatchWireShape:
+    async def test_2025_03_26_batched_listing_parses(self):
+        conn = _stdio("legacy-batch")
+        await conn.connect()
+        try:
+            assert conn.negotiated_version == "2025-03-26"
+            discovery = await conn.discover_tools()
+            assert any(t.name == "echo" for t in discovery.tools)
+        finally:
+            await conn.disconnect()
+
+
+class TestLegacyServerInitiatedRequests:
+    async def test_stdio_push_gets_method_not_found_reply(self):
+        conn = _stdio("legacy-pushy")
+        await conn.connect()
+        try:
+            await asyncio.sleep(0.3)  # let the pushed request round-trip
+            discovery = await conn.discover_tools()
+            tool = next(t for t in discovery.tools if t.name == "pushy_reply")
+            outcome = await conn.call_tool(tool, {})
+            assert outcome.ok
+            reply = json.loads(outcome.text.replace("echo: ", "", 1))
+            assert reply is not None, "server-initiated request was silently dropped"
+            assert reply["id"] == "srv-req-1"
+            assert reply["error"]["code"] == -32601
+        finally:
+            await conn.disconnect()
+
+
+class TestHttpEraDetection:
+    async def test_modern_http_adopts_2026(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("m", "http", url=url)
+        try:
+            await conn.connect()
+            assert conn.era == "modern"
+            assert conn.negotiated_version == "2026-07-28"
+            assert state["calls"]["server/discover"] == 1
+            assert "initialize" not in state["calls"]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_bare_400_probe_falls_back_to_legacy(self):
+        server, url, state = await _http_server("legacy-session")
+        conn = MCPServerConnection("ls", "http", url=url)
+        try:
+            await conn.connect()
+            assert conn.era == "legacy"
+            assert conn.negotiated_version == "2025-06-18"
+            assert state["calls"]["initialize"] == 1
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_json_rpc_method_not_found_probe_falls_back(self):
+        server, url, state = await _http_server("legacy-stateless")
+        conn = MCPServerConnection("lst", "http", url=url)
+        try:
+            await conn.connect()
+            assert conn.era == "legacy"
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_401_is_not_era_evidence(self):
+        server, url, state = await _http_server("auth-401")
+        conn = MCPServerConnection("a401", "http", url=url)
+        try:
+            with pytest.raises(MCPConnectError, match="401"):
+                await conn.connect()
+            # A 401 must never trigger a legacy initialize attempt.
+            assert "initialize" not in state["calls"]
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestHttpSessions:
+    async def test_session_captured_echoed_and_deleted(self):
+        server, url, state = await _http_server("legacy-session")
+        conn = MCPServerConnection("sess", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()  # requires the session header
+            assert any(t.name == "echo" for t in discovery.tools)
+        finally:
+            await conn.disconnect()
+            assert state["session_deleted"] is True
+            await server.close()
+
+    async def test_stateless_legacy_sends_no_session_and_no_delete(self):
+        server, url, state = await _http_server("legacy-stateless")
+        conn = MCPServerConnection("nosess", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "hi"})
+            assert outcome.ok
+            assert conn._http.session_id is None  # noqa: SLF001
+        finally:
+            await conn.disconnect()
+            assert state["session_deleted"] is False
+            await server.close()
+
+    async def test_session_expiry_is_definite_failure_never_reissued(self):
+        server, url, state = await _http_server("legacy-session")
+        conn = MCPServerConnection("exp", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            state["expired"] = True
+            before = state["calls"].get("tools/call", 0)
+            outcome = await conn.call_tool(echo, {"text": "after-expiry"})
+            assert outcome.status == "failed"
+            assert "session" in outcome.text
+            # Exactly ONE wire attempt: the rejected call was never reissued.
+            assert state["calls"].get("tools/call", 0) == before + 1
+            assert not conn.connected  # session loss marks the connection down
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestHttpCallsAndStreams:
+    async def test_modern_sse_response_with_notifications(self):
+        server, url, state = await _http_server("modern-sse")
+        conn = MCPServerConnection("msse", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "streamed"})
+            assert outcome.ok and "echo: streamed" in outcome.text
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_x_mcp_header_param_mirrored(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("hdr", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            region_tool = next(t for t in discovery.tools if t.name == "region_tool")
+            assert region_tool.header_params  # annotation extracted
+            # The fake 400s with HeaderMismatch when the mirrored header is
+            # absent or wrong — success proves the client mirrored it.
+            outcome = await conn.call_tool(region_tool, {"region": "us-west1", "query": "q"})
+            assert outcome.ok and "region=us-west1" in outcome.text
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_legacy_sse_server_request_answered_via_post(self):
+        server, url, state = await _http_server("legacy-sse")
+        conn = MCPServerConnection("lsse", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "hi"})
+            assert outcome.ok
+            for _ in range(50):
+                if state["client_replies"]:
+                    break
+                await asyncio.sleep(0.05)
+            assert state["client_replies"], "client never answered the server request"
+            reply = state["client_replies"][0]
+            assert reply["id"] == "srv-http-req-1"
+            assert reply["error"]["code"] == -32601
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_legacy_fail_tool(self):
+        server, url, state = await _http_server("legacy-stateless")
+        conn = MCPServerConnection("lfail", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            fail = next(t for t in discovery.tools if t.name == "fail")
+            outcome = await conn.call_tool(fail, {})
+            assert outcome.status == "failed"
+        finally:
+            await conn.disconnect()
+            await server.close()

--- a/tests/test_mcp_edges.py
+++ b/tests/test_mcp_edges.py
@@ -342,3 +342,40 @@ class TestSpawnEdgeCases:
         )
         with pytest.raises(MCPConnectError, match="requires 'command'"):
             await transport.start()
+
+    async def test_header_mismatch_relists_and_uses_changed_annotation(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("metadata-refresh", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            region_tool = next(t for t in discovery.tools if t.name == "region_tool")
+            state["header_name"] = "Geo"
+            state["reject_calls"] = 1
+            before_list = state["calls"].get("tools/list", 0)
+            outcome = await conn.call_tool(region_tool, {"region": "eu-north1"})
+            assert outcome.ok
+            assert state["calls"]["tools/list"] == before_list + 1
+            assert state["calls"]["tools/call"] == 2
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_header_mismatch_http_200_also_relists_and_retries(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("metadata-refresh-200", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            region_tool = next(t for t in discovery.tools if t.name == "region_tool")
+            state["header_name"] = "Geo"
+            state["reject_calls"] = 1
+            state["reject_status"] = 200
+            before_list = state["calls"].get("tools/list", 0)
+            outcome = await conn.call_tool(region_tool, {"region": "eu-north1"})
+            assert outcome.ok
+            assert state["calls"]["tools/list"] == before_list + 1
+            assert state["calls"]["tools/call"] == 2
+        finally:
+            await conn.disconnect()
+            await server.close()

--- a/tests/test_mcp_edges.py
+++ b/tests/test_mcp_edges.py
@@ -1,0 +1,344 @@
+"""Edge pins: result rendering, manager mutation flows, lost connections,
+HTTP definite rejections, HeaderMismatch retry-once recovery."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestServer
+
+from src.tools.mcp.client import MCPServerConnection, _render_tool_result
+from src.tools.mcp.errors import MCPConnectError
+from src.tools.mcp.manager import (
+    STATE_CONNECTED,
+    STATE_DISABLED,
+    STATE_ERROR,
+    MCPManager,
+)
+from src.tools.mcp.transport_stdio import StdioTransport
+from tests.fakes.mcp_http import make_app
+
+FAKE = str(Path(__file__).parent / "fakes" / "mcp_stdio_server.py")
+
+
+def _stdio_config(mode: str = "legacy", **extra) -> dict:
+    return {
+        "transport": "stdio",
+        "command": sys.executable,
+        "args": [FAKE, mode],
+        "timeout_seconds": 30,
+        **extra,
+    }
+
+
+async def _http_server(mode: str):
+    app, state = make_app(mode)
+    server = TestServer(app)
+    await server.start_server()
+    return server, str(server.make_url("/mcp")), state
+
+
+class TestResultRendering:
+    def test_text_content_joined(self):
+        text, is_error = _render_tool_result(
+            {
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ]
+            }
+        )
+        assert text == "a\nb" and not is_error
+
+    def test_binary_content_described_not_embedded(self):
+        text, _ = _render_tool_result(
+            {
+                "content": [
+                    {"type": "image", "mimeType": "image/png"},
+                    {"type": "audio", "mimeType": "audio/wav"},
+                    {"type": "resource", "resource": {"uri": "file:///x"}},
+                    {"type": "mystery"},
+                    "bare string",
+                ]
+            }
+        )
+        assert "[image: image/png]" in text
+        assert "[audio: audio/wav]" in text
+        assert "[resource: file:///x]" in text
+        assert "[mystery content]" in text
+        assert "bare string" in text
+
+    def test_structured_content_fallback_when_no_text(self):
+        text, _ = _render_tool_result({"content": [], "structuredContent": {"answer": 42}})
+        assert '"answer": 42' in text
+
+    def test_unrenderable_structured_content(self):
+        text, _ = _render_tool_result({"content": [], "structuredContent": {"bad": object()}})
+        assert "unrenderable" in text
+
+    def test_empty_result_says_no_output(self):
+        text, is_error = _render_tool_result({})
+        assert text == "(no output)" and not is_error
+
+    def test_is_error_flag_carried(self):
+        _, is_error = _render_tool_result(
+            {"content": [{"type": "text", "text": "boom"}], "isError": True}
+        )
+        assert is_error
+
+
+class TestManagerMutationFlows:
+    async def test_update_server_republishes_under_new_generation(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            assert manager.has_tool("mcp_fake_echo")
+            old_gen = manager.get_status()["servers"][0]["generation"]
+            await manager.update_server("fake", _stdio_config(tool_allowlist=["fail"]))
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_CONNECTED
+            assert server["generation"] > old_gen
+            assert not manager.has_tool("mcp_fake_echo")
+            assert manager.has_tool("mcp_fake_fail")
+        finally:
+            await manager.shutdown()
+
+    async def test_per_server_disable_via_update_unpublishes(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            assert manager.has_tool("mcp_fake_echo")
+            await manager.update_server("fake", _stdio_config(enabled=False))
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_DISABLED
+            assert manager.get_tool_definitions() == []
+        finally:
+            await manager.shutdown()
+
+    async def test_global_enable_after_disable_reconnects(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            await manager.set_global_enabled(False)
+            assert manager.get_tool_definitions() == []
+            await manager.set_global_enabled(True)
+            assert manager.get_status()["servers"][0]["state"] == STATE_CONNECTED
+            assert manager.has_tool("mcp_fake_echo")
+        finally:
+            await manager.shutdown()
+
+    async def test_connect_failure_lands_in_error_state(self):
+        manager = MCPManager()
+        await manager.load_desired_state(
+            enabled=True,
+            servers={
+                "dead": {
+                    "transport": "stdio",
+                    "command": "/nonexistent/mcp-binary",
+                    "timeout_seconds": 10,
+                }
+            },
+        )
+        await manager.start()
+        try:
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_ERROR
+            assert "not found" in server["last_error"]
+            assert manager.get_tool_definitions() == []
+        finally:
+            await manager.shutdown()
+
+    async def test_connection_loss_unpublishes_then_supervisor_recovers(self):
+        # Observe through the SYNCHRONOUS catalog-changed hook: at each
+        # invalidation, record whether the tool is published. The recovery
+        # can outrun any polling loop; the hook cannot be missed.
+        snapshots: list[bool] = []
+        manager = MCPManager()
+        manager._on_catalog_changed = lambda: snapshots.append(  # noqa: SLF001
+            manager.has_tool("mcp_fake_echo")
+        )
+        await manager.load_desired_state(
+            enabled=True, servers={"fake": _stdio_config("dies-mid-call")}
+        )
+        await manager.start()
+        try:
+            assert manager.has_tool("mcp_fake_echo")
+            outcome = await manager.execute("mcp_fake_echo", {"text": "boom"})
+            assert outcome.uncertain
+            for _ in range(200):
+                if (
+                    False in snapshots
+                    and manager.has_tool("mcp_fake_echo")
+                    and manager.get_status()["servers"][0]["state"] == STATE_CONNECTED
+                ):
+                    break
+                await asyncio.sleep(0.05)
+            assert False in snapshots, "loss never unpublished the tools"
+            assert manager.has_tool("mcp_fake_echo"), "supervisor never recovered"
+        finally:
+            await manager.shutdown()
+
+    async def test_execute_on_disabled_global_is_typed_failure(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            await manager.set_global_enabled(False)
+            outcome = await manager.execute("mcp_fake_echo", {"text": "x"})
+            assert outcome.status == "failed"
+            assert "not currently published" in outcome.text
+        finally:
+            await manager.shutdown()
+
+
+class TestHttpCallRejections:
+    async def test_header_mismatch_retries_exactly_once_then_succeeds(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("retry", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            state["reject_calls"] = 1
+            before = state["calls"].get("tools/call", 0)
+            outcome = await conn.call_tool(echo, {"text": "recovered"})
+            assert outcome.ok and "recovered" in outcome.text
+            # Validation rejection (-32020) means NOT executed: exactly one
+            # spec-sanctioned retry, so two wire attempts total.
+            assert state["calls"].get("tools/call", 0) == before + 2
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+    async def test_persistent_header_mismatch_is_definite_failure(self):
+        server, url, state = await _http_server("modern")
+        conn = MCPServerConnection("retry2", "http", url=url)
+        try:
+            await conn.connect()
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            state["reject_calls"] = 99  # every attempt rejected
+            outcome = await conn.call_tool(echo, {"text": "never"})
+            assert outcome.status == "failed"
+            # One initial attempt + exactly one retry — never more.
+            assert 99 - state["reject_calls"] == 2
+        finally:
+            await conn.disconnect()
+            await server.close()
+
+
+class TestTransportMisuse:
+    async def test_double_start_rejected(self):
+        transport = StdioTransport(
+            "t",
+            sys.executable,
+            [FAKE, "legacy"],
+            on_message=lambda m: None,
+            on_closed=lambda r: None,
+            negotiated_version=lambda: None,
+        )
+        await transport.start()
+        try:
+            with pytest.raises(MCPConnectError, match="already started"):
+                await transport.start()
+        finally:
+            await transport.shutdown()
+
+    async def test_send_after_death_raises_connect_error(self):
+        transport = StdioTransport(
+            "t",
+            sys.executable,
+            [FAKE, "legacy"],
+            on_message=lambda m: None,
+            on_closed=lambda r: None,
+            negotiated_version=lambda: None,
+        )
+        await transport.start()
+        await transport.shutdown()
+        with pytest.raises(MCPConnectError, match="not running"):
+            await transport.send({"jsonrpc": "2.0", "method": "x"})
+
+    async def test_unsupported_transport_kind_rejected(self):
+        conn = MCPServerConnection("weird", "carrier-pigeon")
+        with pytest.raises(MCPConnectError, match="unsupported transport"):
+            await conn.connect()
+
+
+class TestCallPreconditions:
+    async def test_call_on_disconnected_connection_is_typed_failure(self):
+        conn = MCPServerConnection("never", "stdio", command=sys.executable)
+        from src.tools.mcp.client import ToolRecord
+
+        record = ToolRecord(name="t", description="", input_schema={})
+        outcome = await conn.call_tool(record, {})
+        assert outcome.status == "failed"
+        assert "not connected" in outcome.text
+
+    async def test_call_on_excluded_tool_is_typed_failure(self):
+        conn = _live_legacy_connection = MCPServerConnection(
+            "fake_legacy",
+            "stdio",
+            command=sys.executable,
+            args=[FAKE, "legacy"],
+        )
+        await conn.connect()
+        try:
+            from src.tools.mcp.client import ToolRecord
+
+            excluded = ToolRecord(
+                name="bad",
+                description="",
+                input_schema={},
+                excluded=True,
+                exclusion_reason="schema too deep",
+            )
+            outcome = await conn.call_tool(excluded, {})
+            assert outcome.status == "failed"
+            assert "excluded" in outcome.text
+            assert "schema too deep" in outcome.text
+        finally:
+            await conn.disconnect()
+
+
+class TestSpawnEdgeCases:
+    async def test_non_executable_command_is_connect_error(self):
+        transport = StdioTransport(
+            "t",
+            "/dev/null",  # exists, is not executable → OSError branch
+            [],
+            on_message=lambda m: None,
+            on_closed=lambda r: None,
+            negotiated_version=lambda: None,
+        )
+        with pytest.raises(MCPConnectError, match="failed to start"):
+            await transport.start()
+
+    def test_pid_none_before_start(self):
+        transport = StdioTransport(
+            "t",
+            sys.executable,
+            [],
+            on_message=lambda m: None,
+            on_closed=lambda r: None,
+            negotiated_version=lambda: None,
+        )
+        assert transport.pid is None
+        assert transport.stderr_tail() == ""
+
+    async def test_empty_command_rejected_by_transport(self):
+        transport = StdioTransport(
+            "t",
+            "",
+            [],
+            on_message=lambda m: None,
+            on_closed=lambda r: None,
+            negotiated_version=lambda: None,
+        )
+        with pytest.raises(MCPConnectError, match="requires 'command'"):
+            await transport.start()

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1,0 +1,308 @@
+"""Control-plane pins: the four-state publication predicate, blocked-not-
+truncated limits, generation fencing, synchronous catalog invalidation,
+first-server bootstrap, typed dispatch — real stdio fakes for the
+end-to-end paths, synthetic records for the publication-logic edges."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.tools.mcp import manager as manager_mod
+from src.tools.mcp.client import DiscoveryResult, ToolRecord
+from src.tools.mcp.errors import MCPConfigError, MCPError
+from src.tools.mcp.manager import (
+    STATE_BLOCKED,
+    STATE_CONNECTED,
+    STATE_DISABLED,
+    STATE_STALE,
+    MCPManager,
+)
+
+FAKE = str(Path(__file__).parent / "fakes" / "mcp_stdio_server.py")
+
+
+def _stdio_config(mode: str = "legacy", **extra) -> dict:
+    return {
+        "transport": "stdio",
+        "command": sys.executable,
+        "args": [FAKE, mode],
+        "timeout_seconds": 30,
+        **extra,
+    }
+
+
+def _record(name: str, description: str = "d") -> ToolRecord:
+    return ToolRecord(
+        name=name,
+        description=description,
+        input_schema={"type": "object", "properties": {}},
+    )
+
+
+class TestControlPlaneAlwaysPresent:
+    async def test_constructible_and_inspectable_while_disabled(self):
+        manager = MCPManager()
+        assert manager.global_enabled is False
+        assert manager.get_tool_definitions() == []
+        status = manager.get_status()
+        assert status["enabled"] is False and status["servers"] == []
+
+    async def test_first_server_bootstrap_while_disabled(self):
+        # The plan's first-server rule: an enabled-but-empty (or disabled)
+        # install must accept its first server through the control plane.
+        manager = MCPManager()
+        await manager.add_server("first", _stdio_config())
+        status = manager.get_status()
+        assert status["server_count"] == 1
+        assert status["servers"][0]["state"] == STATE_DISABLED
+        assert manager.get_tool_definitions() == []
+        await manager.shutdown()
+
+    async def test_execute_unknown_tool_is_typed_failure(self):
+        manager = MCPManager()
+        outcome = await manager.execute("mcp_ghost_tool", {})
+        assert outcome.status == "failed"
+        assert "not currently published" in outcome.text
+
+
+class TestEndToEndPublication:
+    async def test_connect_publish_execute(self):
+        changes: list[int] = []
+        manager = MCPManager(on_catalog_changed=lambda: changes.append(1))
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            status = manager.get_status()
+            server = status["servers"][0]
+            assert server["state"] == STATE_CONNECTED
+            assert server["era"] == "legacy"
+            assert server["published_count"] > 0
+            defs = manager.get_tool_definitions()
+            names = {d["name"] for d in defs}
+            assert "mcp_fake_echo" in names
+            echo_def = next(d for d in defs if d["name"] == "mcp_fake_echo")
+            assert echo_def["description"].startswith("[MCP:fake]")
+            assert manager.has_tool("mcp_fake_echo")
+            assert changes, "publication must invalidate the catalog"
+            outcome = await manager.execute("mcp_fake_echo", {"text": "hello"})
+            assert outcome.ok and "echo: hello" in outcome.text
+            assert outcome.generation == server["generation"]
+        finally:
+            await manager.shutdown()
+        assert manager.get_tool_definitions() == []
+
+    async def test_per_server_disabled_never_connects(self):
+        manager = MCPManager()
+        await manager.load_desired_state(
+            enabled=True, servers={"off": _stdio_config(enabled=False)}
+        )
+        await manager.start()
+        try:
+            assert manager.get_status()["servers"][0]["state"] == STATE_DISABLED
+            assert manager.get_tool_definitions() == []
+        finally:
+            await manager.shutdown()
+
+    async def test_allowlist_narrows_publication(self):
+        manager = MCPManager()
+        await manager.load_desired_state(
+            enabled=True,
+            servers={"fake": _stdio_config(tool_allowlist=["echo"])},
+        )
+        await manager.start()
+        try:
+            defs = manager.get_tool_definitions()
+            assert {d["name"] for d in defs} == {"mcp_fake_echo"}
+            server = manager.get_status()["servers"][0]
+            assert server["discovered_count"] > 1  # the rest stayed visible
+        finally:
+            await manager.shutdown()
+
+    async def test_global_disable_unpublishes_synchronously(self):
+        changes: list[int] = []
+        manager = MCPManager(on_catalog_changed=lambda: changes.append(1))
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        assert manager.get_tool_definitions()
+        await manager.set_global_enabled(False)
+        # By the time the call returns, publication is gone and the catalog
+        # was invalidated — no later model request can carry these tools.
+        assert manager.get_tool_definitions() == []
+        assert manager.get_status()["servers"][0]["state"] == STATE_DISABLED
+        assert changes
+        await manager.shutdown()
+
+    async def test_remove_server_unpublishes(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        assert manager.has_tool("mcp_fake_echo")
+        await manager.remove_server("fake")
+        assert not manager.has_tool("mcp_fake_echo")
+        assert manager.get_status()["server_count"] == 0
+        await manager.shutdown()
+
+    async def test_reconnect_server_round_trip(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            await manager.reconnect_server("fake")
+            assert manager.get_status()["servers"][0]["state"] == STATE_CONNECTED
+            outcome = await manager.execute("mcp_fake_echo", {"text": "again"})
+            assert outcome.ok
+        finally:
+            await manager.shutdown()
+
+    async def test_refresh_failure_unpublishes_to_stale(self):
+        changes: list[int] = []
+        manager = MCPManager(on_catalog_changed=lambda: changes.append(1))
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        try:
+            runtime = manager._servers["fake"]  # noqa: SLF001
+            assert runtime.connection is not None
+
+            async def broken_discovery():
+                raise MCPError("listing exploded")
+
+            runtime.connection.discover_tools = broken_discovery  # type: ignore[method-assign]
+            changes.clear()
+            await manager.refresh_server_tools("fake")
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_STALE
+            assert server["published_count"] == 0
+            # Stale diagnostics remain visible; the catalog does not.
+            assert server["discovered_count"] > 0
+            assert manager.get_tool_definitions() == []
+            assert changes, "unpublish must invalidate the catalog"
+        finally:
+            await manager.shutdown()
+
+
+class TestPublicationLimits:
+    async def _manager_with_connection(self) -> tuple[MCPManager, object, int]:
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        runtime = manager._servers["fake"]  # noqa: SLF001
+        return manager, runtime.connection, runtime.generation
+
+    async def test_over_per_server_limit_blocks_never_truncates(self):
+        manager, connection, generation = await self._manager_with_connection()
+        try:
+            many = DiscoveryResult(tools=[_record(f"tool_{i}") for i in range(41)])
+            await manager._publish("fake", generation, connection, many)  # noqa: SLF001
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_BLOCKED
+            assert server["published_count"] == 0
+            assert "tool_allowlist" in server["blocked_reason"]
+            assert manager.get_tool_definitions() == []
+        finally:
+            await manager.shutdown()
+
+    async def test_allowlist_resolves_a_block(self):
+        manager, connection, generation = await self._manager_with_connection()
+        try:
+            runtime = manager._servers["fake"]  # noqa: SLF001
+            runtime.config["tool_allowlist"] = ["tool_1", "tool_2"]
+            many = DiscoveryResult(tools=[_record(f"tool_{i}") for i in range(41)])
+            await manager._publish("fake", generation, connection, many)  # noqa: SLF001
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_CONNECTED
+            assert server["published_count"] == 2
+        finally:
+            await manager.shutdown()
+
+    async def test_stale_generation_never_republishes(self):
+        manager, connection, generation = await self._manager_with_connection()
+        try:
+            before = manager.get_tool_definitions()
+            stale = DiscoveryResult(tools=[_record("late_arrival")])
+            published = await manager._publish(  # noqa: SLF001
+                "fake", generation - 1, connection, stale
+            )
+            assert published is False
+            assert manager.get_tool_definitions() == before
+            assert not manager.has_tool("mcp_fake_late_arrival")
+        finally:
+            await manager.shutdown()
+
+    async def test_name_collision_blocks(self, monkeypatch):
+        manager, connection, generation = await self._manager_with_connection()
+        try:
+            monkeypatch.setattr(manager_mod, "make_published_name", lambda s, t: "mcp_fake_same")
+            two = DiscoveryResult(tools=[_record("a"), _record("b")])
+            await manager._publish("fake", generation, connection, two)  # noqa: SLF001
+            server = manager.get_status()["servers"][0]
+            assert server["state"] == STATE_BLOCKED
+            assert "collision" in server["blocked_reason"]
+            assert manager.get_tool_definitions() == []
+        finally:
+            await manager.shutdown()
+
+
+class TestConfigValidation:
+    @pytest.mark.parametrize(
+        "name,config,match",
+        [
+            ("bad name", {"transport": "stdio", "command": "x"}, "invalid server name"),
+            ("ok", {"transport": "carrier-pigeon"}, "transport"),
+            ("ok", {"transport": "stdio"}, "command"),
+            ("ok", {"transport": "http", "url": "ftp://x"}, "http"),
+            (
+                "ok",
+                {"transport": "stdio", "command": "x", "headers": {"bad\nkey": "v"}},
+                "illegal",
+            ),
+            (
+                "ok",
+                {"transport": "stdio", "command": "x", "tool_allowlist": [1]},
+                "allowlist",
+            ),
+            (
+                "ok",
+                {"transport": "stdio", "command": "x", "timeout_seconds": 0},
+                "timeout",
+            ),
+        ],
+    )
+    async def test_structural_validation(self, name, config, match):
+        manager = MCPManager()
+        with pytest.raises(MCPConfigError, match=match):
+            await manager.add_server(name, config)
+
+    async def test_duplicate_name_rejected(self):
+        manager = MCPManager()
+        await manager.add_server("dup", _stdio_config())
+        with pytest.raises(MCPConfigError, match="exists"):
+            await manager.add_server("dup", _stdio_config())
+        await manager.shutdown()
+
+    async def test_invalid_desired_state_recorded_not_discarded(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"broken": {"transport": "stdio"}})
+        await manager.start()
+        server = manager.get_status()["servers"][0]
+        assert server["state"] == "error"
+        assert "command" in server["last_error"]
+        await manager.shutdown()
+
+
+class TestShutdownBounds:
+    async def test_shutdown_wall_time_bounded(self):
+        manager = MCPManager()
+        await manager.load_desired_state(
+            enabled=True,
+            servers={"a": _stdio_config(), "b": _stdio_config()},
+        )
+        await manager.start()
+        assert manager.get_status()["connected_count"] == 2
+        start = asyncio.get_running_loop().time()
+        await manager.shutdown()
+        assert asyncio.get_running_loop().time() - start < 15
+        assert manager.get_tool_definitions() == []

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -10,9 +10,10 @@ import sys
 from pathlib import Path
 
 import pytest
+from aiohttp.test_utils import TestServer
 
 from src.tools.mcp import manager as manager_mod
-from src.tools.mcp.client import DiscoveryResult, ToolRecord
+from src.tools.mcp.client import DiscoveryResult, MCPServerConnection, ToolRecord
 from src.tools.mcp.errors import MCPConfigError, MCPError
 from src.tools.mcp.manager import (
     STATE_BLOCKED,
@@ -21,6 +22,7 @@ from src.tools.mcp.manager import (
     STATE_STALE,
     MCPManager,
 )
+from tests.fakes.mcp_http import make_app
 
 FAKE = str(Path(__file__).parent / "fakes" / "mcp_stdio_server.py")
 
@@ -306,3 +308,166 @@ class TestShutdownBounds:
         await manager.shutdown()
         assert asyncio.get_running_loop().time() - start < 15
         assert manager.get_tool_definitions() == []
+
+
+class TestDesiredStateReloadRetirement:
+    async def test_reload_retires_removed_and_replaced_runtimes(self):
+        manager = MCPManager()
+        await manager.load_desired_state(
+            enabled=True,
+            servers={"a": _stdio_config(), "b": _stdio_config()},
+        )
+        await manager.start()
+        old_a = manager._servers["a"]  # noqa: SLF001
+        old_b = manager._servers["b"]  # noqa: SLF001
+        old_a_conn = old_a.connection
+        old_b_conn = old_b.connection
+        assert old_a_conn is not None and old_b_conn is not None
+        await manager.load_desired_state(
+            enabled=True,
+            servers={"a": _stdio_config(tool_allowlist=["echo"])},
+        )
+        try:
+            assert manager.server_names == ["a"]
+            assert manager._servers["a"] is not old_a  # noqa: SLF001
+            assert not old_a_conn.connected and not old_b_conn.connected
+            assert old_a.supervisor is None and old_b.supervisor is None
+            assert {d["name"] for d in manager.get_tool_definitions()} == {"mcp_a_echo"}
+        finally:
+            await manager.shutdown()
+
+    async def test_unchanged_reload_reuses_live_runtime(self):
+        config = _stdio_config()
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"a": config})
+        await manager.start()
+        runtime = manager._servers["a"]  # noqa: SLF001
+        connection = runtime.connection
+        try:
+            await manager.load_desired_state(enabled=True, servers={"a": config})
+            assert manager._servers["a"] is runtime  # noqa: SLF001
+            assert manager._servers["a"].connection is connection  # noqa: SLF001
+        finally:
+            await manager.shutdown()
+
+
+class TestSynchronousLossFence:
+    async def test_loss_callback_unpublishes_before_return(self):
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"fake": _stdio_config()})
+        await manager.start()
+        runtime = manager._servers["fake"]  # noqa: SLF001
+        connection = runtime.connection
+        assert connection is not None and manager.has_tool("mcp_fake_echo")
+        manager._on_lost(  # noqa: SLF001
+            "fake", runtime.generation, connection, "synthetic transport loss"
+        )
+        try:
+            assert not manager.has_tool("mcp_fake_echo")
+            assert manager.get_tool_definitions() == []
+            assert runtime.state == "error"
+            assert runtime.connection is None
+        finally:
+            await connection.disconnect()
+            await manager.shutdown()
+
+
+class TestManagerSessionRefreshRecovery:
+    async def test_manual_refresh_recovers_expired_legacy_session(self):
+        app, state = make_app("legacy-session")
+        server = TestServer(app)
+        await server.start_server()
+        manager = MCPManager()
+        await manager.load_desired_state(
+            enabled=True,
+            servers={
+                "http": {
+                    "transport": "http",
+                    "url": str(server.make_url("/mcp")),
+                    "timeout_seconds": 30,
+                }
+            },
+        )
+        await manager.start()
+        try:
+            assert manager.has_tool("mcp_http_echo")
+            before_initialize = state["calls"]["initialize"]
+            state["expire_once"] = True
+            await manager.refresh_server_tools("http")
+            status = manager.get_status()["servers"][0]
+            assert status["state"] == STATE_CONNECTED
+            assert manager.has_tool("mcp_http_echo")
+            assert state["calls"]["initialize"] == before_initialize + 1
+        finally:
+            await manager.shutdown()
+            await server.close()
+
+    async def test_reload_global_disable_retires_unchanged_runtime(self):
+        config = _stdio_config()
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"a": config})
+        await manager.start()
+        runtime = manager._servers["a"]  # noqa: SLF001
+        connection = runtime.connection
+        assert connection is not None
+        await manager.load_desired_state(enabled=False, servers={"a": config})
+        try:
+            replacement = manager._servers["a"]  # noqa: SLF001
+            assert replacement is not runtime
+            assert replacement.state == STATE_DISABLED
+            assert runtime.connection is None
+            assert not connection.connected
+            assert manager.get_tool_definitions() == []
+        finally:
+            await manager.shutdown()
+
+
+class TestConfigSnapshotIsolation:
+    async def test_nested_caller_mutation_cannot_bypass_reload_fence(self):
+        config = _stdio_config(tool_allowlist=["echo"])
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"a": config})
+        await manager.start()
+        old = manager._servers["a"]  # noqa: SLF001
+        config["tool_allowlist"].append("fail")
+        assert old.config["tool_allowlist"] == ["echo"]
+        try:
+            await manager.load_desired_state(enabled=True, servers={"a": config})
+            assert manager._servers["a"] is not old  # noqa: SLF001
+            assert set(manager._servers["a"].config["tool_allowlist"]) == {  # noqa: SLF001
+                "echo",
+                "fail",
+            }
+        finally:
+            await manager.shutdown()
+
+
+class TestInFlightRetirementCleanup:
+    async def test_reload_cancels_inflight_discovery_and_closes_local_connection(self, monkeypatch):
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        created = []
+        original_connect = MCPServerConnection.connect
+
+        async def connect(self):
+            await original_connect(self)
+            created.append(self)
+
+        async def blocked_discover(self):
+            entered.set()
+            await release.wait()
+            raise AssertionError("retired discovery resumed")
+
+        monkeypatch.setattr(MCPServerConnection, "connect", connect)
+        monkeypatch.setattr(MCPServerConnection, "discover_tools", blocked_discover)
+        manager = MCPManager()
+        await manager.load_desired_state(enabled=True, servers={"a": _stdio_config()})
+        manager._started = True  # noqa: SLF001
+        start = asyncio.create_task(manager._reconcile_server("a"))  # noqa: SLF001
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        await manager.load_desired_state(enabled=True, servers={})
+        await start
+        assert len(created) == 1
+        assert not created[0].connected
+        assert created[0]._stdio is None  # noqa: SLF001
+        await manager.shutdown()

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -347,17 +347,48 @@ class TestHeaderParamsStrayPlacements:
         schema = {
             "type": "object",
             "properties": {"a": {"type": "string"}},
-            "definitions": {
-                "aux": {"properties": {"b": {"type": "string", "x-mcp-header": "B"}}}
-            },
+            "definitions": {"aux": {"properties": {"b": {"type": "string", "x-mcp-header": "B"}}}},
         }
         assert not proto.extract_header_params(schema).ok
 
     def test_annotation_under_pattern_properties_invalidates(self):
         schema = {
             "type": "object",
-            "patternProperties": {
-                "^x": {"type": "string", "x-mcp-header": "X"}
-            },
+            "patternProperties": {"^x": {"type": "string", "x-mcp-header": "X"}},
         }
+        assert not proto.extract_header_params(schema).ok
+
+
+class TestStrictSchemaValidation:
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            {"type": "string"},
+            {"type": "object", "properties": []},
+            {"type": "definitely-not-a-type"},
+            {"$ref": 42},
+            {"type": ["object", "string"]},
+            {},
+        ],
+    )
+    def test_invalid_or_non_object_schemas_rejected(self, schema):
+        assert not proto.validate_tool_schema(schema).ok
+
+    def test_local_ref_can_establish_object_semantics(self):
+        schema = {
+            "$ref": "#/$defs/args",
+            "$defs": {"args": {"type": "object", "properties": {"q": {"type": "string"}}}},
+        }
+        assert proto.validate_tool_schema(schema).ok
+
+    def test_all_union_branches_must_be_objects(self):
+        assert proto.validate_tool_schema(
+            {"oneOf": [{"type": "object"}, {"type": "object", "properties": {}}]}
+        ).ok
+        assert not proto.validate_tool_schema(
+            {"oneOf": [{"type": "object"}, {"type": "string"}]}
+        ).ok
+
+    def test_root_header_annotation_rejected(self):
+        schema = {"type": "object", "x-mcp-header": "Root", "properties": {}}
         assert not proto.extract_header_params(schema).ok

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,0 +1,363 @@
+"""Pure-unit pins for src/tools/mcp/protocol.py — versions, eras, message
+model, resultType strictness, schema bounds, x-mcp-header, naming."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from src.tools.mcp import protocol as proto
+from src.tools.mcp.errors import MCPProtocolError
+from src.tools.mcp.manager import make_published_name
+from src.tools.mcp.outcomes import MCPToolOutcome
+
+
+class TestVersionSets:
+    def test_exact_supported_set(self):
+        assert proto.MODERN_VERSIONS == ("2026-07-28",)
+        assert proto.LEGACY_VERSIONS_STDIO == (
+            "2025-11-25",
+            "2025-06-18",
+            "2025-03-26",
+            "2024-11-05",
+        )
+        # HTTP floor is 2025-03-26 — 2024-11-05 HTTP is the dropped
+        # HTTP+SSE transport.
+        assert "2024-11-05" not in proto.LEGACY_VERSIONS_HTTP
+        assert proto.SUPPORTED_VERSIONS == {
+            "2026-07-28",
+            "2025-11-25",
+            "2025-06-18",
+            "2025-03-26",
+            "2024-11-05",
+        }
+
+    def test_legacy_counteroffer_exact_set_only(self):
+        assert proto.select_legacy_version("2025-06-18", transport="stdio")
+        assert proto.select_legacy_version("2024-11-05", transport="stdio")
+        assert proto.select_legacy_version("2024-11-05", transport="http") is None
+        # Unknown counteroffers are never accepted — even future-looking ones.
+        assert proto.select_legacy_version("2027-01-01", transport="stdio") is None
+        assert proto.select_legacy_version("", transport="stdio") is None
+
+
+class TestModernVersionSelection:
+    def test_selects_by_our_preference(self):
+        sel = proto.select_modern_version(["2026-07-28", "2025-11-25"])
+        assert sel.version == "2026-07-28"
+
+    def test_legacy_only_list_is_modern_incompatible(self):
+        sel = proto.select_modern_version(["2025-11-25", "2025-06-18"])
+        assert sel.version is None
+        assert "modern" in sel.reason
+
+    def test_empty_list_rejected(self):
+        assert proto.select_modern_version([]).version is None
+
+    def test_malformed_lists_rejected(self):
+        assert proto.select_modern_version(None).version is None
+        assert proto.select_modern_version("2026-07-28").version is None
+        assert proto.select_modern_version([42, "2026-07-28"]).version is None
+
+    def test_unknown_future_version_not_accepted(self):
+        assert proto.select_modern_version(["2099-01-01"]).version is None
+
+
+class TestModernErrorRecognition:
+    def test_recognized_codes(self):
+        for code in (-32020, -32021, -32022):
+            assert proto.is_recognized_modern_error({"code": code})
+
+    def test_plain_errors_not_recognized(self):
+        assert not proto.is_recognized_modern_error({"code": -32601})
+        assert not proto.is_recognized_modern_error({"code": -32602})
+        assert not proto.is_recognized_modern_error(None)
+
+    def test_supported_versions_extraction(self):
+        err = {"code": -32022, "data": {"supported": ["2026-07-28", 42]}}
+        assert proto.supported_versions_from_error(err) == ["2026-07-28"]
+        assert proto.supported_versions_from_error({"code": -32022}) == []
+
+
+class TestMessageKind:
+    def test_kinds(self):
+        assert proto.message_kind({"jsonrpc": "2.0", "id": 1, "method": "x"}) == "request"
+        assert proto.message_kind({"jsonrpc": "2.0", "method": "x"}) == "notification"
+        assert proto.message_kind({"jsonrpc": "2.0", "id": 1, "result": {}}) == "response"
+        assert proto.message_kind({"jsonrpc": "2.0", "id": 1, "error": {}}) == "response"
+
+    def test_invalid_shapes(self):
+        assert proto.message_kind({}) == "invalid"
+        assert proto.message_kind({"jsonrpc": "1.0", "method": "x"}) == "invalid"
+        assert proto.message_kind({"jsonrpc": "2.0", "id": None, "result": {}}) == "invalid"
+        assert proto.message_kind("nope") == "invalid"
+
+
+class TestWirePayloadParsing:
+    def test_single_object(self):
+        msgs = proto.parse_wire_payload(
+            '{"jsonrpc":"2.0","id":1,"result":{}}', negotiated_version="2025-06-18"
+        )
+        assert len(msgs) == 1
+
+    def test_batch_allowed_only_on_2025_03_26(self):
+        batch = '[{"jsonrpc":"2.0","id":1,"result":{}},{"jsonrpc":"2.0","method":"n"}]'
+        msgs = proto.parse_wire_payload(batch, negotiated_version="2025-03-26")
+        assert len(msgs) == 2
+
+    @pytest.mark.parametrize("version", ["2024-11-05", "2025-06-18", "2025-11-25", "2026-07-28"])
+    def test_batch_rejected_on_other_versions(self, version):
+        batch = '[{"jsonrpc":"2.0","id":1,"result":{}}]'
+        with pytest.raises(MCPProtocolError, match="batch"):
+            proto.parse_wire_payload(batch, negotiated_version=version)
+
+    def test_batch_tolerated_before_negotiation(self):
+        batch = '[{"jsonrpc":"2.0","id":1,"result":{}}]'
+        assert proto.parse_wire_payload(batch, negotiated_version=None)
+
+    def test_empty_batch_rejected(self):
+        with pytest.raises(MCPProtocolError):
+            proto.parse_wire_payload("[]", negotiated_version="2025-03-26")
+
+    def test_invalid_json_rejected(self):
+        with pytest.raises(MCPProtocolError):
+            proto.parse_wire_payload("not json", negotiated_version=None)
+
+    def test_oversized_bytes_rejected(self):
+        blob = b"x" * (proto.WIRE_RESULT_CEILING + 1)
+        with pytest.raises(MCPProtocolError, match="exceeds"):
+            proto.parse_wire_payload(blob, negotiated_version=None)
+
+
+class TestResultTypeStrictness:
+    def test_modern_complete_passes(self):
+        check = proto.check_result_type({"resultType": "complete"}, era="modern")
+        assert check.ok and not check.input_required
+
+    def test_modern_missing_rejected(self):
+        check = proto.check_result_type({}, era="modern")
+        assert not check.ok and "missing" in check.reason
+
+    def test_modern_unknown_rejected(self):
+        check = proto.check_result_type({"resultType": "partial"}, era="modern")
+        assert not check.ok
+
+    def test_modern_input_required_flagged_never_ok(self):
+        check = proto.check_result_type({"resultType": "input_required"}, era="modern")
+        assert not check.ok and check.input_required
+
+    def test_legacy_missing_treated_complete(self):
+        assert proto.check_result_type({}, era="legacy").ok
+
+    def test_legacy_ignores_the_field(self):
+        assert proto.check_result_type({"resultType": "whatever"}, era="legacy").ok
+
+
+class TestSchemaValidation:
+    def test_plain_object_schema_ok(self):
+        check = proto.validate_tool_schema(
+            {"type": "object", "properties": {"a": {"type": "string"}}}
+        )
+        assert check.ok
+
+    def test_composition_without_literal_object_root_ok(self):
+        # A valid JSON Schema OBJECT, not a literal root type — composition
+        # may establish object semantics (plan §2).
+        check = proto.validate_tool_schema(
+            {"allOf": [{"type": "object", "properties": {"a": {"type": "string"}}}]}
+        )
+        assert check.ok
+
+    def test_non_dict_rejected(self):
+        assert not proto.validate_tool_schema(["not", "a", "schema"]).ok
+        assert not proto.validate_tool_schema(None).ok
+
+    def test_depth_bound(self):
+        schema: dict = {"type": "object"}
+        node = schema
+        for _ in range(proto.MAX_SCHEMA_DEPTH + 2):
+            node["properties"] = {"n": {"type": "object"}}
+            node = node["properties"]["n"]
+        assert not proto.validate_tool_schema(schema).ok
+
+    def test_node_bound(self):
+        schema = {
+            "type": "object",
+            "properties": {f"p{i}": {"type": "string"} for i in range(proto.MAX_SCHEMA_NODES)},
+        }
+        assert not proto.validate_tool_schema(schema).ok
+
+    def test_byte_bound(self):
+        schema = {"type": "object", "description": "x" * proto.MAX_SCHEMA_BYTES_PER_TOOL}
+        assert not proto.validate_tool_schema(schema).ok
+
+
+class TestHeaderParams:
+    def test_extraction_happy_path(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "region": {"type": "string", "x-mcp-header": "Region"},
+                "count": {"type": "integer", "x-mcp-header": "Count"},
+                "plain": {"type": "string"},
+            },
+        }
+        check = proto.extract_header_params(schema)
+        assert check.ok
+        assert {p.name for p in check.params} == {"Region", "Count"}
+
+    def test_nested_properties_chain_reachable(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {"inner": {"type": "string", "x-mcp-header": "In"}},
+                }
+            },
+        }
+        check = proto.extract_header_params(schema)
+        assert check.ok and check.params[0].path == ("outer", "inner")
+
+    def test_number_type_invalid(self):
+        schema = {
+            "type": "object",
+            "properties": {"n": {"type": "number", "x-mcp-header": "N"}},
+        }
+        assert not proto.extract_header_params(schema).ok
+
+    def test_duplicate_case_insensitive_invalid(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string", "x-mcp-header": "Region"},
+                "b": {"type": "string", "x-mcp-header": "region"},
+            },
+        }
+        assert not proto.extract_header_params(schema).ok
+
+    def test_non_token_name_invalid(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string", "x-mcp-header": "bad name"}},
+        }
+        assert not proto.extract_header_params(schema).ok
+
+    def test_annotation_inside_composition_invalid(self):
+        schema = {
+            "type": "object",
+            "oneOf": [{"properties": {"a": {"type": "string", "x-mcp-header": "A"}}}],
+        }
+        assert not proto.extract_header_params(schema).ok
+
+    def test_annotation_inside_items_invalid(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "arr": {
+                    "type": "array",
+                    "items": {"properties": {"a": {"type": "string", "x-mcp-header": "A"}}},
+                }
+            },
+        }
+        assert not proto.extract_header_params(schema).ok
+
+    def test_value_extraction_and_types(self):
+        param = proto.HeaderParam("Region", ("region",))
+        assert proto.header_param_value({"region": "us-west1"}, param) == "us-west1"
+        assert proto.header_param_value({"region": None}, param) is None
+        assert proto.header_param_value({}, param) is None
+        count = proto.HeaderParam("C", ("c",))
+        assert proto.header_param_value({"c": 42}, count) == "42"
+        assert proto.header_param_value({"c": True}, count) == "true"
+        assert proto.header_param_value({"c": 2**53}, count) is None  # JS-unsafe
+
+    def test_base64_sentinel_encoding(self):
+        assert proto.encode_header_value("us-west1") == "us-west1"
+        encoded = proto.encode_header_value("Hello, 世界")
+        assert encoded.startswith("=?base64?") and encoded.endswith("?=")
+        inner = encoded[len("=?base64?") : -2]
+        assert base64.b64decode(inner).decode() == "Hello, 世界"
+        # Padded values and sentinel-shaped plain values must be encoded.
+        assert proto.encode_header_value(" padded ").startswith("=?base64?")
+        assert proto.encode_header_value("=?base64?literal?=") != "=?base64?literal?="
+
+
+class TestPublishedNames:
+    def test_plain_names_stay_readable(self):
+        assert make_published_name("gh", "list_issues") == "mcp_gh_list_issues"
+
+    def test_deterministic(self):
+        assert make_published_name("s", "weird/tool") == make_published_name("s", "weird/tool")
+
+    def test_unsafe_chars_get_digest_suffix(self):
+        name = make_published_name("s", "weird/tool")
+        assert name.startswith("mcp_s_weird_tool_")
+        assert len(name) <= 64
+
+    def test_distinct_tools_never_merge(self):
+        a = make_published_name("s", "a/b")
+        b = make_published_name("s", "a_b")
+        assert a != b
+
+    def test_length_bound(self):
+        name = make_published_name("server", "t" * 200)
+        assert len(name) <= 64
+
+
+class TestOutcomeType:
+    def test_valid_statuses(self):
+        for status in ("ok", "failed", "uncertain"):
+            outcome = MCPToolOutcome(status=status, text="x", server="s", tool="t")
+            assert outcome.status == status
+
+    def test_invalid_status_rejected(self):
+        with pytest.raises(ValueError):
+            MCPToolOutcome(status="maybe", text="x", server="s", tool="t")
+
+    def test_flags(self):
+        assert MCPToolOutcome(status="ok", text="", server="s", tool="t").ok
+        assert MCPToolOutcome(status="uncertain", text="", server="s", tool="t").uncertain
+
+
+class TestRequestBuilders:
+    def test_modern_request_carries_meta(self):
+        req = proto.build_request(
+            1, "tools/call", {"name": "x"}, era="modern", version="2026-07-28"
+        )
+        meta = req["params"]["_meta"]
+        assert meta[proto.META_PROTOCOL_VERSION] == "2026-07-28"
+        assert meta[proto.META_CLIENT_INFO]["name"] == "odin"
+        assert meta[proto.META_CLIENT_CAPABILITIES] == {}
+
+    def test_legacy_request_has_no_meta(self):
+        req = proto.build_request(1, "tools/list", {}, era="legacy", version="2025-06-18")
+        assert "_meta" not in (req.get("params") or {})
+
+    def test_error_response_shape(self):
+        resp = proto.build_error_response("abc", -32601, "nope")
+        assert resp["id"] == "abc" and resp["error"]["code"] == -32601
+
+
+class TestHeaderParamsStrayPlacements:
+    def test_annotation_under_definitions_invalidates(self):
+        # The spec invalidates the tool for an annotation ANYWHERE outside a
+        # pure `properties` chain — not only composition keywords.
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "definitions": {
+                "aux": {"properties": {"b": {"type": "string", "x-mcp-header": "B"}}}
+            },
+        }
+        assert not proto.extract_header_params(schema).ok
+
+    def test_annotation_under_pattern_properties_invalidates(self):
+        schema = {
+            "type": "object",
+            "patternProperties": {
+                "^x": {"type": "string", "x-mcp-header": "X"}
+            },
+        }
+        assert not proto.extract_header_params(schema).ok

--- a/tests/test_mcp_transport_http.py
+++ b/tests/test_mcp_transport_http.py
@@ -1,0 +1,185 @@
+"""HTTP transport unit pins: managed-header protection, redirect rejection,
+bounded bodies, SSE parsing edges — the pieces the era suite exercises only
+indirectly."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from src.tools.mcp.errors import MCPConnectError, MCPProtocolError
+from src.tools.mcp.transport_http import (
+    RESULT_HTTP_ERROR,
+    RESULT_JSON,
+    HttpTransport,
+    _filter_configured_headers,
+)
+
+
+class TestManagedHeaders:
+    def test_configured_headers_cannot_override_managed(self):
+        filtered = _filter_configured_headers(
+            {
+                "Authorization": "Bearer keepme",
+                "X-Custom": "ok",
+                "Host": "evil.example",
+                "MCP-Protocol-Version": "1999-01-01",
+                "mcp-session-id": "forged",
+                "Mcp-Method": "forged",
+                "Mcp-Name": "forged",
+                "Mcp-Param-Region": "forged",
+                "Content-Length": "0",
+                "Accept": "text/html",
+            }
+        )
+        assert filtered == {"Authorization": "Bearer keepme", "X-Custom": "ok"}
+
+    def test_rejects_non_http_url(self):
+        with pytest.raises(MCPConnectError):
+            HttpTransport("s", "ftp://example.com/mcp")
+        with pytest.raises(MCPConnectError):
+            HttpTransport("s", "")
+
+
+async def _serve(handler) -> tuple[TestServer, str]:
+    app = web.Application()
+    app.router.add_post("/mcp", handler)
+    server = TestServer(app)
+    await server.start_server()
+    return server, str(server.make_url("/mcp"))
+
+
+class TestPostMechanics:
+    async def test_redirects_are_refused(self):
+        async def handler(request):
+            raise web.HTTPFound(location="https://elsewhere.example/mcp")
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("s", url)
+        await transport.start()
+        try:
+            with pytest.raises(MCPConnectError, match="redirect"):
+                await transport.post(
+                    {"jsonrpc": "2.0", "id": 1, "method": "x"},
+                    protocol_version=None,
+                )
+        finally:
+            await transport.close()
+            await server.close()
+
+    async def test_oversized_json_body_rejected(self, monkeypatch):
+        import src.tools.mcp.transport_http as http_mod
+
+        monkeypatch.setattr(http_mod, "WIRE_RESULT_CEILING", 1024)
+
+        async def handler(request):
+            return web.json_response({"jsonrpc": "2.0", "id": 1, "result": {"pad": "x" * 4096}})
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("s", url)
+        await transport.start()
+        try:
+            with pytest.raises(MCPProtocolError, match="exceeds"):
+                await transport.post(
+                    {"jsonrpc": "2.0", "id": 1, "method": "x"},
+                    protocol_version=None,
+                )
+        finally:
+            await transport.close()
+            await server.close()
+
+    async def test_error_body_kept_only_as_bounded_snippet(self):
+        async def handler(request):
+            return web.Response(status=500, text="<html>" + "upstream garbage " * 500 + "</html>")
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("s", url)
+        await transport.start()
+        try:
+            outcome = await transport.post(
+                {"jsonrpc": "2.0", "id": 1, "method": "x"},
+                protocol_version=None,
+            )
+            assert outcome.kind == RESULT_HTTP_ERROR
+            assert outcome.status == 500
+            assert len(outcome.body_snippet) <= 200
+        finally:
+            await transport.close()
+            await server.close()
+
+    async def test_sse_comments_and_split_frames_parse(self):
+        response_msg = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+        note = {"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}
+
+        async def handler(request):
+            resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await resp.prepare(request)
+            await resp.write(b": keep-alive\n\n")
+            payload = f"data: {json.dumps(note)}\n\n".encode()
+            await resp.write(payload[:10])  # deliberately split mid-frame
+            await resp.write(payload[10:])
+            await resp.write(f"data: {json.dumps(response_msg)}\n\n".encode())
+            await resp.write_eof()
+            return resp
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("s", url)
+        await transport.start()
+        seen: list[dict] = []
+        try:
+            outcome = await transport.post(
+                {"jsonrpc": "2.0", "id": 1, "method": "x"},
+                protocol_version=None,
+                on_message=seen.append,
+            )
+            assert outcome.kind == "stream_ended"
+            methods = [m.get("method") for m in seen]
+            assert "notifications/progress" in methods
+            assert any(m.get("id") == 1 for m in seen)
+        finally:
+            await transport.close()
+            await server.close()
+
+    async def test_plain_json_response(self):
+        async def handler(request):
+            return web.json_response({"jsonrpc": "2.0", "id": 7, "result": {}})
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("s", url)
+        await transport.start()
+        try:
+            outcome = await transport.post(
+                {"jsonrpc": "2.0", "id": 7, "method": "x"},
+                protocol_version=None,
+            )
+            assert outcome.kind == RESULT_JSON
+            assert outcome.messages[0]["id"] == 7
+        finally:
+            await transport.close()
+            await server.close()
+
+    async def test_configured_auth_header_reaches_the_wire(self):
+        seen: dict = {}
+
+        async def handler(request):
+            seen.update(request.headers)
+            return web.json_response({"jsonrpc": "2.0", "id": 1, "result": {}})
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("s", url, headers={"Authorization": "Bearer tok"})
+        await transport.start()
+        try:
+            await transport.post(
+                {"jsonrpc": "2.0", "id": 1, "method": "x"},
+                protocol_version="2025-06-18",
+            )
+            assert seen.get("Authorization") == "Bearer tok"
+            assert seen.get("MCP-Protocol-Version") == "2025-06-18"
+            assert "application/json" in seen.get("Accept", "")
+            assert "text/event-stream" in seen.get("Accept", "")
+        finally:
+            await transport.close()
+            await server.close()

--- a/tests/test_mcp_transport_http.py
+++ b/tests/test_mcp_transport_http.py
@@ -10,6 +10,8 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
+from src.tools.mcp import transport_http
+from src.tools.mcp.client import MCPServerConnection
 from src.tools.mcp.errors import MCPConnectError, MCPProtocolError
 from src.tools.mcp.transport_http import (
     RESULT_HTTP_ERROR,
@@ -17,6 +19,7 @@ from src.tools.mcp.transport_http import (
     HttpTransport,
     _filter_configured_headers,
 )
+from tests.fakes.mcp_http import make_app
 
 
 class TestManagedHeaders:
@@ -183,3 +186,51 @@ class TestPostMechanics:
         finally:
             await transport.close()
             await server.close()
+
+    async def test_mixed_sse_line_endings_and_split_crlf_parse(self):
+        first = {"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}
+        second = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+
+        async def handler(request):
+            resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await resp.prepare(request)
+            await resp.write(f"data: {json.dumps(first)}\n\n".encode())
+            second_frame = f"data: {json.dumps(second)}\r\n\r\n".encode()
+            split = second_frame.index(b"\r\n") + 1
+            await resp.write(second_frame[:split])
+            await resp.write(second_frame[split:])
+            await resp.write_eof()
+            return resp
+
+        server, url = await _serve(handler)
+        transport = HttpTransport("mixed", url)
+        await transport.start()
+        seen: list[dict] = []
+        try:
+            outcome = await transport.post(
+                {"jsonrpc": "2.0", "id": 1, "method": "x"},
+                protocol_version=None,
+                on_message=seen.append,
+            )
+            assert outcome.kind == "stream_ended"
+            assert seen == [first, second]
+        finally:
+            await transport.close()
+            await server.close()
+
+
+class TestBoundedSessionDelete:
+    @pytest.mark.parametrize("mode", ["oversized", "stall"])
+    async def test_delete_is_bounded_and_close_still_runs(self, mode, monkeypatch):
+        monkeypatch.setattr(transport_http, "_SESSION_DELETE_TIMEOUT", 0.1)
+        app, state = make_app("legacy-session")
+        server = TestServer(app)
+        await server.start_server()
+        conn = MCPServerConnection("bounded-delete", "http", url=str(server.make_url("/mcp")))
+        await conn.connect()
+        transport = conn._http  # noqa: SLF001
+        assert transport is not None
+        state["delete_mode"] = mode
+        await conn.disconnect()
+        assert not transport.started
+        await server.close()

--- a/tests/test_mcp_transport_stdio.py
+++ b/tests/test_mcp_transport_stdio.py
@@ -127,15 +127,14 @@ class TestBoundedLines:
         # Shrink the ceiling so the fake's echo of a large payload overflows
         # the reader limit; the pump must close and the call classify
         # UNCERTAIN (the request was written; the reply was unreadable).
-        conn = _conn("legacy")
+        conn = _conn("oversized-response")
         await conn.connect()
         try:
             discovery = await conn.discover_tools()
             echo = next(t for t in discovery.tools if t.name == "echo")
             lost: list[str] = []
             conn._on_connection_lost = lost.append  # noqa: SLF001
-            big = "x" * (transport_stdio.MAX_STDOUT_LINE_BYTES + 4096)
-            outcome = await conn.call_tool(echo, {"text": big}, timeout=30)
+            outcome = await conn.call_tool(echo, {"text": "small request"}, timeout=30)
             assert outcome.uncertain
             assert lost and "exceeded" in lost[0]
         finally:
@@ -220,3 +219,150 @@ class TestCwdIsolation:
             assert outcome.text.replace("echo: ", "").strip() == str(tmp_path)
         finally:
             await conn.disconnect()
+
+
+class TestCancellationSafeShutdown:
+    async def test_cancellation_waits_for_full_teardown(self, monkeypatch):
+        monkeypatch.setattr(transport_stdio, "_STDIN_CLOSE_GRACE", 0.2)
+        monkeypatch.setattr(transport_stdio, "_TERM_GRACE", 0.2)
+        monkeypatch.setattr(transport_stdio, "_KILL_GRACE", 2.0)
+        closed: list[str] = []
+        transport = StdioTransport(
+            "cancel-shutdown",
+            sys.executable,
+            [FAKE, "hang-shutdown"],
+            on_message=lambda _m: None,
+            on_closed=closed.append,
+            negotiated_version=lambda: None,
+        )
+        await transport.start()
+        pid = transport.pid
+        assert pid is not None
+        task = asyncio.create_task(transport.shutdown())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+        assert closed == ["transport shut down"]
+
+
+class TestBoundedWrites:
+    async def test_request_budget_covers_write_and_response(self, monkeypatch):
+        conn = _conn("legacy")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            assert conn._stdio is not None  # noqa: SLF001
+            original_send = conn._stdio.send  # noqa: SLF001
+
+            async def stalled_send(message, *, timeout=None):
+                if message.get("method") == "tools/call":
+                    await asyncio.sleep(timeout or 60)
+                    raise TimeoutError
+                await original_send(message, timeout=timeout)
+
+            monkeypatch.setattr(conn._stdio, "send", stalled_send)  # noqa: SLF001
+            started = time.monotonic()
+            outcome = await conn.call_tool(echo, {"text": "blocked"}, timeout=0.1)
+            assert outcome.uncertain
+            assert time.monotonic() - started < 2
+        finally:
+            await conn.disconnect()
+
+    async def test_oversized_outbound_frame_rejected_before_write(self):
+        transport = StdioTransport(
+            "bounded-send",
+            sys.executable,
+            [FAKE, "legacy"],
+            on_message=lambda _m: None,
+            on_closed=lambda _r: None,
+            negotiated_version=lambda: None,
+        )
+        await transport.start()
+        try:
+            from src.tools.mcp.errors import MCPProtocolError
+
+            with pytest.raises(MCPProtocolError, match="outbound frame exceeds"):
+                await transport.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "tools/call",
+                        "params": {"value": "x" * transport_stdio.MAX_STDIN_FRAME_BYTES},
+                    }
+                )
+        finally:
+            await transport.shutdown()
+
+    async def test_repeated_cancellation_cannot_abort_teardown(self, monkeypatch):
+        monkeypatch.setattr(transport_stdio, "_STDIN_CLOSE_GRACE", 0.2)
+        monkeypatch.setattr(transport_stdio, "_TERM_GRACE", 0.2)
+        monkeypatch.setattr(transport_stdio, "_KILL_GRACE", 2.0)
+        transport = StdioTransport(
+            "repeat-cancel-shutdown",
+            sys.executable,
+            [FAKE, "hang-shutdown"],
+            on_message=lambda _m: None,
+            on_closed=lambda _r: None,
+            negotiated_version=lambda: None,
+        )
+        await transport.start()
+        pid = transport.pid
+        assert pid is not None
+        task = asyncio.create_task(transport.shutdown())
+        await asyncio.sleep(0.03)
+        task.cancel()
+        await asyncio.sleep(0.03)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+
+    async def test_real_blocked_pipe_write_is_bounded(self):
+        transport = StdioTransport(
+            "real-blocked-write",
+            sys.executable,
+            [FAKE, "blocked-write"],
+            on_message=lambda _m: None,
+            on_closed=lambda _r: None,
+            negotiated_version=lambda: None,
+        )
+        await transport.start()
+        assert transport._process is not None  # noqa: SLF001
+        ready = await asyncio.wait_for(transport._process.stdout.readline(), timeout=2)  # noqa: SLF001
+        assert ready == b"READY\n"
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "notice",
+            "params": {"x": "x" * (1024 * 1024)},
+        }
+        try:
+            with pytest.raises(TimeoutError):
+                await transport.send(payload, timeout=0.05)
+        finally:
+            await transport.shutdown()
+
+    async def test_cancelled_shutdown_waits_for_grandchild_group(self, monkeypatch):
+        monkeypatch.setattr(transport_stdio, "_STDIN_CLOSE_GRACE", 0.2)
+        monkeypatch.setattr(transport_stdio, "_TERM_GRACE", 0.2)
+        monkeypatch.setattr(transport_stdio, "_KILL_GRACE", 2.0)
+        conn = _conn("grandchild")
+        await conn.connect()
+        discovery = await conn.discover_tools()
+        tool = next(t for t in discovery.tools if t.name == "child_pid")
+        grandchild = int((await conn.call_tool(tool, {})).text)
+        task = asyncio.create_task(conn.disconnect())
+        await asyncio.sleep(0.03)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        try:
+            os.kill(grandchild, 0)
+            with open(f"/proc/{grandchild}/stat") as fh:
+                assert fh.read().split()[2] == "Z"
+        except ProcessLookupError:
+            pass

--- a/tests/test_mcp_transport_stdio.py
+++ b/tests/test_mcp_transport_stdio.py
@@ -1,0 +1,222 @@
+"""stdio transport pins: env allowlist, stderr drain, process-group
+teardown, bounded shutdown — against the real fake subprocess."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from src.tools.mcp import transport_stdio
+from src.tools.mcp.client import MCPServerConnection
+from src.tools.mcp.transport_stdio import StdioTransport, build_child_env
+
+FAKE = str(Path(__file__).parent / "fakes" / "mcp_stdio_server.py")
+
+
+def _conn(mode: str, **kwargs) -> MCPServerConnection:
+    return MCPServerConnection(
+        f"fake_{mode.replace('-', '_')}",
+        "stdio",
+        command=sys.executable,
+        args=[FAKE, mode],
+        **kwargs,
+    )
+
+
+class TestChildEnv:
+    def test_allowlist_only(self, monkeypatch):
+        monkeypatch.setenv("ODIN_FAKE_SECRET", "credential")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        env = build_child_env({"MARKER": "yes"})
+        assert env["MARKER"] == "yes"
+        assert env["PATH"] == "/usr/bin"
+        assert "ODIN_FAKE_SECRET" not in env
+
+    def test_configured_env_stringified(self):
+        env = build_child_env({"NUM": 7})  # type: ignore[dict-item]
+        assert env["NUM"] == "7"
+
+
+class TestEnvLeakage:
+    async def test_spawned_server_never_sees_service_env(self, monkeypatch):
+        monkeypatch.setenv("ODIN_FAKE_SECRET", "credential")
+        conn = _conn("legacy", env={"MARKER": "present"})
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "env_keys")
+            outcome = await conn.call_tool(echo, {})
+            assert outcome.ok
+            keys = outcome.text.replace("echo: ", "").split(",")
+            assert "MARKER" in keys
+            assert "ODIN_FAKE_SECRET" not in keys
+            assert "PATH" in keys
+        finally:
+            await conn.disconnect()
+
+
+class TestStderr:
+    async def test_flooding_stderr_never_deadlocks(self):
+        conn = _conn("stderr-flood")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            # Give the flood a moment to produce far more than the ring cap.
+            await asyncio.sleep(0.5)
+            outcome = await conn.call_tool(echo, {"text": "alive"})
+            assert outcome.ok and "alive" in outcome.text
+            tail = conn.status()["stderr_tail"]
+            assert tail and len(tail) <= 4000
+        finally:
+            await conn.disconnect()
+
+
+class TestShutdown:
+    async def test_hang_shutdown_escalates_to_kill_bounded(self, monkeypatch):
+        monkeypatch.setattr(transport_stdio, "_STDIN_CLOSE_GRACE", 0.3)
+        monkeypatch.setattr(transport_stdio, "_TERM_GRACE", 0.5)
+        monkeypatch.setattr(transport_stdio, "_KILL_GRACE", 3.0)
+        conn = _conn("hang-shutdown")
+        await conn.connect()
+        pid = conn._stdio.pid  # noqa: SLF001
+        assert pid
+        start = time.monotonic()
+        await conn.disconnect()
+        elapsed = time.monotonic() - start
+        assert elapsed < 10
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+
+    async def test_process_group_teardown_reaps_grandchild(self):
+        conn = _conn("grandchild")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            tool = next(t for t in discovery.tools if t.name == "child_pid")
+            outcome = await conn.call_tool(tool, {})
+            assert outcome.ok
+            grandchild = int(outcome.text.replace("echo: ", "").strip() or "0")
+            assert grandchild > 1
+        finally:
+            await conn.disconnect()
+        await asyncio.sleep(0.3)  # let the kernel finish reaping
+        # The grandchild was in the server's process group: it must be gone
+        # (or a zombie awaiting its dead parent's reaper — not running).
+        try:
+            os.kill(grandchild, 0)
+            with open(f"/proc/{grandchild}/stat") as fh:
+                assert fh.read().split()[2] == "Z"
+        except ProcessLookupError:
+            pass
+
+    async def test_double_shutdown_is_idempotent(self):
+        conn = _conn("legacy")
+        await conn.connect()
+        await conn.disconnect()
+        await conn.disconnect()
+
+
+class TestBoundedLines:
+    async def test_oversized_response_line_closes_connection(self, monkeypatch):
+        # Shrink the ceiling so the fake's echo of a large payload overflows
+        # the reader limit; the pump must close and the call classify
+        # UNCERTAIN (the request was written; the reply was unreadable).
+        conn = _conn("legacy")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            lost: list[str] = []
+            conn._on_connection_lost = lost.append  # noqa: SLF001
+            big = "x" * (transport_stdio.MAX_STDOUT_LINE_BYTES + 4096)
+            outcome = await conn.call_tool(echo, {"text": big}, timeout=30)
+            assert outcome.uncertain
+            assert lost and "exceeded" in lost[0]
+        finally:
+            await conn.disconnect()
+
+    async def test_garbage_stdout_lines_are_dropped(self):
+        conn = _conn("garbage")
+        await conn.connect()
+        try:
+            assert conn.era == "legacy"
+            discovery = await conn.discover_tools()
+            assert any(t.name == "echo" for t in discovery.tools)
+        finally:
+            await conn.disconnect()
+
+
+class TestSpawnFailures:
+    async def test_missing_command(self):
+        conn = MCPServerConnection("missing", "stdio", command="/nonexistent/mcp-server-binary")
+        from src.tools.mcp.errors import MCPConnectError
+
+        with pytest.raises(MCPConnectError, match="not found"):
+            await conn.connect()
+
+    async def test_bad_cwd(self):
+        conn = MCPServerConnection(
+            "badcwd",
+            "stdio",
+            command=sys.executable,
+            args=[FAKE, "legacy"],
+            cwd="/nonexistent/dir",
+        )
+        from src.tools.mcp.errors import MCPConnectError
+
+        with pytest.raises(MCPConnectError, match="cwd"):
+            await conn.connect()
+
+    async def test_transport_reports_running(self):
+        transport = StdioTransport(
+            "t",
+            sys.executable,
+            [FAKE, "legacy"],
+            on_message=lambda m: None,
+            on_closed=lambda r: None,
+            negotiated_version=lambda: None,
+        )
+        assert not transport.running
+        await transport.start()
+        assert transport.running
+        await transport.shutdown()
+        assert not transport.running
+
+
+class TestCwdIsolation:
+    async def test_unconfigured_cwd_never_inherits_odin_process_cwd(self):
+        # The 2026-07-27 hazard class: a spawned process inheriting the
+        # service cwd turns any relative path destructive. Unconfigured
+        # servers must run from the temp dir instead.
+        import tempfile
+
+        conn = _conn("legacy")
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            tool = next(t for t in discovery.tools if t.name == "report_cwd")
+            outcome = await conn.call_tool(tool, {})
+            assert outcome.ok
+            reported = outcome.text.replace("echo: ", "").strip()
+            assert reported == tempfile.gettempdir()
+            assert reported != os.getcwd()
+        finally:
+            await conn.disconnect()
+
+    async def test_configured_cwd_is_honored(self, tmp_path):
+        conn = _conn("legacy", cwd=str(tmp_path))
+        await conn.connect()
+        try:
+            discovery = await conn.discover_tools()
+            tool = next(t for t in discovery.tools if t.name == "report_cwd")
+            outcome = await conn.call_tool(tool, {})
+            assert outcome.ok
+            assert outcome.text.replace("echo: ", "").strip() == str(tmp_path)
+        finally:
+            await conn.disconnect()


### PR DESCRIPTION
## P1 of the MCP wiring campaign

First phase PR onto the campaign branch `feat/mcp-wiring` (never master). Plan of record: `docs/plans/mcp-wiring-plan.md` (the jointly agreed R2.1 plan). **Purely additive — zero behavior change**: nothing constructs `MCPManager`, no catalog merge, no dispatch branch, no route changes. Publication stays impossible by construction until P2–P4 integrate. The legacy `src/tools/mcp_client.py` and its 1,741-line test file remain untouched dead code until P4 retires them with the explicit survivorship listing.

### Content

- **`protocol.py`** — the plan's protocol matrix in executable form: exact 5-revision set with per-transport floors, Modern/Legacy era rules, strict modern `resultType` (missing/unknown reject; `input_required` = unsupported-never-replayed; missing-means-complete is legacy-only), deterministic modern version selection (malformed/empty/legacy-only lists = modern-incompatible), 2025-03-26 receive-side batch parsing, recognized-modern error codes, `x-mcp-header` extraction/validation (any stray placement invalidates the tool) + Base64 sentinel encoding, schema bounds (32 KiB/tool, 256 KiB/server, depth 20, 2,048 nodes).
- **`transport_stdio.py`** — owned process group with the v3.59.1 signalling guard **plus a post-exit descendant sweep**; allowlisted child env (PATH/HOME/locale/TERM/TMPDIR/USER + configured `env` — never the service environment); **temp-dir default cwd** (never Odin's process cwd implicitly — the 2026-07-27 class); continuous bounded stderr drain (the old PIPE-never-read deadlock is impossible); bounded stdout lines; stdin-close → TERM(group) → KILL(group) escalation.
- **`transport_http.py`** — both Streamable HTTP shapes: sessionful 2025 (optional `Mcp-Session-Id` echo, DELETE only when minted) and stateless 2026 (`Mcp-Method`/`Mcp-Name`/`Mcp-Param-*` headers); SSE parsed incrementally with mid-stream dispatch (a legacy server waiting on a reply to its own request cannot deadlock); managed headers unoverridable by config; redirects never followed; bodies bounded; upstream error bodies never surfaced raw.
- **`client.py`** — spec-sanctioned era detection (probe with `server/discover`; stdio falls back on ANY unrecognized error/timeout, never one code; HTTP falls back ONLY on 400-with-unrecognized-body; 401/403/429/5xx are never era evidence); legacy negotiation from the exact allowlists (unknown counteroffers rejected); typed ok/failed/**uncertain** outcomes with uncertain-never-replayed (explicit session rejection = definite failure, still not reissued; HeaderMismatch = validation rejection, one spec-sanctioned retry); era-correct cancellation (`notifications/cancelled` everywhere except modern HTTP stream-abort; initialize never cancelled; late responses ignored); `-32601` replies to legacy server-initiated requests on both channels; `server/discover.instructions` bounded and never prompt-injected.
- **`manager.py`** — always-constructible control plane (status/CRUD work while disabled — first-server bootstrap); the four-state publication predicate with synchronous catalog invalidation (`on_catalog_changed` fires before any mutation returns); monotonic config generations + stale-task fencing (an old connect/refresh can never republish); per-server single-flight; supervised reconnect with jittered exponential backoff to 30 min; TTL-clamped refresh (60 s–10 min ±10 %) with **unpublish-on-failed-refresh**; blocked-not-truncated limits (40/server, 40 global, resolved via `tool_allowlist`); provider-safe published names (`[A-Za-z0-9_-]`, ≤64 chars, digest disambiguation, cross-server collision → blocked); typed dispatch (stale calls fail honestly).
- **`errors.py` / `outcomes.py`** — the typed surfaces; `MCPProtocolError.rpc_code` for structural (never stringly) error reaction.

### Tests — 147 new, no mocks of our own code, no network

Two fake servers: `tests/fakes/mcp_stdio_server.py` (14 modes: modern, legacy ×4 revisions, batch-emitting, pushy server-initiated requests, unknown-version, modern-legacy-only-list, missing-resultType, silent, garbage, dies-mid-call, stderr-flood, hang-shutdown, grandchild) and `tests/fakes/mcp_http.py` (modern header-validating, modern-SSE, session-REQUIRING legacy, stateless legacy, legacy-SSE with server-initiated request, auth-401, HeaderMismatch reject-N-calls knob).

Six suites: protocol units (all seven R2-correction pins), stdio transport (env leakage, stderr flood, group teardown incl. grandchild reaping, bounded shutdown incl. SIGTERM-immune servers, cwd isolation both directions), HTTP transport units (managed headers, redirects, bounds, SSE split frames/comments), era detection + calls (both transports × both eras, session expiry = definite-failure-never-reissued with wire-attempt counting, x-mcp-header mirroring proven by a rejecting fake, batch wire shape, -32601 replies verified from the server side), manager (publication predicate, blocked semantics, fencing, sync invalidation, supervised recovery observed through the invalidation hook), and edges (rendering, mutation flows, retry-once bounds).

### Gates

- Full suite: **9,799 passed / 5 skipped** (was 9,652 — +147)
- ruff: clean; formatted
- mypy: 0 findings across the 8 new modules
- coverage: every new gated file ≥ the 85 % new-file bucket (client 85.1, manager 88.5, protocol 96.2, http 89.8, stdio 85.3, rest 100)
- spawn-site guard: `transport_stdio.py` classified in `test_local_workspace.py` with claims the code actually satisfies

### Fixed before review (caught by my own tests/self-review)

1. A gracefully-exiting stdio leader orphaned its process-group descendants — the sweep now runs even after clean leader exit (the v3.59.1 lesson, reproduced by the grandchild fake before the fix).
2. Blocked servers made the supervisor reconnect in a tight loop (subprocess churn) — blocked now holds the refresh cycle.
3. `start()` returned before the first bounded connect attempt, breaking the boot/mutation `connected: true|false` contract — first-attempt future added.
4. Unconfigured stdio servers inherited Odin's process cwd (the 2026-07-27 relative-path hazard); the workspace guard caught the unclassified spawn site, and verifying my classification text against the code caught the inheritance. Temp-dir default now, pinned both directions.

### Review focus

- `protocol.py` against `docs/plans/mcp-wiring-plan.md` — the normative pairing the plan requires.
- Uncertainty classification boundaries in `client.call_tool` (send-path failures classify conservative-uncertain).
- Generation fencing and lock coverage in `manager.py` (`_publish` fence, supervisor loop, mutation paths).
- The era-detection edge where a legacy server answers the HTTP probe 200 + JSON-RPC `-32601` (treated as legacy) vs a malformed null-id error body (treated as retryable connect error, era undetermined).
