### PR TITLE
fix(mcp): one-shot legacy respawn for stdio servers that die on the era probe

### DIFF
--- a/src/tools/mcp/client.py
+++ b/src/tools/mcp/client.py
@@ -292,19 +292,24 @@ class MCPServerConnection:
         initialize on it. Any failure raises ONE bounded error naming both
         phases (exit status only — never command, environment, or stderr);
         cancellation propagates unchanged."""
-        exit_status = dead.returncode
+        # A phase-one server request may have created an asynchronous -32601
+        # reply. Cancel it before shutdown can block on a task waiting to
+        # write to the dying process; each reply is also bound to the
+        # transport that originated its request.
+        await self._cancel_server_reply_tasks()
         await dead.shutdown()
+        exit_status = dead.returncode
+        # Retire phase one's loss before phase two starts. A later closure
+        # from the replacement may then set a fresh, truthful error without
+        # being overwritten after its handshake.
+        self._lost_reason = None
         fresh = self._new_stdio_transport()
         self._stdio = fresh
         try:
             await fresh.start()
             await self._initialize_legacy_stdio()
-        except asyncio.CancelledError:
-            raise
-        except BaseException as e:
-            detail = (
-                _clean_text(str(e), 200) if isinstance(e, MCPError) else e.__class__.__name__
-            )
+        except Exception as e:
+            detail = _clean_text(str(e), 200) if isinstance(e, MCPError) else e.__class__.__name__
             suffix = (
                 f" (first process exit status {exit_status})" if exit_status is not None else ""
             )
@@ -379,7 +384,9 @@ class MCPServerConnection:
         elif kind == proto.KIND_NOTIFICATION:
             self._handle_notification(msg)
         elif kind == proto.KIND_REQUEST:
-            self._handle_server_request(msg, channel="stdio")
+            # Capture the originating transport now. A delayed phase-one
+            # reply must never follow self._stdio to a respawned process.
+            self._handle_server_request(msg, channel="stdio", stdio_transport=self._stdio)
 
     # --------------------------- HTTP ----------------------------------
 
@@ -618,7 +625,13 @@ class MCPServerConnection:
         else:
             log.debug("MCP %s: notification %s", self.name, method)
 
-    def _handle_server_request(self, msg: dict, *, channel: str) -> None:
+    def _handle_server_request(
+        self,
+        msg: dict,
+        *,
+        channel: str,
+        stdio_transport: StdioTransport | None = None,
+    ) -> None:
         """Legacy servers may initiate requests (sampling/roots/elicitation).
         We support none of those capabilities: answer -32601 on the correct
         channel instead of silently dropping (a dropped request hangs the
@@ -646,11 +659,20 @@ class MCPServerConnection:
             )
             return
         task = asyncio.get_running_loop().create_task(
-            self._send_reply(reply, channel),
+            self._send_reply(reply, channel, stdio_transport=stdio_transport),
             name=f"mcp-server-reply-{self.name}",
         )
         self._server_reply_tasks.add(task)
         task.add_done_callback(self._server_reply_tasks.discard)
+
+    async def _cancel_server_reply_tasks(self) -> None:
+        """Cancel and reap replies owned by a transport being retired."""
+        while self._server_reply_tasks:
+            tasks = tuple(self._server_reply_tasks)
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._server_reply_tasks.difference_update(tasks)
 
     async def _drain_server_reply_tasks(self) -> None:
         tasks = tuple(self._server_reply_tasks)
@@ -667,11 +689,18 @@ class MCPServerConnection:
             except (asyncio.CancelledError, Exception):
                 pass
 
-    async def _send_reply(self, reply: dict, channel: str) -> None:
+    async def _send_reply(
+        self,
+        reply: dict,
+        channel: str,
+        *,
+        stdio_transport: StdioTransport | None = None,
+    ) -> None:
         try:
-            if channel == "stdio" and self._stdio is not None:
-                await self._stdio.send(reply)
-            elif self._http is not None:
+            if channel == "stdio":
+                if stdio_transport is not None:
+                    await stdio_transport.send(reply)
+            elif channel == "http" and self._http is not None:
                 await self._http.post(
                     reply,
                     protocol_version=self.negotiated_version,

--- a/src/tools/mcp/client.py
+++ b/src/tools/mcp/client.py
@@ -33,7 +33,14 @@ from typing import Any
 
 from ...odin_log import get_logger
 from . import protocol as proto
-from .errors import MCPConnectError, MCPError, MCPPreWriteError, MCPProtocolError, MCPTimeoutError
+from .errors import (
+    MCPConnectError,
+    MCPError,
+    MCPPreWriteError,
+    MCPProtocolError,
+    MCPStdioEOFError,
+    MCPTimeoutError,
+)
 from .outcomes import (
     OUTCOME_FAILED,
     OUTCOME_OK,
@@ -214,8 +221,11 @@ class MCPServerConnection:
 
     # -------------------------- stdio ---------------------------------
 
-    async def _connect_stdio(self) -> None:
-        transport = StdioTransport(
+    def _new_stdio_transport(self) -> StdioTransport:
+        """One construction site for every stdio transport this connection
+        spawns — the initial probe process and the compatibility respawn
+        must be built identically (env allowlist, cwd, pumps, callbacks)."""
+        return StdioTransport(
             self.name,
             self.command,
             self.args,
@@ -225,6 +235,9 @@ class MCPServerConnection:
             on_closed=self._on_transport_closed,
             negotiated_version=lambda: self.negotiated_version,
         )
+
+    async def _connect_stdio(self) -> None:
+        transport = self._new_stdio_transport()
         self._stdio = transport
         try:
             await transport.start()
@@ -240,6 +253,15 @@ class MCPServerConnection:
                 reply = await self._stdio_roundtrip(probe_id, probe, _PROBE_TIMEOUT)
             except MCPTimeoutError:
                 reply = None  # silence ⇒ legacy probe outcome
+            except MCPStdioEOFError:
+                # A strict legacy server closed stdout and exited on the
+                # unknown probe (die-on-unknown-method class — Uncraftbar's
+                # field report). Ambiguous, NOT era evidence: retire the
+                # first process completely, then grant exactly one
+                # fresh-process legacy attempt. Era is established only if
+                # that initialize returns a valid supported result.
+                await self._respawn_probe_casualty_for_legacy(transport)
+                return
             if reply is not None and "result" in reply:
                 self._adopt_modern(reply["result"])
                 return
@@ -255,9 +277,41 @@ class MCPServerConnection:
             # Any other error or timeout: legacy fallback.
             await self._initialize_legacy_stdio()
         except BaseException:
-            self._stdio = None
-            await transport.shutdown()
+            # Reap the ACTIVE transport: after a compatibility respawn the
+            # local ``transport`` is the phase-one corpse — cleaning up only
+            # that would leak the replacement child.
+            active, self._stdio = self._stdio, None
+            if active is not None:
+                await active.shutdown()
             raise
+
+    async def _respawn_probe_casualty_for_legacy(self, dead: StdioTransport) -> None:
+        """The one-shot compatibility respawn for servers that die on the
+        era probe. Fully retires the first process group (bounded), starts
+        exactly one fresh identical transport, and runs the legacy
+        initialize on it. Any failure raises ONE bounded error naming both
+        phases (exit status only — never command, environment, or stderr);
+        cancellation propagates unchanged."""
+        exit_status = dead.returncode
+        await dead.shutdown()
+        fresh = self._new_stdio_transport()
+        self._stdio = fresh
+        try:
+            await fresh.start()
+            await self._initialize_legacy_stdio()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as e:
+            detail = (
+                _clean_text(str(e), 200) if isinstance(e, MCPError) else e.__class__.__name__
+            )
+            suffix = (
+                f" (first process exit status {exit_status})" if exit_status is not None else ""
+            )
+            raise MCPConnectError(
+                f"{self.name}: server/discover ended by unexpected stdio EOF{suffix}; "
+                f"fresh legacy initialization failed: {detail}"
+            ) from e
 
     async def _initialize_legacy_stdio(self) -> None:
         req_id = next(self._ids)
@@ -630,7 +684,13 @@ class MCPServerConnection:
         was_connected = self.connected
         self.connected = False
         self._lost_reason = reason
-        self._fail_pending(MCPConnectError(f"{self.name}: {reason}"))
+        # Typed classification for pending waiters: only a clean stdout EOF
+        # (the transport's flag, set before this callback fires) raises the
+        # subtype the era probe may treat as a die-on-unknown-method legacy
+        # server. Every other closure stays the plain connect error.
+        eof = bool(self._stdio is not None and getattr(self._stdio, "closed_by_eof", False))
+        exc_type = MCPStdioEOFError if eof else MCPConnectError
+        self._fail_pending(exc_type(f"{self.name}: {reason}"))
         if was_connected and self._on_connection_lost is not None:
             try:
                 self._on_connection_lost(reason)

--- a/src/tools/mcp/errors.py
+++ b/src/tools/mcp/errors.py
@@ -23,6 +23,14 @@ class MCPConnectError(MCPError):
     negotiation, or the initialize handshake. Retryable by reconnect."""
 
 
+class MCPStdioEOFError(MCPConnectError):
+    """Typed classification: the stdio server closed stdout (unexpected
+    EOF). Raised into pending futures so the era probe can distinguish a
+    die-on-unknown-method strict-legacy server (grants exactly one
+    fresh-process legacy attempt) from every other transport failure —
+    never by exception-text matching."""
+
+
 class MCPPreWriteError(MCPConnectError):
     """A tool request was rejected locally before any bytes could be written."""
 

--- a/src/tools/mcp/transport_stdio.py
+++ b/src/tools/mcp/transport_stdio.py
@@ -95,10 +95,18 @@ class StdioTransport:
         self._closed_fired = False
         self._closing = False
         self._shutdown_task: asyncio.Task[None] | None = None
+        # True exactly when the closure cause was a clean stdout EOF — the
+        # typed signal the era probe reads (never exception-text matching).
+        self.closed_by_eof = False
 
     @property
     def running(self) -> bool:
         return self._process is not None and self._process.returncode is None
+
+    @property
+    def returncode(self) -> int | None:
+        """Child exit status if it has exited (diagnostics only)."""
+        return self._process.returncode if self._process else None
 
     @property
     def pid(self) -> int | None:
@@ -173,6 +181,7 @@ class StdioTransport:
     async def _pump_stdout(self) -> None:
         assert self._process and self._process.stdout
         reason = "server closed its output stream"
+        eof = False
         try:
             while True:
                 try:
@@ -181,6 +190,9 @@ class StdioTransport:
                     reason = f"stdout line exceeded {MAX_STDOUT_LINE_BYTES} bytes"
                     break
                 if not line:
+                    # Clean stdout EOF — the ONE closure cause the era probe
+                    # may treat as a die-on-unknown-method legacy server.
+                    eof = True
                     break
                 stripped = line.strip()
                 if not stripped:
@@ -203,6 +215,7 @@ class StdioTransport:
             log.exception("MCP %s: stdout pump error", self.server_name)
             reason = f"stdout pump error: {e.__class__.__name__}"
         finally:
+            self.closed_by_eof = eof
             self._fire_closed(reason)
 
     async def _pump_stderr(self) -> None:

--- a/src/tools/mcp/transport_stdio.py
+++ b/src/tools/mcp/transport_stdio.py
@@ -95,8 +95,10 @@ class StdioTransport:
         self._closed_fired = False
         self._closing = False
         self._shutdown_task: asyncio.Task[None] | None = None
-        # True exactly when the closure cause was a clean stdout EOF — the
-        # typed signal the era probe reads (never exception-text matching).
+        # True exactly when the closure cause was a clean stdout EOF with
+        # no earlier malformed/oversized frame. The era probe reads this
+        # typed signal; a protocol-faulted stream never earns compatibility
+        # respawn merely because the process later exits.
         self.closed_by_eof = False
 
     @property
@@ -182,11 +184,13 @@ class StdioTransport:
         assert self._process and self._process.stdout
         reason = "server closed its output stream"
         eof = False
+        protocol_faulted = False
         try:
             while True:
                 try:
                     line = await self._process.stdout.readline()
                 except (ValueError, asyncio.LimitOverrunError):
+                    protocol_faulted = True
                     reason = f"stdout line exceeded {MAX_STDOUT_LINE_BYTES} bytes"
                     break
                 if not line:
@@ -202,6 +206,7 @@ class StdioTransport:
                         stripped, negotiated_version=self._negotiated_version()
                     )
                 except MCPProtocolError as e:
+                    protocol_faulted = True
                     log.warning("MCP %s: dropping stdout line: %s", self.server_name, e)
                     continue
                 for msg in messages:
@@ -215,7 +220,7 @@ class StdioTransport:
             log.exception("MCP %s: stdout pump error", self.server_name)
             reason = f"stdout pump error: {e.__class__.__name__}"
         finally:
-            self.closed_by_eof = eof
+            self.closed_by_eof = eof and not protocol_faulted
             self._fire_closed(reason)
 
     async def _pump_stderr(self) -> None:

--- a/tests/fakes/mcp_stdio_server.py
+++ b/tests/fakes/mcp_stdio_server.py
@@ -23,6 +23,13 @@ Modes:
                     the legacy handshake normally otherwise (the strict
                     die-on-unknown-method class; compatibility respawn pin).
   legacy-die-always closes stdout and exits on ANY request (both-phase pin).
+  legacy-malformed-die-on-discover  emits malformed JSON before probe EOF;
+                    the protocol-fault latch must forbid compatibility respawn.
+  legacy-pushy-die-on-discover  sends a server request before probe EOF;
+                    phase-one reply tasks must be retired before respawn.
+  legacy-delayed-die-discover-bad-version  closes stdout, exits 7 after a
+                    delay, then counteroffers an unsupported legacy version
+                    from the replacement (post-reap exit-status pin).
   oversized-on-discover  answers the probe with an over-ceiling line while
                     staying alive (non-EOF probe failure: no respawn pin).
   garbage           emits non-JSON noise, then behaves like `legacy`.
@@ -58,6 +65,7 @@ LEGACY_COUNTEROFFERS = {
     # Fresh process of the respawn counteroffers an unsupported version and
     # STAYS ALIVE — the ownership pin needs a living phase-2 child.
     "legacy-die-discover-bad-version": "9999-01-01",
+    "legacy-delayed-die-discover-bad-version": "9999-01-01",
     "legacy": "2025-06-18",
     "legacy-oldest": "2024-11-05",
     "legacy-batch": "2025-03-26",
@@ -204,6 +212,37 @@ def handle(msg: dict) -> None:
         sys.stdout.write("x" * (5 * 1024 * 1024) + "\n")
         sys.stdout.flush()
         return
+
+    if method == "server/discover" and MODE == "legacy-malformed-die-on-discover":
+        # A malformed frame poisons clean-EOF classification. Dropping the
+        # bad line and then treating EOF as strict-legacy evidence would
+        # conceal a protocol fault behind a successful replacement.
+        sys.stdout.write("{not-json}\n")
+        sys.stdout.flush()
+        sys.stdout.close()
+        os._exit(6)
+
+    if method == "server/discover" and MODE == "legacy-pushy-die-on-discover":
+        # Create a phase-one client-reply task, then die. The client must
+        # cancel/reap that task before constructing the replacement.
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": "phase-one-request",
+                "method": "sampling/createMessage",
+                "params": {"messages": []},
+            }
+        )
+        time.sleep(0.1)
+        sys.stdout.close()
+        os._exit(5)
+
+    if method == "server/discover" and MODE == "legacy-delayed-die-discover-bad-version":
+        # stdout EOF can precede process exit. Shutdown/reap must complete
+        # before the first-phase status is read for the combined diagnostic.
+        sys.stdout.close()
+        time.sleep(0.15)
+        os._exit(7)
 
     if method == "server/discover" and MODE == "legacy-die-discover-bad-version":
         # Phase 1 dies on the probe like the strict class...

--- a/tests/fakes/mcp_stdio_server.py
+++ b/tests/fakes/mcp_stdio_server.py
@@ -19,6 +19,12 @@ Modes:
   modern-missing-discover-result-type  modern server whose DiscoverResult omits resultType.
   modern-missing-call-result-type  modern server whose tools/call result omits resultType.
   silent            never answers anything (probe/initialize time out).
+  legacy-die-on-discover  closes stdout and exits on the era probe, serves
+                    the legacy handshake normally otherwise (the strict
+                    die-on-unknown-method class; compatibility respawn pin).
+  legacy-die-always closes stdout and exits on ANY request (both-phase pin).
+  oversized-on-discover  answers the probe with an over-ceiling line while
+                    staying alive (non-EOF probe failure: no respawn pin).
   garbage           emits non-JSON noise, then behaves like `legacy`.
   dies-mid-call     exits abruptly during tools/call.
   oversized-response emits a response line beyond the transport ceiling.
@@ -181,6 +187,28 @@ def handle(msg: dict) -> None:
 
     if MODE == "silent":
         return
+
+    if MODE == "legacy-die-always":
+        # Dies on receipt of ANY request — the fresh process of a
+        # compatibility respawn dies again at initialize (both-phase pin).
+        sys.stdout.close()
+        os._exit(4)
+
+    if method == "server/discover" and MODE == "oversized-on-discover":
+        # Non-EOF probe-phase transport failure: an oversized frame while
+        # the process stays ALIVE — must remain an honest failure with no
+        # compatibility respawn (typed-classification pin).
+        sys.stdout.write("x" * (5 * 1024 * 1024) + "\n")
+        sys.stdout.flush()
+        return
+
+    if method == "server/discover" and MODE == "legacy-die-on-discover":
+        # Strict legacy server (Uncraftbar's Roblox Studio proxy class):
+        # an unknown method makes it close stdout and EXIT instead of
+        # answering -32601 or staying alive. A fresh process serves the
+        # legacy handshake normally (the mode only kills on the probe).
+        sys.stdout.close()
+        os._exit(3)
 
     if method == "server/discover":
         if MODE in {"modern", "modern-missing-call-result-type"}:

--- a/tests/fakes/mcp_stdio_server.py
+++ b/tests/fakes/mcp_stdio_server.py
@@ -55,6 +55,9 @@ MODE = sys.argv[1] if len(sys.argv) > 1 else "legacy"
 
 MODERN_VERSION = "2026-07-28"
 LEGACY_COUNTEROFFERS = {
+    # Fresh process of the respawn counteroffers an unsupported version and
+    # STAYS ALIVE — the ownership pin needs a living phase-2 child.
+    "legacy-die-discover-bad-version": "9999-01-01",
     "legacy": "2025-06-18",
     "legacy-oldest": "2024-11-05",
     "legacy-batch": "2025-03-26",
@@ -201,6 +204,11 @@ def handle(msg: dict) -> None:
         sys.stdout.write("x" * (5 * 1024 * 1024) + "\n")
         sys.stdout.flush()
         return
+
+    if method == "server/discover" and MODE == "legacy-die-discover-bad-version":
+        # Phase 1 dies on the probe like the strict class...
+        sys.stdout.close()
+        os._exit(3)
 
     if method == "server/discover" and MODE == "legacy-die-on-discover":
         # Strict legacy server (Uncraftbar's Roblox Studio proxy class):

--- a/tests/test_mcp_client_eras.py
+++ b/tests/test_mcp_client_eras.py
@@ -779,7 +779,7 @@ class TestBoundedServerRequestReplies:
         active = 0
         peak = 0
 
-        async def parked_reply(_reply, _channel):
+        async def parked_reply(_reply, _channel, **_kwargs):
             nonlocal active, peak
             active += 1
             peak = max(peak, active)
@@ -834,6 +834,7 @@ class TestStdioProbeCasualtyRespawn:
             assert len(spawns) == 2
             assert conn.era == "legacy"
             assert conn.negotiated_version == "2025-06-18"
+            assert conn.status()["last_error"] == ""
             discovery = await conn.discover_tools()
             echo = next(t for t in discovery.tools if t.name == "echo")
             outcome = await conn.call_tool(echo, {"text": "respawned"})
@@ -889,6 +890,161 @@ class TestStdioProbeCasualtyRespawn:
             await conn.connect()
         assert "stdio EOF" not in str(excinfo.value)
         assert len(spawns) == 1
+
+    async def test_protocol_fault_before_eof_forbids_respawn(self, monkeypatch):
+        """Malformed output followed by EOF is a protocol-faulted stream,
+        never the clean strict-legacy EOF that grants a fresh process."""
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy-malformed-die-on-discover")
+        with pytest.raises(MCPConnectError):
+            await conn.connect()
+        assert len(spawns) == 1
+        assert not spawns[0].closed_by_eof
+
+    async def test_phase_one_reply_tasks_cancelled_before_respawn(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy-pushy-die-on-discover")
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def parked_reply(_reply, _channel, **_kwargs):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        monkeypatch.setattr(conn, "_send_reply", parked_reply)
+        await conn.connect()
+        try:
+            assert started.is_set()
+            assert cancelled.is_set()
+            assert conn._server_reply_tasks == set()  # noqa: SLF001
+            assert len(spawns) == 2
+        finally:
+            await conn.disconnect()
+
+    async def test_phase_one_reply_tasks_finish_before_shutdown(self, monkeypatch):
+        """Ordering pin: teardown must not await transport shutdown while a
+        phase-one reply can still be parked in that transport's send path."""
+        conn = _stdio("legacy")
+
+        class ParkedTransport:
+            async def send(self, _message):
+                await asyncio.Event().wait()
+
+        conn._accept_server_requests = True  # noqa: SLF001
+        conn._stdio = ParkedTransport()  # type: ignore[assignment]  # noqa: SLF001
+        conn._on_stdio_message(  # noqa: SLF001
+            {
+                "jsonrpc": "2.0",
+                "id": "phase-one-request",
+                "method": "sampling/createMessage",
+                "params": {},
+            }
+        )
+        await asyncio.sleep(0)
+
+        class DeadTransport:
+            returncode = 3
+
+            async def shutdown(self):
+                assert conn._server_reply_tasks == set()  # noqa: SLF001
+
+        class FreshTransport:
+            async def start(self):
+                return None
+
+        monkeypatch.setattr(conn, "_new_stdio_transport", FreshTransport)
+
+        async def fail_initialize():
+            raise MCPConnectError("unsupported")
+
+        monkeypatch.setattr(conn, "_initialize_legacy_stdio", fail_initialize)
+        with pytest.raises(MCPConnectError):
+            await conn._respawn_probe_casualty_for_legacy(  # noqa: SLF001
+                DeadTransport()  # type: ignore[arg-type]
+            )
+
+    async def test_stdio_server_reply_is_bound_to_originating_transport(self):
+        """Even without lifecycle cancellation as a backstop, a delayed
+        phase-one reply cannot resolve self._stdio to a replacement."""
+
+        class RecordingTransport:
+            def __init__(self):
+                self.sent: list[dict] = []
+
+            async def send(self, message):
+                self.sent.append(message)
+
+        conn = _stdio("legacy")
+        first = RecordingTransport()
+        replacement = RecordingTransport()
+        conn._accept_server_requests = True  # noqa: SLF001
+        conn._stdio = first  # type: ignore[assignment]  # noqa: SLF001
+        conn._on_stdio_message(  # noqa: SLF001
+            {
+                "jsonrpc": "2.0",
+                "id": "phase-one-request",
+                "method": "sampling/createMessage",
+                "params": {},
+            }
+        )
+        # No await occurred after task creation, so this swap precedes the
+        # reply coroutine's first instruction deterministically.
+        conn._stdio = replacement  # type: ignore[assignment]  # noqa: SLF001
+        await conn._drain_server_reply_tasks()  # noqa: SLF001
+        assert [msg.get("id") for msg in first.sent] == ["phase-one-request"]
+        assert replacement.sent == []
+
+    async def test_delayed_phase_one_exit_status_captured_after_reap(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy-delayed-die-discover-bad-version")
+        with pytest.raises(MCPConnectError) as excinfo:
+            await conn.connect()
+        assert "first process exit status 7" in str(excinfo.value)
+        assert len(spawns) == 2
+        assert all(not transport.running for transport in spawns)
+
+    async def test_exit_status_is_sampled_only_after_shutdown(self, monkeypatch):
+        """Deterministic ordering pin: EOF can arrive before wait() publishes
+        returncode, so diagnostics must inspect it only after shutdown/reap."""
+
+        class DeadTransport:
+            returncode = None
+
+            async def shutdown(self):
+                self.returncode = 7
+
+        class FreshTransport:
+            async def start(self):
+                return None
+
+        conn = _stdio("legacy")
+        fresh = FreshTransport()
+        monkeypatch.setattr(conn, "_new_stdio_transport", lambda: fresh)
+
+        async def fail_initialize():
+            raise MCPConnectError("unsupported")
+
+        monkeypatch.setattr(conn, "_initialize_legacy_stdio", fail_initialize)
+        with pytest.raises(MCPConnectError) as excinfo:
+            await conn._respawn_probe_casualty_for_legacy(  # noqa: SLF001
+                DeadTransport()  # type: ignore[arg-type]
+            )
+        assert "first process exit status 7" in str(excinfo.value)
+
+    @pytest.mark.parametrize("control", [asyncio.CancelledError, SystemExit, KeyboardInterrupt])
+    async def test_respawn_does_not_wrap_process_control_exceptions(self, monkeypatch, control):
+        conn = _stdio("legacy-die-on-discover")
+
+        async def stop_control():
+            raise control
+
+        monkeypatch.setattr(conn, "_initialize_legacy_stdio", stop_control)
+        with pytest.raises(control):
+            await conn.connect()
+        assert conn._stdio is None  # noqa: SLF001
 
     async def test_failed_second_phase_reaps_the_living_replacement(self, monkeypatch):
         """Ownership pin: when the fresh process survives its own failed

--- a/tests/test_mcp_client_eras.py
+++ b/tests/test_mcp_client_eras.py
@@ -889,3 +889,16 @@ class TestStdioProbeCasualtyRespawn:
             await conn.connect()
         assert "stdio EOF" not in str(excinfo.value)
         assert len(spawns) == 1
+
+    async def test_failed_second_phase_reaps_the_living_replacement(self, monkeypatch):
+        """Ownership pin: when the fresh process survives its own failed
+        initialize (unsupported counteroffer), connect cleanup must reap
+        THE REPLACEMENT — reaping only the phase-one corpse leaks a live
+        child."""
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy-die-discover-bad-version")
+        with pytest.raises(MCPConnectError):
+            await conn.connect()
+        assert len(spawns) == 2
+        assert conn._stdio is None  # noqa: SLF001
+        assert not spawns[1].running, "replacement child must be reaped"

--- a/tests/test_mcp_client_eras.py
+++ b/tests/test_mcp_client_eras.py
@@ -806,3 +806,86 @@ class TestBoundedServerRequestReplies:
         finally:
             release.set()
             await conn.disconnect()
+
+
+class TestStdioProbeCasualtyRespawn:
+    """Die-on-unknown-method strict legacy servers (Uncraftbar's field
+    report): a clean stdout EOF during the era probe — and ONLY that,
+    typed, never text-matched — grants exactly one fresh-process legacy
+    attempt. Era is established solely by the fresh initialize."""
+
+    def _count_spawns(self, monkeypatch):
+        instances: list = []
+        real = client_mod.StdioTransport
+
+        class CountingTransport(real):  # type: ignore[misc, valid-type]
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                instances.append(self)
+
+        monkeypatch.setattr(client_mod, "StdioTransport", CountingTransport)
+        return instances
+
+    async def test_strict_legacy_two_spawns_then_full_service(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy-die-on-discover")
+        await conn.connect()
+        try:
+            assert len(spawns) == 2
+            assert conn.era == "legacy"
+            assert conn.negotiated_version == "2025-06-18"
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "respawned"})
+            assert outcome.ok and "respawned" in outcome.text
+        finally:
+            await conn.disconnect()
+
+    async def test_both_phases_dead_names_both_and_reaps(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy-die-always")
+        with pytest.raises(MCPConnectError) as excinfo:
+            await conn.connect()
+        message = str(excinfo.value)
+        assert "server/discover ended by unexpected stdio EOF" in message
+        assert "fresh legacy initialization failed" in message
+        assert "exit status 4" in message
+        assert len(spawns) == 2
+        # Both children reaped; no transport left owned.
+        assert conn._stdio is None  # noqa: SLF001
+        for transport in spawns:
+            assert not transport.running
+
+    async def test_post_handshake_death_keeps_single_spawn(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("dies-mid-call")
+        await conn.connect()
+        try:
+            assert len(spawns) == 1
+            discovery = await conn.discover_tools()
+            echo = next(t for t in discovery.tools if t.name == "echo")
+            outcome = await conn.call_tool(echo, {"text": "boom"})
+            # Existing lost/uncertain semantics — and no compatibility
+            # respawn for post-handshake deaths, ever.
+            assert not outcome.ok
+            assert len(spawns) == 1
+        finally:
+            await conn.disconnect()
+
+    async def test_compliant_legacy_single_spawn(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("legacy")
+        await conn.connect()
+        try:
+            assert len(spawns) == 1
+            assert conn.era == "legacy"
+        finally:
+            await conn.disconnect()
+
+    async def test_non_eof_probe_failure_no_respawn(self, monkeypatch):
+        spawns = self._count_spawns(monkeypatch)
+        conn = _stdio("oversized-on-discover")
+        with pytest.raises(MCPConnectError) as excinfo:
+            await conn.connect()
+        assert "stdio EOF" not in str(excinfo.value)
+        assert len(spawns) == 1


### PR DESCRIPTION
Field report by **@Uncraftbar** ([gist](https://gist.github.com/Uncraftbar/3cedc797651c01858ce488883fd2e197)): a strict legacy stdio server (Roblox Studio MCP proxy) closes stdout and exits on the unknown `server/discover` probe, so era detection's legacy fallback initialized a dead process ("server closed its output stream"). Our design assumed unknown-method servers answer `-32601` or stay alive under timeout — die-on-unknown-method is a real wild class. Design settled jointly; all amendments applied.

## The fix
- **Typed EOF classification, never text matching:** the transport records a clean stdout EOF (`closed_by_eof`) before `on_closed` fires; pending waiters get `MCPStdioEOFError` exactly then. Oversized frames, pump faults, launch/write failures, and cancellation remain honest failures.
- **Ambiguity grants ONE legacy attempt — never era evidence:** on probe-phase EOF the corpse is fully retired (bounded process-group shutdown), exactly one fresh transport is built by the new `_new_stdio_transport()` factory (identical construction), and `era=legacy` only if its `initialize` returns a valid supported result.
- **Active-owner cleanup:** the connect error path now reaps the ACTIVE transport, not the phase-one local — a second-phase failure reaps the replacement instead of leaking a live child.
- **Both-phase diagnostics:** one bounded `MCPConnectError` naming the probe EOF (with exit status) and the fresh initialization's actual failure; MCP error text only, class name otherwise — never command, environment, or stderr. `CancelledError` propagates unchanged.

## Verification
Three new fake modes (`legacy-die-on-discover`, `legacy-die-always`, `oversized-on-discover` + a bad-version variant whose fresh process SURVIVES its failed initialize). Seven pins across the six agreed classes: strict-legacy exactly-two-spawns then full connect→discover→call; both-phases-dead names both phases with exit status and reaps both children; post-handshake death keeps one spawn and existing semantics; compliant legacy one spawn; non-EOF probe failure one spawn, honest, no respawn; HTTP era suite untouched (62/62). Mutation battery: removing the respawn path, removing the EOF typing, and reverting the owner fix each turn pins red — the ownership mutation originally survived against a self-dying child, so the pin was strengthened with a living phase-2 child (under mutation its orphaned pumps crash the loop, making the leak visible). Coverage gate findings=0 @ 90.3%; ruff and type gates clean.

Credit: report, repro, and the workaround wrapper by @Uncraftbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHfEwTsEyuS8RUhwdoW66g