### PR TITLE
Fix search identity fusion and query errors

### DIFF
--- a/src/discord/background_task.py
+++ b/src/discord/background_task.py
@@ -19,6 +19,7 @@ import discord
 from ..audit.diff_tracker import DIFF_TOOLS, DiffTracker
 from ..llm.secret_scrubber import scrub_output_secrets
 from ..odin_log import get_logger
+from ..search.errors import InvalidSearchQuery
 from ..tools.executor import _ERROR_RESULT_PREFIXES
 from ..tools.result_validator import ToolResult
 from ..tools.risk_classifier import classify_tool
@@ -487,10 +488,20 @@ async def _execute_tool(
     if tool_name == "search_knowledge" and knowledge_store and embedder:
         query = tool_input.get("query", "")
         limit = min(tool_input.get("limit", 5), 10)
-        results = await knowledge_store.search(query, embedder, limit=limit)
+        try:
+            results = await knowledge_store.search_hybrid(query, embedder, limit=limit)
+        except InvalidSearchQuery:
+            return "Invalid query: unsupported control character."
+        except Exception:
+            log.exception("Background knowledge search failed")
+            return "Search failed while searching the knowledge base."
         if not results:
             return f"No results for '{query}'."
-        lines = [f"[{r['source']}] (score: {r['score']}): {r['content'][:200]}" for r in results]
+        lines = [
+            f"[{r['source']}] (score: {r.get('score', r.get('rrf_score', 0))}): "
+            f"{r['content'][:200]}"
+            for r in results
+        ]
         return "\n".join(lines)
 
     if tool_name == "list_knowledge" and knowledge_store:

--- a/src/discord/background_task.py
+++ b/src/discord/background_task.py
@@ -491,7 +491,7 @@ async def _execute_tool(
         try:
             results = await knowledge_store.search_hybrid(query, embedder, limit=limit)
         except InvalidSearchQuery:
-            return "Invalid query: unsupported control character."
+            return "Invalid query: unsupported character."
         except Exception:
             log.exception("Background knowledge search failed")
             return "Search failed while searching the knowledge base."

--- a/src/discord/channel_logger.py
+++ b/src/discord/channel_logger.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+from ..search.errors import validate_search_query
 
 if TYPE_CHECKING:
     from ..search.fts import FullTextIndex
@@ -144,6 +145,7 @@ class ChannelLogger:
         Returns dicts with content, author, channel_id, timestamp, type="channel".
         Reads files in reverse (newest messages first) for better relevance.
         """
+        validate_search_query(query)
         results: list[dict] = []
         query_lower = query.lower()
         if not query_lower:

--- a/src/discord/native_tools/knowledge.py
+++ b/src/discord/native_tools/knowledge.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 
 from ...llm.secret_scrubber import scrub_output_secrets
 from ...odin_log import get_logger
+from ...search.errors import InvalidSearchQuery
 
 log = get_logger("discord")
 
@@ -34,7 +35,13 @@ class KnowledgeTools:
         if not query:
             return "A search query is required."
 
-        results = await self.sessions.search_history(query, limit=limit)
+        try:
+            results = await self.sessions.search_history(query, limit=limit)
+        except InvalidSearchQuery:
+            return "Invalid query: unsupported control character."
+        except Exception:
+            log.exception("History search failed")
+            return "Search failed while searching conversation history."
         if not results:
             return f"No past conversations found matching '{query}'."
 
@@ -59,7 +66,15 @@ class KnowledgeTools:
         if not query:
             return "A search query is required."
 
-        results = await self._knowledge_store.search_hybrid(query, self._embedder, limit=limit)
+        try:
+            results = await self._knowledge_store.search_hybrid(
+                query, self._embedder, limit=limit
+            )
+        except InvalidSearchQuery:
+            return "Invalid query: unsupported control character."
+        except Exception:
+            log.exception("Knowledge search failed")
+            return "Search failed while searching the knowledge base."
         if not results:
             return (
                 f"No knowledge base results for '{query}'. "

--- a/src/discord/native_tools/knowledge.py
+++ b/src/discord/native_tools/knowledge.py
@@ -38,7 +38,7 @@ class KnowledgeTools:
         try:
             results = await self.sessions.search_history(query, limit=limit)
         except InvalidSearchQuery:
-            return "Invalid query: unsupported control character."
+            return "Invalid query: unsupported character."
         except Exception:
             log.exception("History search failed")
             return "Search failed while searching conversation history."
@@ -71,7 +71,7 @@ class KnowledgeTools:
                 query, self._embedder, limit=limit
             )
         except InvalidSearchQuery:
-            return "Invalid query: unsupported control character."
+            return "Invalid query: unsupported character."
         except Exception:
             log.exception("Knowledge search failed")
             return "Search failed while searching the knowledge base."

--- a/src/knowledge/store.py
+++ b/src/knowledge/store.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+from ..search.errors import SearchExecutionError, validate_search_query
 from ..search.hybrid import reciprocal_rank_fusion
 from ..search.sqlite_vec import load_extension, serialize_vector
 
@@ -310,25 +311,24 @@ class KnowledgeStore:
     ) -> list[dict]:
         """Semantic search across the knowledge base.
 
-        Returns list of dicts with: content, source, score, chunk_index.
+        Returns list of dicts with: chunk_id, content, source, score, chunk_index.
         """
-        if not self.available or not self._has_vec or not embedder:
-            return []
+        validate_search_query(query)
+        if not self.available:
+            raise SearchExecutionError("search failed: knowledge store is unavailable")
+        if not self._has_vec or not embedder:
+            raise SearchExecutionError("search failed: semantic knowledge search is unavailable")
 
         vector = await embedder.embed(query)
         if vector is None:
-            return []
+            raise SearchExecutionError("search failed: query embedding was unavailable")
 
-        try:
-            vec_bytes = serialize_vector(vector)
-            # Over-fetch candidates: the KNN k-cap and the >0.8 distance filter
-            # compound, so fetching exactly `limit` rows often returns far fewer
-            # (or none) after filtering. Fetch a wider pool, then trim to `limit`.
-            candidate_k = max(limit * 4, 20)
-            rows = await asyncio.to_thread(self._search_vec_sync, vec_bytes, candidate_k)
-        except Exception as e:
-            log.warning("Knowledge search failed: %s", e)
-            return []
+        vec_bytes = serialize_vector(vector)
+        # Over-fetch candidates: the KNN k-cap and the >0.8 distance filter
+        # compound, so fetching exactly `limit` rows often returns far fewer
+        # (or none) after filtering. Fetch a wider pool, then trim to `limit`.
+        candidate_k = max(limit * 4, 20)
+        rows = await asyncio.to_thread(self._search_vec_sync, vec_bytes, candidate_k)
 
         out = []
         for row in rows:
@@ -337,6 +337,7 @@ class KnowledgeStore:
             if distance > 0.8:
                 continue
             out.append({
+                "chunk_id": str(row[0]),
                 "content": row[2],
                 "source": row[3],
                 "score": round(1 - distance, 3),  # Convert to similarity
@@ -344,6 +345,28 @@ class KnowledgeStore:
             })
 
         return out[:limit]
+
+    def _search_literal_sync(self, query: str, limit: int) -> list[dict]:
+        """Literal implicit-AND fallback over stored chunks when FTS is not injected."""
+        terms = query.split()
+        if not terms:
+            return []
+        clauses = " AND ".join("instr(lower(content), lower(?)) > 0" for _ in terms)
+        rows = self._conn.execute(  # type: ignore[union-attr]
+            "SELECT chunk_id, content, source, chunk_index FROM knowledge_chunks "
+            f"WHERE {clauses} ORDER BY ingested_at DESC, chunk_index LIMIT ?",
+            (*terms, limit),
+        ).fetchall()
+        return [
+            {
+                "chunk_id": str(row[0]),
+                "content": row[1],
+                "source": row[2],
+                "chunk_index": row[3],
+                "type": "literal",
+            }
+            for row in rows
+        ]
 
     def _search_vec_sync(self, vec_bytes: bytes, limit: int) -> list:
         """Execute vector similarity search (sync, for use with asyncio.to_thread)."""
@@ -509,22 +532,26 @@ class KnowledgeStore:
 
         Works in FTS-only mode when embedder is None or vector search unavailable.
         """
+        validate_search_query(query)
+        if not self.available:
+            raise SearchExecutionError("search failed: knowledge store is unavailable")
+
         semantic_results = []
-        if embedder:
+        searched = False
+        if embedder and self._has_vec:
             semantic_results = await self.search(query, embedder, limit=limit * 2)
+            searched = True
         fts_results = []
         if self._fts:
             fts_results = await asyncio.to_thread(
                 self._fts.search_knowledge, query, limit * 2,
             )
+            searched = True
 
+        if not searched:
+            return await asyncio.to_thread(self._search_literal_sync, query, limit)
         if not semantic_results and not fts_results:
             return []
-
-        # Normalize semantic results to use chunk_id
-        for r in semantic_results:
-            if "chunk_id" not in r:
-                r["chunk_id"] = f"{r.get('source', '')}_{r.get('chunk_index', 0)}"
 
         return reciprocal_rank_fusion(
             semantic_results, fts_results, id_key="chunk_id", limit=limit,

--- a/src/search/__init__.py
+++ b/src/search/__init__.py
@@ -1,6 +1,15 @@
 from .embedder import LocalEmbedder
+from .errors import InvalidSearchQuery, SearchExecutionError, SearchInvariantError
 from .fts import FullTextIndex
 from .hybrid import reciprocal_rank_fusion
 from .vectorstore import SessionVectorStore
 
-__all__ = ["FullTextIndex", "LocalEmbedder", "SessionVectorStore", "reciprocal_rank_fusion"]
+__all__ = [
+    "FullTextIndex",
+    "InvalidSearchQuery",
+    "LocalEmbedder",
+    "SearchExecutionError",
+    "SearchInvariantError",
+    "SessionVectorStore",
+    "reciprocal_rank_fusion",
+]

--- a/src/search/errors.py
+++ b/src/search/errors.py
@@ -1,0 +1,21 @@
+"""Typed failures shared by the search stack and its public boundaries."""
+
+from __future__ import annotations
+
+
+class InvalidSearchQuery(ValueError):  # noqa: N818 — public domain exception name
+    """The caller supplied text that cannot be represented safely in search."""
+
+
+class SearchExecutionError(RuntimeError):
+    """A configured search backend could not execute the query."""
+
+
+class SearchInvariantError(RuntimeError):
+    """An internal search result violated the identity contract."""
+
+
+def validate_search_query(query: str) -> None:
+    """Reject input containing NUL, which SQLite text values cannot represent safely."""
+    if "\x00" in query:
+        raise InvalidSearchQuery("invalid query: unsupported control character")

--- a/src/search/errors.py
+++ b/src/search/errors.py
@@ -16,6 +16,10 @@ class SearchInvariantError(RuntimeError):
 
 
 def validate_search_query(query: str) -> None:
-    """Reject input containing NUL, which SQLite text values cannot represent safely."""
+    """Reject text that cannot be represented safely as SQLite UTF-8 input."""
     if "\x00" in query:
-        raise InvalidSearchQuery("invalid query: unsupported control character")
+        raise InvalidSearchQuery("invalid query: unsupported character")
+    try:
+        query.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise InvalidSearchQuery("invalid query: text is not valid UTF-8") from exc

--- a/src/search/fts.py
+++ b/src/search/fts.py
@@ -5,19 +5,13 @@ Two tables: session_fts (archived conversations) and knowledge_fts (ingested doc
 """
 from __future__ import annotations
 
-import re
 import sqlite3
 import threading
 
 from ..odin_log import get_logger
+from .errors import SearchExecutionError, validate_search_query
 
 log = get_logger("search.fts")
-
-# Characters that have special meaning in FTS5 query syntax
-_FTS5_SPECIAL = re.compile(r'[*"{}()\[\]:^~]')
-
-# FTS5 keywords that cause "no such column" errors when used as bare terms
-_FTS5_KEYWORDS = frozenset({"AND", "OR", "NOT", "NEAR", "TO"})
 
 
 class FullTextIndex:
@@ -104,42 +98,38 @@ class FullTextIndex:
         self, query: str, limit: int = 20, channel_id: str | None = None,
     ) -> list[dict]:
         if not self._conn:
-            return []
+            raise SearchExecutionError("full-text search is unavailable")
         fts_query = _prepare_query(query)
         if not fts_query:
             return []
-        try:
-            if channel_id:
-                rows = self._conn.execute(
-                    "SELECT doc_id, snippet(session_fts, 1, '>>>', '<<<', '...', 64), "
-                    "channel_id, last_active, bm25(session_fts) as rank "
-                    "FROM session_fts WHERE session_fts MATCH ? "
-                    "AND channel_id = ? "
-                    "ORDER BY rank LIMIT ?",
-                    (fts_query, channel_id, limit),
-                ).fetchall()
-            else:
-                rows = self._conn.execute(
-                    "SELECT doc_id, snippet(session_fts, 1, '>>>', '<<<', '...', 64), "
-                    "channel_id, last_active, bm25(session_fts) as rank "
-                    "FROM session_fts WHERE session_fts MATCH ? "
-                    "ORDER BY rank LIMIT ?",
-                    (fts_query, limit),
-                ).fetchall()
-            return [
-                {
-                    "doc_id": r[0],
-                    "content": r[1],
-                    "channel_id": r[2],
-                    "timestamp": float(r[3]) if r[3] else 0.0,
-                    "type": "fts",
-                    "rank": r[4],
-                }
-                for r in rows
-            ]
-        except Exception as e:
-            log.warning("FTS session search failed: %s", e)
-            return []
+        if channel_id:
+            rows = self._conn.execute(
+                "SELECT doc_id, snippet(session_fts, 1, '>>>', '<<<', '...', 64), "
+                "channel_id, last_active, bm25(session_fts) as rank "
+                "FROM session_fts WHERE session_fts MATCH ? "
+                "AND channel_id = ? "
+                "ORDER BY rank LIMIT ?",
+                (fts_query, channel_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT doc_id, snippet(session_fts, 1, '>>>', '<<<', '...', 64), "
+                "channel_id, last_active, bm25(session_fts) as rank "
+                "FROM session_fts WHERE session_fts MATCH ? "
+                "ORDER BY rank LIMIT ?",
+                (fts_query, limit),
+            ).fetchall()
+        return [
+            {
+                "doc_id": r[0],
+                "content": r[1],
+                "channel_id": r[2],
+                "timestamp": float(r[3]) if r[3] else 0.0,
+                "type": "fts",
+                "rank": r[4],
+            }
+            for r in rows
+        ]
 
     def has_session(self, doc_id: str) -> bool:
         if not self._conn:
@@ -174,32 +164,28 @@ class FullTextIndex:
 
     def search_knowledge(self, query: str, limit: int = 20) -> list[dict]:
         if not self._conn:
-            return []
+            raise SearchExecutionError("full-text search is unavailable")
         fts_query = _prepare_query(query)
         if not fts_query:
             return []
-        try:
-            rows = self._conn.execute(
-                "SELECT chunk_id, snippet(knowledge_fts, 1, '>>>', '<<<', '...', 64), "
-                "source, chunk_index, bm25(knowledge_fts) as rank "
-                "FROM knowledge_fts WHERE knowledge_fts MATCH ? "
-                "ORDER BY rank LIMIT ?",
-                (fts_query, limit),
-            ).fetchall()
-            return [
-                {
-                    "chunk_id": r[0],
-                    "content": r[1],
-                    "source": r[2],
-                    "chunk_index": int(r[3]) if r[3] else 0,
-                    "type": "fts",
-                    "rank": r[4],
-                }
-                for r in rows
-            ]
-        except Exception as e:
-            log.warning("FTS knowledge search failed: %s", e)
-            return []
+        rows = self._conn.execute(
+            "SELECT chunk_id, snippet(knowledge_fts, 1, '>>>', '<<<', '...', 64), "
+            "source, chunk_index, bm25(knowledge_fts) as rank "
+            "FROM knowledge_fts WHERE knowledge_fts MATCH ? "
+            "ORDER BY rank LIMIT ?",
+            (fts_query, limit),
+        ).fetchall()
+        return [
+            {
+                "chunk_id": r[0],
+                "content": r[1],
+                "source": r[2],
+                "chunk_index": int(r[3]) if r[3] else 0,
+                "type": "fts",
+                "rank": r[4],
+            }
+            for r in rows
+        ]
 
     def delete_knowledge_source(self, source: str) -> int:
         if not self._conn:
@@ -283,65 +269,53 @@ class FullTextIndex:
         Returns dicts with content, author, channel_id, timestamp, type="channel".
         """
         if not self._conn:
-            return []
+            raise SearchExecutionError("full-text search is unavailable")
         fts_query = _prepare_query(query)
         if not fts_query:
             return []
-        try:
-            if channel_id:
-                rows = self._conn.execute(
-                    "SELECT snippet(channel_log_fts, 0, '>>>', '<<<', '...', 64), "
-                    "author, channel_id, timestamp, bm25(channel_log_fts) as rank "
-                    "FROM channel_log_fts WHERE channel_log_fts MATCH ? "
-                    "AND channel_id = ? "
-                    "ORDER BY rank LIMIT ?",
-                    (fts_query, channel_id, limit),
-                ).fetchall()
-            else:
-                rows = self._conn.execute(
-                    "SELECT snippet(channel_log_fts, 0, '>>>', '<<<', '...', 64), "
-                    "author, channel_id, timestamp, bm25(channel_log_fts) as rank "
-                    "FROM channel_log_fts WHERE channel_log_fts MATCH ? "
-                    "ORDER BY rank LIMIT ?",
-                    (fts_query, limit),
-                ).fetchall()
-            return [
-                {
-                    "content": r[0],
-                    "author": r[1],
-                    "channel_id": r[2],
-                    "timestamp": float(r[3]) if r[3] else 0.0,
-                    "type": "channel",
-                    "rank": r[4],
-                }
-                for r in rows
-            ]
-        except Exception as e:
-            log.warning("FTS channel log search failed: %s", e)
-            return []
+        if channel_id:
+            rows = self._conn.execute(
+                "SELECT snippet(channel_log_fts, 0, '>>>', '<<<', '...', 64), "
+                "author, channel_id, timestamp, bm25(channel_log_fts) as rank "
+                "FROM channel_log_fts WHERE channel_log_fts MATCH ? "
+                "AND channel_id = ? "
+                "ORDER BY rank LIMIT ?",
+                (fts_query, channel_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT snippet(channel_log_fts, 0, '>>>', '<<<', '...', 64), "
+                "author, channel_id, timestamp, bm25(channel_log_fts) as rank "
+                "FROM channel_log_fts WHERE channel_log_fts MATCH ? "
+                "ORDER BY rank LIMIT ?",
+                (fts_query, limit),
+            ).fetchall()
+        return [
+            {
+                "content": r[0],
+                "author": r[1],
+                "channel_id": r[2],
+                "timestamp": float(r[3]) if r[3] else 0.0,
+                "type": "channel",
+                "rank": r[4],
+            }
+            for r in rows
+        ]
 
 
 def _prepare_query(raw: str) -> str:
-    """Prepare a raw query string for FTS5 MATCH.
+    """Quote each whitespace-delimited term for literal FTS5 implicit-AND search.
 
-    - Wraps in quotes if it contains FTS5 special characters (for literal matching)
-    - Handles IP addresses, PromQL expressions, error codes, etc.
-    - Quotes individual terms that are FTS5 reserved keywords (AND, OR, NOT, NEAR, TO)
+    Advanced FTS5 syntax is deliberately unsupported. Quoting terms separately
+    preserves the ordinary multi-term AND semantics without converting the whole
+    query into an adjacent phrase.
     """
+    validate_search_query(raw)
     raw = raw.strip()
     if not raw:
         return ""
-    # If query contains special chars, hyphens, or looks like an IP/path, quote for literal match
-    if _FTS5_SPECIAL.search(raw) or "." in raw or "/" in raw or "-" in raw:
-        escaped = raw.replace('"', '""')
-        return f'"{escaped}"'
-    # Quote individual terms that are FTS5 reserved keywords to prevent
-    # "no such column" errors (e.g. "to" being treated as a column reference)
-    terms = raw.split()
-    escaped_terms = []
-    for term in terms:
-        if term.upper() in _FTS5_KEYWORDS:
-            escaped_terms.append(f'"{term}"')
-        else:
-            escaped_terms.append(term)
-    return " ".join(escaped_terms)
+    quoted = []
+    for term in raw.split():
+        escaped = term.replace('"', '""')
+        quoted.append(f'"{escaped}"')
+    return " ".join(quoted)

--- a/src/search/hybrid.py
+++ b/src/search/hybrid.py
@@ -1,6 +1,8 @@
 """Reciprocal Rank Fusion for merging multiple ranked result lists."""
 from __future__ import annotations
 
+from .errors import SearchInvariantError
+
 
 def reciprocal_rank_fusion(
     *result_lists: list[dict],
@@ -12,7 +14,9 @@ def reciprocal_rank_fusion(
 
     Each list is assumed to be in rank order (best first).
     Results identified by *id_key* are deduplicated; the dict from the
-    highest-ranked occurrence is kept.  Returns top *limit* results
+    highest-ranked occurrence is kept. A missing identity is an invariant
+    violation rather than an invitation to synthesize one from rank or metadata.
+    Returns top *limit* results
     sorted by fused score descending, with ``rrf_score`` added.
     """
     scores: dict[str, float] = {}
@@ -20,7 +24,11 @@ def reciprocal_rank_fusion(
 
     for result_list in result_lists:
         for rank_0, item in enumerate(result_list):
-            item_id = str(item.get(id_key, rank_0))
+            if id_key not in item or item[id_key] in (None, ""):
+                raise SearchInvariantError(
+                    f"search result is missing required identity field {id_key!r}"
+                )
+            item_id = str(item[id_key])
             rrf = 1.0 / (k + rank_0 + 1)  # rank is 1-based in the formula
             scores[item_id] = scores.get(item_id, 0.0) + rrf
             # Keep the version from the list where it ranked highest

--- a/src/search/vectorstore.py
+++ b/src/search/vectorstore.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..odin_log import get_logger
+from .errors import SearchExecutionError, validate_search_query
 from .hybrid import reciprocal_rank_fusion
 from .sqlite_vec import load_extension, serialize_vector
 
@@ -153,19 +154,18 @@ class SessionVectorStore:
 
     async def search(self, query: str, embedder: LocalEmbedder, limit: int = 10) -> list[dict]:
         """Semantic search across archived sessions."""
-        if not self.available or not self._has_vec:
-            return []
+        validate_search_query(query)
+        if not self.available:
+            raise SearchExecutionError("search failed: session store is unavailable")
+        if not self._has_vec:
+            raise SearchExecutionError("search failed: semantic session search is unavailable")
 
         vector = await embedder.embed(query)
         if vector is None:
-            return []
+            raise SearchExecutionError("search failed: query embedding was unavailable")
 
-        try:
-            vec_bytes = serialize_vector(vector)
-            rows = await asyncio.to_thread(self._search_vec_sync, vec_bytes, limit)
-        except Exception as e:
-            log.warning("Session vector search failed: %s", e)
-            return []
+        vec_bytes = serialize_vector(vector)
+        rows = await asyncio.to_thread(self._search_vec_sync, vec_bytes, limit)
 
         out = []
         for row in rows:
@@ -174,6 +174,7 @@ class SessionVectorStore:
             if distance > 0.8:
                 continue
             out.append({
+                "doc_id": str(row[0]),
                 "type": "semantic",
                 "content": row[2][:500],
                 "timestamp": float(row[4]),
@@ -260,23 +261,24 @@ class SessionVectorStore:
 
         Works in FTS-only mode when embedder is None or vector search unavailable.
         """
+        validate_search_query(query)
         semantic_results = []
+        searched = False
         if embedder and self._has_vec:
             semantic_results = await self.search(query, embedder, limit=limit * 2)
+            searched = True
 
         fts_results = []
         if self._fts:
             fts_results = await asyncio.to_thread(
                 self._fts.search_sessions, query, limit * 2,
             )
+            searched = True
 
+        if not searched:
+            raise SearchExecutionError("search failed: no session search backend is available")
         if not semantic_results and not fts_results:
             return []
-
-        # Normalize both to use doc_id as the merge key
-        for r in semantic_results:
-            if "doc_id" not in r:
-                r["doc_id"] = f"{r.get('channel_id', '')}_{r.get('timestamp', 0)}"
 
         return reciprocal_rank_fusion(
             semantic_results, fts_results, id_key="doc_id", limit=limit,

--- a/src/sessions/manager.py
+++ b/src/sessions/manager.py
@@ -15,6 +15,7 @@ from ..llm.cost_tracker import estimate_tokens
 from ..odin_log import get_logger
 from ..relevance import rank as relevance_rank
 from ..relevance import score as relevance_score
+from ..search.errors import validate_search_query
 
 if TYPE_CHECKING:
     from ..learning.reflector import ConversationReflector
@@ -1353,6 +1354,7 @@ class SessionManager:
         - after: only messages with timestamp >= after (epoch seconds)
         - before: only messages with timestamp <= before (epoch seconds)
         """
+        validate_search_query(query)
         query_lower = query.lower()
         results: list[dict] = []
 
@@ -1414,64 +1416,61 @@ class SessionManager:
         if len(results) >= limit:
             return results[:limit]
 
-        # Step 3: hybrid search (FTS5 + semantic) fills remaining slots
+        # Step 3: hybrid search (FTS5 + semantic) fills remaining slots.
+        # Backend failures propagate to the caller rather than masquerading as
+        # a keyword-only result set.
         if len(results) < limit and self._vector_store:
-            try:
-                hybrid_results = await self._vector_store.search_hybrid(
-                    query, self._embedder, limit=limit,
-                )
-                seen = {(r["channel_id"], r.get("timestamp", 0)) for r in results}
-                for hr in hybrid_results:
-                    if channel_id and hr.get("channel_id") != channel_id:
-                        continue
-                    ts = hr.get("timestamp", 0)
-                    if not _ts_ok(ts):
-                        continue
-                    # Reset content stays purged from the semantic index too.
-                    if ts <= self._reset_epochs.get(hr.get("channel_id", ""), 0.0):
-                        continue
-                    key = (hr["channel_id"], ts)
-                    if key not in seen:
-                        results.append(hr)
-                        seen.add(key)
-                        if len(results) >= limit:
-                            break
-            except Exception as e:
-                log.warning("Hybrid search failed, returning keyword-only results: %s", e)
+            hybrid_results = await self._vector_store.search_hybrid(
+                query, self._embedder, limit=limit,
+            )
+            seen = {(r["channel_id"], r.get("timestamp", 0)) for r in results}
+            for hr in hybrid_results:
+                if channel_id and hr.get("channel_id") != channel_id:
+                    continue
+                ts = hr.get("timestamp", 0)
+                if not _ts_ok(ts):
+                    continue
+                # Reset content stays purged from the semantic index too.
+                if ts <= self._reset_epochs.get(hr.get("channel_id", ""), 0.0):
+                    continue
+                key = (hr["channel_id"], ts)
+                if key not in seen:
+                    results.append(hr)
+                    seen.add(key)
+                    if len(results) >= limit:
+                        break
 
-        # Step 4: channel log search (full channel history from all users)
+        # Step 4: channel log search (full channel history from all users).
+        # An FTS execution failure is not equivalent to an empty result set.
         if len(results) < limit and self._channel_logger:
-            try:
-                remaining = limit - len(results)
-                fts = self._fts_index
-                channel_results = []
-                if fts and hasattr(fts, "search_channel_logs"):
-                    channel_results = fts.search_channel_logs(
-                        query, limit=remaining, channel_id=channel_id,
-                    )
-                if not channel_results and hasattr(self._channel_logger, "search"):
-                    channel_results = await asyncio.to_thread(
-                        self._channel_logger.search, query, remaining,
-                    )
-                seen = {(r.get("channel_id", ""), r.get("timestamp", 0)) for r in results}
-                for cr in channel_results:
-                    ts = cr.get("timestamp", 0)
-                    if not _ts_ok(ts):
-                        continue
-                    cr_cid = cr.get("channel_id", "")
-                    if channel_id and cr_cid != channel_id:
-                        continue
-                    # Reset content stays purged from channel-log search too.
-                    if ts <= self._reset_epochs.get(cr_cid, 0.0):
-                        continue
-                    key = (cr_cid, ts)
-                    if key not in seen:
-                        results.append(cr)
-                        seen.add(key)
-                        if len(results) >= limit:
-                            break
-            except Exception as e:
-                log.warning("Channel log search failed: %s", e)
+            remaining = limit - len(results)
+            fts = self._fts_index
+            channel_results = []
+            if fts and hasattr(fts, "search_channel_logs"):
+                channel_results = fts.search_channel_logs(
+                    query, limit=remaining, channel_id=channel_id,
+                )
+            if not channel_results and hasattr(self._channel_logger, "search"):
+                channel_results = await asyncio.to_thread(
+                    self._channel_logger.search, query, remaining,
+                )
+            seen = {(r.get("channel_id", ""), r.get("timestamp", 0)) for r in results}
+            for cr in channel_results:
+                ts = cr.get("timestamp", 0)
+                if not _ts_ok(ts):
+                    continue
+                cr_cid = cr.get("channel_id", "")
+                if channel_id and cr_cid != channel_id:
+                    continue
+                # Reset content stays purged from channel-log search too.
+                if ts <= self._reset_epochs.get(cr_cid, 0.0):
+                    continue
+                key = (cr_cid, ts)
+                if key not in seen:
+                    results.append(cr)
+                    seen.add(key)
+                    if len(results) >= limit:
+                        break
 
         return results
 

--- a/src/web/api/knowledge_mem.py
+++ b/src/web/api/knowledge_mem.py
@@ -16,6 +16,7 @@ from aiohttp import web
 
 from ...json_store import StoreCorruptError
 from ...odin_log import get_logger
+from ...search.errors import InvalidSearchQuery
 from ..api_common import (
     _MAX_CONTENT_LEN,
     _MAX_NAME_LEN,
@@ -94,7 +95,13 @@ def register_knowledge(routes: web.RouteTableDef, bot) -> None:
             limit = _safe_int_param(request, "limit", 10, hi=50)
         except ValueError:
             return web.json_response({"error": "limit must be an integer"}, status=400)
-        results = await store.search_hybrid(query, embedder=bot.embedder, limit=limit)
+        try:
+            results = await store.search_hybrid(query, embedder=bot.embedder, limit=limit)
+        except InvalidSearchQuery:
+            return web.json_response({"error": "invalid query"}, status=400)
+        except Exception:
+            log.exception("Knowledge search failed")
+            return web.json_response({"error": "search failed"}, status=500)
         return web.json_response(results)
 
     @routes.get("/api/knowledge/{source}/chunks")

--- a/src/web/api/sessions_chat.py
+++ b/src/web/api/sessions_chat.py
@@ -14,6 +14,7 @@ import uuid
 from aiohttp import web
 
 from ...odin_log import get_logger
+from ...search.errors import InvalidSearchQuery
 from ..api_common import (
     _SESSION_ID_RE,
     _safe_filename,
@@ -260,10 +261,16 @@ def register_sessions(routes: web.RouteTableDef, bot) -> None:
                 before = float(request.query["before"])
             except ValueError:
                 pass
-        results = await bot.sessions.search_history(
-            query, limit=limit, channel_id=channel_id,
-            user_id=user_id, after=after, before=before,
-        )
+        try:
+            results = await bot.sessions.search_history(
+                query, limit=limit, channel_id=channel_id,
+                user_id=user_id, after=after, before=before,
+            )
+        except InvalidSearchQuery:
+            return web.json_response({"error": "invalid query"}, status=400)
+        except Exception:
+            log.exception("Session search failed")
+            return web.json_response({"error": "search failed"}, status=500)
         return web.json_response({"query": query, "results": results, "count": len(results)})
 
     def _check_session_access(request: web.Request, channel_id: str) -> web.Response | None:

--- a/tests/test_fts_channel_and_errors.py
+++ b/tests/test_fts_channel_and_errors.py
@@ -77,11 +77,14 @@ class TestErrorBranches:
         idx._conn.close()   # every subsequent sqlite op raises → caught by except arms
 
         assert idx.index_session("s2", "x", "c1", 1.0) is False
-        assert idx.search_sessions("content") == []
+        with pytest.raises(Exception, match="closed database"):
+            idx.search_sessions("content")
         assert idx.index_knowledge_chunk("k2", "x", "s", 0) is False
-        assert idx.search_knowledge("content") == []
+        with pytest.raises(Exception, match="closed database"):
+            idx.search_knowledge("content")
         assert idx.delete_knowledge_source("src") == 0
         assert idx.index_channel_messages([
             {"content": "x", "author": "a", "channel_id": "c", "ts": 1.0}]) == 0
-        assert idx.search_channel_logs("x") == []
+        with pytest.raises(Exception, match="closed database"):
+            idx.search_channel_logs("x")
         assert idx.clear_channel_logs() is False

--- a/tests/test_fts_search.py
+++ b/tests/test_fts_search.py
@@ -49,6 +49,10 @@ class TestPrepareQuery:
         with pytest.raises(InvalidSearchQuery, match="invalid query"):
             _prepare_query("bad\x00query")
 
+    def test_non_utf8_text_is_invalid(self):
+        with pytest.raises(InvalidSearchQuery, match="invalid query"):
+            _prepare_query("\ud800")
+
 
 # ---------------------------------------------------------------------------
 # FullTextIndex initialization

--- a/tests/test_fts_search.py
+++ b/tests/test_fts_search.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import os
 import tempfile
 
-from src.search.fts import _FTS5_KEYWORDS, FullTextIndex, _prepare_query
+import pytest
+
+from src.search.errors import InvalidSearchQuery, SearchExecutionError
+from src.search.fts import FullTextIndex, _prepare_query
 
 # ---------------------------------------------------------------------------
 # _prepare_query
@@ -22,17 +25,13 @@ class TestPrepareQuery:
     def test_whitespace_only(self):
         assert _prepare_query("   ") == ""
 
-    def test_simple_terms(self):
-        assert _prepare_query("hello world") == "hello world"
+    def test_quotes_each_term(self):
+        assert _prepare_query("hello world") == '"hello" "world"'
 
-    def test_quotes_special_chars(self):
-        """FTS5 special chars trigger quoting."""
-        result = _prepare_query("status[0]")
-        assert result.startswith('"')
-        assert result.endswith('"')
+    def test_quotes_punctuation_terms_without_changing_and_semantics(self):
+        assert _prepare_query("error.log recovered") == '"error.log" "recovered"'
 
     def test_quotes_ip_address(self):
-        """IP addresses contain dots, which trigger quoting."""
         result = _prepare_query("192.168.1.1")
         assert result == '"192.168.1.1"'
 
@@ -41,43 +40,14 @@ class TestPrepareQuery:
         assert result == '"/var/log/syslog"'
 
     def test_escapes_internal_quotes(self):
-        result = _prepare_query('say "hello"')
-        assert '""' in result  # Internal quotes escaped
+        assert _prepare_query('say "hello"') == '"say" """hello"""'
 
-    def test_reserved_keyword_AND(self):  # noqa: N802 — established public name; rename is an API change
-        result = _prepare_query("this AND that")
-        assert '"AND"' in result
+    def test_reserved_words_are_literals(self):
+        assert _prepare_query("this AND that") == '"this" "AND" "that"'
 
-    def test_reserved_keyword_OR(self):  # noqa: N802 — established public name; rename is an API change
-        result = _prepare_query("this OR that")
-        assert '"OR"' in result
-
-    def test_reserved_keyword_NOT(self):  # noqa: N802 — established public name; rename is an API change
-        result = _prepare_query("NOT error")
-        assert '"NOT"' in result
-
-    def test_reserved_keyword_NEAR(self):  # noqa: N802 — established public name; rename is an API change
-        result = _prepare_query("NEAR match")
-        assert '"NEAR"' in result
-
-    def test_reserved_keyword_TO(self):  # noqa: N802 — established public name; rename is an API change
-        result = _prepare_query("from TO end")
-        assert '"TO"' in result
-
-    def test_mixed_normal_and_keyword(self):
-        result = _prepare_query("error AND warning")
-        assert '"AND"' in result
-        assert "error" in result
-        assert "warning" in result
-
-    def test_case_insensitive_keywords(self):
-        result = _prepare_query("error and warning")
-        assert '"and"' in result
-
-    def test_all_fts5_keywords_frozenset(self):
-        assert isinstance(_FTS5_KEYWORDS, frozenset)
-        assert "AND" in _FTS5_KEYWORDS
-        assert "OR" in _FTS5_KEYWORDS
+    def test_control_character_is_invalid(self):
+        with pytest.raises(InvalidSearchQuery, match="invalid query"):
+            _prepare_query("bad\x00query")
 
 
 # ---------------------------------------------------------------------------
@@ -103,11 +73,14 @@ class TestFullTextIndexInit:
         idx = FullTextIndex("/nonexistent/dir/test.db")
         assert idx.available is False
 
-    def test_unavailable_returns_empty(self):
+    def test_unavailable_search_is_explicit_failure(self):
         idx = FullTextIndex("/nonexistent/dir/test.db")
-        assert idx.search_sessions("test") == []
-        assert idx.search_knowledge("test") == []
-        assert idx.search_channel_logs("test") == []
+        with pytest.raises(SearchExecutionError, match="unavailable"):
+            idx.search_sessions("test")
+        with pytest.raises(SearchExecutionError, match="unavailable"):
+            idx.search_knowledge("test")
+        with pytest.raises(SearchExecutionError, match="unavailable"):
+            idx.search_channel_logs("test")
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +107,23 @@ class TestSessionIndex:
         self.idx.index_session("s1", "hello world", "ch1", 1000.0)
         results = self.idx.search_sessions("nonexistent")
         assert results == []
+
+    @pytest.mark.parametrize("term", ["don't", "C++", "foo,bar", "a=b", "hello!"])
+    def test_punctuation_terms_return_real_results(self, term):
+        self.idx.index_session("s1", f"prefix {term} suffix", "ch1", 1000.0)
+        assert [r["doc_id"] for r in self.idx.search_sessions(term)] == ["s1"]
+
+    def test_dotted_multi_term_query_is_implicit_and_not_phrase(self):
+        self.idx.index_session(
+            "s1", "error.log appeared many unrelated words before recovered", "ch1", 1000.0
+        )
+        results = self.idx.search_sessions("error.log recovered")
+        assert [r["doc_id"] for r in results] == ["s1"]
+
+    def test_control_character_surfaces_invalid_query(self):
+        self.idx.index_session("s1", "bad query", "ch1", 1000.0)
+        with pytest.raises(InvalidSearchQuery, match="invalid query"):
+            self.idx.search_sessions("bad\x00query")
 
     def test_search_with_channel_filter(self):
         self.idx.index_session("s1", "error in production", "ch1", 1000.0)
@@ -196,6 +186,11 @@ class TestKnowledgeIndex:
         self.idx.index_knowledge_chunk("k1", "something else", "src.md", 0)
         results = self.idx.search_knowledge("nonexistent")
         assert results == []
+
+    @pytest.mark.parametrize("term", ["don't", "C++", "foo,bar", "a=b", "hello!"])
+    def test_punctuation_terms_return_real_results(self, term):
+        self.idx.index_knowledge_chunk("k1", f"prefix {term} suffix", "src.md", 0)
+        assert [r["chunk_id"] for r in self.idx.search_knowledge(term)] == ["k1"]
 
     def test_search_limit(self):
         for i in range(10):
@@ -285,6 +280,16 @@ class TestChannelLogIndex:
         self.idx.index_channel_messages(msgs)
         results = self.idx.search_channel_logs("error", channel_id="ch1")
         assert len(results) == 1
+
+    @pytest.mark.parametrize("term", ["don't", "C++", "foo,bar", "a=b", "hello!"])
+    def test_punctuation_terms_return_real_results(self, term):
+        self.idx.index_channel_messages([{
+            "content": f"prefix {term} suffix",
+            "author": "user",
+            "channel_id": "ch1",
+            "ts": 1.0,
+        }])
+        assert len(self.idx.search_channel_logs(term)) == 1
 
     def test_clear_channel_logs(self):
         msgs = [{"content": "hello world", "author": "user", "channel_id": "ch1", "ts": 1.0}]

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -5,6 +5,9 @@ custom id_key, k parameter, empty inputs, and single-list passthrough.
 """
 from __future__ import annotations
 
+import pytest
+
+from src.search.errors import SearchInvariantError
 from src.search.hybrid import reciprocal_rank_fusion
 
 # ---------------------------------------------------------------------------
@@ -127,11 +130,22 @@ class TestCustomIdKey:
         result = reciprocal_rank_fusion(items, id_key="chunk_id")
         assert result[0]["chunk_id"] == "c1"
 
-    def test_missing_id_key_uses_rank(self):
-        """When id_key is not present, items should still be processed."""
-        items = [{"text": "x"}, {"text": "y"}]
-        result = reciprocal_rank_fusion(items, id_key="missing_key")
-        assert len(result) == 2
+    def test_missing_id_key_is_invariant_violation(self):
+        items = [{"text": "x"}]
+        with pytest.raises(SearchInvariantError, match="missing required identity"):
+            reciprocal_rank_fusion(items, id_key="missing_key")
+
+    def test_hash_chunk_id_fuses_and_sums_rrf(self):
+        chunk_id = "a1b2c3d4e5f6_0"
+        semantic = [{"chunk_id": chunk_id, "source": "guide.md", "content": "semantic"}]
+        fts = [{"chunk_id": chunk_id, "source": "guide.md", "content": "fts"}]
+        result = reciprocal_rank_fusion(semantic, fts, id_key="chunk_id")
+        assert result == [{
+            "chunk_id": chunk_id,
+            "source": "guide.md",
+            "content": "semantic",
+            "rrf_score": round(2 / 61, 6),
+        }]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_knowledge_import.py
+++ b/tests/test_knowledge_import.py
@@ -22,7 +22,7 @@ from src.knowledge.importer import (
     ImportResult,
 )
 from src.knowledge.store import KnowledgeStore
-from src.search.errors import InvalidSearchQuery
+from src.search.errors import validate_search_query
 
 try:
     import fitz  # noqa: F401 — availability probe for the [pdf] extra
@@ -790,9 +790,14 @@ class TestToolHandler:
         skill_mgr = MagicMock()
         skill_mgr.has_skill.return_value = False
         store = MagicMock()
-        store.search_hybrid = AsyncMock(side_effect=InvalidSearchQuery("invalid query"))
+
+        async def search_with_real_validation(query, *_args, **_kwargs):
+            validate_search_query(query)
+            return []
+
+        store.search_hybrid = AsyncMock(side_effect=search_with_real_validation)
         result = await _execute_tool(
-            "search_knowledge", {"query": "bad\x00query"}, executor, skill_mgr,
+            "search_knowledge", {"query": "\ud800"}, executor, skill_mgr,
             store, object(), "test-user",
         )
         assert "Invalid query" in result

--- a/tests/test_knowledge_import.py
+++ b/tests/test_knowledge_import.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -22,6 +22,7 @@ from src.knowledge.importer import (
     ImportResult,
 )
 from src.knowledge.store import KnowledgeStore
+from src.search.errors import InvalidSearchQuery
 
 try:
     import fitz  # noqa: F401 — availability probe for the [pdf] extra
@@ -782,6 +783,27 @@ class TestImportBatch:
 
 
 class TestToolHandler:
+    async def test_search_knowledge_tool_reports_invalid_query_and_failure(self):
+        from src.discord.background_task import _execute_tool
+
+        executor = MagicMock()
+        skill_mgr = MagicMock()
+        skill_mgr.has_skill.return_value = False
+        store = MagicMock()
+        store.search_hybrid = AsyncMock(side_effect=InvalidSearchQuery("invalid query"))
+        result = await _execute_tool(
+            "search_knowledge", {"query": "bad\x00query"}, executor, skill_mgr,
+            store, object(), "test-user",
+        )
+        assert "Invalid query" in result
+
+        store.search_hybrid = AsyncMock(side_effect=RuntimeError("database failure"))
+        result = await _execute_tool(
+            "search_knowledge", {"query": "valid"}, executor, skill_mgr,
+            store, object(), "test-user",
+        )
+        assert "Search failed" in result
+
     async def test_bulk_ingest_tool_routing(self):
         from src.discord.background_task import _execute_tool
 

--- a/tests/test_native_knowledge.py
+++ b/tests/test_native_knowledge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.discord.native_tools.knowledge import KnowledgeTools
-from src.search.errors import InvalidSearchQuery
+from src.search.errors import validate_search_query
 
 
 def _tools(store=None, sessions=None, audit=None):
@@ -28,6 +28,11 @@ def _store():
     s.ingest = AsyncMock(return_value=3)
     s.delete_source_async = AsyncMock(return_value=2)
     return s
+
+
+async def _search_with_real_validation(query, *_args, **_kwargs):
+    validate_search_query(query)
+    return []
 
 
 class TestSearchHistory:
@@ -48,10 +53,10 @@ class TestSearchHistory:
         out = await _tools(sessions=s)._handle_search_history({"query": "q"})
         assert "Found 1 result(s)" in out and "(user)" in out
 
-    async def test_invalid_query_is_explicit(self):
+    async def test_surrogate_query_is_invalid_at_native_boundary(self):
         s = MagicMock()
-        s.search_history = AsyncMock(side_effect=InvalidSearchQuery("invalid query"))
-        out = await _tools(sessions=s)._handle_search_history({"query": "bad\x00query"})
+        s.search_history = AsyncMock(side_effect=_search_with_real_validation)
+        out = await _tools(sessions=s)._handle_search_history({"query": "\ud800"})
         assert "Invalid query" in out
 
     async def test_search_failure_is_explicit(self):
@@ -80,10 +85,10 @@ class TestSearchKnowledge:
         out = await _tools(store=s)._handle_search_knowledge({"query": "q"})
         assert "[doc.md]" in out and "score: 0.9" in out
 
-    async def test_invalid_query_is_explicit(self):
+    async def test_surrogate_query_is_invalid_at_native_boundary(self):
         s = _store()
-        s.search_hybrid = AsyncMock(side_effect=InvalidSearchQuery("invalid query"))
-        out = await _tools(store=s)._handle_search_knowledge({"query": "bad\x00query"})
+        s.search_hybrid = AsyncMock(side_effect=_search_with_real_validation)
+        out = await _tools(store=s)._handle_search_knowledge({"query": "\ud800"})
         assert "Invalid query" in out
 
     async def test_search_failure_is_explicit(self):

--- a/tests/test_native_knowledge.py
+++ b/tests/test_native_knowledge.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.discord.native_tools.knowledge import KnowledgeTools
+from src.search.errors import InvalidSearchQuery
 
 
 def _tools(store=None, sessions=None, audit=None):
@@ -47,6 +48,18 @@ class TestSearchHistory:
         out = await _tools(sessions=s)._handle_search_history({"query": "q"})
         assert "Found 1 result(s)" in out and "(user)" in out
 
+    async def test_invalid_query_is_explicit(self):
+        s = MagicMock()
+        s.search_history = AsyncMock(side_effect=InvalidSearchQuery("invalid query"))
+        out = await _tools(sessions=s)._handle_search_history({"query": "bad\x00query"})
+        assert "Invalid query" in out
+
+    async def test_search_failure_is_explicit(self):
+        s = MagicMock()
+        s.search_history = AsyncMock(side_effect=RuntimeError("database failure"))
+        out = await _tools(sessions=s)._handle_search_history({"query": "q"})
+        assert "Search failed" in out
+
 
 class TestSearchKnowledge:
     async def test_store_unavailable(self):
@@ -66,6 +79,18 @@ class TestSearchKnowledge:
         ])
         out = await _tools(store=s)._handle_search_knowledge({"query": "q"})
         assert "[doc.md]" in out and "score: 0.9" in out
+
+    async def test_invalid_query_is_explicit(self):
+        s = _store()
+        s.search_hybrid = AsyncMock(side_effect=InvalidSearchQuery("invalid query"))
+        out = await _tools(store=s)._handle_search_knowledge({"query": "bad\x00query"})
+        assert "Invalid query" in out
+
+    async def test_search_failure_is_explicit(self):
+        s = _store()
+        s.search_hybrid = AsyncMock(side_effect=RuntimeError("database failure"))
+        out = await _tools(store=s)._handle_search_knowledge({"query": "q"})
+        assert "Search failed" in out
 
 
 class TestIngest:

--- a/tests/test_search_identity.py
+++ b/tests/test_search_identity.py
@@ -1,0 +1,74 @@
+"""Canonical identity pins for semantic and hybrid search results."""
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.knowledge.store import KnowledgeStore
+from src.search.fts import FullTextIndex
+from src.search.vectorstore import SessionVectorStore
+
+
+def _embedder():
+    return SimpleNamespace(embed=AsyncMock(return_value=[0.1] * 384))
+
+
+async def test_session_fractional_timestamp_fuses_on_filename_doc_id(tmp_path):
+    archive = tmp_path / "channel_1700000000.json"
+    archive.write_text(json.dumps({
+        "channel_id": "channel",
+        "last_active": 1700000000.25,
+        "messages": [{"role": "user", "content": "needle"}],
+    }))
+    fts = FullTextIndex(str(tmp_path / "session-fts.db"))
+    store = SessionVectorStore(str(tmp_path / "sessions.db"), fts_index=fts)
+    if not store._has_vec:
+        pytest.skip("sqlite-vec not available")
+    embedder = _embedder()
+    assert await store.index_session(archive, embedder) is True
+
+    results = await store.search_hybrid("needle", embedder, limit=5)
+
+    assert len(results) == 1
+    assert results[0]["doc_id"] == archive.stem
+    assert results[0]["timestamp"] == 1700000000.25
+    assert results[0]["rrf_score"] == round(2 / 61, 6)
+    store._conn.close()
+    fts._conn.close()
+
+
+async def test_knowledge_hash_chunk_id_fuses_both_lists_with_summed_score(tmp_path):
+    source = "runbook.md"
+    fts = FullTextIndex(str(tmp_path / "knowledge-fts.db"))
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"), fts_index=fts)
+    if not store._has_vec:
+        pytest.skip("sqlite-vec not available")
+    embedder = _embedder()
+    assert await store.ingest("needle body", source, embedder=embedder) == 1
+
+    results = await store.search_hybrid("needle", embedder, limit=5)
+
+    expected_id = f"{hashlib.md5(source.encode()).hexdigest()[:8]}_0"
+    assert expected_id != f"{source}_0"
+    assert len(results) == 1
+    assert results[0]["chunk_id"] == expected_id
+    assert results[0]["rrf_score"] == round(2 / 61, 6)
+    store.close()
+    fts._conn.close()
+
+
+async def test_missing_semantic_identity_is_never_reconstructed():
+    store = object.__new__(SessionVectorStore)
+    store._conn = MagicMock()
+    store._has_vec = True
+    store._fts = None
+    store.search = AsyncMock(return_value=[{
+        "channel_id": "channel", "timestamp": 1.25, "content": "body"
+    }])
+
+    with pytest.raises(Exception, match="missing required identity"):
+        await store.search_hybrid("needle", MagicMock(), limit=5)

--- a/tests/test_web_api_knowledge_mem.py
+++ b/tests/test_web_api_knowledge_mem.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from aiohttp import web
@@ -16,6 +17,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from src.knowledge.store import KnowledgeStore
 from src.learning.reflector import ConversationReflector
+from src.search.errors import InvalidSearchQuery
 from src.web.api.knowledge_mem import (
     register_knowledge,
     register_learned_context,
@@ -110,6 +112,21 @@ class TestKnowledgeCrud:
             assert (await c.get("/api/knowledge/search?q=")).status == 400
             # a non-integer limit gracefully falls back to the default (no 400)
             assert (await c.get("/api/knowledge/search?q=x&limit=notanint")).status == 200
+
+    async def test_search_invalid_query_and_failure_are_distinct(self, kbot):
+        kbot.knowledge.search_hybrid = AsyncMock(
+            side_effect=InvalidSearchQuery("invalid query")
+        )
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            r = await c.get("/api/knowledge/search?q=bad")
+            assert r.status == 400
+            assert (await r.json()) == {"error": "invalid query"}
+
+        kbot.knowledge.search_hybrid = AsyncMock(side_effect=RuntimeError("database failure"))
+        async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:
+            r = await c.get("/api/knowledge/search?q=valid")
+            assert r.status == 500
+            assert (await r.json()) == {"error": "search failed"}
 
     async def test_chunks(self, kbot):
         async with TestClient(TestServer(_app(register_knowledge, bot=kbot))) as c:

--- a/tests/test_web_api_knowledge_mem.py
+++ b/tests/test_web_api_knowledge_mem.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -17,7 +18,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from src.knowledge.store import KnowledgeStore
 from src.learning.reflector import ConversationReflector
-from src.search.errors import InvalidSearchQuery
+from src.search.errors import InvalidSearchQuery, validate_search_query
 from src.web.api.knowledge_mem import (
     register_knowledge,
     register_learned_context,
@@ -112,6 +113,21 @@ class TestKnowledgeCrud:
             assert (await c.get("/api/knowledge/search?q=")).status == 400
             # a non-integer limit gracefully falls back to the default (no 400)
             assert (await c.get("/api/knowledge/search?q=x&limit=notanint")).status == 200
+
+    async def test_surrogate_query_is_400_at_route_boundary(self, kbot):
+        async def search_with_real_validation(query, **_kwargs):
+            validate_search_query(query)
+            return []
+
+        kbot.knowledge.search_hybrid = AsyncMock(side_effect=search_with_real_validation)
+        routes = web.RouteTableDef()
+        register_knowledge(routes, kbot)
+        handler = next(
+            route.handler for route in routes if route.handler.__name__ == "search_knowledge"
+        )
+        response = await handler(SimpleNamespace(query={"q": "\ud800"}))
+        assert response.status == 400
+        assert response.text == '{"error": "invalid query"}'
 
     async def test_search_invalid_query_and_failure_are_distinct(self, kbot):
         kbot.knowledge.search_hybrid = AsyncMock(

--- a/tests/test_web_api_sessions_chat.py
+++ b/tests/test_web_api_sessions_chat.py
@@ -13,7 +13,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from src.config.schema import Config
-from src.search.errors import InvalidSearchQuery
+from src.search.errors import InvalidSearchQuery, validate_search_query
 from src.web.api.sessions_chat import (
     register_agent_trajectories,
     register_chat,
@@ -121,6 +121,23 @@ class TestSessionsCrud:
             assert (await c.get("/api/sessions/search")).status == 400  # no q
             s = await (await c.get("/api/sessions/search?q=hi&after=1&before=2")).json()
             assert s["count"] == 1
+
+    async def test_surrogate_query_is_400_at_route_boundary(self):
+        bot = _bot()
+
+        async def search_with_real_validation(query, **_kwargs):
+            validate_search_query(query)
+            return []
+
+        bot.sessions.search_history = AsyncMock(side_effect=search_with_real_validation)
+        routes = web.RouteTableDef()
+        register_sessions(routes, bot)
+        handler = next(
+            route.handler for route in routes if route.handler.__name__ == "search_sessions"
+        )
+        response = await handler(SimpleNamespace(query={"q": "\ud800"}))
+        assert response.status == 400
+        assert response.text == '{"error": "invalid query"}'
 
     async def test_search_invalid_query_and_failure_are_distinct(self):
         bot = _bot()

--- a/tests/test_web_api_sessions_chat.py
+++ b/tests/test_web_api_sessions_chat.py
@@ -13,6 +13,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from src.config.schema import Config
+from src.search.errors import InvalidSearchQuery
 from src.web.api.sessions_chat import (
     register_agent_trajectories,
     register_chat,
@@ -120,6 +121,22 @@ class TestSessionsCrud:
             assert (await c.get("/api/sessions/search")).status == 400  # no q
             s = await (await c.get("/api/sessions/search?q=hi&after=1&before=2")).json()
             assert s["count"] == 1
+
+    async def test_search_invalid_query_and_failure_are_distinct(self):
+        bot = _bot()
+        bot.sessions.search_history = AsyncMock(
+            side_effect=InvalidSearchQuery("invalid query")
+        )
+        async with TestClient(TestServer(_app(register_sessions, bot=bot))) as c:
+            r = await c.get("/api/sessions/search?q=bad")
+            assert r.status == 400
+            assert (await r.json()) == {"error": "invalid query"}
+
+        bot.sessions.search_history = AsyncMock(side_effect=RuntimeError("database failure"))
+        async with TestClient(TestServer(_app(register_sessions, bot=bot))) as c:
+            r = await c.get("/api/sessions/search?q=valid")
+            assert r.status == 500
+            assert (await r.json()) == {"error": "search failed"}
 
     async def test_get_export_delete(self):
         bot = _bot()


### PR DESCRIPTION
## Summary
- preserve canonical session `doc_id` and knowledge `chunk_id` from vector query rows so reciprocal-rank fusion combines semantic and FTS hits
- reject missing fusion identities as invariant violations instead of reconstructing them from lossy metadata
- treat search input as literal whitespace-delimited terms, preserving implicit AND semantics while safely handling punctuation
- distinguish invalid NUL-containing input, backend failures, and genuine empty result sets across web and Discord/native boundaries

## Validation
- `python -m pytest -q` — 10,267 passed, 5 skipped
- focused search/boundary suite — 335 passed
- `ruff check src tests` — passed
- `python scripts/ci/type_gate.py` — no new type findings
- `python scripts/ci/lint_gate.py` — no new lint findings
- `git diff --check` — passed

Closes #302
Closes #306
