### PR TITLE
Fix bulk knowledge import integrity and file identity

### DIFF
--- a/src/knowledge/importer.py
+++ b/src/knowledge/importer.py
@@ -6,8 +6,9 @@ KnowledgeStore in a single operation, with per-item status tracking.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -34,6 +35,7 @@ MAX_PDF_BYTES = 50_000_000  # 50 MB
 FETCH_TIMEOUT = aiohttp.ClientTimeout(total=30)
 FETCH_MAX_CHARS = 100_000  # larger than tool output — we want full content for ingestion
 PDF_MAX_CHARS = 500_000
+_LEGACY_MIGRATION_LOCK = asyncio.Lock()
 DIR_ALLOWED_EXTENSIONS = {
     ".md",
     ".txt",
@@ -75,6 +77,194 @@ class BulkImporter:
         self._store = store
         self._embedder = embedder
 
+    @staticmethod
+    def _in_safe_import_root(path: Path) -> bool:
+        return any(path.is_relative_to(root) for root in SAFE_IMPORT_ROOTS)
+
+    @staticmethod
+    def _canonical_file_source(path: Path) -> str:
+        """Return a base-independent identity for a resolved local file."""
+        return path.as_uri()
+
+    @staticmethod
+    def _legacy_source_matches_path(source: str, path: Path) -> bool:
+        """Whether *source* could be an old base-relative name for *path*."""
+        if not source or "://" in source:
+            return False
+        candidate = PurePosixPath(source)
+        parts = candidate.parts
+        if candidate.is_absolute() or not parts or any(part in (".", "..") for part in parts):
+            return False
+        return len(parts) <= len(path.parts) and tuple(path.parts[-len(parts):]) == parts
+
+    def _legacy_source_for(
+        self,
+        path: Path,
+        content: str,
+        canonical_source: str,
+    ) -> tuple[str | None, str | None]:
+        """Find one safely identifiable old base-relative source.
+
+        Old source names discarded their import base.  Exact normalized content
+        is therefore required in addition to a path-suffix match; ambiguous or
+        changed legacy entries are reported instead of creating a second source.
+        """
+        entries = self._store.list_sources()
+        if any(str(entry.get("source", "")) == canonical_source for entry in entries):
+            return None, None
+
+        candidates = [
+            entry for entry in entries
+            if self._legacy_source_matches_path(str(entry.get("source", "")), path)
+        ]
+        if not candidates:
+            return None, None
+
+        content_hash = hashlib.sha256(content.strip().lower().encode("utf-8")).hexdigest()
+        matching = [
+            str(entry["source"])
+            for entry in candidates
+            if entry.get("content_hash") == content_hash
+        ]
+        if len(matching) == 1:
+            return matching[0], None
+
+        names = ", ".join(sorted(str(entry.get("source", "")) for entry in candidates))
+        if not matching:
+            reason = "none has matching content"
+        else:
+            reason = f"{len(matching)} have matching content"
+        return None, (
+            f"legacy source conflict ({names}; {reason}); refusing to create "
+            f"'{canonical_source}'"
+        )
+
+    @staticmethod
+    def _read_file_bytes(path: Path) -> bytes:
+        """Read at most one byte beyond the local-file size fence."""
+        with path.open("rb") as handle:
+            return handle.read(MAX_FILE_BYTES + 1)
+
+    async def _import_resolved_file(
+        self,
+        path: Path,
+        uploader: str,
+    ) -> ImportResult:
+        source_name = self._canonical_file_source(path)
+        ext = path.suffix.lower()
+        if ext not in DIR_ALLOWED_EXTENSIONS:
+            return ImportResult(
+                source=source_name,
+                status="skipped",
+                error=f"unsupported file extension '{ext or '<none>'}'",
+            )
+
+        try:
+            size = path.stat().st_size
+            if size > MAX_FILE_BYTES:
+                return ImportResult(
+                    source=source_name,
+                    status="skipped",
+                    error=f"file too large ({size} bytes, max {MAX_FILE_BYTES})",
+                )
+            data = await asyncio.to_thread(self._read_file_bytes, path)
+            if len(data) > MAX_FILE_BYTES:
+                return ImportResult(
+                    source=source_name,
+                    status="skipped",
+                    error=f"file too large (more than {MAX_FILE_BYTES} bytes)",
+                )
+            try:
+                content = data.decode("utf-8", errors="strict")
+            except UnicodeDecodeError as exc:
+                return ImportResult(
+                    source=source_name,
+                    status="error",
+                    error=f"invalid UTF-8: {exc}",
+                )
+            if not content.strip():
+                return ImportResult(
+                    source=source_name,
+                    status="skipped",
+                    error="empty file",
+                )
+
+            legacy_source, conflict = self._legacy_source_for(path, content, source_name)
+            if conflict:
+                return ImportResult(source=source_name, status="error", error=conflict)
+
+            if legacy_source is None:
+                chunks = await self._store.ingest(
+                    content, source_name, embedder=self._embedder, uploader=uploader,
+                )
+                return ImportResult(source=source_name, status="ok", chunks=chunks)
+
+            # Every BulkImporter shares this migration lock.  Re-check after
+            # admission so concurrent imports cannot both copy/delete the same
+            # legacy source and roll back each other's canonical document.
+            async with _LEGACY_MIGRATION_LOCK:
+                legacy_source, conflict = self._legacy_source_for(path, content, source_name)
+                if conflict:
+                    return ImportResult(source=source_name, status="error", error=conflict)
+                if legacy_source is None:
+                    chunks = await self._store.ingest(
+                        content, source_name, embedder=self._embedder, uploader=uploader,
+                    )
+                    return ImportResult(source=source_name, status="ok", chunks=chunks)
+
+                # Store the canonical copy first, then remove the uniquely
+                # matched legacy source.  A failed copy is removed while the
+                # legacy document remains intact.
+                expected_chunks = len(self._store._chunk_text(content))
+                chunks = await self._store.ingest(
+                    content,
+                    source_name,
+                    embedder=self._embedder,
+                    uploader=uploader,
+                    dedup=False,
+                )
+                if chunks != expected_chunks:
+                    await self._store.delete_source_async(source_name)
+                    return ImportResult(
+                        source=source_name,
+                        status="error",
+                        error=(
+                            f"legacy migration from '{legacy_source}' failed: indexed "
+                            f"{chunks}/{expected_chunks} chunks"
+                        ),
+                    )
+                removed = await self._store.delete_source_async(legacy_source)
+                if removed <= 0:
+                    await self._store.delete_source_async(source_name)
+                    return ImportResult(
+                        source=source_name,
+                        status="error",
+                        error=(
+                            f"legacy migration from '{legacy_source}' failed; "
+                            "canonical copy removed"
+                        ),
+                    )
+                return ImportResult(source=source_name, status="ok", chunks=chunks)
+        except Exception as exc:
+            return ImportResult(source=source_name, status="error", error=str(exc))
+
+    async def import_file(
+        self,
+        file_path: str,
+        uploader: str = "bulk-import",
+    ) -> ImportResult:
+        """Import one local text file under the existing safe-root fence."""
+        path = Path(file_path).resolve()
+        if not path.is_file():
+            return ImportResult(source=file_path, status="error", error="file not found")
+        if not self._in_safe_import_root(path):
+            return ImportResult(
+                source=file_path,
+                status="error",
+                error=f"file not in allowed import roots: {', '.join(SAFE_IMPORT_ROOTS)}",
+            )
+        return await self._import_resolved_file(path, uploader)
+
     async def import_directory(
         self,
         directory: str,
@@ -84,7 +274,7 @@ class BulkImporter:
         base = Path(directory).resolve()
         if not base.is_dir():
             return [ImportResult(source=directory, status="error", error="directory not found")]
-        if not any(base.is_relative_to(root) for root in SAFE_IMPORT_ROOTS):
+        if not self._in_safe_import_root(base):
             return [ImportResult(
                 source=directory, status="error",
                 error=f"directory not in allowed import roots: {', '.join(SAFE_IMPORT_ROOTS)}",
@@ -93,7 +283,7 @@ class BulkImporter:
         results: list[ImportResult] = []
         resolved_base = base.resolve()
         files = sorted(
-            f for f in base.glob(pattern)
+            f.resolve() for f in base.glob(pattern)
             if f.resolve().is_relative_to(resolved_base)
         )
         if not files:
@@ -107,44 +297,16 @@ class BulkImporter:
         for fpath in files:
             if not fpath.is_file():
                 continue
-            ext = fpath.suffix.lower()
-            if ext not in DIR_ALLOWED_EXTENSIONS:
+            if fpath.suffix.lower() not in DIR_ALLOWED_EXTENSIONS:
                 continue
-            source_name = str(fpath.relative_to(base))
+            source_name = self._canonical_file_source(fpath)
             if count >= MAX_BATCH_SIZE:
                 results.append(ImportResult(
                     source=source_name, status="skipped",
                     error=f"batch limit ({MAX_BATCH_SIZE}) reached",
                 ))
                 continue
-            try:
-                size = fpath.stat().st_size
-                if size > MAX_FILE_BYTES:
-                    results.append(ImportResult(
-                        source=source_name, status="skipped",
-                        error=f"file too large ({size} bytes, max {MAX_FILE_BYTES})",
-                    ))
-                    count += 1
-                    continue
-                content = await asyncio.to_thread(
-                    fpath.read_text,
-                    encoding="utf-8",
-                    errors="replace",
-                )
-                if not content.strip():
-                    results.append(ImportResult(
-                        source=source_name,
-                        status="skipped",
-                        error="empty file",
-                    ))
-                    count += 1
-                    continue
-                chunks = await self._store.ingest(
-                    content, source_name, embedder=self._embedder, uploader=uploader,
-                )
-                results.append(ImportResult(source=source_name, status="ok", chunks=chunks))
-            except Exception as e:
-                results.append(ImportResult(source=source_name, status="error", error=str(e)))
+            results.append(await self._import_resolved_file(fpath, uploader))
             count += 1
 
         return results
@@ -237,7 +399,14 @@ class BulkImporter:
         if resp.status != 200:
             return ImportResult(source=src, status="error", error=f"HTTP {resp.status}")
         ct = resp.content_type
-        body = resp.text(errors="replace")
+        try:
+            body = resp.text(errors="strict")
+        except UnicodeDecodeError as exc:
+            return ImportResult(
+                source=src,
+                status="error",
+                error=f"response text could not be decoded without data loss: {exc}",
+            )
 
         if "html" in ct:
             content = _html_to_text(body)
@@ -282,6 +451,13 @@ class BulkImporter:
                 else:
                     results = await self.import_directory(path, pattern=pattern, uploader=uploader)
 
+            elif item_type == "file":
+                path = item.get("path", "")
+                if not path:
+                    results = [ImportResult(source="", status="error", error="path is required")]
+                else:
+                    results = [await self.import_file(path, uploader=uploader)]
+
             elif item_type == "pdf":
                 url = item.get("url", "")
                 source = item.get("source")
@@ -301,7 +477,9 @@ class BulkImporter:
             else:
                 results = [ImportResult(
                     source=str(item), status="error",
-                    error=f"unknown type '{item_type}' — use 'directory', 'pdf', or 'url'",
+                    error=(
+                        f"unknown type '{item_type}' — use 'directory', 'file', 'pdf', or 'url'"
+                    ),
                 )]
 
             for r in results:

--- a/src/tools/defs/tasks_knowledge.py
+++ b/src/tools/defs/tasks_knowledge.py
@@ -144,8 +144,9 @@ TOOLS_SECTION: list[dict] = [
         "name": "bulk_ingest_knowledge",
         "description": (
             "Bulk-import documents into the knowledge base. Accepts a list of items: "
-            "directories of markdown/text files, PDF URLs, or web page URLs. "
-            "Each item needs a type ('directory', 'pdf', or 'url') plus type-specific params."
+            "directories or individual markdown/text files, PDF URLs, or web page URLs. "
+            "Each item needs a type ('directory', 'file', 'pdf', or 'url') plus type-specific "
+            "params."
         ),
         "input_schema": {
             "type": "object",
@@ -155,13 +156,16 @@ TOOLS_SECTION: list[dict] = [
                     "description": (
                         "Import jobs. Each object needs 'type' plus: "
                         "directory → 'path' (+ optional 'pattern', default '**/*.md'); "
-                        "pdf → 'url' (+ optional 'source'); "
+                        "file → 'path'; pdf → 'url' (+ optional 'source'); "
                         "url → 'url' (+ optional 'source')"
                     ),
                     "items": {
                         "type": "object",
                         "properties": {
-                            "type": {"type": "string", "enum": ["directory", "pdf", "url"]},
+                            "type": {
+                                "type": "string",
+                                "enum": ["directory", "file", "pdf", "url"],
+                            },
                             "path": {"type": "string"},
                             "url": {"type": "string"},
                             "source": {"type": "string"},

--- a/tests/characterization/test_tool_parity.py
+++ b/tests/characterization/test_tool_parity.py
@@ -86,7 +86,7 @@ EXPECTED_TOOL_HASHES = {
     "cancel_task": "aaffe5a4cdfa32e0",
     "search_knowledge": "3e5555a61c0509da",
     "ingest_document": "622541a401f80226",
-    "bulk_ingest_knowledge": "0427db261b28cd7e",
+    "bulk_ingest_knowledge": "db9fc05af1e13cdf",
     "list_knowledge": "4ea7f4f545878fdc",
     "delete_knowledge": "73268085bef06627",
     "browser_screenshot": "89e8d695b035d5f2",

--- a/tests/test_knowledge_import.py
+++ b/tests/test_knowledge_import.py
@@ -271,6 +271,41 @@ class TestImportDirectory:
             _cleanup(store)
 
 
+    async def test_matched_entry_that_is_not_a_file_is_ignored(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "ignored.md"
+                path.write_text("ignored", encoding="utf-8")
+                with patch.object(Path, "is_file", return_value=False):
+                    results = await importer.import_directory(tmpdir)
+                assert results == []
+        finally:
+            _cleanup(store)
+
+    async def test_matched_directory_entry_removed_before_read(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "vanished.md"
+                path.write_text("temporary", encoding="utf-8")
+                original = Path.is_file
+
+                def remove_after_match(candidate):
+                    matched = original(candidate)
+                    if candidate == path.resolve() and matched:
+                        candidate.unlink()
+                    return matched
+
+                with patch.object(Path, "is_file", remove_after_match):
+                    results = await importer.import_directory(tmpdir)
+                assert len(results) == 1
+                assert results[0].status == "error"
+                assert "No such file" in results[0].error
+        finally:
+            _cleanup(store)
+
+
 class TestLocalFileIntegrity:
     async def test_invalid_utf8_is_failed_without_ingestion(self):
         importer, store = _make_importer()
@@ -281,6 +316,61 @@ class TestLocalFileIntegrity:
                 result = await importer.import_file(str(path))
                 assert result.status == "error"
                 assert "invalid UTF-8" in result.error
+                assert store.list_sources() == []
+        finally:
+            _cleanup(store)
+
+    def test_legacy_source_rejects_absolute_and_traversal_names(self):
+        path = Path("/tmp/project/docs/doc.md")
+        assert not BulkImporter._legacy_source_matches_path("", path)
+        assert not BulkImporter._legacy_source_matches_path("/tmp/project/docs/doc.md", path)
+        assert not BulkImporter._legacy_source_matches_path("../docs/doc.md", path)
+        assert not BulkImporter._legacy_source_matches_path("https://example.com/doc.md", path)
+
+    async def test_single_file_missing_and_outside_safe_roots(self):
+        importer, store = _make_importer()
+        try:
+            missing = await importer.import_file("/tmp/definitely-missing-odin-import.md")
+            assert missing.status == "error"
+            assert missing.error == "file not found"
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "outside.md"
+                path.write_text("outside", encoding="utf-8")
+                with patch("src.knowledge.importer.SAFE_IMPORT_ROOTS", ("/opt/odin",)):
+                    outside = await importer.import_file(str(path))
+                assert outside.status == "error"
+                assert "not in allowed import roots" in outside.error
+        finally:
+            _cleanup(store)
+
+    async def test_single_file_rejects_unsupported_extension(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "binary.bin"
+                path.write_bytes(b"not really binary")
+                result = await importer.import_file(str(path))
+                assert result.status == "skipped"
+                assert "unsupported file extension" in result.error
+                assert store.list_sources() == []
+        finally:
+            _cleanup(store)
+
+    async def test_file_growth_during_read_hits_size_fence(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "growing.md"
+                path.write_text("small", encoding="utf-8")
+                with patch.object(
+                    BulkImporter,
+                    "_read_file_bytes",
+                    return_value=b"x" * (MAX_FILE_BYTES + 1),
+                ):
+                    result = await importer.import_file(str(path))
+                assert result.status == "skipped"
+                assert "more than" in result.error
                 assert store.list_sources() == []
         finally:
             _cleanup(store)
@@ -337,6 +427,101 @@ class TestLocalFileIntegrity:
                 assert store.get_source_content(canonical) == content
         finally:
             _cleanup(store)
+
+    async def test_migration_recheck_uses_existing_canonical_source(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "docs" / "doc.md"
+                path.parent.mkdir()
+                content = "raced migration content"
+                path.write_text(content, encoding="utf-8")
+                await store.ingest(content, "docs/doc.md", dedup=False)
+                original = importer._legacy_source_for
+                calls = 0
+
+                def migrate_then_observe_canonical(*args):
+                    nonlocal calls
+                    calls += 1
+                    if calls == 1:
+                        return original(*args)
+                    store.delete_source("docs/doc.md")
+                    store._conn.execute(
+                        "UPDATE knowledge_chunks SET source = ? WHERE source = ?",
+                        (path.resolve().as_uri(), "docs/doc.md"),
+                    )
+                    return None, None
+
+                # Simulate a concurrent importer completing migration between
+                # the optimistic check and admission to the shared lock.
+                with patch.object(importer, "_legacy_source_for", side_effect=[
+                    ("docs/doc.md", None), (None, None),
+                ]):
+                    await store.ingest(content, path.resolve().as_uri(), dedup=False)
+                    store.delete_source("docs/doc.md")
+                    result = await importer.import_file(str(path))
+
+                assert result.status == "ok"
+                assert store.get_source_content(path.resolve().as_uri()) == content
+        finally:
+            _cleanup(store)
+
+    async def test_migration_recheck_reports_new_conflict(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "docs" / "doc.md"
+                path.parent.mkdir()
+                content = "raced conflict content"
+                path.write_text(content, encoding="utf-8")
+                await store.ingest(content, "docs/doc.md", dedup=False)
+                with patch.object(importer, "_legacy_source_for", side_effect=[
+                    ("docs/doc.md", None), (None, "legacy source conflict after lock"),
+                ]):
+                    result = await importer.import_file(str(path))
+                assert result.status == "error"
+                assert result.error == "legacy source conflict after lock"
+                assert store.get_source_content(path.resolve().as_uri()) is None
+        finally:
+            _cleanup(store)
+
+    async def test_failed_migration_copy_removes_partial_canonical(self):
+        store = MagicMock()
+        store.list_sources.return_value = [{
+            "source": "docs/doc.md",
+            "content_hash": KnowledgeStore._content_hash("copy failure content"),
+        }]
+        store._chunk_text.return_value = ["copy failure content"]
+        store.ingest = AsyncMock(return_value=0)
+        store.delete_source_async = AsyncMock(return_value=0)
+        importer = BulkImporter(store)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "docs" / "doc.md"
+            path.parent.mkdir()
+            path.write_text("copy failure content", encoding="utf-8")
+            result = await importer.import_file(str(path))
+        assert result.status == "error"
+        assert "indexed 0/1 chunks" in result.error
+        store.delete_source_async.assert_awaited_once_with(path.resolve().as_uri())
+
+    async def test_failed_legacy_delete_rolls_back_canonical_copy(self):
+        store = MagicMock()
+        store.list_sources.return_value = [{
+            "source": "docs/doc.md",
+            "content_hash": KnowledgeStore._content_hash("delete failure content"),
+        }]
+        store._chunk_text.return_value = ["delete failure content"]
+        store.ingest = AsyncMock(return_value=1)
+        store.delete_source_async = AsyncMock(side_effect=[0, 1])
+        importer = BulkImporter(store)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "docs" / "doc.md"
+            path.parent.mkdir()
+            path.write_text("delete failure content", encoding="utf-8")
+            result = await importer.import_file(str(path))
+        assert result.status == "error"
+        assert "canonical copy removed" in result.error
+        assert store.delete_source_async.await_args_list[1].args == (path.resolve().as_uri(),)
 
     async def test_migrated_source_accepts_later_content_updates(self):
         importer, store = _make_importer()
@@ -706,6 +891,20 @@ class TestImportWebUrl:
         finally:
             _cleanup(store)
 
+    async def test_store_failure_is_reported(self):
+        store = MagicMock()
+        store.ingest = AsyncMock(side_effect=RuntimeError("index failed"))
+        importer = BulkImporter(store)
+        response = _mock_aiohttp_response(
+            status=200,
+            text_data="valid web content",
+            headers={"Content-Type": "text/plain; charset=utf-8"},
+        )
+        with patch("src.tools.safe_fetch.safe_fetch", response):
+            result = await importer.import_web_url("https://example.com/fail")
+        assert result.status == "error"
+        assert result.error == "index failed"
+
     async def test_custom_source(self):
         importer, store = _make_importer()
         try:
@@ -909,6 +1108,18 @@ class TestImportBatch:
             items = [{"type": "url", "url": f"ftp://bad/{i}"} for i in range(MAX_BATCH_SIZE + 10)]
             batch = await importer.import_batch(items)
             assert batch.total == MAX_BATCH_SIZE
+        finally:
+            _cleanup(store)
+
+    async def test_skipped_result_is_counted(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                batch = await importer.import_batch([
+                    {"type": "directory", "path": tmpdir},
+                ])
+                assert batch.skipped == 1
+                assert batch.results[0]["status"] == "skipped"
         finally:
             _cleanup(store)
 

--- a/tests/test_knowledge_import.py
+++ b/tests/test_knowledge_import.py
@@ -133,7 +133,7 @@ class TestImportDirectory:
                 results = await importer.import_directory(tmpdir)
                 assert len(results) == 1
                 assert results[0].status == "ok"
-                assert results[0].source == "readme.md"
+                assert results[0].source == md.resolve().as_uri()
                 assert results[0].chunks > 0
         finally:
             _cleanup(store)
@@ -160,7 +160,7 @@ class TestImportDirectory:
                 results = await importer.import_directory(tmpdir)
                 assert len(results) == 1
                 assert results[0].status == "ok"
-                assert "docs/api/endpoints.md" in results[0].source
+                assert results[0].source == (subdir / "endpoints.md").resolve().as_uri()
         finally:
             _cleanup(store)
 
@@ -172,7 +172,7 @@ class TestImportDirectory:
                 (Path(tmpdir) / "b.txt").write_text("text file")
                 results = await importer.import_directory(tmpdir, pattern="**/*.txt")
                 assert len(results) == 1
-                assert results[0].source == "b.txt"
+                assert results[0].source == (Path(tmpdir) / "b.txt").resolve().as_uri()
         finally:
             _cleanup(store)
 
@@ -184,8 +184,8 @@ class TestImportDirectory:
                 (Path(tmpdir) / "doc.md").write_text("valid doc")
                 results = await importer.import_directory(tmpdir, pattern="*")
                 sources = [r.source for r in results]
-                assert "doc.md" in sources
-                assert "binary.exe" not in sources
+                assert (Path(tmpdir) / "doc.md").resolve().as_uri() in sources
+                assert all("binary.exe" not in source for source in sources)
         finally:
             _cleanup(store)
 
@@ -197,8 +197,8 @@ class TestImportDirectory:
                 (Path(tmpdir) / "content.md").write_text("real content")
                 results = await importer.import_directory(tmpdir)
                 statuses = {r.source: r.status for r in results}
-                assert statuses.get("empty.md") == "skipped"
-                assert statuses.get("content.md") == "ok"
+                assert statuses.get((Path(tmpdir) / "empty.md").resolve().as_uri()) == "skipped"
+                assert statuses.get((Path(tmpdir) / "content.md").resolve().as_uri()) == "ok"
         finally:
             _cleanup(store)
 
@@ -253,7 +253,7 @@ class TestImportDirectory:
                 sub.mkdir()
                 (sub / "file.md").write_text("content")
                 results = await importer.import_directory(tmpdir)
-                assert results[0].source == "subdir/file.md"
+                assert results[0].source == (sub / "file.md").resolve().as_uri()
         finally:
             _cleanup(store)
 
@@ -266,7 +266,135 @@ class TestImportDirectory:
                 results = await importer.import_directory(tmpdir, pattern="*")
                 ok_sources = {r.source for r in results if r.status == "ok"}
                 for ext in [".md", ".txt", ".rst", ".yaml", ".json", ".toml"]:
-                    assert f"file{ext}" in ok_sources
+                    assert (Path(tmpdir) / f"file{ext}").resolve().as_uri() in ok_sources
+        finally:
+            _cleanup(store)
+
+
+class TestLocalFileIntegrity:
+    async def test_invalid_utf8_is_failed_without_ingestion(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "invalid.md"
+                path.write_bytes(b"valid\n\xff\xfe")
+                result = await importer.import_file(str(path))
+                assert result.status == "error"
+                assert "invalid UTF-8" in result.error
+                assert store.list_sources() == []
+        finally:
+            _cleanup(store)
+
+    async def test_single_file_import_is_first_class(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "one.md"
+                path.write_text("single-file content", encoding="utf-8")
+                result = await importer.import_file(str(path))
+                assert result.status == "ok"
+                assert result.source == path.resolve().as_uri()
+                assert store.get_source_content(result.source) == "single-file content"
+        finally:
+            _cleanup(store)
+
+    async def test_directory_base_does_not_change_source_identity(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                outer = Path(tmpdir) / "a"
+                inner = outer / "b"
+                inner.mkdir(parents=True)
+                path = inner / "doc.md"
+                path.write_text("stable identity content", encoding="utf-8")
+
+                first = await importer.import_directory(str(outer))
+                second = await importer.import_directory(str(inner))
+
+                canonical = path.resolve().as_uri()
+                assert first[0].source == canonical
+                assert second[0].source == canonical
+                assert [entry["source"] for entry in store.list_sources()] == [canonical]
+        finally:
+            _cleanup(store)
+
+    async def test_exact_legacy_source_is_migrated_to_canonical_identity(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "docs" / "doc.md"
+                path.parent.mkdir()
+                content = "legacy migration content"
+                path.write_text(content, encoding="utf-8")
+                await store.ingest(content, "docs/doc.md", dedup=False)
+
+                result = await importer.import_file(str(path))
+
+                canonical = path.resolve().as_uri()
+                assert result.status == "ok"
+                assert result.source == canonical
+                assert store.get_source_content("docs/doc.md") is None
+                assert store.get_source_content(canonical) == content
+        finally:
+            _cleanup(store)
+
+    async def test_migrated_source_accepts_later_content_updates(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "docs" / "doc.md"
+                path.parent.mkdir()
+                path.write_text("original content", encoding="utf-8")
+                await store.ingest("original content", "docs/doc.md", dedup=False)
+                migrated = await importer.import_file(str(path))
+                assert migrated.status == "ok"
+
+                path.write_text("updated content", encoding="utf-8")
+                updated = await importer.import_file(str(path))
+
+                assert updated.status == "ok"
+                assert store.get_source_content("docs/doc.md") is None
+                assert store.get_source_content(path.resolve().as_uri()) == "updated content"
+        finally:
+            _cleanup(store)
+
+    async def test_changed_legacy_source_conflicts_without_duplicate(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "docs" / "doc.md"
+                path.parent.mkdir()
+                path.write_text("new content", encoding="utf-8")
+                await store.ingest("old content", "docs/doc.md", dedup=False)
+
+                result = await importer.import_file(str(path))
+
+                assert result.status == "error"
+                assert "legacy source conflict" in result.error
+                assert store.get_source_content("docs/doc.md") == "old content"
+                assert store.get_source_content(path.resolve().as_uri()) is None
+        finally:
+            _cleanup(store)
+
+    async def test_ambiguous_legacy_sources_conflict_without_duplicate(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "docs" / "doc.md"
+                path.parent.mkdir()
+                content = "ambiguous content"
+                path.write_text(content, encoding="utf-8")
+                await store.ingest(content, "doc.md", dedup=False)
+                await store.ingest(content, "docs/doc.md", dedup=False)
+
+                result = await importer.import_file(str(path))
+
+                assert result.status == "error"
+                assert "2 have matching content" in result.error
+                assert store.get_source_content(path.resolve().as_uri()) is None
+                assert {entry["source"] for entry in store.list_sources()} == {
+                    "doc.md", "docs/doc.md",
+                }
         finally:
             _cleanup(store)
 
@@ -531,6 +659,53 @@ class TestImportWebUrl:
         finally:
             _cleanup(store)
 
+    async def test_invalid_declared_text_encoding_is_failed(self):
+        importer, store = _make_importer()
+        try:
+            from src.tools.safe_fetch import SafeFetchResponse
+
+            response = SafeFetchResponse(
+                status=200,
+                headers={"Content-Type": "text/plain; charset=utf-8"},
+                body=b"valid\n\xff",
+                content_type="text/plain; charset=utf-8",
+                url="https://example.com/invalid.txt",
+            )
+
+            async def mock_fetch(url, **kwargs):
+                return response
+
+            with patch("src.tools.safe_fetch.safe_fetch", mock_fetch):
+                result = await importer.import_web_url(response.url)
+            assert result.status == "error"
+            assert "without data loss" in result.error
+            assert store.list_sources() == []
+        finally:
+            _cleanup(store)
+
+    async def test_declared_non_utf8_charset_is_supported_strictly(self):
+        importer, store = _make_importer()
+        try:
+            from src.tools.safe_fetch import SafeFetchResponse
+
+            response = SafeFetchResponse(
+                status=200,
+                headers={"Content-Type": "text/plain; charset=latin-1"},
+                body="café knowledge".encode("latin-1"),
+                content_type="text/plain; charset=latin-1",
+                url="https://example.com/latin1.txt",
+            )
+
+            async def mock_fetch(url, **kwargs):
+                return response
+
+            with patch("src.tools.safe_fetch.safe_fetch", mock_fetch):
+                result = await importer.import_web_url(response.url)
+            assert result.status == "ok"
+            assert store.get_source_content(response.url) == "café knowledge"
+        finally:
+            _cleanup(store)
+
     async def test_custom_source(self):
         importer, store = _make_importer()
         try:
@@ -641,6 +816,29 @@ class TestImportBatch:
         finally:
             _cleanup(store)
 
+    async def test_file_type(self):
+        importer, store = _make_importer()
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "doc.md"
+                path.write_text("batch file import content", encoding="utf-8")
+                batch = await importer.import_batch([
+                    {"type": "file", "path": str(path)},
+                ])
+                assert batch.succeeded == 1
+                assert batch.results[0]["source"] == path.resolve().as_uri()
+        finally:
+            _cleanup(store)
+
+    async def test_file_missing_path(self):
+        importer, store = _make_importer()
+        try:
+            batch = await importer.import_batch([{"type": "file"}])
+            assert batch.failed == 1
+            assert "path is required" in batch.results[0]["error"]
+        finally:
+            _cleanup(store)
+
     async def test_directory_missing_path(self):
         importer, store = _make_importer()
         try:
@@ -738,7 +936,7 @@ class TestImportBatch:
                     {"type": "directory", "path": tmpdir, "pattern": "*.txt"},
                 ])
                 assert batch.succeeded == 1
-                assert batch.results[0]["source"] == "b.txt"
+                assert batch.results[0]["source"] == (Path(tmpdir) / "b.txt").resolve().as_uri()
         finally:
             _cleanup(store)
 
@@ -1057,7 +1255,7 @@ class TestToolDefinition:
         from src.tools.registry import TOOLS
         tool = next(t for t in TOOLS if t["name"] == "bulk_ingest_knowledge")
         item_schema = tool["input_schema"]["properties"]["items"]["items"]
-        assert item_schema["properties"]["type"]["enum"] == ["directory", "pdf", "url"]
+        assert item_schema["properties"]["type"]["enum"] == ["directory", "file", "pdf", "url"]
 
     def test_tool_has_description(self):
         from src.tools.registry import TOOLS


### PR DESCRIPTION
## Summary
- reject malformed UTF-8 local files and malformed response text instead of persisting replacement characters, while honoring valid declared web charsets
- identify local files by resolved `file://` URI so import roots do not alter document identity
- conservatively migrate uniquely content-matched legacy relative sources and fail ambiguous/changed legacy identities without creating duplicates
- add a first-class `file` bulk-import item with the existing safe-root, extension, and 500 KB limits

## Migration behavior
Old relative source names discarded their import base, so they cannot be rewritten safely in bulk. On first import under the new scheme, a legacy path-suffix candidate is migrated only when exactly one stored source also has the incoming file's exact normalized content hash. Changed or ambiguous candidates fail explicitly and no canonical duplicate is created. Once canonicalized, later content changes replace the canonical source normally.

## Validation
- full suite at implementation commit: `10293 passed, 5 skipped`
- focused importer/path/parity suite at current head: `171 passed`
- focused importer coverage at current head: `98%`, 5 missed lines versus baseline 9
- Ruff: clean
- lint no-new gate: 0 new findings
- type no-new gate: 0 new findings
- `git diff --check`: clean

The first CI coverage run correctly caught the importer missed-line ceiling (`21` versus baseline `9`). Commit `ae6c328` adds branch/failure-path tests; focused coverage now reports `5` missed lines. The rerun is authoritative for the current head.

## Live finding on current importer
Before this patch, the enabled live bulk importer was exercised with isolated `/tmp` fixtures and reproduced both defects: malformed UTF-8 was reported successful after replacement decoding, and importing the same changed file from parent vs nested roots created two source documents. The three temporary knowledge documents and filesystem fixtures were removed afterward.

No merge, deployment, or release is included.